### PR TITLE
In BO Product page, use ecotax excl. tax instead of tax incl.

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -532,9 +532,15 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
      */
     private function mapStep2FormData(Product $product)
     {
+        // ecotax is stored with tax included but form uses the tax excluded value
+        $ecotax = $this->tools->round(
+            $product->ecotax * (1 + $this->taxRuleDataProvider->getProductEcotaxRate() / 100),
+            2
+        );
+
         return [
             'price' => $product->price,
-            'ecotax' => $product->ecotax,
+            'ecotax' => $ecotax,
             'id_tax_rules_group' => isset($product->id_tax_rules_group)
                 ? (int) $product->id_tax_rules_group
                 : $this->taxRuleDataProvider->getIdTaxRulesGroupMostUsed(),

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -533,9 +533,11 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
     private function mapStep2FormData(Product $product)
     {
         // ecotax is stored with tax included but form uses the tax excluded value
+        // using a precision of 6 digits as `AdminProductsController::_removeTaxFromEcotax()`
+        // which does the opposite uses 6 digits too
         $ecotax = $this->tools->round(
             $product->ecotax * (1 + $this->taxRuleDataProvider->getProductEcotaxRate() / 100),
-            2
+            6
         );
 
         return [


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Ecotax is stored with tax included but form uses the tax excluded value. However BO Product page would load the form with tax. incl. value, leading to the crazy scenario described in https://github.com/PrestaShop/PrestaShop/issues/18550. I fix that.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18550 and number 4 of https://github.com/PrestaShop/PrestaShop/issues/10026
| How to test?  | Please test the scenario described in https://github.com/PrestaShop/PrestaShop/issues/18550 . It should not happen anymore. Please check the ecotax amount is correctly being stored and computed for both "with ecotax tax and "without ecotax tax". By this I mean: you can add tax on ecotax 😄See below screenshot. Everything is explained in https://github.com/PrestaShop/PrestaShop/issues/18550

Screenshot
<img src="https://user-images.githubusercontent.com/3830050/78999942-f7e58800-7b4b-11ea-95db-756c78dc18ca.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18580)
<!-- Reviewable:end -->
