### PR TITLE
Fix wrong number of "Last emails" in BO - Customer View page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/sent_emails.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/sent_emails.html.twig
@@ -23,34 +23,38 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% if customerInformation.sentEmailsInformation is not empty %}
-  <div class="card">
-    <h3 class="card-header">
-      <i class="material-icons">mail_outline</i>
-      {{ 'Last emails'|trans({}, 'Admin.Orderscustomers.Feature') }}
-      <span class="badge badge-primary rounded">{{ customerInformation.productsInformation.boughtProductsInformation|length }}</span>
-    </h3>
-    <div class="card-body">
-      <table class="table">
-        <thead>
-        <tr>
-          <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-          <th>{{ 'Language'|trans({}, 'Admin.Global') }}</th>
-          <th>{{ 'Subject'|trans({}, 'Admin.Global') }}</th>
-          <th>{{ 'Template'|trans({}, 'Admin.Global') }}</th>
+<div class="card customer-sent-emails-card">
+  <h3 class="card-header">
+    <i class="material-icons">mail_outline</i>
+    {{ 'Last emails'|trans({}, 'Admin.Orderscustomers.Feature') }}
+    <span class="badge badge-primary rounded">{{ customerInformation.sentEmailsInformation|length }}</span>
+  </h3>
+  <div class="card-body">
+  {% if customerInformation.sentEmailsInformation is not empty %}
+    <table class="table">
+      <thead>
+      <tr>
+        <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+        <th>{{ 'Language'|trans({}, 'Admin.Global') }}</th>
+        <th>{{ 'Subject'|trans({}, 'Admin.Global') }}</th>
+        <th>{{ 'Template'|trans({}, 'Admin.Global') }}</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for sentEmail in customerInformation.sentEmailsInformation %}
+        <tr class="customer-sent-email">
+          <td class="customer-sent-email-date">{{ sentEmail.date }}</td>
+          <td class="customer-sent-email-language">{{ sentEmail.language }}</td>
+          <td class="customer-sent-email-subject">{{ sentEmail.subject }}</td>
+          <td class="customer-sent-email-template">{{ sentEmail.template }}</td>
         </tr>
-        </thead>
-        <tbody>
-        {% for sentEmail in customerInformation.sentEmailsInformation %}
-          <tr>
-            <td>{{ sentEmail.date }}</td>
-            <td>{{ sentEmail.language }}</td>
-            <td>{{ sentEmail.subject }}</td>
-            <td>{{ sentEmail.template }}</td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    </div>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="text-muted text-center mb-0">
+      {{ 'No records found'|trans({}, 'Admin.Global') }}
+    </p>
+  {% endif %}
   </div>
-{% endif %}
+</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x 
| Description?  | In the BO => Customers => Customer View page, the number of last emails is incorrect.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18602
| How to test?  | See #18602 by @khouloudbelguith .

Hi @khouloudbelguith 


I proposed other improvements on this block:

I think that the block should always be displayed even if no record is found (to keep consistency with other blocks, see for example: https://github.com/PrestaShop/PrestaShop/blob/develop/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/discounts.html.twig#L33).

### 1 - If no record is found:
![fixpatch-4-empty](https://user-images.githubusercontent.com/16455155/79159636-bcabb900-7dd8-11ea-9131-ea966954706d.png)


### 2 - if there is at least one recording

![fix-patch-4](https://user-images.githubusercontent.com/16455155/79159687-d0efb600-7dd8-11ea-8fc9-ddb15fdb4089.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18607)
<!-- Reviewable:end -->
