### PR TITLE
Add array in @return of PaymentModule::getCurrency

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -788,7 +788,7 @@ abstract class PaymentModuleCore extends Module
     /**
      * @param int $current_id_currency optional but on 1.5 it will be REQUIRED
      *
-     * @return Currency|false
+     * @return Currency|array|false
      */
     public function getCurrency($current_id_currency = null)
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Update the PHPdoc of PaymentModule::getCurrency so static analysis tools like PHPStan do not trigger false positive errors. This method returns the result of a SQL request in this case: `$this->currencies_mode == 'checkbox'`
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | None
| How to test?  | Run PHPStan on a foreach using the result of PaymentModule::getCurrency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18680)
<!-- Reviewable:end -->
