### PR TITLE
[POC] Vue app on the whole page to keep hooks existing

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -33,7 +33,7 @@ const bourbon = require('bourbon');
 
 module.exports = {
   externals: {
-    jquery: 'jQuery',
+    jquery: 'jQuery'
   },
   entry: {
     address: './js/pages/address',
@@ -86,7 +86,7 @@ module.exports = {
     order_preferences: './js/pages/order-preferences',
     order_view: './js/pages/order/view.js',
     payment_preferences: './js/pages/payment-preferences',
-    product_page: './js/product-page/index',
+    product_page: './js/app/pages/product',
     product_preferences: './js/pages/product-preferences',
     profiles: './js/pages/profiles',
     sql_manager: './js/pages/sql-manager',
@@ -99,7 +99,7 @@ module.exports = {
     translation_settings: './js/pages/translation-settings',
     translations: './js/app/pages/translations',
     webservice: './js/pages/webservice',
-    theme: ['./scss/theme.scss'],
+    theme: ['./scss/theme.scss']
   },
   output: {
     path: path.resolve(__dirname, '../public'),
@@ -108,7 +108,7 @@ module.exports = {
     library: '[name]',
 
     sourceMapFilename: '[name].[hash:8].map',
-    chunkFilename: '[id].[hash:8].js',
+    chunkFilename: '[id].[hash:8].js'
   },
   resolve: {
     extensions: ['.js', '.vue', '.json'],
@@ -118,10 +118,11 @@ module.exports = {
       '@js': path.resolve(__dirname, '../js'),
       '@pages': path.resolve(__dirname, '../js/pages'),
       '@components': path.resolve(__dirname, '../js/components'),
+      '@vueComponents': path.resolve(__dirname, '../js/app/components'),
       '@scss': path.resolve(__dirname, '../scss'),
       '@node_modules': path.resolve(__dirname, '../node_modules'),
-      '@vue': path.resolve(__dirname, '../js/vue'),
-    },
+      '@vue': path.resolve(__dirname, '../js/vue')
+    }
   },
   module: {
     rules: [
@@ -133,64 +134,64 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               presets: [['env', {useBuiltIns: 'usage', modules: false}]],
-              plugins: ['transform-object-rest-spread', 'transform-runtime'],
-            },
-          },
-        ],
+              plugins: ['transform-object-rest-spread', 'transform-runtime']
+            }
+          }
+        ]
       },
       {
         test: /jquery-ui\.js/,
-        use: 'imports-loader?define=>false&this=>window',
+        use: 'imports-loader?define=>false&this=>window'
       },
       {
         test: /jquery\.magnific-popup\.js/,
-        use: 'imports-loader?define=>false&exports=>false&this=>window',
+        use: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bloodhound\.min\.js/,
         use: [
           {
             loader: 'expose-loader',
-            query: 'Bloodhound',
-          },
-        ],
+            query: 'Bloodhound'
+          }
+        ]
       },
       {
         test: /dropzone\/dist\/dropzone\.js/,
-        loader: 'imports-loader?this=>window&module=>null',
+        loader: 'imports-loader?this=>window&module=>null'
       },
       {
         test: require.resolve('moment'),
-        loader: 'imports-loader?define=>false&this=>window',
+        loader: 'imports-loader?define=>false&this=>window'
       },
       {
         test: /typeahead\.jquery\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bootstrap-tokenfield\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bootstrap-datetimepicker\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /jwerty\/jwerty\.js/,
-        loader: 'imports-loader?this=>window&module=>false',
+        loader: 'imports-loader?this=>window&module=>false'
       },
       {
         test: /\.vue$/,
-        loader: 'vue-loader',
+        loader: 'vue-loader'
       },
       {
         test: /\.css$/,
         use: [
           {
-            loader: MiniCssExtractPlugin.loader,
+            loader: MiniCssExtractPlugin.loader
           },
-          'css-loader',
-        ],
+          'css-loader'
+        ]
       },
       {
         test: /\.scss$/,
@@ -201,50 +202,50 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
-            },
+              sourceMap: true
+            }
           },
           {
             loader: 'postcss-loader',
             options: {
-              sourceMap: true,
-            },
+              sourceMap: true
+            }
           },
           {
             loader: 'sass-loader',
             options: {
               sourceMap: true,
               sassOptions: {
-                includePaths: [bourbon.includePaths],
-              },
-            },
-          },
-        ],
+                includePaths: [bourbon.includePaths]
+              }
+            }
+          }
+        ]
       },
       {
         test: /\.scss$/,
         include: /js/,
-        use: ['vue-style-loader', 'css-loader', 'sass-loader'],
+        use: ['vue-style-loader', 'css-loader', 'sass-loader']
       },
       // FILES
       {
         test: /.(jpg|png|woff2?|eot|otf|ttf|svg|gif)$/,
-        loader: 'file-loader?name=[hash].[ext]',
-      },
-    ],
+        loader: 'file-loader?name=[hash].[ext]'
+      }
+    ]
   },
   plugins: [
     new FixStyleOnlyEntriesPlugin(),
     new CleanWebpackPlugin({
-      cleanOnceBeforeBuildPatterns: ['!theme.rtlfix'],
+      cleanOnceBeforeBuildPatterns: ['!theme.rtlfix']
     }),
     new MiniCssExtractPlugin({filename: '[name].css'}),
     new webpack.ProvidePlugin({
       moment: 'moment', // needed for bootstrap datetime picker
       $: 'jquery', // needed for jquery-ui
-      jQuery: 'jquery',
+      jQuery: 'jquery'
     }),
     new CopyPlugin([{from: 'static'}]),
-    new VueLoaderPlugin(),
-  ],
+    new VueLoaderPlugin()
+  ]
 };

--- a/admin-dev/themes/new-theme/js/app/components/Form/FormGroup/FormGroup.vue
+++ b/admin-dev/themes/new-theme/js/app/components/Form/FormGroup/FormGroup.vue
@@ -1,0 +1,55 @@
+<!--**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *-->
+<template>
+  <div class="form-group">
+    <h2>
+      {{ title }}
+      <span
+        class="help-box"
+        data-toggle="popover"
+        :data-content="helpbox"
+      ></span>
+    </h2>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "FormGroup",
+  props: {
+    title: {
+      type: String,
+      default: ""
+    },
+    helpbox: {
+      type: String,
+      default: ""
+    }
+  }
+};
+</script>
+
+<style lang="scss" type="text/scss"></style>

--- a/admin-dev/themes/new-theme/js/app/components/Form/RadioButtons/RadioButtons.vue
+++ b/admin-dev/themes/new-theme/js/app/components/Form/RadioButtons/RadioButtons.vue
@@ -1,0 +1,68 @@
+<!--**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *-->
+<template>
+  <div class="radio-buttons">
+    <slot name="radios" :setter="setValue" :chosen="chosen"></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "RadioButtons",
+  props: {
+    chosen: {
+      type: String,
+      default: 0
+    },
+    storeName: {
+      type: String,
+      default: "radioButtons",
+      required: true
+    }
+  },
+  data: () => ({
+    active: null
+  }),
+  mounted() {
+    this.active = this.chosen;
+  },
+  methods: {
+    /**
+     * Changing the active state of every radio button and pushing productType state to the store
+     *
+     * @param {Number} value of the radio button clicked
+     */
+    setValue(value) {
+      this.active = parseInt(value);
+
+      this.$store.dispatch("setGlobalValue", {
+        globalState: { label: this.storeName, value }
+      });
+    }
+  }
+};
+</script>
+
+<style lang="scss" type="text/scss"></style>

--- a/admin-dev/themes/new-theme/js/app/pages/product/components/App.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/product/components/App.vue
@@ -1,0 +1,45 @@
+<!--**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *-->
+<script>
+export default {
+  name: "App",
+  data: () => ({
+    isReady: true
+  })
+};
+</script>
+
+<style lang="scss" type="text/scss">
+.product-page {
+  .tab-pane {
+    display: none;
+
+    &.active,
+    &.show {
+      display: block;
+    }
+  }
+}
+</style>

--- a/admin-dev/themes/new-theme/js/app/pages/product/components/ProductStatus/ProductStatus.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/product/components/ProductStatus/ProductStatus.vue
@@ -1,0 +1,54 @@
+<!--**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *-->
+<script>
+export default {
+  name: "ProductStatus",
+  props: {
+    activeStatus: {
+      type: String,
+      default: ""
+    }
+  },
+  data: () => ({
+    chosenStatus: ""
+  }),
+  mounted() {
+    this.chosenStatus = this.activeStatus;
+  }
+};
+</script>
+
+<style lang="scss" type="text/scss">
+.product-page {
+  .tab-pane {
+    display: none;
+
+    &.active,
+    &.show {
+      display: block;
+    }
+  }
+}
+</style>

--- a/admin-dev/themes/new-theme/js/app/pages/product/index.js
+++ b/admin-dev/themes/new-theme/js/app/pages/product/index.js
@@ -1,0 +1,36 @@
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+import Vue from 'vue';
+import FormGroup from '@vueComponents/Form/FormGroup/FormGroup';
+import RadioButtons from '@vueComponents/Form/RadioButtons/RadioButtons';
+import App from './components/App';
+import store from './store';
+
+new Vue({
+  delimiters: ['((', '))'],
+  store,
+  el: '#product-app',
+  components: {App, FormGroup, RadioButtons}
+});

--- a/admin-dev/themes/new-theme/js/app/pages/product/store/actions.js
+++ b/admin-dev/themes/new-theme/js/app/pages/product/store/actions.js
@@ -1,0 +1,33 @@
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+import Vue from 'vue';
+import VueResource from 'vue-resource';
+import * as types from '@app/pages/product/store/mutation-types';
+
+Vue.use(VueResource);
+
+export const setGlobalValue = ({commit}, {globalState}) => {
+  commit(types.SET_GLOBAL_TYPE, globalState);
+};

--- a/admin-dev/themes/new-theme/js/app/pages/product/store/index.js
+++ b/admin-dev/themes/new-theme/js/app/pages/product/store/index.js
@@ -1,0 +1,52 @@
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+import Vue from 'vue';
+import Vuex from 'vuex';
+import _ from 'lodash';
+import * as actions from './actions';
+import mutations from './mutations';
+
+Vue.use(Vuex);
+
+// root state object.
+const state = {
+  values: {}
+};
+
+// getters are functions
+const getters = {
+  getValue(rootState, value) {
+    return rootState[value];
+  }
+};
+
+// A Vuex instance is created by combining the state, mutations, actions,
+// and getters.
+export default new Vuex.Store({
+  state,
+  getters,
+  actions,
+  mutations
+});

--- a/admin-dev/themes/new-theme/js/app/pages/product/store/mutation-types.js
+++ b/admin-dev/themes/new-theme/js/app/pages/product/store/mutation-types.js
@@ -1,0 +1,25 @@
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+export const SET_GLOBAL_TYPE = 'SET_GLOBAL_VALUE';

--- a/admin-dev/themes/new-theme/js/app/pages/product/store/mutations.js
+++ b/admin-dev/themes/new-theme/js/app/pages/product/store/mutations.js
@@ -1,0 +1,33 @@
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+import _ from 'lodash';
+import * as types from './mutation-types';
+
+export default {
+  [types.SET_GLOBAL_TYPE](state, globalState) {
+    state[globalState.label] = globalState.value;
+  }
+};

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/Vue/tabs.vue.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/Vue/tabs.vue.twig
@@ -1,0 +1,44 @@
+{#**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+<div class="tabs">
+  <div class="arrow d-xl-none js-arrow left-arrow float-left">
+    <i class="material-icons hide">chevron_left</i>
+  </div>
+
+  <ul class="nav nav-tabs" id="form-nav" role="tablist">
+    <li id="tab_step1" class="nav-item"><a href="#step1" role="tab" data-toggle="tab" class="nav-link active">{{ 'Basic settings'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step3" class="nav-item"><a href="#step3" role="tab" data-toggle="tab" class="nav-link">{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step4" class="nav-item"><a href="#step4" role="tab" data-toggle="tab" class="nav-link">{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step2" class="nav-item"><a href="#step2" role="tab" data-toggle="tab" class="nav-link">{{ 'Pricing'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step5" class="nav-item"><a href="#step5" role="tab" data-toggle="tab" class="nav-link">{{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    <li id="tab_step6" class="nav-item"><a href="#step6" role="tab" data-toggle="tab" class="nav-link">{{ 'Options'|trans({}, 'Admin.Global') }}</a></li>
+    {% if hookcount('displayAdminProductsExtra') > 0 %}
+      <li id="tab_hooks" class="nav-item"><a href="#hooks" role="tab" data-toggle="tab" class="nav-link">{{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
+    {% endif %}
+  </ul>
+  <div class="arrow d-xl-none js-arrow right-arrow visible float-right">
+    <i class="material-icons hide">chevron_right</i>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/Vue/combinations.vue.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/Vue/combinations.vue.twig
@@ -1,0 +1,176 @@
+{#**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+<div role="tabpanel" class="form-contenttab tab-pane" id="step3">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="container-fluid">
+        <div class="row">
+
+          <div class="col-md-12">
+
+            <div id="quantities" style="{% if has_combinations or formDependsOnStocks.vars.value != "0" %}display: none;{% endif %}">
+              <h2>{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+              <fieldset class="form-group">
+                <div class="row">
+                  {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+                    <div class="col-md-4">
+                      <label class="form-control-label">{{ formStockQuantity.vars.label }}</label>
+                      {{ form_errors(formStockQuantity) }}
+                      {{ form_widget(formStockQuantity) }}
+                    </div>
+                  {% endif %}
+                  <div class="col-md-4">
+                    <label class="form-control-label">{{ formStockMinimalQuantity.vars.label }}</label>
+                    <span class="help-box" data-toggle="popover"
+                          data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    {{ form_errors(formStockMinimalQuantity) }}
+                    {{ form_widget(formStockMinimalQuantity) }}
+                  </div>
+                </div>
+              </fieldset>
+
+              <h2>{{ 'Stock'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+              <fieldset class="form-group">
+                <div class="row">
+                  <div class="col-md-4">
+                    <label class="form-control-label">{{ formLocation.vars.label }}</label>
+                    {{ form_errors(formLocation) }}
+                    {{ form_widget(formLocation) }}
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-4">
+                    <label class="form-control-label">{{ formLowStockThreshold.vars.label }}</label>
+                    {{ form_errors(formLowStockThreshold) }}
+                    {{ form_widget(formLowStockThreshold) }}
+                  </div>
+                  <div class="col-md-8">
+                    <label class="form-control-label">&nbsp;</label>
+                    <div class="widget-checkbox-inline">
+                      {{ form_errors(formLowStockAlert) }}
+                      {{ form_widget(formLowStockAlert) }}
+                      <span class="help-box" data-toggle="popover" data-html="true" data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" ></span>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+
+            <div id="virtual_product" data-action="{{ path('admin_product_virtual_save_action', { 'idProduct': productId }) }}" data-action-remove="{{ path('admin_product_virtual_remove_action', {'idProduct': productId }) }}">
+
+              <div class="row">
+                <div class="col-md-4">
+                  <h2>{{ formVirtualProduct.vars.label }}</h2>
+                </div>
+                <div class="col-md-8">
+                  <fieldset class="form-group">
+                    {{ form_widget(formVirtualProduct.is_virtual_file) }}
+                  </fieldset>
+                </div>
+              </div>
+
+              
+                <div class="col-md-6">
+                  <fieldset class="form-group">
+                    <label class="form-control-label">{{ formVirtualProduct.name.vars.label }}</label>
+                    <span class="help-box" data-toggle="popover"
+                          data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    {{ form_errors(formVirtualProduct.name) }}
+                    {{ form_widget(formVirtualProduct.name) }}
+                  </fieldset>
+                </div>
+                <div class="col-md-6">
+                  <fieldset class="form-group">
+                    <label class="form-control-label">{{ formVirtualProduct.nb_downloadable.vars.label }}</label>
+                    <span class="help-box" data-toggle="popover"
+                          data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    {{ form_errors(formVirtualProduct.nb_downloadable) }}
+                    {{ form_widget(formVirtualProduct.nb_downloadable) }}
+                  </fieldset>
+                </div>
+                <div class="col-md-6">
+                  <fieldset class="form-group">
+                    <label class="form-control-label">{{ formVirtualProduct.expiration_date.vars.label }}</label>
+                    <span class="help-box" data-toggle="popover"
+                          data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    {{ form_errors(formVirtualProduct.expiration_date) }}
+                    {{ form_widget(formVirtualProduct.expiration_date) }}
+                  </fieldset>
+                </div>
+                <div class="col-md-6">
+                  <fieldset class="form-group">
+                    <label class="form-control-label">{{ formVirtualProduct.nb_days.vars.label }}</label>
+                    <span class="help-box" data-toggle="popover"
+                          data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    {{ form_errors(formVirtualProduct.nb_days) }}
+                    {{ form_widget(formVirtualProduct.nb_days) }}
+                  </fieldset>
+                </div>
+                <div class="col-md-12">
+                  {{ form_widget(formVirtualProduct.save) }}
+                </div>
+              </div>
+            </div>
+
+            {% if asm_globally_activated and formType.vars.value != "2" %}
+              <div class="form-group" id="asm_quantity_management">
+                <label class="col-sm-2 control-label" for="form_step3_advanced_stock_management"></label>
+                <div class="col-sm-10">
+                  {{ form_errors(formAdvancedStockManagement) }}
+                  {{ form_widget(formAdvancedStockManagement) }}
+                  {% if form.step1.type_product.vars.value == "1" %}
+                    {{ 'When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.'|trans({}, 'Admin.Catalog.Notification') }}
+                  {% endif %}
+                </div>
+              </div>
+              <div class="form-group" id="depends_on_stock_div" style="{% if not(formAdvancedStockManagement.vars.checked) %}display: none;{% endif %}">
+                <label class="col-sm-2 control-label" for="form_step3_depends_on_stock"></label>
+                <div class="col-sm-10">
+                  {{ form_errors(formDependsOnStocks) }}
+                  {{ form_widget(formDependsOnStocks) }}
+                </div>
+              </div>
+            {% endif %}
+            {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+              <div id="pack_stock_type">
+                <h2>{{ formPackStockType.vars.label }}</h2>
+                <div class="row col-md-4">
+                  <fieldset class="form-group">
+                    {{ form_errors(formPackStockType) }}
+                    {{ form_widget(formPackStockType) }}
+                  </fieldset>
+                </div>
+              </div>
+            {% endif %}
+            {{ include('@Product/ProductPage/Forms/form_combinations.html.twig', {'form': formStep3, 'form_combination_bulk': formCombinations}) }}
+
+            {{ renderhook('displayAdminProductsQuantitiesStepBottom', { 'id_product': productId }) }}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/Vue/essentials.vue.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/Vue/essentials.vue.twig
@@ -1,0 +1,76 @@
+{#**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+<div role="tabpanel" class="form-contenttab tab-pane active" id="step1">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="container-fluid">
+        <div class="row">
+          {# LEFT #}
+          <div class="col-md-9 left-column">
+            {{ renderhook('displayAdminProductsMainStepLeftColumnMiddle', { 'id_product': productId }) }}
+          </div>
+
+          {# RIGHT #}
+          <div class="col-md-3 right-column">
+            <div class="row">
+              <div class="col-md-12">
+                {% if is_combination_active %}
+                  <form-group class="mb-3" title="{{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}" helpbox="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}">
+                    <radio-buttons store-name="productType" chosen="{% if not has_combinations %}0{% else %}1{% endif %}">
+                      <template slot="radios" scope="props">
+                        <div class="radio">
+                          <label>
+                            <input type="radio" name="show_variations" value="0" @click="props.setter(0)" :checked="!props.chosen ? 'checked' : 'false'">
+                            {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
+                          </label>
+                        </div>
+
+                        <div class="radio">
+                          <label>
+                            <input type="radio" name="show_variations" value="1" @click="props.setter(1)" :checked="props.chosen ? 'checked' : 'false'">
+                            {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
+                          </label>
+                        </div>
+                      </template>
+                    </radio-buttons> 
+
+                    <div id="product_type_combinations_shortcut">
+                        <span class="small font-secondary">
+                          {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+                          {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                        </span>
+                    </div>
+                  </form-group>
+                {% endif %}
+
+                {{ renderhook('displayAdminProductsMainStepRightColumnBottom', { 'id_product': productId }) }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -25,7 +25,6 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-
   <form name="form" id="form" method="post" class="form-horizontal product-page row justify-content-md-center" novalidate="novalidate">
 
     {% if not editable %} <fieldset disabled id="field-disabled"> {% endif %}
@@ -42,290 +41,73 @@
       }}
     {% endblock %}
 
-    <div class="col-md-10">
-      <div id="form_bubbling_errors">
-        {{ form_errors(form) }}
-      </div>
-    </div>
+    <div id="product-app" class="col-xxl-10"> 
+      <h1>The VueJS Product App</h1>
 
-    <div id="form-loading" class="col-xxl-10">
-      {# FORM TABS CONTAINER #}
-      {% block product_tabs_container %}
-        {{ include('@Product/ProductPage/Blocks/tabs.html.twig') }}
+      {% block product_tabs_container_poc %}
+        {{ include('@Product/ProductPage/Blocks/Vue/tabs.vue.twig') }}
       {% endblock %}
-      <div id="form_content" class="tab-content">
 
-        {# PANEL ESSENTIALS #}
-        {% block product_panel_essentials %}
-          {% set formQuantityShortcut = form.step1.qty_0_shortcut is defined ? form.step1.qty_0_shortcut : null  %}
-          {{ include('@Product/ProductPage/Panels/essentials.html.twig', {
-              'formPackItems': form.step1.inputPackItems,
-              'productId': id_product,
-              'images': form.step1.vars.value.images,
-              'formShortDescription': form.step1.description_short,
-              'formDescription': form.step1.description,
-              'formFeatures': form.step1.features,
-              'formManufacturer': form.step1.id_manufacturer,
-              'formRelatedProducts': form.step1.related_products,
-              'is_combination_active': is_combination_active,
-              'has_combinations': has_combinations,
-              'formReference': form.step6.reference,
-              'formQuantityShortcut': formQuantityShortcut,
-              'formPriceShortcut': form.step1.price_shortcut,
-              'formPriceShortcutTTC': form.step1.price_ttc_shortcut,
-              'formCategories': form.step1,
-            })
-          }}
-        {% endblock %}
+      {# PANEL ESSENTIALS #}
+      {% block product_panel_essentials %}
+        {% set formQuantityShortcut = form.step1.qty_0_shortcut is defined ? form.step1.qty_0_shortcut : null  %}
+        {{ include('@Product/ProductPage/Panels/Vue/essentials.vue.twig', {
+            'formPackItems': form.step1.inputPackItems,
+            'productId': id_product,
+            'images': form.step1.vars.value.images,
+            'formShortDescription': form.step1.description_short,
+            'formDescription': form.step1.description,
+            'formFeatures': form.step1.features,
+            'formManufacturer': form.step1.id_manufacturer,
+            'formRelatedProducts': form.step1.related_products,
+            'is_combination_active': is_combination_active,
+            'has_combinations': has_combinations,
+            'formReference': form.step6.reference,
+            'formQuantityShortcut': formQuantityShortcut,
+            'formPriceShortcut': form.step1.price_shortcut,
+            'formPriceShortcutTTC': form.step1.price_ttc_shortcut,
+            'formCategories': form.step1,
+          })
+        }}
+      {% endblock %}
 
-        {# PANEL COMBINATIONS #}
-        {% block product_panel_combinations %}
-          {% set formStockQuantity = form.step3.qty_0 is defined ? form.step3.qty_0 : null  %}
-          {{ include('@Product/ProductPage/Panels/combinations.html.twig', {
-              'formDependsOnStocks': form.step3.depends_on_stock,
-              'productId': id_product,
-              'formStockQuantity': formStockQuantity,
-              'formStockMinimalQuantity': form.step3.minimal_quantity,
-              'formLowStockThreshold': form.step3.low_stock_threshold,
-              'formLocation': form.step3.location,
-              'formLowStockAlert': form.step3.low_stock_alert,
-              'formVirtualProduct': form.step3.virtual_product,
-              'asm_globally_activated': asm_globally_activated,
-              'formType': form.step1.type_product,
-              'formAdvancedStockManagement': form.step3.advanced_stock_management,
-              'formPackStockType': form.step3.pack_stock_type,
-              'formStep3': form.step3,
-              'formCombinations': formCombinations,
-              'has_combinations': has_combinations,
-              'max_upload_size': max_upload_size
-            })
-          }}
-        {% endblock %}
-
-        {# PANEL SHIPPING #}
-        {% block product_panel_shipping %}
-          <div role="tabpanel" class="form-contenttab tab-pane" id="step4">
-            <div class="row">
-              <div class="col-md-12">
-                <div class="container-fluid">
-                  <div class="row">
-                    {{ include('@Product/ProductPage/Forms/form_shipping.html.twig', {
-                      'form' : form.step4,
-                      'asm_globally_activated': asm_globally_activated,
-                      'isNotVirtual': form.step1.type_product.vars.value != "2",
-                      'isChecked': form.step3.advanced_stock_management.vars.checked,
-                      'warehouses': warehouses
-                    }) }}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        {% endblock %}
-
-        {# PANEL PRICING #}
-        {% block product_panel_pricing %}
-          {{ include('@Product/ProductPage/Panels/pricing.html.twig', {
-            'pricingForm': form.step2,
-            'is_multishop_context': is_multishop_context,
-            'productId': id_product
-          }) }}
-        {% endblock %}
-
-        {# PANEL SEO #}
-        {% block product_panel_seo %}
-          {{ include('@Product/ProductPage/Panels/seo.html.twig', {
-            'seoForm': form.step5,
-            'productId': id_product
-          }) }}
-        {% endblock %}
-
-        {# PANEL OPTIONS #}
-        {% block product_panel_options %}
-          {{ include('@Product/ProductPage/Panels/options.html.twig', {
-            'optionsForm': form.step6,
-            'productId': id_product
-          }) }}
-        {% endblock %}
-
-        {# PANEL HOOKED MODULES #}
-        {% block product_panel_modules %}
-          {% if hookcount('displayAdminProductsExtra') > 0 %}
-            <div role="tabpanel" class="form-contenttab tab-pane" id="hooks">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="container-fluid">
-                    <div class="row">
-
-                      {# LEFT #}
-                      <div class="col-md-12">
-                        {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
-
-                        <div class="row module-selection" style="display: none;">
-                          <div class="col-md-12 col-lg-7">
-                            {% for module in hooks %}
-                              <div class="module-render-container module-{{ module.attributes.name }}">
-                                <div>
-                                  <img class="top-logo" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
-                                  <h2 class="text-ellipsis module-name-grid">
-                                    {{ module.attributes.displayName }}
-                                  </h2>
-                                  <div class="text-ellipsis small-text module-version">
-                                    {{ module.attributes.version }} by {{ module.attributes.author }}
-                                  </div>
-                                </div>
-                                <div class="small no-padding">
-                                  {{ module.attributes.description }}
-                                </div>
-                              </div>
-                            {% endfor %}
-                          </div>
-                          <div class="col-md-12 col-lg-5">
-                            <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                            <select class="modules-list-select" data-toggle="select2">
-                              {% for module in hooks %}
-                                <option value="module-{{ module.attributes.name }}">{{ module.attributes.displayName }}</option>
-                              {% endfor %}
-                            </select>
-                          </div>
-                        </div>
-
-                        <div class="module-render-container all-modules">
-                          <p>
-                            <h2>{{ 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                            {{ 'These modules are relative to the product page of your shop.'|trans({}, 'Admin.Catalog.Feature') }}<br />
-                            {{ 'To manage all your modules go to the [1]Installed module page[/1]'|trans({}, 'Admin.Catalog.Feature')|replace({'[1]': '<a href="' ~ path("admin_module_manage") ~ '">', '[/1]': '</a>'})|raw }}
-                          </p>
-                          <div class="row">
-                            {% for module in hooks %}
-                              <div class="col-md-12 col-lg-6 col-xl-4">
-                                <div class="module-item-wrapper-grid">
-                                  <div class="module-item-heading-grid">
-                                    <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
-                                    <h3 class="text-ellipsis module-name-grid">
-                                      {{ module.attributes.displayName }}
-                                    </h3>
-                                    <div class="text-ellipsis small-text module-version-author-grid">
-                                      {{ module.attributes.version }} by {{ module.attributes.author }}
-                                    </div>
-                                  </div>
-                                  <div class="module-quick-description-grid small no-padding">
-                                    {{ module.attributes.description }}
-                                  </div>
-                                  <div class="module-container">
-                                    <div class="module-quick-action-grid clearfix">
-                                      <button class="modules-list-button btn btn-outline-primary pull-xs-right" data-target="module-{{ module.id }}">
-                                        {{ 'Configure'|trans({}, 'Admin.Actions') }}
-                                      </button>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            {% endfor %}
-                          </div>
-                        </div>
-
-                        {% for module in hooks %}
-                          <div
-                            id="module_{{ module.id }}"
-                            class="module-render-container module-{{ module.attributes.name }}"
-                            style="display: none;"
-                          >
-                            <div>
-                              {{ module.content|raw }}
-                            </div>
-                          </div>
-                        {% endfor %}
-                      </div>
-
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          {% endif %}
-        {% endblock %}
-      </div>
-
-      {{ form_widget(form.id_product) }}
-      {{ form_widget(form._token) }}
-
+      {# PANEL COMBINATIONS #}
+      {% block product_panel_combinations %}
+        {% set formStockQuantity = form.step3.qty_0 is defined ? form.step3.qty_0 : null  %}
+        {{ include('@Product/ProductPage/Panels/Vue/combinations.vue.twig', {
+            'formDependsOnStocks': form.step3.depends_on_stock,
+            'productId': id_product,
+            'formStockQuantity': formStockQuantity,
+            'formStockMinimalQuantity': form.step3.minimal_quantity,
+            'formLowStockThreshold': form.step3.low_stock_threshold,
+            'formLocation': form.step3.location,
+            'formLowStockAlert': form.step3.low_stock_alert,
+            'formVirtualProduct': form.step3.virtual_product,
+            'asm_globally_activated': asm_globally_activated,
+            'formType': form.step1.type_product,
+            'formAdvancedStockManagement': form.step3.advanced_stock_management,
+            'formPackStockType': form.step3.pack_stock_type,
+            'formStep3': form.step3,
+            'formCombinations': formCombinations,
+            'has_combinations': has_combinations,
+            'max_upload_size': max_upload_size
+          })
+        }}
+      {% endblock %}
     </div>
-    {# FOOTER #}
-    {{ include('@Product/ProductPage/Blocks/footer.html.twig', {
-      'preview_link': preview_link,
-      'preview_link_deactivate': preview_link_deactivate,
-      'is_shop_context': is_shop_context,
-      'editable': editable,
-      'is_active': form.step1.vars.value.active,
-      'productId': id_product
-    }) }}
+
     {% if not editable %} </fieldset> {% endif %}
   </form>
-
-
-  {% embed '@PrestaShop/Admin/Helpers/bootstrap_popup.html.twig' with {
-    'id': 'confirmation_modal',
-    'title': "Warning"|trans({}, 'Admin.Notifications.Warning'),
-    'closable': false,
-    'actions': [
-      {
-        'type': 'button',
-        'label': "No"|trans({}, 'Admin.Global'),
-        'class': 'btn btn-outline-secondary btn-lg cancel'
-      },
-      {
-        'type': 'button',
-        'label': "Yes"|trans({}, 'Admin.Global'),
-        'class': 'btn btn-primary btn-lg continue'
-      }
-    ],
-  } %}
-    {% block content %}
-      <div class="modal-body"></div>
-    {% endblock %}
-  {% endembed %}
-
 {% endblock %}
 
 {% block javascripts %}
   {{ parent() }}
 
-  <script src="{{ asset('themes/default/js/bundle/product/form.js') }}"></script>
-  <script src="{{ asset('themes/new-theme/public/catalog_product.bundle.js') }}"></script>
-
-  <script src="{{ asset('themes/default/js/bundle/product/product-manufacturer.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/product/product-related.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/product/product-category-tags.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/product/default-category.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/product/product-combinations.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/category-tree.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/modal-confirmation.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/product_page.bundle.js') }}"></script>
   <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
-  <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>
-
-  <script>
-      $(function() {
-        var editable = '{{ editable }}';
-
-        if (editable !== '1'){
-          $('#field-disabled').find("select").each(function() {
-            $(this).removeClass('select2-hidden-accessible');
-          });
-          $('#field-disabled').find("span.select2").each(function() {
-            $(this).hide();
-          });
-          $('#field-disabled').find("a.pstaggerClosingCross").each(function() {
-            $(this).attr("disabled", "disabled").on("click", function() {
-              return false;
-            });
-          });
-        }
-      });
-  </script>
+  <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script> 
+  
 {% endblock %}
 
 {% set js_translatable = {


### PR DESCRIPTION
# Proof Of Concept

The goal of this proof of concept (POC) is to show that we can manage to use Vue on a whole back-office page. This means that we needs to be able to put hooks inside our vue markup. These hooks can use informations shared in the main twig file and execute JS after our Vue app loaded.


# General workflow

This POC is using the exact same structure as the stock page already does, except that it use a new folders inside `/admin-dev/themes/new-theme/js/app/` named `components` which contains global Vue components.

The entry point is `/admin-dev/themes/new-theme/js/app/pages/product/index.js` and the entry point of the vue app is `/admin-dev/themes/new-theme/js/app/pages/product/components/App.vue`.

Notice that `delimiters` are changed to `(( ))` in order to avoid conflict with Twig tags.

Notice that in this file, there are no template tag, this is done to be able to use `.twig` files to manage the vue markup.

It's loading by selecting an id inside `src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig`, called `#product-page`

After we've done this, we're able to write any VueJS markup, including templating logic of this library such as components as you can see on the line 40 of `src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/Vue/essentials.vue.twig`

## Pros

 - We can keep hooks and extensibility of every pages/blocks. (but they will may be not retrocompatible)
 - We can use twig templating, this means that we can maybe use our current symfony forms, grids, any components we use. But we can also structure the markup in different files thanks to the `include` function of twig in order to keep the project clean.
 - It's a smooth transition to a complete Vue application, even if this stay a monolith, it's adding a modern stack to the whole project, which will make the future easier if we wants to switch to Vue.

## Cons

 - A lot of logic is inside Twig files, but as we are already adding some loops, including JS traductions and other twig logics, it shouldn't be a problem but it would require a solid structure that we need to stick on.
 - It require a lot of `slots` scoped and getting `props` from their parent
 - These slots needs to communicate with their parents components (which are basically smart components on this POC) but they can't use `$emit()` so we need to pass `methods definitions` as a `props` which isn't a defined vue workflow.
 - It require to stick to a solid design pattern, otherwise it will be chaotic (like smart/dumb maybe)

## What's next?

- We need to test with some hooks/modules to verify that everything is fine.
- We need to think about the structure of any folder and files this pattern needs

# Testing hooks inside the VueJS application


I tested to hook inside a VueJS app with markup managed by twig :
 - The hook SHOULDN’T contain any script tag
 - Any JS working on the hooks markup should be executed AFTER VueJS init

Sorry for my english if there are typos <3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18683)
<!-- Reviewable:end -->
