### PR TITLE
Missing log datas in some controllers and classes

### DIFF
--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -79,7 +79,7 @@ class HookManager
                 return Hook::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
             } catch (\Exception $e) {
                 $logger = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\LegacyLogger');
-                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()));
+                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type'=>'Module', 'object_id'=>$$id_module]);
             }
         }
     }

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -79,7 +79,7 @@ class HookManager
                 return Hook::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
             } catch (\Exception $e) {
                 $logger = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\LegacyLogger');
-                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type' => 'Module', 'object_id' => $$id_module]);
+                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type' => 'Module', 'object_id' => $id_module]);
             }
         }
     }

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -79,7 +79,7 @@ class HookManager
                 return Hook::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
             } catch (\Exception $e) {
                 $logger = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\LegacyLogger');
-                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type'=>'Module', 'object_id'=>$$id_module]);
+                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type' => 'Module', 'object_id' => $$id_module]);
             }
         }
     }

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -219,6 +219,10 @@ class ModuleDataProvider
         }
 
         $parser = (new PhpParser\ParserFactory())->create(PhpParser\ParserFactory::PREFER_PHP7);
+        $log_context_data = [
+            'object_type' => 'Module',
+            'object_id' => LegacyModule::getModuleIdByName($name),
+         ];
 
         try {
             $parser->parse(file_get_contents($file_path));
@@ -231,11 +235,7 @@ class ModuleDataProvider
                         '%parse_error%' => $exception->getMessage(),
                     ],
                     'Admin.Modules.Notification'
-                ),
-                    [
-                        'object_type' => 'Module',
-                        'object_id' => LegacyModule::getModuleIdByName($name),
-                    ]
+                ), $log_context_data
             );
 
             return false;
@@ -258,11 +258,7 @@ class ModuleDataProvider
                             '%module%' => $name,
                             '%error_message%' => $e->getMessage(), ],
                         'Admin.Modules.Notification'
-                    ),
-                    [
-                        'object_type' => 'Module',
-                        'object_id' => LegacyModule::getModuleIdByName($name),
-                    ]
+                    ), $log_context_data
                 );
 
                 return false;

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -231,7 +231,11 @@ class ModuleDataProvider
                         '%parse_error%' => $exception->getMessage(),
                     ],
                     'Admin.Modules.Notification'
-                )
+                ),
+                    [
+						'object_type' => 'Module',
+						'object_id' => LegacyModule::getModuleIdByName($name),
+					]
             );
 
             return false;
@@ -254,7 +258,11 @@ class ModuleDataProvider
                             '%module%' => $name,
                             '%error_message%' => $e->getMessage(), ],
                         'Admin.Modules.Notification'
-                    )
+                    ),
+                    [
+						'object_type' => 'Module',
+						'object_id' => LegacyModule::getModuleIdByName($name),
+					]
                 );
 
                 return false;

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -233,9 +233,9 @@ class ModuleDataProvider
                     'Admin.Modules.Notification'
                 ),
                     [
-						'object_type' => 'Module',
-						'object_id' => LegacyModule::getModuleIdByName($name),
-					]
+                        'object_type' => 'Module',
+                        'object_id' => LegacyModule::getModuleIdByName($name),
+                    ]
             );
 
             return false;
@@ -260,9 +260,9 @@ class ModuleDataProvider
                         'Admin.Modules.Notification'
                     ),
                     [
-						'object_type' => 'Module',
-						'object_id' => LegacyModule::getModuleIdByName($name),
-					]
+                        'object_type' => 'Module',
+                        'object_id' => LegacyModule::getModuleIdByName($name),
+                    ]
                 );
 
                 return false;

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -222,7 +222,7 @@ class ModuleDataProvider
         $log_context_data = [
             'object_type' => 'Module',
             'object_id' => LegacyModule::getModuleIdByName($name),
-         ];
+        ];
 
         try {
             $parser->parse(file_get_contents($file_path));

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -375,6 +375,10 @@ class ModuleController extends ModuleAbstractController
         $moduleManager->setActionParams($request->request->get('actionParams', []));
         $moduleRepository = $this->container->get('prestashop.core.admin.module.repository');
         $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
+        // Get accessed module object
+        $moduleAccessed = $moduleRepository->getModule($module_name);
+        // Get accessed module DB Id
+        $moduleAccessedId = (int) $moduleAccessed->database->get('id');
         $response = [$module => []];
 
         if (!method_exists($moduleManager, $action)) {
@@ -465,7 +469,7 @@ class ModuleController extends ModuleAbstractController
             );
 
             $logger = $this->container->get('logger');
-            $logger->error($response[$module]['msg']);
+            $logger->error($response[$module]['msg'], ['object_type' => 'Module', 'object_id'=> $moduleAccessedId]);
         }
 
         if ($response[$module]['status'] === true && $action != 'uninstall') {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -376,7 +376,7 @@ class ModuleController extends ModuleAbstractController
         $moduleRepository = $this->container->get('prestashop.core.admin.module.repository');
         $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
         // Get accessed module object
-        $moduleAccessed = $moduleRepository->getModule($module_name);
+        $moduleAccessed = $moduleRepository->getModule($module);
         // Get accessed module DB Id
         $moduleAccessedId = (int) $moduleAccessed->database->get('id');
         $response = [$module => []];

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -469,7 +469,7 @@ class ModuleController extends ModuleAbstractController
             );
 
             $logger = $this->container->get('logger');
-            $logger->error($response[$module]['msg'], ['object_type' => 'Module', 'object_id'=> $moduleAccessedId]);
+            $logger->error($response[$module]['msg'], ['object_type' => 'Module', 'object_id' => $moduleAccessedId]);
         }
 
         if ($response[$module]['status'] === true && $action != 'uninstall') {

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -768,7 +768,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products activated: (' . implode(',', $productIdList) . ').');
+                    $logger->info('Products activated: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminActivateAfter',
                         $hookEventParameters
@@ -797,7 +797,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products deactivated: (' . implode(',', $productIdList) . ').');
+                    $logger->info('Products deactivated: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeactivateAfter',
                         $hookEventParameters
@@ -826,7 +826,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products deleted: (' . implode(',', $productIdList) . ').');
+                    $logger->info('Products deleted: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeleteAfter',
                         $hookEventParameters
@@ -855,7 +855,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products duplicated: (' . implode(',', $productIdList) . ').');
+                    $logger->info('Products duplicated: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDuplicateAfter',
                         $hookEventParameters
@@ -871,7 +871,7 @@ class ProductController extends FrameworkBundleAdminController
                      * should never happens since the route parameters are
                      * restricted to a set of action values in YML file.
                      */
-                    $logger->error('Bulk action from ProductController received a bad parameter.');
+                    $logger->error('Bulk action from ProductController received a bad parameter.', static::getLogDataContext());
 
                     throw new Exception('Bad action received from call to ProductController::bulkAction: "' . $action . '"', 2001);
             }
@@ -879,7 +879,7 @@ class ProductController extends FrameworkBundleAdminController
             //TODO : need to translate this with an domain name
             $message = $due->getMessage();
             $this->addFlash('failure', $message);
-            $logger->warning($message);
+            $logger->warning($message, static::getLogDataContext());
         }
 
         return new Response(json_encode(['result' => 'ok']));
@@ -960,6 +960,7 @@ class ProductController extends FrameworkBundleAdminController
                     $logger->info(
                         'Products sorted: (' . implode(',', $productIdList) .
                         ') with positions (' . implode(',', $productPositionList) . ').'
+                        , static::getLogDataContext()
                     );
                     $hookEventParameters = [
                         'product_list_id' => $productIdList,
@@ -980,7 +981,7 @@ class ProductController extends FrameworkBundleAdminController
                      * should never happens since the route parameters are
                      * restricted to a set of action values in YML file.
                      */
-                    $logger->error('Mass edit action from ProductController received a bad parameter.');
+                    $logger->error('Mass edit action from ProductController received a bad parameter.', static::getLogDataContext());
 
                     throw new Exception('Bad action received from call to ProductController::massEditAction: "' . $action . '"', 2001);
             }
@@ -988,7 +989,7 @@ class ProductController extends FrameworkBundleAdminController
             //TODO : need to translate with domain name
             $message = $due->getMessage();
             $this->addFlash('failure', $message);
-            $logger->warning($message);
+            $logger->warning($message, static::getLogDataContext());
         }
 
         $urlGenerator = $this->get('prestashop.core.admin.url_generator');
@@ -1045,7 +1046,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully deleted.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product deleted: (' . $id . ').');
+                    $logger->info('Product deleted: (' . $id . ').', static::getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeleteAfter',
                         $hookEventParameters
@@ -1071,7 +1072,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully duplicated.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product duplicated: (from ' . $id . ' to ' . $duplicateProductId . ').');
+                    $logger->info('Product duplicated: (from ' . $id . ' to ' . $duplicateProductId . ').', static::getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDuplicateAfter',
                         $hookEventParameters
@@ -1097,7 +1098,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully activated.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product activated: ' . $id);
+                    $logger->info('Product activated: ' . $id, static::getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminActivateAfter',
                         $hookEventParameters
@@ -1123,7 +1124,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully deactivated.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product deactivated: ' . $id);
+                    $logger->info('Product deactivated: ' . $id, static::getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeactivateAfter',
                         $hookEventParameters
@@ -1139,7 +1140,7 @@ class ProductController extends FrameworkBundleAdminController
                      * should never happens since the route parameters are
                      * restricted to a set of action values in YML file.
                      */
-                    $logger->error('Unit action from ProductController received a bad parameter.');
+                    $logger->error('Unit action from ProductController received a bad parameter.', static::getLogDataContext($id));
 
                     throw new Exception('Bad action received from call to ProductController::unitAction: "' . $action . '"', 2002);
             }
@@ -1147,7 +1148,7 @@ class ProductController extends FrameworkBundleAdminController
             //TODO : need to translate with a domain name
             $message = $due->getMessage();
             $this->addFlash('failure', $message);
-            $logger->warning($message);
+            $logger->warning($message, static::getLogDataContext($id));
         }
 
         return $this->redirect($this->get('prestashop.core.admin.url_generator')->generate('admin_product_catalog'));
@@ -1336,4 +1337,17 @@ class ProductController extends FrameworkBundleAdminController
             CannotUpdateProductException::class => $this->trans('An error occurred while updating the status for an object.', 'Admin.Notifications.Error'),
         ];
     }
+    
+    /**
+     * @return array
+     */
+     private static function getLogDataContext($id_product = null, $error_code = null, $allow_duplicate = null) : array
+     {
+			return [
+				'object_type' => 'Product',
+				'object_id' => $id_product,
+				'error_code' => $error_code,
+				'allow_duplicate' => $allow_duplicate,
+			];
+	 }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -768,7 +768,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products activated: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
+                    $logger->info('Products activated: (' . implode(',', $productIdList) . ').', $this->getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminActivateAfter',
                         $hookEventParameters
@@ -797,7 +797,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products deactivated: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
+                    $logger->info('Products deactivated: (' . implode(',', $productIdList) . ').', $this->getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeactivateAfter',
                         $hookEventParameters
@@ -826,7 +826,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products deleted: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
+                    $logger->info('Products deleted: (' . implode(',', $productIdList) . ').', $this->getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeleteAfter',
                         $hookEventParameters
@@ -855,7 +855,7 @@ class ProductController extends FrameworkBundleAdminController
                         );
                     }
 
-                    $logger->info('Products duplicated: (' . implode(',', $productIdList) . ').', static::getLogDataContext());
+                    $logger->info('Products duplicated: (' . implode(',', $productIdList) . ').', $this->getLogDataContext());
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDuplicateAfter',
                         $hookEventParameters
@@ -871,7 +871,7 @@ class ProductController extends FrameworkBundleAdminController
                      * should never happens since the route parameters are
                      * restricted to a set of action values in YML file.
                      */
-                    $logger->error('Bulk action from ProductController received a bad parameter.', static::getLogDataContext());
+                    $logger->error('Bulk action from ProductController received a bad parameter.', $this->getLogDataContext());
 
                     throw new Exception('Bad action received from call to ProductController::bulkAction: "' . $action . '"', 2001);
             }
@@ -879,7 +879,7 @@ class ProductController extends FrameworkBundleAdminController
             //TODO : need to translate this with an domain name
             $message = $due->getMessage();
             $this->addFlash('failure', $message);
-            $logger->warning($message, static::getLogDataContext());
+            $logger->warning($message, $this->getLogDataContext());
         }
 
         return new Response(json_encode(['result' => 'ok']));
@@ -959,7 +959,7 @@ class ProductController extends FrameworkBundleAdminController
                     );
                     $logger->info(
                         'Products sorted: (' . implode(',', $productIdList) .
-                        ') with positions (' . implode(',', $productPositionList) . ').', static::getLogDataContext()
+                        ') with positions (' . implode(',', $productPositionList) . ').', $this->getLogDataContext()
                     );
                     $hookEventParameters = [
                         'product_list_id' => $productIdList,
@@ -980,7 +980,7 @@ class ProductController extends FrameworkBundleAdminController
                      * should never happens since the route parameters are
                      * restricted to a set of action values in YML file.
                      */
-                    $logger->error('Mass edit action from ProductController received a bad parameter.', static::getLogDataContext());
+                    $logger->error('Mass edit action from ProductController received a bad parameter.', $this->getLogDataContext());
 
                     throw new Exception('Bad action received from call to ProductController::massEditAction: "' . $action . '"', 2001);
             }
@@ -988,7 +988,7 @@ class ProductController extends FrameworkBundleAdminController
             //TODO : need to translate with domain name
             $message = $due->getMessage();
             $this->addFlash('failure', $message);
-            $logger->warning($message, static::getLogDataContext());
+            $logger->warning($message, $this->getLogDataContext());
         }
 
         $urlGenerator = $this->get('prestashop.core.admin.url_generator');
@@ -1045,7 +1045,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully deleted.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product deleted: (' . $id . ').', static::getLogDataContext($id));
+                    $logger->info('Product deleted: (' . $id . ').', $this->getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeleteAfter',
                         $hookEventParameters
@@ -1071,7 +1071,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully duplicated.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product duplicated: (from ' . $id . ' to ' . $duplicateProductId . ').', static::getLogDataContext($id));
+                    $logger->info('Product duplicated: (from ' . $id . ' to ' . $duplicateProductId . ').', $this->getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDuplicateAfter',
                         $hookEventParameters
@@ -1097,7 +1097,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully activated.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product activated: ' . $id, static::getLogDataContext($id));
+                    $logger->info('Product activated: ' . $id, $this->getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminActivateAfter',
                         $hookEventParameters
@@ -1123,7 +1123,7 @@ class ProductController extends FrameworkBundleAdminController
                         'success',
                         $this->trans('Product successfully deactivated.', 'Admin.Catalog.Notification')
                     );
-                    $logger->info('Product deactivated: ' . $id, static::getLogDataContext($id));
+                    $logger->info('Product deactivated: ' . $id, $this->getLogDataContext($id));
                     $hookDispatcher->dispatchWithParameters(
                         'actionAdminDeactivateAfter',
                         $hookEventParameters
@@ -1139,7 +1139,7 @@ class ProductController extends FrameworkBundleAdminController
                      * should never happens since the route parameters are
                      * restricted to a set of action values in YML file.
                      */
-                    $logger->error('Unit action from ProductController received a bad parameter.', static::getLogDataContext($id));
+                    $logger->error('Unit action from ProductController received a bad parameter.', $this->getLogDataContext($id));
 
                     throw new Exception('Bad action received from call to ProductController::unitAction: "' . $action . '"', 2002);
             }
@@ -1147,7 +1147,7 @@ class ProductController extends FrameworkBundleAdminController
             //TODO : need to translate with a domain name
             $message = $due->getMessage();
             $this->addFlash('failure', $message);
-            $logger->warning($message, static::getLogDataContext($id));
+            $logger->warning($message, $this->getLogDataContext($id));
         }
 
         return $this->redirect($this->get('prestashop.core.admin.url_generator')->generate('admin_product_catalog'));
@@ -1340,7 +1340,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * @return array
      */
-    private static function getLogDataContext($id_product = null, $error_code = null, $allow_duplicate = null): array
+    private function getLogDataContext($id_product = null, $error_code = null, $allow_duplicate = null): array
     {
         return [
                 'object_type' => 'Product',

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -959,8 +959,7 @@ class ProductController extends FrameworkBundleAdminController
                     );
                     $logger->info(
                         'Products sorted: (' . implode(',', $productIdList) .
-                        ') with positions (' . implode(',', $productPositionList) . ').'
-                        , static::getLogDataContext()
+                        ') with positions (' . implode(',', $productPositionList) . ').', static::getLogDataContext()
                     );
                     $hookEventParameters = [
                         'product_list_id' => $productIdList,
@@ -1337,17 +1336,17 @@ class ProductController extends FrameworkBundleAdminController
             CannotUpdateProductException::class => $this->trans('An error occurred while updating the status for an object.', 'Admin.Notifications.Error'),
         ];
     }
-    
+
     /**
      * @return array
      */
-     private static function getLogDataContext($id_product = null, $error_code = null, $allow_duplicate = null) : array
-     {
-			return [
-				'object_type' => 'Product',
-				'object_id' => $id_product,
-				'error_code' => $error_code,
-				'allow_duplicate' => $allow_duplicate,
-			];
-	 }
+    private static function getLogDataContext($id_product = null, $error_code = null, $allow_duplicate = null): array
+    {
+        return [
+                'object_type' => 'Product',
+                'object_id' => $id_product,
+                'error_code' => $error_code,
+                'allow_duplicate' => $allow_duplicate,
+            ];
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -1343,10 +1343,10 @@ class ProductController extends FrameworkBundleAdminController
     private function getLogDataContext($id_product = null, $error_code = null, $allow_duplicate = null): array
     {
         return [
-                'object_type' => 'Product',
-                'object_id' => $id_product,
-                'error_code' => $error_code,
-                'allow_duplicate' => $allow_duplicate,
-            ];
+            'object_type' => 'Product',
+            'object_id' => $id_product,
+            'error_code' => $error_code,
+            'allow_duplicate' => $allow_duplicate,
+        ];
     }
 }

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -288,9 +288,10 @@ class TranslationService
 
         $validator = Validation::createValidator();
         $violations = $validator->validate($translation, new PassVsprintf());
+        $log_context = ['object_type' => 'Translation'];
         if (0 !== count($violations)) {
             foreach ($violations as $violation) {
-                $logger->error($violation->getMessage());
+                $logger->error($violation->getMessage(), $log_context);
             }
 
             return false;
@@ -304,7 +305,7 @@ class TranslationService
 
             $updatedTranslationSuccessfully = true;
         } catch (Exception $exception) {
-            $logger->error($exception->getMessage());
+            $logger->error($violation->getMessage(), $log_context);
         }
 
         return $updatedTranslationSuccessfully;

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -305,7 +305,7 @@ class TranslationService
 
             $updatedTranslationSuccessfully = true;
         } catch (Exception $exception) {
-            $logger->error($violation->getMessage(), $log_context);
+            $logger->error($exception->getMessage(), $log_context);
         }
 
         return $updatedTranslationSuccessfully;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Missing log datas in some controllers and classes. When writing the logs, the **object_type** and **object_id** fields must be filled in (if necessary ...)
| Type?         | bug fix 
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18517
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/18517
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18519)
<!-- Reviewable:end -->
