### PR TITLE
Delete specific price if addProductToCart throw an exception

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -124,7 +124,14 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
                 $combination
             );
 
-            $this->addProductToCart($cart, $product, $combination, $command->getProductQuantity());
+            try {
+                $this->addProductToCart($cart, $product, $combination, $command->getProductQuantity());
+            } catch (Exception $exception) {
+                if (null !== $specificPrice) {
+                    $specificPrice->delete();
+                }
+                throw $exception;
+            }
 
             // Fetch Cart Product
             $productCart = $this->getCartProductData($cart, $product, $command->getProductQuantity());


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When trying to add a product to an existing order with a quantity lower than the minimal quantity of the product, the first time, the right error message was shown but the following times, an exception was thrown. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18568
| How to test?  | 1. Create a product ProductA with quantity=20 and minimal quantity=10<br>2. Go to `admin-dev/sell/orders/orders/{orderId}/view`<br>3. Make sure order status is not "delivered" and you can add products.<br>4. Click Add product, search and select the last product created productA with quantity=1. An error message should appears (see screenshot below).<br>5. Try again, the same error message should appears.

![Capture d’écran 2020-04-14 à 11 47 22](https://user-images.githubusercontent.com/2168836/79216376-57de7600-7e4d-11ea-8ac5-40eee1432a83.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18614)
<!-- Reviewable:end -->
