### PR TITLE
Remove ability to apply discount on all invoices in order view page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
@@ -34,7 +34,6 @@ export default {
   privateNoteInput: '#private_note_note',
   privateNoteSubmitBtn: '.js-private-note-btn',
   addCartRuleModal: '#addOrderDiscountModal',
-  addCartRuleApplyOnAllInvoicesCheckbox: '#add_order_cart_rule_apply_on_all_invoices',
   addCartRuleInvoiceIdSelect: '#add_order_cart_rule_invoice_id',
   addCartRuleTypeSelect: '#add_order_cart_rule_type',
   addCartRuleValueInput: '#add_order_cart_rule_value',

--- a/admin-dev/themes/new-theme/js/pages/order/view.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view.js
@@ -125,15 +125,8 @@ $(() => {
     const $modal = $(OrderViewPageMap.addCartRuleModal);
     const $form = $modal.find('form');
     const $valueHelp = $modal.find(OrderViewPageMap.cartRuleHelpText);
-    const $invoiceSelect = $modal.find(OrderViewPageMap.addCartRuleInvoiceIdSelect);
     const $valueInput = $form.find(OrderViewPageMap.addCartRuleValueInput);
     const $valueFormGroup = $valueInput.closest('.form-group');
-
-    $form.find(OrderViewPageMap.addCartRuleApplyOnAllInvoicesCheckbox).on('change', event => {
-      const isChecked = $(event.currentTarget).is(':checked');
-
-      $invoiceSelect.attr('disabled', isChecked);
-    });
 
     $form.find(OrderViewPageMap.addCartRuleTypeSelect).on('change', event => {
       const selectedCartRuleType = $(event.currentTarget).val();

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -878,7 +878,7 @@ class OrderController extends CommonController
                             $data['name'],
                             $data['type'],
                             $data['value'] ?? null,
-                            (int) $data['invoice_id']
+                            empty($data['invoice_id']) ? null : (int) $data['invoice_id']
                         )
                     );
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -871,8 +871,6 @@ class OrderController extends CommonController
             if ($addOrderCartRuleForm->isValid()) {
                 $data = $addOrderCartRuleForm->getData();
 
-                $invoiceId = $data['apply_on_all_invoices'] ? null : (int) $data['invoice_id'];
-
                 try {
                     $this->getCommandBus()->handle(
                         new AddCartRuleToOrderCommand(
@@ -880,7 +878,7 @@ class OrderController extends CommonController
                             $data['name'],
                             $data['type'],
                             $data['value'] ?? null,
-                            $invoiceId
+                            (int) $data['invoice_id']
                         )
                     );
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddOrderCartRuleType.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -118,10 +117,6 @@ class AddOrderCartRuleType extends AbstractType
                 'choices' => $invoices,
                 'required' => false,
                 'placeholder' => false,
-            ])
-            ->add('apply_on_all_invoices', CheckboxType::class, [
-                'required' => false,
-                'label' => $this->trans('Apply on all invoices', [], 'Admin.Orderscustomers.Feature'),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
@@ -89,17 +89,6 @@
                 </div>
               </div>
             </div>
-
-            <div class="row">
-              <div class="col">
-                <div class="form-group mb-0">
-                  {{ ps.form_widget_with_error(addOrderCartRuleForm.apply_on_all_invoices,
-                    {'material_design': true, 'attr': { 'disabled': not orderForViewing.hasInvoice }},
-                    {'help': 'If you choose to create this discount for all invoices, only one discount will be created per order invoice.'|trans({}, 'Admin.Orderscustomers.Help')}
-                  ) }}
-                </div>
-              </div>
-            </div>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This PR comes from another pr (#17348) which scope increased too much, so it needed to be separated. Removes ability to apply a discount to all invoices of an order in order view page. From user point of view it removes the checkbox from this (check screenshot) ![Screenshot from 2020-04-08 15-40-42](https://user-images.githubusercontent.com/31609858/78785398-c3d56000-79af-11ea-9fe2-549675166bdc.png)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See description

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18524)
<!-- Reviewable:end -->
