### PR TITLE
Remove unwanted replace and raw calls in twig and fix js error

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
@@ -81,14 +81,16 @@ export default class CurrencyForm {
       return;
     }
 
+    const i18n = new VueI18n({
+      locale: 'en',
+      formatter: new ReplaceFormatter(),
+      messages: {en: this.translations},
+    });
+
     $(`<div id="${this.currencyFormatterId}"></div>`).insertBefore(this.$currencyFormFooter);
     this.currencyFormatter = new Vue({
       el: this.map.currencyFormatter,
-      i18n: new VueI18n({
-        locale: 'en',
-        formatter: new ReplaceFormatter(),
-        messages: {en: this.translations},
-      }),
+      i18n,
       components: {CurrencyFormatter},
       data: this.state,
       template: `<currency-formatter

--- a/admin-dev/themes/new-theme/js/vue/plugins/vue-i18n/replace-formatter.js
+++ b/admin-dev/themes/new-theme/js/vue/plugins/vue-i18n/replace-formatter.js
@@ -38,6 +38,10 @@ export default class ReplaceFormatter {
    * @returns {array}
    */
   interpolate(message, values) {
+    if (!values) {
+      return [message];
+    }
+
     let msg = message;
     Object.keys(values).forEach((param) => {
       msg = msg.replace(param, values[param]);

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -1,27 +1,27 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://devdocs.prestashop.com/ for more information.
+  *
+  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  *#}
 
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
@@ -30,7 +30,7 @@
     'attr': {
       'id': 'currency_form',
       'data-reference-url': path('admin_currencies_get_reference_data', {'currencyIsoCode': 'CURRENCY_ISO_CODE'})|replace({'/CURRENCY_ISO_CODE': '{/id}'}),
-      'data-languages': languages|json_encode|replace("'", "&#39;")|raw,
+      'data-languages': languages|json_encode,
       'data-translations': {
         'step.symbol': '1. Enter symbol'|trans({}, 'Admin.International.Feature'),
         'step.format': '2. Choose format'|trans({}, 'Admin.International.Feature'),
@@ -48,96 +48,95 @@
         'modal.restore.apply': 'Restore'|trans({}, 'Admin.Actions'),
         'modal.restore.cancel': 'Cancel'|trans({}, 'Admin.Actions'),
         'modal.restore.body': 'Restoring your currency\'s default settings will delete all the customizations you made before. Parameters will look just the same as when the currency is freshly imported.'|trans({}, 'Admin.International.Feature')
-      }|json_encode|replace("'", "&#39;")|raw
+      }|json_encode
     }
-  }) }}
+    }) }}
 
-  <div class="card card-currency">
-    <div class="card-header">
-      {{ 'Currencies'|trans({}, 'Admin.Global') }}
-    </div>
-    <div class="card-block row">
-      <div class="card-text">
-        {{ form_errors(currencyForm) }}
+    <div class="card card-currency">
+      <div class="card-header">
+        {{ 'Currencies'|trans({}, 'Admin.Global') }}
+      </div>
+      <div class="card-block row">
+        <div class="card-text">
+          {{ form_errors(currencyForm) }}
 
-        {% if not currencyForm.vars.data.id is defined %}
-          {% set selectIsoCodeHelp %}
+          {% if not currencyForm.vars.data.id is defined %}
+            {% set selectIsoCodeHelp %}
             {{ 'By default, PrestaShop comes with a list of official currencies. If you want to use a local currency, you will have to add it manually. For example, to accept the Iranian Toman on your store, you need to create it before.'|trans({}, 'Admin.International.Help') }}
           {% endset %}
           {{ ps.form_group_row(currencyForm.selected_iso_code, {}, {
             'label': 'Select a currency'|trans({}, 'Admin.International.Feature'),
             'help': selectIsoCodeHelp
-          }) }}
+            }) }}
 
           {{ ps.form_group_row(currencyForm.unofficial, {}, {
             'label': 'or'|trans({}, 'Admin.Global'),
-          }) }}
-        {% endif %}
+            }) }}
+          {% endif %}
 
-        {{ ps.form_group_row(currencyForm.names, {}, {
-          'label': 'Currency name'|trans({}, 'Admin.International.Feature'),
-        }) }}
+          {{ ps.form_group_row(currencyForm.names, {}, {
+            'label': 'Currency name'|trans({}, 'Admin.International.Feature'),
+            }) }}
 
-        {% set symbolsClass = currencyForm.symbols.vars.errors|length ? '' : 'd-none' %}
-        {{ ps.form_group_row(currencyForm.symbols, {}, {
-          'label': 'Symbol'|trans({}, 'Admin.International.Feature'),
-          'class': symbolsClass
-        }) }}
+          {% set symbolsClass = currencyForm.symbols.vars.errors|length ? '' : 'd-none' %}
+          {{ ps.form_group_row(currencyForm.symbols, {}, {
+            'label': 'Symbol'|trans({}, 'Admin.International.Feature'),
+            'class': symbolsClass
+            }) }}
 
-        {{ ps.form_group_row(currencyForm.iso_code, {}, {
-          'label': 'ISO code'|trans({}, 'Admin.International.Feature'),
-          'help': 'ISO 4217 code (e.g. USD for Dollars, EUR for Euros, etc.)'|trans({}, 'Admin.International.Help')
-        }) }}
+          {{ ps.form_group_row(currencyForm.iso_code, {}, {
+            'label': 'ISO code'|trans({}, 'Admin.International.Feature'),
+            'help': 'ISO 4217 code (e.g. USD for Dollars, EUR for Euros, etc.)'|trans({}, 'Admin.International.Help')
+            }) }}
 
-        {% set exchangeRateHelp %}
+          {% set exchangeRateHelp %}
           {{ 'Exchange rates are calculated from one unit of your shop\'s default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1&euro; = $1.20).'|trans({}, 'Admin.International.Help') }}
         {% endset %}
 
         {{ ps.form_group_row(currencyForm.exchange_rate, {}, {
           'label': 'Exchange rate'|trans({}, 'Admin.International.Feature'),
           'help': exchangeRateHelp
-        }) }}
+          }) }}
 
         {{ ps.form_group_row(currencyForm.precision, {}, {
           'label': 'Decimals'|trans({}, 'Admin.International.Feature')
-        }) }}
+          }) }}
 
         {{ ps.form_group_row(currencyForm.active, {}, {
           'label': 'Status'|trans({}, 'Admin.Global'),
-        }) }}
+          }) }}
 
         {{ ps.form_group_row(currencyForm.transformations, {}, {'class': 'd-none'}) }}
 
         {% if isShopFeatureEnabled %}
           {{ ps.form_group_row(currencyForm.shop_association, {}, {
             'label': 'Shop association'|trans({}, 'Admin.Global'),
-          }) }}
+            }) }}
         {% endif %}
 
         {% block currency_form_rest %}
           {{ form_rest(currencyForm) }}
         {% endblock %}
-      </div>
-    </div>
-
-    <div class="card-footer">
-      <div class="card-footer-left">
-        <a href="{{ path('admin_currencies_index') }}" class="btn btn-outline-secondary">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </a>
-
-        {% if currencyForm.vars.data.id is defined and not currencyForm.vars.data.unofficial %}
-          <button type="button" id="currency_reset_default_settings" class="btn btn-outline-primary card-currency-reset">
-            <i class="material-icons">refresh</i>
-            {{ 'Restore default settings'|trans({}, 'Admin.International.Feature') }}
-          </button>
-        {% endif %}
+        </div>
       </div>
 
-      <button type="submit" class="btn btn-primary" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-    </div>
+      <div class="card-footer">
+        <div class="card-footer-left">
+          <a href="{{ path('admin_currencies_index') }}" class="btn btn-outline-secondary">
+            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+          </a>
 
-  </div>
+          {% if currencyForm.vars.data.id is defined and not currencyForm.vars.data.unofficial %}
+            <button type="button" id="currency_reset_default_settings" class="btn btn-outline-primary card-currency-reset">
+              <i class="material-icons">refresh</i>
+              {{ 'Restore default settings'|trans({}, 'Admin.International.Feature') }}
+            </button>
+          {% endif %}
+        </div>
+
+        <button type="submit" class="btn btn-primary" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
   {{ form_end(currencyForm) }}
 
   <!-- Modal -->

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -33,6 +33,7 @@
     {% set isColumnRefundedDisplayed = true %}
   {% endif %}
 {% endfor %}
+
 <div class="card" id="orderProductsPanel">
   <div class="card-header">
     <h3 class="card-header-title">
@@ -108,162 +109,164 @@
         </tbody>
       </table>
 
-    <div class="row mb-3">
-      <div class="col-md-6 text-left d-print-none">
-        <div class="order-product-pagination">
-          <div class="form-group row">
-            <label for="paginator_select_page_limit" class="col-form-label ml-3">{{ "Items per page:"|trans({}, 'Admin.Catalog.Feature') }}</label>
-            <div class="col">
-              <select id="orderProductsTablePaginationNumberSelector" class="pagination-link custom-select">
-                {% for numPageOption in paginationNumOptions %}
-                  <option value="{{ numPageOption }}"{% if numPageOption == paginationNum %} selected{% endif %}>{{ numPageOption }}</option>
-                {% endfor %}
-              </select>
+      <div class="row mb-3">
+        <div class="col-md-6 text-left d-print-none">
+          <div class="order-product-pagination">
+            <div class="form-group row">
+              <label for="paginator_select_page_limit" class="col-form-label ml-3">{{ "Items per page:"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              <div class="col">
+                <select id="orderProductsTablePaginationNumberSelector" class="pagination-link custom-select">
+                  {% for numPageOption in paginationNumOptions %}
+                    <option value="{{ numPageOption }}"{% if numPageOption == paginationNum %} selected{% endif %}>{{ numPageOption }}</option>
+                  {% endfor %}
+                </select>
+              </div>
             </div>
+            {% set numPages = (orderForViewing.products.products|length / paginationNum)|round(0, 'ceil') %}
+            <nav aria-label="Products Navigation"{% if orderForViewing.products.products|length <= paginationNum %} class="d-none"{% endif %} id="orderProductsNavPagination">
+              <ul class="pagination" id="orderProductsTablePagination" data-num-per-page="{{ paginationNum }}" data-num-pages="{{ numPages }}">
+                <li class="page-item disabled" id="orderProductsTablePaginationPrev">
+                  <a class="page-link" href="javascript:void(0);" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                    <span class="sr-only">Previous</span>
+                  </a>
+                </li>
+                {% for numPage in 1..numPages %}
+                  <li class="page-item{% if numPage==1 %} active{% endif %}"><span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page="{{ numPage }}">{{ numPage }}</span></li>
+                {% endfor %}
+                <li class="page-item d-none"><span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page=""></span></li>
+                <li class="page-item" id="orderProductsTablePaginationNext">
+                  <a class="page-link" href="javascript:void(0);" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                    <span class="sr-only">Next</span>
+                  </a>
+                </li>
+              </ul>
+            </nav>
           </div>
-          {% set numPages = (orderForViewing.products.products|length / paginationNum)|round(0, 'ceil') %}
-          <nav aria-label="Products Navigation"{% if orderForViewing.products.products|length <= paginationNum %} class="d-none"{% endif %} id="orderProductsNavPagination">
-            <ul class="pagination" id="orderProductsTablePagination" data-num-per-page="{{ paginationNum }}" data-num-pages="{{ numPages }}">
-              <li class="page-item disabled" id="orderProductsTablePaginationPrev">
-                <a class="page-link" href="javascript:void(0);" aria-label="Previous">
-                  <span aria-hidden="true">&laquo;</span>
-                  <span class="sr-only">Previous</span>
-                </a>
-              </li>
-              {% for numPage in 1..numPages %}
-                <li class="page-item{% if numPage==1 %} active{% endif %}"><span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page="{{ numPage }}">{{ numPage }}</span></li>
-              {% endfor %}
-              <li class="page-item d-none"><span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page=""></span></li>
-              <li class="page-item" id="orderProductsTablePaginationNext">
-                <a class="page-link" href="javascript:void(0);" aria-label="Next">
-                  <span aria-hidden="true">&raquo;</span>
-                  <span class="sr-only">Next</span>
-                </a>
-              </li>
-            </ul>
-          </nav>
-        </div>
 
-        <div class="col-xl-8 text-right discount-action">
-          {% if not orderForViewing.delivered %}
-            <button type="button" class="btn btn-outline-secondary js-product-action-btn mr-3" id="addProductBtn">
-              <i class="material-icons">add_circle_outline</i>
-              {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          <div class="col-xl-8 text-right discount-action">
+            {% if not orderForViewing.delivered %}
+              <button type="button" class="btn btn-outline-secondary js-product-action-btn mr-3" id="addProductBtn">
+                <i class="material-icons">add_circle_outline</i>
+                {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}
+              </button>
+            {% endif %}
+            <button type="button" class="btn btn-outline-secondary js-product-action-btn" data-toggle="modal" data-target="#addOrderDiscountModal">
+              <i class="material-icons">confirmation_number</i>
+              {{ 'Add a discount'|trans({}, 'Admin.Orderscustomers.Feature') }}
             </button>
-          {% endif %}
-          <button type="button" class="btn btn-outline-secondary js-product-action-btn" data-toggle="modal" data-target="#addOrderDiscountModal">
-            <i class="material-icons">confirmation_number</i>
-            {{ 'Add a discount'|trans({}, 'Admin.Orderscustomers.Feature') }}
-          </button>
+          </div>
         </div>
-      </div>
 
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig' with {
-        'discounts': orderForViewing.discounts.discounts,
-        'orderId': orderForViewing.id
-        } %}
+        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig' with {
+          'discounts': orderForViewing.discounts.discounts,
+          'orderId': orderForViewing.id
+          } %}
 
-      <div class="row">
-        <div class="col-md-12">
-          <div class="info-block">
-            <div class="row">
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Products'|trans({}, 'Admin.Global') }}</strong></p>
-                <strong id="orderProductsTotal">{{ orderForViewing.prices.productsPriceFormatted }}</strong>
-              </div>
-
-              <div id="order-discounts-total-container" class="col-sm text-center{% if not orderForViewing.prices.discountsAmountRaw.greaterThan((number(0))) %} d-none{% endif %}">
-                <p class="text-muted mb-0"><strong>{{ 'Discounts'|trans({}, 'Admin.Global') }}</strong></p>
-                <strong id="orderDiscountsTotal">-{{ orderForViewing.prices.discountsAmountFormatted }}</strong>
-              </div>
-
-              {% if orderForViewing.prices.wrappingPriceRaw.greaterThan(number(0)) %}
+        <div class="row">
+          <div class="col-md-12">
+            <div class="info-block">
+              <div class="row">
                 <div class="col-sm text-center">
-                  <p class="text-muted mb-0"><strong>{{ 'Wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong></p>
-                  <strong id="orderWrappingTotal">{{ orderForViewing.prices.wrappingPriceFormatted }}</strong>
+                  <p class="text-muted mb-0"><strong>{{ 'Products'|trans({}, 'Admin.Global') }}</strong></p>
+                  <strong id="orderProductsTotal">{{ orderForViewing.prices.productsPriceFormatted }}</strong>
                 </div>
-              {% endif %}
 
-              {% if orderForViewing.prices.shippingPriceRaw.greaterThan(number(0)) %}
-                <div class="col-sm text-center">
-                  <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
-                  <div class="shipping-price">
-                    <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
-                    <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-                      <div class="input-group">
-                        {{ form_widget(cancelProductForm.shipping_amount) }}
-                        <div class="input-group-append">
-                          <div class="input-group-text">{{ orderCurrency.symbol }}</div>
+                <div id="order-discounts-total-container" class="col-sm text-center{% if not orderForViewing.prices.discountsAmountRaw.greaterThan((number(0))) %} d-none{% endif %}">
+                  <p class="text-muted mb-0"><strong>{{ 'Discounts'|trans({}, 'Admin.Global') }}</strong></p>
+                  <strong id="orderDiscountsTotal">-{{ orderForViewing.prices.discountsAmountFormatted }}</strong>
+                </div>
+
+                {% if orderForViewing.prices.wrappingPriceRaw.greaterThan(number(0)) %}
+                  <div class="col-sm text-center">
+                    <p class="text-muted mb-0"><strong>{{ 'Wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong></p>
+                    <strong id="orderWrappingTotal">{{ orderForViewing.prices.wrappingPriceFormatted }}</strong>
+                  </div>
+                {% endif %}
+
+                {% if orderForViewing.prices.shippingPriceRaw.greaterThan(number(0)) %}
+                  <div class="col-sm text-center">
+                    <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
+                    <div class="shipping-price">
+                      <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
+                      <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+                        <div class="input-group">
+                          {{ form_widget(cancelProductForm.shipping_amount) }}
+                          <div class="input-group-append">
+                            <div class="input-group-text">{{ orderCurrency.symbol }}</div>
+                          </div>
                         </div>
+                        <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
                       </div>
-                      <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
                     </div>
                   </div>
-                </div>
-              {% else %}
-                {# No shippping, the form field is hidden in this div to avoid it being displayed through automatic form_rest #}
-                <div class="d-none">
-                  {{ form_widget(cancelProductForm.shipping_amount) }}
-                </div>
-              {% endif %}
+                {% else %}
+                  {# No shippping, the form field is hidden in this div to avoid it being displayed through automatic form_rest #}
+                  <div class="d-none">
+                    {{ form_widget(cancelProductForm.shipping_amount) }}
+                  </div>
+                {% endif %}
 
-              {% if not orderForViewing.taxIncluded %}
+                {% if not orderForViewing.taxIncluded %}
+                  <div class="col-sm text-center">
+                    <p class="text-muted mb-0"><strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong></p>
+                    <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
+                  </div>
+                {% endif %}
+
                 <div class="col-sm text-center">
-                  <p class="text-muted mb-0"><strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong></p>
-                  <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
+                  <p class="text-muted mb-0"><strong>{{ 'Total'|trans({}, 'Admin.Global') }}</strong></p>
+                  <span class="badge rounded badge-dark font-size-100" id="orderTotal">{{ orderForViewing.prices.totalAmountFormatted }}</span>
                 </div>
-              {% endif %}
 
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Total'|trans({}, 'Admin.Global') }}</strong></p>
-                <span class="badge rounded badge-dark font-size-100" id="orderTotal">{{ orderForViewing.prices.totalAmountFormatted }}</span>
-              </div>
-
-            </div>
-          </div>
-        </div>
-        <div class="col-md-12">
-          <p class="mb-0 mt-1 text-center text-muted">
-            <small>
-              {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
-                '%tax_method%': orderForViewing.taxMethod,
-                '[1]': '<strong>',
-                '[/1]': '</strong>'
-                }, 'Admin.Orderscustomers.Notification')|raw }}.
-
-              {% if not 'PS_ORDER_RETURN'|configuration %}
-                <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
-              {% endif %}
-            </small>
-          </p>
-          <div class="cancel-product-element refund-checkboxes-container">
-            <div class="cancel-product-element form-group restock-products">
-              {{ form_widget(cancelProductForm.restock) }}
-            </div>
-            <div class="cancel-product-element form-group refund-credit-slip">
-              {{ form_widget(cancelProductForm.credit_slip) }}
-            </div>
-            <div class="cancel-product-element form-group refund-voucher">
-              {{ form_widget(cancelProductForm.voucher) }}
-            </div>
-            <div class="cancel-product-element shipping-refund{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-              <div class="form-group">
-                {{ form_widget(cancelProductForm.shipping) }}
-                <small class="shipping-refund-amount">({{ orderForViewing.prices.shippingRefundableAmountFormatted }})</small>
-              </div>
-            </div>
-            <div class="cancel-product-element form-group voucher-refund-type{% if orderForViewing.prices.discountsAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-              {{ 'This order has been partially paid by voucher. Choose the amount you want to refund:'|trans({}, 'Admin.Orderscustomers.Feature') }}
-              {{ form_widget(cancelProductForm.voucher_refund_type) }}
-              <div class="voucher-refund-type-negative-error">
-                {{ 'Error. You cannot refund a negative amount.'|trans({}, 'Admin.Orderscustomers.Notification') }}
               </div>
             </div>
           </div>
-        </div>
-        <div class="cancel-product-element form-submit text-right">
-          {{ form_widget(cancelProductForm.cancel) }}
-          {{ form_widget(cancelProductForm.save) }}
+
+          <div class="col-md-12">
+            <p class="mb-0 mt-1 text-center text-muted">
+              <small>
+                {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
+                  '%tax_method%': orderForViewing.taxMethod,
+                  '[1]': '<strong>',
+                  '[/1]': '</strong>'
+                  }, 'Admin.Orderscustomers.Notification')|raw }}.
+
+                {% if not 'PS_ORDER_RETURN'|configuration %}
+                  <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
+                {% endif %}
+              </small>
+            </p>
+            <div class="cancel-product-element refund-checkboxes-container">
+              <div class="cancel-product-element form-group restock-products">
+                {{ form_widget(cancelProductForm.restock) }}
+              </div>
+              <div class="cancel-product-element form-group refund-credit-slip">
+                {{ form_widget(cancelProductForm.credit_slip) }}
+              </div>
+              <div class="cancel-product-element form-group refund-voucher">
+                {{ form_widget(cancelProductForm.voucher) }}
+              </div>
+              <div class="cancel-product-element shipping-refund{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+                <div class="form-group">
+                  {{ form_widget(cancelProductForm.shipping) }}
+                  <small class="shipping-refund-amount">({{ orderForViewing.prices.shippingRefundableAmountFormatted }})</small>
+                </div>
+              </div>
+              <div class="cancel-product-element form-group voucher-refund-type{% if orderForViewing.prices.discountsAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+                {{ 'This order has been partially paid by voucher. Choose the amount you want to refund:'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                {{ form_widget(cancelProductForm.voucher_refund_type) }}
+                <div class="voucher-refund-type-negative-error">
+                  {{ 'Error. You cannot refund a negative amount.'|trans({}, 'Admin.Orderscustomers.Notification') }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="cancel-product-element form-submit text-right">
+            {{ form_widget(cancelProductForm.cancel) }}
+            {{ form_widget(cancelProductForm.save) }}
+          </div>
         </div>
       </div>
     {{ form_end(cancelProductForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -1,27 +1,27 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://devdocs.prestashop.com/ for more information.
+  *
+  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  *#}
 
 {% set isColumnLocationDisplayed = false %}
 {% set isColumnRefundedDisplayed = false %}
@@ -47,66 +47,66 @@
         'data-is-delivered': orderForViewing.isDelivered,
         'data-is-tax-included': orderForViewing.isTaxIncluded,
         'data-discounts-amount': orderForViewing.prices.discountsAmountRaw,
-        'data-price-specification': priceSpecification|json_encode|replace("'", "&#39;")|raw
+        'data-price-specification': priceSpecification|json_encode
       }
-    } %}
+      } %}
     {{ form_start(cancelProductForm, formOptions) }}
-    <table class="table" id="orderProductsTable" data-currency-precision="{{ orderCurrency.precision }}">
-      <thead>
-      <tr>
-        <th>
-          <p>{{ 'Product'|trans({}, 'Admin.Global') }}</p>
-        </th>
-        <th></th>
-        <th>
-          <p class="mb-0">{{ 'Price per unit'|trans({}, 'Admin.Advparameters.Feature') }}</p>
-          <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
-        </th>
-        <th>
-          <p>{{ 'Quantity'|trans({}, 'Admin.Global') }}</p>
-        </th>
-        <th class="cellProductLocation{% if not isColumnLocationDisplayed %} d-none{% endif %}">
-          <p>{{ 'Stock location'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
-        </th>
-        <th class="cellProductRefunded{% if not isColumnRefundedDisplayed %} d-none{% endif %}">
-          <p>{{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
-        </th>
-        <th>
-          <p>{{ 'Available'|trans({}, 'Admin.Global') }}</p>
-        </th>
-        <th>
-          <p class="mb-0">{{ 'Total'|trans({}, 'Admin.Global') }}</p>
-          <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
-        </th>
-        {% if orderForViewing.hasInvoice() %}
-          <th>
-            <p>{{ 'Invoice'|trans({}, 'Admin.Global') }}</p>
-          </th>
-        {% endif %}
-        {% if not orderForViewing.delivered %}
-          <th class="text-right product_actions d-print-none">
-            <p>{{ 'Actions'|trans({}, 'Admin.Global') }}</p>
-          </th>
-        {% endif %}
-        <th class="text-center cancel-product-element">
-          <p>{{ 'Partial refund'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      {% for product in orderForViewing.products.products %}
-        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/product.html.twig' with {
-          'product': product,
-          'productIndex': loop.index,
-          'paginationNum': paginationNum,
-          'isColumnLocationDisplayed': isColumnLocationDisplayed,
-          'isColumnRefundedDisplayed': isColumnRefundedDisplayed
-        } %}
-      {% endfor %}
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig' %}
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig' %}
-      </tbody>
-    </table>
+      <table class="table" id="orderProductsTable" data-currency-precision="{{ orderCurrency.precision }}">
+        <thead>
+          <tr>
+            <th>
+              <p>{{ 'Product'|trans({}, 'Admin.Global') }}</p>
+            </th>
+            <th></th>
+            <th>
+              <p class="mb-0">{{ 'Price per unit'|trans({}, 'Admin.Advparameters.Feature') }}</p>
+              <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
+            </th>
+            <th>
+              <p>{{ 'Quantity'|trans({}, 'Admin.Global') }}</p>
+            </th>
+            <th class="cellProductLocation{% if not isColumnLocationDisplayed %} d-none{% endif %}">
+              <p>{{ 'Stock location'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+            </th>
+            <th class="cellProductRefunded{% if not isColumnRefundedDisplayed %} d-none{% endif %}">
+              <p>{{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+            </th>
+            <th>
+              <p>{{ 'Available'|trans({}, 'Admin.Global') }}</p>
+            </th>
+            <th>
+              <p class="mb-0">{{ 'Total'|trans({}, 'Admin.Global') }}</p>
+              <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
+            </th>
+            {% if orderForViewing.hasInvoice() %}
+              <th>
+                <p>{{ 'Invoice'|trans({}, 'Admin.Global') }}</p>
+              </th>
+            {% endif %}
+            {% if not orderForViewing.delivered %}
+              <th class="text-right product_actions d-print-none">
+                <p>{{ 'Actions'|trans({}, 'Admin.Global') }}</p>
+              </th>
+            {% endif %}
+            <th class="text-center cancel-product-element">
+              <p>{{ 'Partial refund'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for product in orderForViewing.products.products %}
+            {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/product.html.twig' with {
+              'product': product,
+              'productIndex': loop.index,
+              'paginationNum': paginationNum,
+              'isColumnLocationDisplayed': isColumnLocationDisplayed,
+              'isColumnRefundedDisplayed': isColumnRefundedDisplayed
+              } %}
+          {% endfor %}
+          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig' %}
+          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig' %}
+        </tbody>
+      </table>
 
     <div class="row mb-3">
       <div class="col-md-6 text-left d-print-none">
@@ -144,129 +144,128 @@
           </nav>
         </div>
 
-      </div>
-      <div class="col-xl-8 text-right discount-action">
-        {% if not orderForViewing.delivered %}
-          <button type="button" class="btn btn-outline-secondary js-product-action-btn mr-3" id="addProductBtn">
-            <i class="material-icons">add_circle_outline</i>
-            {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        <div class="col-xl-8 text-right discount-action">
+          {% if not orderForViewing.delivered %}
+            <button type="button" class="btn btn-outline-secondary js-product-action-btn mr-3" id="addProductBtn">
+              <i class="material-icons">add_circle_outline</i>
+              {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}
+            </button>
+          {% endif %}
+          <button type="button" class="btn btn-outline-secondary js-product-action-btn" data-toggle="modal" data-target="#addOrderDiscountModal">
+            <i class="material-icons">confirmation_number</i>
+            {{ 'Add a discount'|trans({}, 'Admin.Orderscustomers.Feature') }}
           </button>
-        {% endif %}
-        <button type="button" class="btn btn-outline-secondary js-product-action-btn" data-toggle="modal" data-target="#addOrderDiscountModal">
-          <i class="material-icons">confirmation_number</i>
-          {{ 'Add a discount'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </button>
+        </div>
       </div>
-    </div>
 
-    {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig' with {
-      'discounts': orderForViewing.discounts.discounts,
-      'orderId': orderForViewing.id
-    } %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig' with {
+        'discounts': orderForViewing.discounts.discounts,
+        'orderId': orderForViewing.id
+        } %}
 
-    <div class="row">
-      <div class="col-md-12">
-        <div class="info-block">
-          <div class="row">
-            <div class="col-sm text-center">
-              <p class="text-muted mb-0"><strong>{{ 'Products'|trans({}, 'Admin.Global') }}</strong></p>
-              <strong id="orderProductsTotal">{{ orderForViewing.prices.productsPriceFormatted }}</strong>
-            </div>
-
-            <div id="order-discounts-total-container" class="col-sm text-center{% if not orderForViewing.prices.discountsAmountRaw.greaterThan((number(0))) %} d-none{% endif %}">
-              <p class="text-muted mb-0"><strong>{{ 'Discounts'|trans({}, 'Admin.Global') }}</strong></p>
-              <strong id="orderDiscountsTotal">-{{ orderForViewing.prices.discountsAmountFormatted }}</strong>
-            </div>
-
-            {% if orderForViewing.prices.wrappingPriceRaw.greaterThan(number(0)) %}
+      <div class="row">
+        <div class="col-md-12">
+          <div class="info-block">
+            <div class="row">
               <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong></p>
-                <strong id="orderWrappingTotal">{{ orderForViewing.prices.wrappingPriceFormatted }}</strong>
+                <p class="text-muted mb-0"><strong>{{ 'Products'|trans({}, 'Admin.Global') }}</strong></p>
+                <strong id="orderProductsTotal">{{ orderForViewing.prices.productsPriceFormatted }}</strong>
               </div>
-            {% endif %}
 
-            {% if orderForViewing.prices.shippingPriceRaw.greaterThan(number(0)) %}
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
-                <div class="shipping-price">
-                  <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
-                  <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-                    <div class="input-group">
-                      {{ form_widget(cancelProductForm.shipping_amount) }}
-                      <div class="input-group-append">
-                        <div class="input-group-text">{{ orderCurrency.symbol }}</div>
+              <div id="order-discounts-total-container" class="col-sm text-center{% if not orderForViewing.prices.discountsAmountRaw.greaterThan((number(0))) %} d-none{% endif %}">
+                <p class="text-muted mb-0"><strong>{{ 'Discounts'|trans({}, 'Admin.Global') }}</strong></p>
+                <strong id="orderDiscountsTotal">-{{ orderForViewing.prices.discountsAmountFormatted }}</strong>
+              </div>
+
+              {% if orderForViewing.prices.wrappingPriceRaw.greaterThan(number(0)) %}
+                <div class="col-sm text-center">
+                  <p class="text-muted mb-0"><strong>{{ 'Wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong></p>
+                  <strong id="orderWrappingTotal">{{ orderForViewing.prices.wrappingPriceFormatted }}</strong>
+                </div>
+              {% endif %}
+
+              {% if orderForViewing.prices.shippingPriceRaw.greaterThan(number(0)) %}
+                <div class="col-sm text-center">
+                  <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
+                  <div class="shipping-price">
+                    <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
+                    <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+                      <div class="input-group">
+                        {{ form_widget(cancelProductForm.shipping_amount) }}
+                        <div class="input-group-append">
+                          <div class="input-group-text">{{ orderCurrency.symbol }}</div>
+                        </div>
                       </div>
+                      <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
                     </div>
-                    <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
                   </div>
                 </div>
-              </div>
-            {% else %}
-              {# No shippping, the form field is hidden in this div to avoid it being displayed through automatic form_rest #}
-              <div class="d-none">
-                {{ form_widget(cancelProductForm.shipping_amount) }}
-              </div>
-            {% endif %}
+              {% else %}
+                {# No shippping, the form field is hidden in this div to avoid it being displayed through automatic form_rest #}
+                <div class="d-none">
+                  {{ form_widget(cancelProductForm.shipping_amount) }}
+                </div>
+              {% endif %}
 
-            {% if not orderForViewing.taxIncluded %}
+              {% if not orderForViewing.taxIncluded %}
+                <div class="col-sm text-center">
+                  <p class="text-muted mb-0"><strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong></p>
+                  <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
+                </div>
+              {% endif %}
+
               <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong></p>
-                <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
+                <p class="text-muted mb-0"><strong>{{ 'Total'|trans({}, 'Admin.Global') }}</strong></p>
+                <span class="badge rounded badge-dark font-size-100" id="orderTotal">{{ orderForViewing.prices.totalAmountFormatted }}</span>
               </div>
-            {% endif %}
 
-            <div class="col-sm text-center">
-              <p class="text-muted mb-0"><strong>{{ 'Total'|trans({}, 'Admin.Global') }}</strong></p>
-              <span class="badge rounded badge-dark font-size-100" id="orderTotal">{{ orderForViewing.prices.totalAmountFormatted }}</span>
-            </div>
-
-          </div>
-        </div>
-      </div>
-      <div class="col-md-12">
-        <p class="mb-0 mt-1 text-center text-muted">
-          <small>
-            {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
-              '%tax_method%': orderForViewing.taxMethod,
-              '[1]': '<strong>',
-              '[/1]': '</strong>'
-            }, 'Admin.Orderscustomers.Notification')|raw }}.
-
-            {% if not 'PS_ORDER_RETURN'|configuration %}
-              <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
-            {% endif %}
-          </small>
-        </p>
-        <div class="cancel-product-element refund-checkboxes-container">
-          <div class="cancel-product-element form-group restock-products">
-            {{ form_widget(cancelProductForm.restock) }}
-          </div>
-          <div class="cancel-product-element form-group refund-credit-slip">
-            {{ form_widget(cancelProductForm.credit_slip) }}
-          </div>
-          <div class="cancel-product-element form-group refund-voucher">
-            {{ form_widget(cancelProductForm.voucher) }}
-          </div>
-          <div class="cancel-product-element shipping-refund{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-            <div class="form-group">
-              {{ form_widget(cancelProductForm.shipping) }}
-              <small class="shipping-refund-amount">({{ orderForViewing.prices.shippingRefundableAmountFormatted }})</small>
-            </div>
-          </div>
-          <div class="cancel-product-element form-group voucher-refund-type{% if orderForViewing.prices.discountsAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-            {{ 'This order has been partially paid by voucher. Choose the amount you want to refund:'|trans({}, 'Admin.Orderscustomers.Feature') }}
-            {{ form_widget(cancelProductForm.voucher_refund_type) }}
-            <div class="voucher-refund-type-negative-error">
-              {{ 'Error. You cannot refund a negative amount.'|trans({}, 'Admin.Orderscustomers.Notification') }}
             </div>
           </div>
         </div>
+        <div class="col-md-12">
+          <p class="mb-0 mt-1 text-center text-muted">
+            <small>
+              {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
+                '%tax_method%': orderForViewing.taxMethod,
+                '[1]': '<strong>',
+                '[/1]': '</strong>'
+                }, 'Admin.Orderscustomers.Notification')|raw }}.
+
+              {% if not 'PS_ORDER_RETURN'|configuration %}
+                <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
+              {% endif %}
+            </small>
+          </p>
+          <div class="cancel-product-element refund-checkboxes-container">
+            <div class="cancel-product-element form-group restock-products">
+              {{ form_widget(cancelProductForm.restock) }}
+            </div>
+            <div class="cancel-product-element form-group refund-credit-slip">
+              {{ form_widget(cancelProductForm.credit_slip) }}
+            </div>
+            <div class="cancel-product-element form-group refund-voucher">
+              {{ form_widget(cancelProductForm.voucher) }}
+            </div>
+            <div class="cancel-product-element shipping-refund{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+              <div class="form-group">
+                {{ form_widget(cancelProductForm.shipping) }}
+                <small class="shipping-refund-amount">({{ orderForViewing.prices.shippingRefundableAmountFormatted }})</small>
+              </div>
+            </div>
+            <div class="cancel-product-element form-group voucher-refund-type{% if orderForViewing.prices.discountsAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+              {{ 'This order has been partially paid by voucher. Choose the amount you want to refund:'|trans({}, 'Admin.Orderscustomers.Feature') }}
+              {{ form_widget(cancelProductForm.voucher_refund_type) }}
+              <div class="voucher-refund-type-negative-error">
+                {{ 'Error. You cannot refund a negative amount.'|trans({}, 'Admin.Orderscustomers.Notification') }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="cancel-product-element form-submit text-right">
+          {{ form_widget(cancelProductForm.cancel) }}
+          {{ form_widget(cancelProductForm.save) }}
+        </div>
       </div>
-      <div class="cancel-product-element form-submit text-right">
-        {{ form_widget(cancelProductForm.cancel) }}
-        {{ form_widget(cancelProductForm.save) }}
-      </div>
-    </div>
     {{ form_end(cancelProductForm) }}
   </div>
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Because we use the `attr` form option, we don't need to use `replace|raw` after a json_encode. Values are automatically escape for `html_attr`. There is also a js error with how translations are parsed in the custom VueJs replace formatter.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Product and currencies can be edited: http://ps-develop.localhost/admin-dev/index.php/sell/orders/orders/5/view<br>http://ps-develop.localhost/admin-dev/index.php/improve/international/currencies/1/edit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18690)
<!-- Reviewable:end -->
