### PR TITLE
Installation under CLI doesn't take BASE_URI and Apache rewrite in consideration

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -226,7 +226,7 @@ class Datas
                 } else {
                     $this->$key = $row['default'];
                 }
-            } elseif (isset($row['validate']) && !call_user_func(array('Validate', $row['validate']), $args_ok[$name])) {
+            } elseif (isset($row['validate']) && class_exists('Validate') && !call_user_func(array('Validate', $row['validate']), $args_ok[$name])) {
                 $errors[] = 'Field '.$key.' is not valid';
             } else {
                 $this->$key = $args_ok[$name];

--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -160,6 +160,11 @@ class Datas
             'default' => 0,
             'help' => 'enable SSL for PrestaShop',
         ),
+        'rewrite_engine' => array(
+            'name' => 'rewrite',
+            'default' => 1,
+            'help' => 'enable rewrite engine for PrestaShop',
+        ),
     );
 
     protected $datas = array();

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -246,18 +246,19 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         $this->initializeContext();
 
         return $this->model_install->configureShop(array(
-            'shop_name' =>                $this->datas->shop_name,
-            'shop_activity' =>            $this->datas->shop_activity,
-            'shop_country' =>            $this->datas->shop_country,
-            'shop_timezone' =>            $this->datas->timezone,
-            'use_smtp' =>                false,
-            'admin_firstname' =>        $this->datas->admin_firstname,
-            'admin_lastname' =>            $this->datas->admin_lastname,
-            'admin_password' =>            $this->datas->admin_password,
-            'admin_email' =>            $this->datas->admin_email,
-            'configuration_agrement' =>    true,
+            'shop_name' => $this->datas->shop_name,
+            'shop_activity' => $this->datas->shop_activity,
+            'shop_country' => $this->datas->shop_country,
+            'shop_timezone' => $this->datas->timezone,
+            'use_smtp' => false,
+            'admin_firstname' => $this->datas->admin_firstname,
+            'admin_lastname' => $this->datas->admin_lastname,
+            'admin_password' => $this->datas->admin_password,
+            'admin_email' => $this->datas->admin_email,
+            'configuration_agrement' => true,
             'send_informations' => true,
             'enable_ssl' => $this->datas->enable_ssl,
+            'rewrite_engine' => $this->datas->rewrite_engine,
         ));
     }
 

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -33,9 +33,20 @@ if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSI
 
 /* Redefine REQUEST_URI */
 $_SERVER['REQUEST_URI'] = '/install/index_cli.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'classes/datas.php';
+/**
+ * The autoload needs constant (__PS_BASE_URI__) declared in the init.php
+ * to work properly.
+ * And, this one can have a custom value depending on what the user specify in arguments.
+ *
+ * Using getAndCheckArgs is quite redundant because it's also used in controllerConsole,
+ * but it prevent a duplicate logic and allows the program to retrieve the base_uri
+ * value from the CLI.
+ */
+Datas::getInstance()->getAndCheckArgs($argv);
+
 require_once dirname(__FILE__).'/init.php';
 require_once(__DIR__).DIRECTORY_SEPARATOR.'autoload.php';
-require_once _PS_INSTALL_PATH_.'classes/datas.php';
 
 try {
     require_once _PS_INSTALL_PATH_.'classes/controllerConsole.php';

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -54,7 +54,24 @@ $_SERVER['REQUEST_URI'] = str_replace('//', '/', $_SERVER['REQUEST_URI']);
 // we check if theses constants are defined
 // in order to use init.php in upgrade.php script
 if (!defined('__PS_BASE_URI__')) {
-    define('__PS_BASE_URI__', substr($_SERVER['REQUEST_URI'], 0, -1 * (strlen($_SERVER['REQUEST_URI']) - strrpos($_SERVER['REQUEST_URI'], '/')) - strlen(substr(dirname($_SERVER['REQUEST_URI']), strrpos(dirname($_SERVER['REQUEST_URI']), '/') + 1))));
+    if (PHP_SAPI !== 'cli') {
+        define(
+            '__PS_BASE_URI__',
+            substr(
+                $_SERVER['REQUEST_URI'],
+                0,
+                -1 * (strlen($_SERVER['REQUEST_URI']) - strrpos($_SERVER['REQUEST_URI'], '/'))
+                - strlen(
+                    substr(
+                        dirname($_SERVER['REQUEST_URI']),
+                        strrpos(dirname($_SERVER['REQUEST_URI']), '/') + 1
+                    )
+                )
+            )
+        );
+    } else {
+        define('__PS_BASE_URI__', '/' . trim(Datas::getInstance()->base_uri, '/') . '/');
+    }
 }
 
 if (!defined('_PS_CORE_DIR_')) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | File `index_cli.php` ignores the `__PS_BASE_URI__` const when running under a CLI context. The problem is `Datas` class needs `Validate` class, `Validate` class need to be autoloaded, and to make the autoload work, it need `__PS_BASE_URI__`...  <br>To make it work, I add a `class_exist` check in `Datas` class to ignore the CLI validation only to initialize the const value.<br>One more thing is added here, the url rewrite engine is not properly configured during the installation. It should be configurable by a simple `--rewrite` parameter, default value is true.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Execute this pull request with the `PrestaShop/vagrant` and see the blockreassurance module if images are displayed in the Cart process. Moreover, the apache rewrite is activated in the FO.<br>`PR=18491 BRANCH=1.7.6.x vagrant up --provision`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18491)
<!-- Reviewable:end -->
