### PR TITLE
Fix error when updating a used address with no DNI

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -347,7 +347,7 @@ class AddressCore extends ObjectModel
         }
 
         // Special validation for dni, check if the country needs it
-        if (static::dniRequired((int) $this->id_country) && Tools::isEmpty($value)) {
+        if (!$this->deleted && static::dniRequired((int) $this->id_country) && Tools::isEmpty($value)) {
             if ($human_errors) {
                 return $this->trans(
                     'The %s field is required.',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7
| Description?  |  When the DNI required settings is turned on, existing used addresses with no DNI cannot be updated.<br>When an address is already used, the model is not modified, a copy is created and the original is flagged as deleted. When PrestaShop fetches the data to flag the original model, the validation fails.
| Type?         | Bug fix
| Category?     | CO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | #18740
| How to test?  | 1. Set the DNI to not required for the default country<br>2. Create an address<br>3. Create an order to use the address<br>4. Set the DNI to required for the country's address<br>5. Update the address<br>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18697)
<!-- Reviewable:end -->
