### PR TITLE
Fix init method not existing in module_card

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/module-card/index.js
+++ b/admin-dev/themes/new-theme/js/app/pages/module-card/index.js
@@ -28,5 +28,5 @@ import ModuleCard from '@components/module-card';
 const {$} = window;
 
 $(() => {
-  new ModuleCard().init();
+  new ModuleCard();
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There was an error when you click on "Recommended module" on the top right caused by one file and blocking a PR of ps_mbo module
| Type?         | bug fix
| Category?     | BO
| BC breaks?    |  no
| Deprecations? | no
| How to test?  | Go on a legacy page, click "Recommended module" on top right. Everything should works fine

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18554)
<!-- Reviewable:end -->
