### PR TITLE
[WS] Context currency

### DIFF
--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -35,9 +35,7 @@ Context::getContext()->cart = new Cart();
 Context::getContext()->container = ContainerBuilder::getContainer('webservice', _PS_MODE_DEV_);
 
 // If the currency is not defined in the context, initialize with the default one !
-if (null === Context::getContext()->currency) {
-    Context::getContext()->currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
-}
+Context::getContext()->currency = Context::getContext()->currency ?? new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
 
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -34,6 +34,11 @@ require_once dirname(__FILE__).'/../config/config.inc.php';
 Context::getContext()->cart = new Cart();
 Context::getContext()->container = ContainerBuilder::getContainer('webservice', _PS_MODE_DEV_);
 
+// If the currency is not defined in the context, initialize with the default one !
+if (null === Context::getContext()->currency) {
+    Context::getContext()->currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+}
+
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {
     list($name, $password) = explode(':', base64_decode($matches[1]));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In a multi-currency and webservice context, the currency is not initialized in the Context object. Initialize the currency with the default one
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14768
| How to test?  | See ticket #14768

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18514)
<!-- Reviewable:end -->
