### PR TITLE
Fix "mixed content" message.

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/employee_name_with_avatar.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/employee_name_with_avatar.html.twig
@@ -25,7 +25,7 @@
 
 {% if record.employee is not null %}
   {%
-    set employeeName, employeeImage = record.employee, 'http://profile.prestashop.com/'~record.email|url_encode~'.jpg'
+    set employeeName, employeeImage = record.employee, 'https://profile.prestashop.com/'~record.email|url_encode~'.jpg'
   %}
   <span class="employee_avatar_small">
     <img class="img rounded-circle" alt="{{ employeeName }}" src="{{ employeeImage }}" height="32" width="32" />


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Due to the non-secure loading protocol of the employee image (avatar), the web browser showed a warning message of mixed content when checking logs backoffice webpage. Fixed by replacing it with the secure protocol (https). You can find version details below this table.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18734.
| How to test?  | To check it's fixed and working fine, please go to backoffice, clic on Advanced -> Logs, wait until the page is fully loaded and then, check the security information of web browser.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Firefox Developer Edition 76.0b6 64 bits
PrestaShop 1.7.6.5
PHP 7.2.25
Advanced -> Logs backoffice menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18735)
<!-- Reviewable:end -->
