### PR TITLE
Introduce smart price search for Catalog Price rule query builder

### DIFF
--- a/src/Core/Grid/Query/CatalogPriceRuleQueryBuilder.php
+++ b/src/Core/Grid/Query/CatalogPriceRuleQueryBuilder.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
+use InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -225,13 +226,13 @@ final class CatalogPriceRuleQueryBuilder extends AbstractDoctrineQueryBuilder
     private function findNumberOfDecimals($value): int
     {
         if (!is_string($value)) {
-            throw new \InvalidArgumentException('Expected string');
+            throw new InvalidArgumentException('Expected string');
         }
 
         $numberOfDecimals = 0;
         $explodedValue = explode('.', $value);
 
-        if (count($explodedValue) > 1) {
+        if (isset($explodedValue[1])) {
             $numberOfDecimals = strlen($explodedValue[1]);
         }
 

--- a/src/Core/Grid/Query/CatalogPriceRuleQueryBuilder.php
+++ b/src/Core/Grid/Query/CatalogPriceRuleQueryBuilder.php
@@ -93,8 +93,7 @@ final class CatalogPriceRuleQueryBuilder extends AbstractDoctrineQueryBuilder
         );
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
-            ->applySorting($searchCriteria, $qb)
-        ;
+            ->applySorting($searchCriteria, $qb);
 
         return $qb;
     }
@@ -105,8 +104,7 @@ final class CatalogPriceRuleQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(DISTINCT pr.`id_specific_price_rule`)')
-        ;
+            ->select('COUNT(DISTINCT pr.`id_specific_price_rule`)');
 
         return $qb;
     }
@@ -146,8 +144,7 @@ final class CatalogPriceRuleQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'group_lang',
                 'pr_group',
                 'pr_group.`id_group` = pr.`id_group` AND pr_group.`id_lang` = :contextLangId'
-            )
-        ;
+            );
 
         $this->applyFilters($qb, $filters);
         $qb->setParameter('contextLangId', $this->contextIdLang);
@@ -176,7 +173,7 @@ final class CatalogPriceRuleQueryBuilder extends AbstractDoctrineQueryBuilder
             'group_name' => 'pr_group.name',
         ];
 
-        $exactMatchFilters = ['id_specific_price_rule', 'from_quantity', 'reduction', 'reduction_type'];
+        $exactMatchFilters = ['id_specific_price_rule', 'from_quantity', 'reduction_type'];
 
         foreach ($filters as $filterName => $value) {
             if (!array_key_exists($filterName, $allowedFiltersAliasMap)) {
@@ -203,8 +200,41 @@ final class CatalogPriceRuleQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
+            if ($filterName === 'reduction') {
+                $numberOfDecimals = $this->findNumberOfDecimals($value);
+                // using TRUNCATE in order to have smart price searches
+                // Smart price searches means:
+                // searching for "10" will return both 10.0, 10.1 and 10.2
+                // searching for "10.0" will only return 10.0
+                // searching for "10.1" will only return 10.1
+                $qb->andWhere('TRUNCATE(' . $allowedFiltersAliasMap[$filterName] . ',' . $numberOfDecimals . ') = :' . $filterName);
+                $qb->setParameter($filterName, $value);
+                continue;
+            }
+
             $qb->andWhere($allowedFiltersAliasMap[$filterName] . ' LIKE :' . $filterName);
             $qb->setParameter($filterName, "%$value%");
         }
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return int
+     */
+    private function findNumberOfDecimals($value): int
+    {
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException('Expected string');
+        }
+
+        $numberOfDecimals = 0;
+        $explodedValue = explode('.', $value);
+
+        if (count($explodedValue) > 1) {
+            $numberOfDecimals = strlen($explodedValue[1]);
+        }
+
+        return $numberOfDecimals;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow Catalog Price rule query builder to consider number of decimals used to search for prices and truncate accordingly search dataset, allowing "smart" searches. See scenario below to fully understand.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/15890
| How to test?  | See below

## How to test

Go on migrated (hidden) page `admin-dev/index.php/sell/catalog/catalog-price-rules`.
Create 2 catalog price rules: one with reduction of 10.0 and the other one with reduction of 10.1.
Before this PR, in listing, try to search using "reduction" field with value 10. You will only see 1 result: the row with 10.0 . This is because the code considers 10 is equal to 10.000000 .
With this PR
- if you search "10" you will see results 10.0 and 10.1
- if you search "10.1" you will see result 10.1
- if you search "10.0" you will see result 10.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18691)
<!-- Reviewable:end -->
