### PR TITLE
Rename CountryChoiceType options using camel case convention

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -334,8 +334,8 @@ class CustomerAddressType extends AbstractType
         ])
         ->add('id_country', CountryChoiceType::class, [
             'required' => true,
-            'withDniAttr' => true,
-            'withPostcodeAttr' => true,
+            'with_dni_attr' => true,
+            'with_postcode_attr' => true,
             'constraints' => [
                 new NotBlank([
                     'message' => $this->translator->trans(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -226,7 +226,7 @@ class ManufacturerAddressType extends AbstractType
             ])
             ->add('id_country', CountryChoiceType::class, [
                 'required' => true,
-                'withDniAttr' => true,
+                'with_dni_attr' => true,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->translator->trans(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -208,7 +208,7 @@ class SupplierType extends TranslatorAwareType
             ])
             ->add('id_country', CountryChoiceType::class, [
                 'required' => true,
-                'withDniAttr' => true,
+                'with_dni_attr' => true,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Type/CountryChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CountryChoiceType.php
@@ -74,9 +74,9 @@ class CountryChoiceType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($options['withDniAttr'] || $options['withPostcodeAttr']) {
-            $this->needDni = $options['withDniAttr'];
-            $this->needPostcode = $options['withPostcodeAttr'];
+        if ($options['with_dni_attr'] || $options['with_postcode_attr']) {
+            $this->needDni = $options['with_dni_attr'];
+            $this->needPostcode = $options['with_postcode_attr'];
             $this->countriesAttr = $this->countriesAttrChoicesProvider->getChoicesAttributes();
         }
         parent::buildForm($builder, $options);
@@ -95,13 +95,13 @@ class CountryChoiceType extends AbstractType
         $resolver->setDefaults([
             'choices' => $choices,
             'choice_attr' => [$this, 'getChoiceAttr'],
-            'withDniAttr' => false,
-            'withPostcodeAttr' => false,
+            'with_dni_attr' => false,
+            'with_postcode_attr' => false,
         ]);
 
         $resolver
-            ->setAllowedTypes('withDniAttr', 'boolean')
-            ->setAllowedTypes('withPostcodeAttr', 'boolean');
+            ->setAllowedTypes('with_dni_attr', 'boolean')
+            ->setAllowedTypes('with_postcode_attr', 'boolean');
     }
 
     public function getChoiceAttr($value, $key)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Some options for `CountryChoiceType` used camel case notation which is unlike any other options, so this PR converts them into appropriate snake case options
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No issue, found thanks to documentation PR 
| How to test?  | Check that Customer, Manufacturer and Supplier form still work correctly Especially regarding their feature for DNI and postcode

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18686)
<!-- Reviewable:end -->
