### PR TITLE
Enable controllers as a service through autowiring

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,9 +19,9 @@ parameters:
 # Autowires Core controllers
 services:
     PrestaShopBundle\Controller\:
-        resource: '../../src/PrestaShopBundle/Controller/*'
-        exclude: '../../src/PrestaShopBundle/Controller/Api'
-        tags: ['prestashop_core.controllers']
+        resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
+        exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
+        tags: ['prestashop.core.controllers']
 
 framework:
     assets:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -16,6 +16,13 @@ parameters:
     mail_themes_uri: "/mails/themes"
     mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
 
+# Autowires Core controllers
+services:
+    PrestaShopBundle\Controller\:
+        resource: '../../src/PrestaShopBundle/Controller/*'
+        exclude: '../../src/PrestaShopBundle/Controller/Api'
+        tags: ['prestashop_core.controllers']
+
 framework:
     assets:
         version: !php/const \AppKernel::VERSION

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\AdvancedParameters\Performance;
 
 use PrestaShop\PrestaShop\Adapter\Feature\CombinationFeature;
-use PrestaShop\PrestaShop\Core\Form\AbstractFormHandler;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -35,7 +34,7 @@ use Symfony\Component\Form\FormFactoryInterface;
  * This class manages the data manipulated using forms
  * in "Configure > Advanced Parameters > Performance" page.
  */
-final class PerformanceFormHandler extends AbstractFormHandler
+final class PerformanceFormHandler
 {
     /**
      * @var FormFactoryInterface

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php
@@ -61,9 +61,6 @@ final class PerformanceFormHandler
         $this->formDataProvider = $formDataProvider;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getForm()
     {
         $formBuilder = $this->formFactory->createBuilder()
@@ -83,9 +80,6 @@ final class PerformanceFormHandler
         return $formBuilder->setData($formBuilder->getData())->getForm();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function save(array $data)
     {
         $errors = $this->formDataProvider->setData($data);

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -2,7 +2,7 @@ services:
     _defaults:
         public: true
 
-    prestashop.core.api.controller:
+    PrestaShopBundle\Controller\Api\ApiController:
         abstract: true
         class: PrestaShopBundle\Controller\Api\ApiController
         calls:
@@ -11,9 +11,12 @@ services:
         tags:
           - { name: prestashop.core.controllers }
 
-    prestashop.core.api.stock.controller:
+    prestashop.core.api.controller:
+        alias: PrestaShopBundle\Controller\Api\ApiController
+
+    PrestaShopBundle\Controller\Api\StockController:
         class: PrestaShopBundle\Controller\Api\StockController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             movements: "@prestashop.core.api.stock.movements_collection"
@@ -22,9 +25,12 @@ services:
         tags:
           - { name: prestashop.core.controllers }
 
-    prestashop.core.api.stock_movement.controller:
+    prestashop.core.api.stock.controller:
+        alias: PrestaShopBundle\Controller\Api\StockController
+
+    PrestaShopBundle\Controller\Api\StockMovementController:
         class: PrestaShopBundle\Controller\Api\StockMovementController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             stockMovementRepository: "@prestashop.core.api.stock_movement.repository"
@@ -32,34 +38,60 @@ services:
         tags:
           - { name: prestashop.core.controllers }
 
-    prestashop.core.api.supplier.controller:
+    prestashop.core.api.stock_movement.controller:
+        alias: PrestaShopBundle\Controller\Api\StockMovementController
+
+    PrestaShopBundle\Controller\Api\SupplierController:
         class: PrestaShopBundle\Controller\Api\SupplierController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             supplierRepository: "@prestashop.core.api.supplier.repository"
         tags:
           - { name: prestashop.core.controllers }
 
-    prestashop.core.api.manufacturer.controller:
+    prestashop.core.api.supplier.controller:
+        alias: PrestaShopBundle\Controller\Api\SupplierController
+
+    PrestaShopBundle\Controller\Api\ManufacturerController:
         class: PrestaShopBundle\Controller\Api\ManufacturerController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             manufacturerRepository: "@prestashop.core.api.manufacturer.repository"
+        tags:
+          - { name: prestashop.core.controllers }
+          
+    prestashop.core.api.manufacturer.controller:
+        alias: PrestaShopBundle\Controller\Api\ManufacturerController
 
-    prestashop.core.api.category.controller:
+    PrestaShopBundle\Controller\Api\CategoryController:
         class: PrestaShopBundle\Controller\Api\CategoryController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             categoryRepository: "@prestashop.core.api.category.repository"
         tags:
           - { name: prestashop.core.controllers }
 
-    prestashop.core.api.attribute.controller:
+    prestashop.core.api.category.controller:
+        alias: PrestaShopBundle\Controller\Api\CategoryController
+
+    PrestaShopBundle\Controller\Api\AttributeController:
         class: PrestaShopBundle\Controller\Api\AttributeController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
+        public: true
+        properties:
+            featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
+        tags:
+          - { name: prestashop.core.controllers }
+
+    prestashop.core.api.attribute.controller:
+        alias: PrestaShopBundle\Controller\Api\AttributeController
+
+    PrestaShopBundle\Controller\Api\FeatureController:
+        class: PrestaShopBundle\Controller\Api\FeatureController
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
@@ -67,28 +99,37 @@ services:
           - { name: prestashop.core.controllers }
 
     prestashop.core.api.feature.controller:
-        class: PrestaShopBundle\Controller\Api\FeatureController
-        parent: prestashop.core.api.controller
+        alias: PrestaShopBundle\Controller\Api\FeatureController
+
+    PrestaShopBundle\Controller\Api\I18nController:
+        class: PrestaShopBundle\Controller\Api\I18nController
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
-        properties:
-            featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
           - { name: prestashop.core.controllers }
 
     prestashop.core.api.i18n.controller:
-        class: PrestaShopBundle\Controller\Api\I18nController
-        parent: prestashop.core.api.controller
-        public: true
+        alias: PrestaShopBundle\Controller\Api\I18nController
 
-    prestashop.core.api.translation.controller:
+    PrestaShopBundle\Controller\Api\TranslationController:
         class: PrestaShopBundle\Controller\Api\TranslationController
-        parent: prestashop.core.api.controller
+        parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         properties:
             translationService: "@prestashop.service.translation"
             queryParams: "@prestashop.core.api.query_translation_params_collection"
+        tags:
+          - { name: prestashop.core.controllers }
+
+    prestashop.core.api.translation.controller:
+        alias: PrestaShopBundle\Controller\Api\TranslationController
+
+    PrestaShopBundle\Controller\Api\Improve\Design\PositionsController:
+        class: PrestaShopBundle\Controller\Api\Improve\Design\PositionsController
+        parent: PrestaShopBundle\Controller\Api\ApiController
+        public: true
+        tags:
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.improve.design.postions.controller:
-        class: PrestaShopBundle\Controller\Api\Improve\Design\PositionsController
-        parent: prestashop.core.api.controller
-        public: true
+        alias:  PrestaShopBundle\Controller\Api\Improve\Design\PositionsController

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -9,7 +9,7 @@ services:
             - [setLogger, ['@logger']]
             - [setContainer, ['@service_container']]
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.stock.controller:
         class: PrestaShopBundle\Controller\Api\StockController
@@ -20,7 +20,7 @@ services:
             stockRepository: "@prestashop.core.api.stock.repository"
             queryParams: "@prestashop.core.api.query_stock_params_collection"
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.stock_movement.controller:
         class: PrestaShopBundle\Controller\Api\StockMovementController
@@ -30,7 +30,7 @@ services:
             stockMovementRepository: "@prestashop.core.api.stock_movement.repository"
             queryParams: "@prestashop.core.api.query_stock_movement_params_collection"
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.supplier.controller:
         class: PrestaShopBundle\Controller\Api\SupplierController
@@ -39,7 +39,7 @@ services:
         properties:
             supplierRepository: "@prestashop.core.api.supplier.repository"
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.manufacturer.controller:
         class: PrestaShopBundle\Controller\Api\ManufacturerController
@@ -55,7 +55,7 @@ services:
         properties:
             categoryRepository: "@prestashop.core.api.category.repository"
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.attribute.controller:
         class: PrestaShopBundle\Controller\Api\AttributeController
@@ -64,7 +64,7 @@ services:
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.feature.controller:
         class: PrestaShopBundle\Controller\Api\FeatureController
@@ -73,7 +73,7 @@ services:
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
-          - { name: prestashop_core.controllers }
+          - { name: prestashop.core.controllers }
 
     prestashop.core.api.i18n.controller:
         class: PrestaShopBundle\Controller\Api\I18nController

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -8,6 +8,8 @@ services:
         calls:
             - [setLogger, ['@logger']]
             - [setContainer, ['@service_container']]
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.stock.controller:
         class: PrestaShopBundle\Controller\Api\StockController
@@ -17,6 +19,8 @@ services:
             movements: "@prestashop.core.api.stock.movements_collection"
             stockRepository: "@prestashop.core.api.stock.repository"
             queryParams: "@prestashop.core.api.query_stock_params_collection"
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.stock_movement.controller:
         class: PrestaShopBundle\Controller\Api\StockMovementController
@@ -25,6 +29,8 @@ services:
         properties:
             stockMovementRepository: "@prestashop.core.api.stock_movement.repository"
             queryParams: "@prestashop.core.api.query_stock_movement_params_collection"
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.supplier.controller:
         class: PrestaShopBundle\Controller\Api\SupplierController
@@ -32,6 +38,8 @@ services:
         public: true
         properties:
             supplierRepository: "@prestashop.core.api.supplier.repository"
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.manufacturer.controller:
         class: PrestaShopBundle\Controller\Api\ManufacturerController
@@ -46,6 +54,8 @@ services:
         public: true
         properties:
             categoryRepository: "@prestashop.core.api.category.repository"
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.attribute.controller:
         class: PrestaShopBundle\Controller\Api\AttributeController
@@ -53,6 +63,8 @@ services:
         public: true
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.feature.controller:
         class: PrestaShopBundle\Controller\Api\FeatureController
@@ -60,6 +72,8 @@ services:
         public: true
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
+        tags:
+          - { name: prestashop_core.controllers }
 
     prestashop.core.api.i18n.controller:
         class: PrestaShopBundle\Controller\Api\I18nController


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Enable controllers as a service through autowiring. See below for details
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no (maybe one, see below)
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No need for QA

## Description

@eternoendless noticed our controllers are not registered as Symfony services, which prevents [decorating](https://symfony.com/doc/3.4/service_container/service_decoration.html) them.

In this PR I enable autowiring for the Controller folder which will register the Controllers inside into the container. I added a custom tag to them as it might be useful in the future, to distinguish them from "regular" services.
I excluded the `Controller\Api` folder because the controllers in this folder are already registered through standard YAML services configuration file.

I also "fixed" a broken class because else autowiring could not work: it's class `src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/PerformanceFormHandler.php` . This class extended a class that is not here anymore. I added a [deprecation notice](https://github.com/PrestaShop/PrestaShop/pull/12968) on develop but I needed to syntaxically fix this class to make the autowiring work.

⚠️autowiring has declared these controllers as **private** so they can be used for decoration but cannot be fetched from container using `$container->get()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18475)
<!-- Reviewable:end -->
