### PR TITLE
Remove call to profile.prestashop.com

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -584,11 +584,7 @@ class EmployeeCore extends ObjectModel
      */
     public function getImage()
     {
-        if (!Validate::isLoadedObject($this)) {
-            return Tools::getAdminImageUrl('prestashop-avatar.png');
-        }
-
-        return Tools::getShopProtocol() . 'profile.prestashop.com/' . urlencode($this->email) . '.jpg';
+        return Tools::getAdminImageUrl('prestashop-avatar.png');
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -51,25 +51,7 @@
         <div class="form-group row">
           <label class="form-control-label"></label>
           <div class="col-sm">
-            <a href="https://www.prestashop.com/forums/" target="_blank">
-              <img class="img-thumbnail clickable-avatar" src="{{ avatarUrl }}" alt="">
-            </a>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label"></label>
-          <div class="col-sm">
-            <div class="alert alert-info" role="alert">
-              <p class="alert-text">
-                {{ 'Your avatar in PrestaShop 1.7.x is your profile picture on %url%. To change your avatar, log in to PrestaShop.com with your email %email% and follow the on-screen instructions.'|trans({}, 'Admin.Advparameters.Help')
-                    |replace({
-                      '%url%': '<a href="https://www.prestashop.com/forums/" class="alert-link" target="_blank">PrestaShop.com</a>',
-                      '%email%': (employeeForm.email.vars.value|escape)
-                    })|raw
-                }}
-              </p>
-            </div>
+            <img class="img-thumbnail clickable-avatar" src="{{ avatarUrl }}" alt="">
           </div>
         </div>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In this PR, I modify how BO Profile avatar URL is fetched and I return default Preston image for all employees. Before this PR, if employee had an account on PrestaShop forum, it would return its profile picture.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes partially https://github.com/PrestaShop/PrestaShop/issues/15671 and https://github.com/PrestaShop/PrestaShop/issues/18503
| How to test?  | See that employee profile picture is always default picture, whether you have a forum account or not.

PM decision was given here: https://github.com/PrestaShop/PrestaShop/pull/18346#issuecomment-611000014

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18622)
<!-- Reviewable:end -->
