### PR TITLE
Make computing precision matching currency's display precision

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -138,7 +138,7 @@ define('_PS_PRICE_DISPLAY_PRECISION_', 2);
 /**
  * @deprecated since 1.7.7
  */
-define('_PS_PRICE_COMPUTE_PRECISION_', 6);
+define('_PS_PRICE_COMPUTE_PRECISION_', 2);
 
 /* Load all languages */
 Language::loadLanguages();

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -186,7 +186,11 @@ class Calculator
     {
         $amount = new AmountImmutable();
         foreach ($this->cartRows as $cartRow) {
-            $amount = $amount->add($cartRow->getInitialTotalPrice());
+            if ($cartRow->getRoundType() !== $cartRow::ROUND_MODE_ITEM) {
+                $amount = $amount->add($cartRow->getInitialTotalPrice());
+            } else {
+                $amount = $amount->add($cartRow->getFinalTotalPrice());
+            }
         }
 
         return $amount;

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -186,11 +186,7 @@ class Calculator
     {
         $amount = new AmountImmutable();
         foreach ($this->cartRows as $cartRow) {
-            if ($cartRow->getRoundType() !== $cartRow::ROUND_MODE_ITEM) {
-                $amount = $amount->add($cartRow->getInitialTotalPrice());
-            } else {
-                $amount = $amount->add($cartRow->getFinalTotalPrice());
-            }
+            $amount = $amount->add($cartRow->getInitialTotalPrice());
         }
 
         return $amount;

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -268,11 +268,21 @@ class CartRow
         $rowData = $this->getRowData();
         $quantity = (int) $rowData['cart_quantity'];
         $this->initialUnitPrice = $this->getProductPrice($cart, $rowData);
-        // store not rounded values
-        $this->initialTotalPrice = new AmountImmutable(
-            $this->initialUnitPrice->getTaxIncluded() * $quantity,
-            $this->initialUnitPrice->getTaxExcluded() * $quantity
-        );
+
+        // store not rounded values, except in round_mode_item, we still need to round individual items
+        if ($this->roundType == self::ROUND_MODE_ITEM) {
+            $tools = new Tools();
+            $this->initialTotalPrice = new AmountImmutable(
+                $tools->round($this->initialUnitPrice->getTaxIncluded(), $this->precision) * $quantity,
+                $tools->round($this->initialUnitPrice->getTaxExcluded(), $this->precision) * $quantity
+            );
+        } else {
+            $this->initialTotalPrice = new AmountImmutable(
+                $this->initialUnitPrice->getTaxIncluded() * $quantity,
+                $this->initialUnitPrice->getTaxExcluded() * $quantity
+            );
+        }
+
         $this->finalTotalPrice = clone $this->initialTotalPrice;
         $this->applyRound();
         // store state
@@ -416,7 +426,6 @@ class CartRow
                     $this->initialUnitPrice->getTaxIncluded() * $quantity,
                     $this->initialUnitPrice->getTaxExcluded() * $quantity
                 );
-
                 break;
         }
     }

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -478,4 +478,12 @@ class CartRow
             $taxExcluded / $quantity
         );
     }
+
+    /**
+     * @return string
+     */
+    public function getRoundType()
+    {
+        return $this->roundType;
+    }
 }

--- a/src/Core/Localization/CLDR/ComputingPrecision.php
+++ b/src/Core/Localization/CLDR/ComputingPrecision.php
@@ -32,6 +32,7 @@ namespace PrestaShop\PrestaShop\Core\Localization\CLDR;
  */
 final class ComputingPrecision implements ComputingPrecisionInterface
 {
+    const MULTIPLIER = 1;
     const MINIMAL_VALUE = 2;
 
     /**
@@ -39,9 +40,9 @@ final class ComputingPrecision implements ComputingPrecisionInterface
      */
     public function getPrecision(int $displayPrecision)
     {
-        /*
-         * For now, in order to avoid rounding issues, the computing precision is hardcoded, its value is 2
-         */
-        return self::MINIMAL_VALUE;
+        // the MULTIPLIER attribute is set to 1 for now, so that it matches display precision
+        $computingPrecision = $displayPrecision * self::MULTIPLIER;
+
+        return ($computingPrecision < self::MINIMAL_VALUE) ? self::MINIMAL_VALUE : $computingPrecision;
     }
 }

--- a/src/Core/Localization/CLDR/ComputingPrecision.php
+++ b/src/Core/Localization/CLDR/ComputingPrecision.php
@@ -32,7 +32,7 @@ namespace PrestaShop\PrestaShop\Core\Localization\CLDR;
  */
 final class ComputingPrecision implements ComputingPrecisionInterface
 {
-    const MULTIPLIER = 3;
+    const MULTIPLIER = 1;
     const MINIMAL_VALUE = 2;
 
     /**
@@ -40,8 +40,9 @@ final class ComputingPrecision implements ComputingPrecisionInterface
      */
     public function getPrecision(int $displayPrecision)
     {
-        $computingPrecision = $displayPrecision * self::MULTIPLIER;
-
-        return ($computingPrecision < self::MINIMAL_VALUE) ? self::MINIMAL_VALUE : $computingPrecision;
+        /*
+         * For now, in order to avoid rounding issues, the computing precision is hardcoded, its value 2
+         */
+        return self::MINIMAL_VALUE;
     }
 }

--- a/src/Core/Localization/CLDR/ComputingPrecision.php
+++ b/src/Core/Localization/CLDR/ComputingPrecision.php
@@ -32,7 +32,6 @@ namespace PrestaShop\PrestaShop\Core\Localization\CLDR;
  */
 final class ComputingPrecision implements ComputingPrecisionInterface
 {
-    const MULTIPLIER = 1;
     const MINIMAL_VALUE = 2;
 
     /**
@@ -41,7 +40,7 @@ final class ComputingPrecision implements ComputingPrecisionInterface
     public function getPrecision(int $displayPrecision)
     {
         /*
-         * For now, in order to avoid rounding issues, the computing precision is hardcoded, its value 2
+         * For now, in order to avoid rounding issues, the computing precision is hardcoded, its value is 2
          */
         return self::MINIMAL_VALUE;
     }

--- a/tests-legacy/Integration/classes/CartGetOrderTotalTest.php
+++ b/tests-legacy/Integration/classes/CartGetOrderTotalTest.php
@@ -453,8 +453,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $cart->updateQty(1, $product_a->id);
         $cart->updateQty(1, $product_b->id);
 
-        $this->assertEquals(3.581, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
-        $this->assertEquals(4.2972, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
+        $this->assertEquals(3.59, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
+        $this->assertEquals(4.29, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
     }
 
     public function testBasicRoundTypeTotal()
@@ -469,8 +469,8 @@ class CartGetOrderTotalTest extends IntegrationTestCase
         $cart->updateQty(1, $product_a->id);
         $cart->updateQty(1, $product_b->id);
 
-        $this->assertEquals(3.581, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
-        $this->assertEquals(4.2972, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
+        $this->assertEquals(3.58, $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS));
+        $this->assertEquals(4.3, $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS));
     }
 
     public function testBasicCartRuleAmountBeforeTax()

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
@@ -74,8 +74,8 @@ Feature: Cart rule (amount) calculation with multiple cart rules
     Given cart rule "cartrule-free-gift" is restricted to the category "Awesome" with a quantity of 1
     Given cart rule "cartrule-free-gift" is restricted to product "product8"
     When I add 1 item of product "product8" in my cart
-    Then my cart total should be precisely 2.345 tax included
-    Then my cart total should be 2.3 tax included
+    Then my cart total should be precisely 2.35 tax included
+    Then my cart total should be 2.4 tax included
     Then my cart total using previous calculation method should be 2.3 tax included
 
   Scenario: One product in my cart, one 10€ global cartRule, 2 free gifts global cartRules
@@ -91,7 +91,7 @@ Feature: Cart rule (amount) calculation with multiple cart rules
     Given cart rule "cartrule-free-gift-2" offers a gift product "product3"
     When I add 1 item of product "product1" in my cart
     Then I should have 3 products in my cart
-    Then my cart total should be precisely 16.812 tax included
+    Then my cart total should be precisely 16.81 tax included
     Then my cart total should be 16.8 tax included
     Then my cart total using previous calculation method should be 16.8 tax included
 

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
@@ -76,7 +76,7 @@ Feature: Cart rule (amount) calculation with multiple cart rules
     When I add 1 item of product "product8" in my cart
     Then my cart total should be precisely 2.35 tax included
     Then my cart total should be 2.4 tax included
-    Then my cart total using previous calculation method should be 2.3 tax included
+    Then my cart total using previous calculation method should be 2.4 tax included
 
   Scenario: One product in my cart, one 10€ global cartRule, 2 free gifts global cartRules
     Given I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -91,7 +91,7 @@ Feature: Cart calculation with currencies
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
     Then my cart total should be 83.1 tax included
-    Then my cart total using previous calculation method should be 83.0 tax included
+    Then my cart total using previous calculation method should be 83.1 tax included
 
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -90,7 +90,7 @@ Feature: Cart calculation with currencies
     Given currency "currency2" is the current one
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
-    Then my cart total should be 83.0 tax included
+    Then my cart total should be 83.1 tax included
     Then my cart total using previous calculation method should be 83.0 tax included
 
   Scenario: 3 products in cart, several quantities

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
@@ -37,10 +37,28 @@ Feature: Cart calculation with rounding type ITEM
     Then my cart total should be precisely 162.4 tax included
     Then my cart total using previous calculation method should be precisely 162.4 tax included
 
-    Scenario: 1 product in cart, with a quantity of 2 and a tricky price
-      Given I have an empty default cart
-      Given specific shop configuration for "rounding type" is set to round each article
-      Given there is a product in the catalog named "product1" with a price of 35.32552 and 1000 items in stock
-      When I add 2 items of product "product1" in my cart
-      Then my cart total should be precisely 77.66 tax included
-      Then my cart total using previous calculation method should be precisely 77.66 tax included
+  Scenario: 1 product in cart, with a quantity of 2 and a tricky price
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round each article
+    Given there is a product in the catalog named "product1" with a price of 35.32552 and 1000 items in stock
+    When I add 2 items of product "product1" in my cart
+    Then my cart total should be precisely 77.66 tax included
+    Then my cart total using previous calculation method should be precisely 77.66 tax included
+
+  Scenario: 1 product in cart, with a quantity of 3 and a percentage cart rule
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round each article
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule1" that applies a percent discount of 15.0% with priority 1, quantity of 1000 and quantity per user 1000
+    When I add 3 items of product "product1" in my cart
+    Then my cart total should be precisely 57.52 tax included
+    Then my cart total using previous calculation method should be precisely 57.52 tax included
+
+  Scenario: 1 product in cart, with a quantity of 3 and an amount cart rule
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round each article
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule1" that applies an amount discount of 5.0 with priority 8, quantity of 1000 and quantity per user 1000
+    When I add 3 items of product "product1" in my cart
+    Then my cart total should be precisely 61.43 tax included
+    Then my cart total using previous calculation method should be precisely 61.43 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
@@ -37,7 +37,7 @@ Feature: Cart calculation with rounding type ITEM
     Then my cart total should be precisely 162.4 tax included
     Then my cart total using previous calculation method should be precisely 162.4 tax included
 
-    Scenario: 1 product in quart, with a quantity of 2 and a tricky price
+    Scenario: 1 product in cart, with a quantity of 2 and a tricky price
       Given I have an empty default cart
       Given specific shop configuration for "rounding type" is set to round each article
       Given there is a product in the catalog named "product1" with a price of 35.32552 and 1000 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
@@ -14,7 +14,7 @@ Feature: Cart calculation with rounding type ITEM
     Given specific shop configuration for "rounding type" is set to round each article
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 1 items of product "product1" in my cart
-    Then my cart total should be precisely 26.812 tax included
+    Then my cart total should be precisely 26.81 tax included
     Then my cart total using previous calculation method should be precisely 26.812 tax included
 
   Scenario: one product in cart, quantity 3
@@ -22,7 +22,7 @@ Feature: Cart calculation with rounding type ITEM
     Given specific shop configuration for "rounding type" is set to round each article
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
-    Then my cart total should be precisely 66.436 tax included
+    Then my cart total should be precisely 66.44 tax included
     Then my cart total using previous calculation method should be precisely 66.436 tax included
 
   Scenario: 3 products in cart, several quantities

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
@@ -15,7 +15,7 @@ Feature: Cart calculation with rounding type ITEM
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 1 items of product "product1" in my cart
     Then my cart total should be precisely 26.81 tax included
-    Then my cart total using previous calculation method should be precisely 26.812 tax included
+    Then my cart total using previous calculation method should be precisely 26.81 tax included
 
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
@@ -23,7 +23,7 @@ Feature: Cart calculation with rounding type ITEM
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
     Then my cart total should be precisely 66.44 tax included
-    Then my cart total using previous calculation method should be precisely 66.436 tax included
+    Then my cart total using previous calculation method should be precisely 66.43 tax included
 
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
@@ -22,7 +22,7 @@ Feature: Cart calculation with rounding type ITEM
     Given specific shop configuration for "rounding type" is set to round each article
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
-    Then my cart total should be precisely 66.44 tax included
+    Then my cart total should be precisely 66.43 tax included
     Then my cart total using previous calculation method should be precisely 66.43 tax included
 
   Scenario: 3 products in cart, several quantities
@@ -36,3 +36,11 @@ Feature: Cart calculation with rounding type ITEM
     When I add 1 items of product "product3" in my cart
     Then my cart total should be precisely 162.4 tax included
     Then my cart total using previous calculation method should be precisely 162.4 tax included
+
+    Scenario: 1 product in quart, with a quantity of 2 and a tricky price
+      Given I have an empty default cart
+      Given specific shop configuration for "rounding type" is set to round each article
+      Given there is a product in the catalog named "product1" with a price of 35.32552 and 1000 items in stock
+      When I add 2 items of product "product1" in my cart
+      Then my cart total should be precisely 77.66 tax included
+      Then my cart total using previous calculation method should be precisely 77.66 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
@@ -15,7 +15,7 @@ Feature: Cart calculation with rounding type LINE
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 1 items of product "product1" in my cart
     Then my cart total should be precisely 26.81 tax included
-    Then my cart total using previous calculation method should be precisely 26.812 tax included
+    Then my cart total using previous calculation method should be precisely 26.81 tax included
 
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
@@ -23,7 +23,7 @@ Feature: Cart calculation with rounding type LINE
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
     Then my cart total should be precisely 66.44 tax included
-    Then my cart total using previous calculation method should be precisely 66.436 tax included
+    Then my cart total using previous calculation method should be precisely 66.44 tax included
 
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart
@@ -35,4 +35,4 @@ Feature: Cart calculation with rounding type LINE
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
     Then my cart total should be precisely 162.4 tax included
-    Then my cart total using previous calculation method should be precisely 162.4 tax included
+    Then my cart total using previous calculation method should be precisely 162.41 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
@@ -36,3 +36,21 @@ Feature: Cart calculation with rounding type LINE
     When I add 1 items of product "product3" in my cart
     Then my cart total should be precisely 162.4 tax included
     Then my cart total using previous calculation method should be precisely 162.41 tax included
+
+  Scenario: one product in cart, quantity 3 with a percentage cart rule
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round each line
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule1" that applies a percent discount of 15.0% with priority 1, quantity of 1000 and quantity per user 1000
+    When I add 3 items of product "product1" in my cart
+    Then my cart total should be precisely 57.52 tax included
+    Then my cart total using previous calculation method should be precisely 57.52 tax included
+
+  Scenario: one product in cart, quantity 3 with an amount cart rule
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round each line
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule1" that applies an amount discount of 5.0 with priority 8, quantity of 1000 and quantity per user 1000
+    When I add 3 items of product "product1" in my cart
+    Then my cart total should be precisely 61.44 tax included
+    Then my cart total using previous calculation method should be precisely 61.44 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
@@ -14,7 +14,7 @@ Feature: Cart calculation with rounding type LINE
     Given specific shop configuration for "rounding type" is set to round each line
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 1 items of product "product1" in my cart
-    Then my cart total should be precisely 26.812 tax included
+    Then my cart total should be precisely 26.81 tax included
     Then my cart total using previous calculation method should be precisely 26.812 tax included
 
   Scenario: one product in cart, quantity 3
@@ -22,7 +22,7 @@ Feature: Cart calculation with rounding type LINE
     Given specific shop configuration for "rounding type" is set to round each line
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
-    Then my cart total should be precisely 66.436 tax included
+    Then my cart total should be precisely 66.44 tax included
     Then my cart total using previous calculation method should be precisely 66.436 tax included
 
   Scenario: 3 products in cart, several quantities

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
@@ -36,3 +36,21 @@ Feature: Cart calculation with rounding type TOTAL
     When I add 1 items of product "product3" in my cart
     Then my cart total should be precisely 162.4 tax included
     Then my cart total using previous calculation method should be precisely 162.4 tax included
+
+  Scenario: one product in cart, quantity 3 with a percentage cart rule
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round cart total
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule1" that applies a percent discount of 15.0% with priority 1, quantity of 1000 and quantity per user 1000
+    When I add 3 items of product "product1" in my cart
+    Then my cart total should be precisely 57.52 tax included
+    Then my cart total using previous calculation method should be precisely 57.52 tax included
+
+  Scenario: one product in cart, quantity 3 with an amount cart rule
+    Given I have an empty default cart
+    Given specific shop configuration for "rounding type" is set to round cart total
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a cart rule named "cartrule1" that applies an amount discount of 5.0 with priority 8, quantity of 1000 and quantity per user 1000
+    When I add 3 items of product "product1" in my cart
+    Then my cart total should be precisely 61.44 tax included
+    Then my cart total using previous calculation method should be precisely 61.44 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
@@ -14,7 +14,7 @@ Feature: Cart calculation with rounding type TOTAL
     Given specific shop configuration for "rounding type" is set to round cart total
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 1 items of product "product1" in my cart
-    Then my cart total should be precisely 26.812 tax included
+    Then my cart total should be precisely 26.81 tax included
     Then my cart total using previous calculation method should be precisely 26.812 tax included
 
   Scenario: one product in cart, quantity 3
@@ -22,7 +22,7 @@ Feature: Cart calculation with rounding type TOTAL
     Given specific shop configuration for "rounding type" is set to round cart total
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
-    Then my cart total should be precisely 66.436 tax included
+    Then my cart total should be precisely 66.44 tax included
     Then my cart total using previous calculation method should be precisely 66.436 tax included
 
   Scenario: 3 products in cart, several quantities

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
@@ -15,7 +15,7 @@ Feature: Cart calculation with rounding type TOTAL
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 1 items of product "product1" in my cart
     Then my cart total should be precisely 26.81 tax included
-    Then my cart total using previous calculation method should be precisely 26.812 tax included
+    Then my cart total using previous calculation method should be precisely 26.81 tax included
 
   Scenario: one product in cart, quantity 3
     Given I have an empty default cart
@@ -23,7 +23,7 @@ Feature: Cart calculation with rounding type TOTAL
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I add 3 items of product "product1" in my cart
     Then my cart total should be precisely 66.44 tax included
-    Then my cart total using previous calculation method should be precisely 66.436 tax included
+    Then my cart total using previous calculation method should be precisely 66.44 tax included
 
   Scenario: 3 products in cart, several quantities
     Given I have an empty default cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -28,10 +28,10 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 20.604480 tax included
-    Then current cart order total for products should be 19.812000 tax excluded
-    Then current cart order total discount should be 10.302240 tax included
-    Then current cart order total discount should be 9.906000 tax excluded
+    Then current cart order total for products should be 20.600000 tax included
+    Then current cart order total for products should be 19.810000 tax excluded
+    Then current cart order total discount should be 10.300000 tax included
+    Then current cart order total discount should be 9.910000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 10.3 tax included and 9.91 tax excluded
@@ -65,10 +65,10 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 20.604480 tax included
-    Then current cart order total for products should be 19.812000 tax excluded
-    Then current cart order total discount should be 15.453360 tax included
-    Then current cart order total discount should be 14.859000 tax excluded
+    Then current cart order total for products should be 20.600000 tax included
+    Then current cart order total for products should be 19.810000 tax excluded
+    Then current cart order total discount should be 15.450000 tax included
+    Then current cart order total discount should be 14.860000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 10.3 tax included and 9.91 tax excluded
@@ -106,10 +106,10 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 119.159040 tax included
-    Then current cart order total for products should be 114.576000 tax excluded
-    Then current cart order total discount should be 59.579520 tax included
-    Then current cart order total discount should be 57.288000 tax excluded
+    Then current cart order total for products should be 119.150000 tax included
+    Then current cart order total for products should be 114.580000 tax excluded
+    Then current cart order total discount should be 59.580000 tax included
+    Then current cart order total discount should be 57.290000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 59.58 tax included and 57.29 tax excluded
@@ -149,14 +149,14 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 119.159040 tax included
-    Then current cart order total for products should be 114.576000 tax excluded
-    Then current cart order total discount should be 89.369280 tax included
-    Then current cart order total discount should be 85.932000 tax excluded
+    Then current cart order total for products should be 119.150000 tax included
+    Then current cart order total for products should be 114.580000 tax excluded
+    Then current cart order total discount should be 89.360000 tax included
+    Then current cart order total discount should be 85.940000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 59.58 tax included and 57.29 tax excluded
-    Then current cart order should have a discount in position 2 with an amount of 29.79 tax included and 28.64 tax excluded
+    Then current cart order should have a discount in position 2 with an amount of 29.79 tax included and 28.65 tax excluded
     Then customer "customer1" should have 0 cart rules that apply to him
 
   Scenario: 1 product in cart, 1 cart rule with too-much amount
@@ -184,10 +184,10 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 20.604480 tax included
-    Then current cart order total for products should be 19.812000 tax excluded
-    Then current cart order total discount should be 20.604480 tax included
-    Then current cart order total discount should be 19.812000 tax excluded
+    Then current cart order total for products should be 20.600000 tax included
+    Then current cart order total for products should be 19.810000 tax excluded
+    Then current cart order total discount should be 20.600000 tax included
+    Then current cart order total discount should be 19.810000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 20.6 tax included and 19.81 tax excluded
@@ -222,10 +222,10 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 57.594160 tax included
-    Then current cart order total for products should be 55.379000 tax excluded
-    Then current cart order total discount should be 36.989680 tax included
-    Then current cart order total discount should be 35.567000 tax excluded
+    Then current cart order total for products should be 57.590000 tax included
+    Then current cart order total for products should be 55.380000 tax excluded
+    Then current cart order total discount should be 36.990000 tax included
+    Then current cart order total discount should be 35.570000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 36.99 tax included and 35.57 tax excluded
@@ -260,10 +260,10 @@ Feature: Check cart to order data copy
     When I select address "address1" in my cart
     When I select carrier "carrier1" in my cart
     When I validate my cart using payment module fake
-    Then current cart order total for products should be 94.583840 tax included
-    Then current cart order total for products should be 90.946000 tax excluded
-    Then current cart order total discount should be 36.989680 tax included
-    Then current cart order total discount should be 35.567000 tax excluded
+    Then current cart order total for products should be 94.580000 tax included
+    Then current cart order total for products should be 90.940000 tax excluded
+    Then current cart order total discount should be 36.990000 tax included
+    Then current cart order total discount should be 35.570000 tax excluded
     Then current cart order shipping fees should be 7.0 tax included
     Then current cart order shipping fees should be 7.0 tax excluded
     Then current cart order should have a discount in position 1 with an amount of 36.99 tax included and 35.57 tax excluded

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -108,12 +108,12 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have 0 cart rule
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
-      | total_products_wt        | 25.228 |
+      | total_products_wt        | 25.230000 |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 30.800 |
-      | total_paid_tax_incl      | 32.228 |
-      | total_paid               | 32.228 |
+      | total_paid_tax_incl      | 32.230000 |
+      | total_paid               | 32.230000 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
@@ -133,12 +133,12 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct"
     Then order "bo_order1" should have following details:
       | total_products           | 38.800 |
-      | total_products_wt        | 40.228 |
+      | total_products_wt        | 40.230000 |
       | total_discounts_tax_excl | 15.000 |
       | total_discounts_tax_incl | 15.000 |
       | total_paid_tax_excl      | 30.8   |
-      | total_paid_tax_incl      | 32.228 |
-      | total_paid               | 32.228 |
+      | total_paid_tax_incl      | 32.230000 |
+      | total_paid               | 32.230000 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
@@ -148,12 +148,12 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have 0 cart rule
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
-      | total_products_wt        | 25.228 |
+      | total_products_wt        | 25.230000 |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 30.800 |
-      | total_paid_tax_incl      | 32.228 |
-      | total_paid               | 32.228 |
+      | total_paid_tax_incl      | 32.230000 |
+      | total_paid               | 32.230000 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
@@ -255,7 +255,7 @@ Feature: Order from Back Office (BO)
       | product_price               | 11.9   |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.9   |
-      | total_price_tax_incl        | 25.228 |
+      | total_price_tax_incl        | 25.230000 |
       | total_price_tax_excl        | 23.8   |
 
   @order-from-bo
@@ -270,7 +270,7 @@ Feature: Order from Back Office (BO)
       | product_price               | 11.9   |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.9   |
-      | total_price_tax_incl        | 25.228 |
+      | total_price_tax_incl        | 25.230000 |
       | total_price_tax_excl        | 23.8   |
 
   @order-from-bo

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -30,16 +30,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Processing in progress     |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -72,16 +72,16 @@ Feature: Refund Order from Back Office (BO)
     And there are 0 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
 
   @order-refund
   @order-partial-refund
@@ -169,16 +169,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Processing in progress     |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -211,16 +211,16 @@ Feature: Refund Order from Back Office (BO)
     And there are 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
 
   @order-refund
   @order-partial-refund
@@ -233,16 +233,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Processing in progress     |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 5.0    |
       | total_discounts_tax_incl | 5.3    |
       | total_paid_tax_excl      | 37.7   |
-      | total_paid_tax_incl      | 39.542 |
-      | total_paid               | 39.542 |
-      | total_paid_real          | 39.542 |
+      | total_paid_tax_incl      | 39.540000 |
+      | total_paid               | 39.540000 |
+      | total_paid_real          | 39.540000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -278,16 +278,16 @@ Feature: Refund Order from Back Office (BO)
     And there are 0 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 5.0    |
       | total_discounts_tax_incl | 5.3    |
       | total_paid_tax_excl      | 37.7   |
-      | total_paid_tax_incl      | 39.542 |
-      | total_paid               | 39.542 |
-      | total_paid_real          | 39.542 |
+      | total_paid_tax_incl      | 39.540000 |
+      | total_paid               | 39.540000 |
+      | total_paid_real          | 39.540000 |
 
   @order-refund
   @order-partial-refund
@@ -299,16 +299,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Processing in progress     |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -342,16 +342,16 @@ Feature: Refund Order from Back Office (BO)
     And customer "testCustomer" last voucher is 13.5
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
 
   @order-refund
   @order-partial-refund
@@ -377,19 +377,19 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8   |
       | shipping_cost_amount    | 7.0    |
       | total_products_tax_excl | 23.8   |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 0      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 0      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 0 more "Mug Today is a good day" in stock
 
@@ -451,19 +451,19 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 14.09     |
       | shipping_cost_amount    | 0.0       |
       | total_products_tax_excl | 14.091378 |
-      | total_products_tax_incl | 14.936860 |
+      | total_products_tax_incl | 14.940000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2         |
       | product_quantity_refunded   | 1         |
       | product_quantity_reinjected | 0         |
-      | total_refunded_tax_excl     | 10.545689 |
-      | total_refunded_tax_incl     | 11.178430 |
+      | total_refunded_tax_excl     | 10.550000 |
+      | total_refunded_tax_incl     | 11.180000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1        |
       | product_quantity_refunded   | 1        |
       | product_quantity_reinjected | 0        |
-      | total_refunded_tax_excl     | 3.545689 |
-      | total_refunded_tax_incl     | 3.758430 |
+      | total_refunded_tax_excl     | 3.550000 |
+      | total_refunded_tax_incl     | 3.760000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 0 more "Mug Today is a good day" in stock
 
@@ -831,12 +831,12 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 1      |
       | product_quantity_return     | 0      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
@@ -95,16 +95,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Processing in progress |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -121,35 +121,35 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 23.8   |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
 
   @order-refund
   @order-return-product
@@ -175,21 +175,21 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 23.8   |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 0      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 0      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 0 more "Mug Today is a good day" in stock
 
@@ -217,7 +217,7 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 7.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -231,7 +231,7 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
 
@@ -246,16 +246,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Processing in progress |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 5.0    |
       | total_discounts_tax_incl | 5.3    |
       | total_paid_tax_excl      | 37.7   |
-      | total_paid_tax_incl      | 39.542 |
-      | total_paid               | 39.542 |
-      | total_paid_real          | 39.542 |
+      | total_paid_tax_incl      | 39.540000 |
+      | total_paid               | 39.540000 |
+      | total_paid_real          | 39.540000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -275,7 +275,7 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9  |
       | shipping_cost_amount    | 7.0   |
       | total_products_tax_excl | 11.9  |
-      | total_products_tax_incl | 7.314 |
+      | total_products_tax_incl | 7.310000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -289,21 +289,21 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 5.0    |
       | total_discounts_tax_incl | 5.3    |
       | total_paid_tax_excl      | 37.7   |
-      | total_paid_tax_incl      | 39.542 |
-      | total_paid               | 39.542 |
-      | total_paid_real          | 39.542 |
+      | total_paid_tax_incl      | 39.540000 |
+      | total_paid               | 39.540000 |
+      | total_paid_real          | 39.540000 |
 
   @order-refund
   @order-return-product
@@ -329,7 +329,7 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 7.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -343,7 +343,7 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 18.9
@@ -374,14 +374,14 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 23.8
@@ -578,14 +578,14 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
       | product_quantity_refunded   | 0 |
@@ -604,20 +604,20 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 23.8   |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 2      |
       | product_quantity_reinjected | 2      |
       | total_refunded_tax_excl     | 23.8   |
-      | total_refunded_tax_incl     | 25.228 |
+      | total_refunded_tax_incl     | 25.220000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 0      |
       | product_quantity_return     | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -95,19 +95,19 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 23.8   |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
 
@@ -143,16 +143,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Payment accepted |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -169,33 +169,33 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 23.8   |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 42.7   |
-      | total_paid_tax_incl      | 44.842 |
-      | total_paid               | 44.842 |
-      | total_paid_real          | 44.842 |
+      | total_paid_tax_incl      | 44.840000 |
+      | total_paid               | 44.840000 |
+      | total_paid_real          | 44.840000 |
 
   @order-refund
   @order-standard-refund
@@ -221,7 +221,7 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 7.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -233,7 +233,7 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
 
@@ -248,16 +248,16 @@ Feature: Refund Order from Back Office (BO)
       | status              | Payment accepted |
     Then order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 5.0    |
       | total_discounts_tax_incl | 5.3    |
       | total_paid_tax_excl      | 37.7   |
-      | total_paid_tax_incl      | 39.542 |
-      | total_paid               | 39.542 |
-      | total_paid_real          | 39.542 |
+      | total_paid_tax_incl      | 39.540000 |
+      | total_paid               | 39.540000 |
+      | total_paid_real          | 39.540000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
@@ -277,7 +277,7 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9  |
       | shipping_cost_amount    | 7.0   |
       | total_products_tax_excl | 11.9  |
-      | total_products_tax_incl | 7.314 |
+      | total_products_tax_incl | 7.310000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -289,21 +289,21 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
-      | total_products_wt        | 37.842 |
+      | total_products_wt        | 37.840000 |
       | total_shipping           | 7.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.0    |
       | total_discounts_tax_excl | 5.0    |
       | total_discounts_tax_incl | 5.3    |
       | total_paid_tax_excl      | 37.7   |
-      | total_paid_tax_incl      | 39.542 |
-      | total_paid               | 39.542 |
-      | total_paid_real          | 39.542 |
+      | total_paid_tax_incl      | 39.540000 |
+      | total_paid               | 39.540000 |
+      | total_paid_real          | 39.540000 |
 
   @order-refund
   @order-standard-refund
@@ -329,7 +329,7 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 7.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2 |
       | product_quantity_refunded   | 0 |
@@ -341,7 +341,7 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 18.9
@@ -371,13 +371,13 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 23.8
@@ -572,13 +572,13 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 11.9   |
       | shipping_cost_amount    | 0.0    |
       | total_products_tax_excl | 11.9   |
-      | total_products_tax_incl | 12.614 |
+      | total_products_tax_incl | 12.610000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
       | product_quantity_refunded   | 0 |
@@ -596,18 +596,18 @@ Feature: Refund Order from Back Office (BO)
       | amount                  | 23.8 |
       | shipping_cost_amount    | 0.0  |
       | total_products_tax_excl | 23.8 |
-      | total_products_tax_incl | 25.228 |
+      | total_products_tax_incl | 25.220000 |
     And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
       | product_quantity            | 2      |
       | product_quantity_refunded   | 2      |
       | product_quantity_reinjected | 2      |
       | total_refunded_tax_excl     | 23.8   |
-      | total_refunded_tax_incl     | 25.228 |
+      | total_refunded_tax_incl     | 25.220000 |
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1      |
       | product_quantity_refunded   | 1      |
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
-      | total_refunded_tax_incl     | 12.614 |
+      | total_refunded_tax_incl     | 12.610000 |
     And there are 1 more "Mug The best is yet to come" in stock
     And there are 1 more "Mug Today is a good day" in stock

--- a/tests/Unit/Core/Localization/CLDR/ComputingPrecisionTest.php
+++ b/tests/Unit/Core/Localization/CLDR/ComputingPrecisionTest.php
@@ -56,8 +56,8 @@ class ComputingPrecisionTest extends TestCase
     public function provider()
     {
         return [
-            [1, 3],
-            [3, 9],
+            [1, 2],
+            [3, 3],
             [0, 2],
         ];
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Make computing precision matching currency's display precision 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #18717 
| How to test?  | This PR changes prices everywhere... it should probably not be tested by itself, but it also fixes a bug, and this can be tested replicating the septs given here: #18640

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18617)
<!-- Reviewable:end -->
