### PR TITLE
Avoid usage of a one Cart by many Employees

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -791,7 +791,7 @@ class AdminCartsControllerCore extends AdminController
         if ((int) Tools::getValue('id_cart')) {
             $this->context->cookie->id_cart = $id_cart = (int) Tools::getValue('id_cart');
         } elseif (!$this->context->cookie->id_cart) {
-            $cart = new Cart;
+            $cart = new Cart();
             $cart->id_currency = $this->context->currency->id;
             $cart->id_lang = $this->context->language->id;
             $cart->save();

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -795,7 +795,7 @@ class AdminCartsControllerCore extends AdminController
             $cart->id_currency = $this->context->currency->id;
             $cart->id_lang = $this->context->language->id;
             $cart->save();
-            $this->context->cookie->id_cart = $cart->id;
+            $this->context->cookie->id_cart = $id_cart = (int) $cart->id;
             $id_cart = (int) $cart->id;
         } else {
             $id_cart = (int) $this->context->cart->id;

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -788,7 +788,18 @@ class AdminCartsControllerCore extends AdminController
 
     public function ajaxReturnVars()
     {
-        $id_cart = (int) $this->context->cart->id;
+        if ((int) Tools::getValue('id_cart')) {
+            $this->context->cookie->id_cart = $id_cart = (int) Tools::getValue('id_cart');
+        } elseif (!$this->context->cookie->id_cart) {
+            $cart = new Cart;
+            $cart->id_currency = $this->context->currency->id;
+            $cart->id_lang = $this->context->language->id;
+            $cart->save();
+            $this->context->cookie->id_cart = $cart->id;
+            $id_cart = (int) $cart->id;
+        } else {
+            $id_cart = (int) $this->context->cart->id;
+        }
         $message_content = '';
         if ($message = Message::getMessageByCartId((int) $this->context->cart->id)) {
             $message_content = $message['message'];


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The problem:<br>1. In the backoffice, employee A creating a new order for customer X<br>2. Employee B is also creating an order for customer X<br>3. The Context class gets the last Cart that is not ordered yet for both employee A and employee B<br4. Both Employees are now change/using the same Cart<br><br>The solution:<br>Using the Context->cookie->id_cart so that new carts are created for each employee.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #18660
| How to test?  | Check description.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18654)
<!-- Reviewable:end -->
