### PR TITLE
Address State field drop down is ordered by ID, instead of State Name

### DIFF
--- a/classes/State.php
+++ b/classes/State.php
@@ -206,18 +206,22 @@ class StateCore extends ObjectModel
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null
      */
-    public static function getStatesByIdCountry($idCountry, $active = false)
+    public static function getStatesByIdCountry($idCountry, $active = false, $orderBy = null)
     {
         if (empty($idCountry)) {
             die(Tools::displayError());
         }
 
-        return Db::getInstance()->executeS(
-            '
-			SELECT *
-			FROM `' . _DB_PREFIX_ . 'state` s
-			WHERE s.`id_country` = ' . (int) $idCountry . ($active ? ' AND s.active = 1' : '')
-        );
+        $sql = new DbQuery();
+        $sql->select('*');
+        $sql->from('state', 's');
+        $sql->where('s.id_country = ' . (int) $idCountry . ($active ? ' AND s.active = 1' : ''));
+
+        if (array_key_exists($orderBy, self::$definition['fields'])) {
+            $sql->orderBy($orderBy);
+        }
+
+        return Db::getInstance()->executeS($sql);
     }
 
     /**

--- a/classes/State.php
+++ b/classes/State.php
@@ -204,14 +204,17 @@ class StateCore extends ObjectModel
      * @param int $idCountry Country ID
      * @param bool $active true if the state must be active
      * @param string $orderBy order by field
+     * @param string $sort sort key (ASC or DESC)
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null
      */
-    public static function getStatesByIdCountry($idCountry, $active = false, $orderBy = null)
+    public static function getStatesByIdCountry($idCountry, $active = false, $orderBy = null, $sort = 'ASC')
     {
         if (empty($idCountry)) {
             die(Tools::displayError());
         }
+
+        $available_sort = ['DESC', 'ASC', 'asc', 'desc'];
 
         $sql = new DbQuery();
         $sql->select('*');
@@ -219,6 +222,10 @@ class StateCore extends ObjectModel
         $sql->where('s.id_country = ' . (int) $idCountry . ($active ? ' AND s.active = 1' : ''));
 
         if (array_key_exists($orderBy, static::$definition['fields'])) {
+            $sort = trim($sort);
+            if (in_array($sort, $available_sort)) {
+                $orderBy = $orderBy . ' ' . $sort;
+            }
             $sql->orderBy($orderBy);
         }
 

--- a/classes/State.php
+++ b/classes/State.php
@@ -203,6 +203,7 @@ class StateCore extends ObjectModel
      *
      * @param int $idCountry Country ID
      * @param bool $active true if the state must be active
+     * @param string $orderBy order by field
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null
      */
@@ -217,7 +218,7 @@ class StateCore extends ObjectModel
         $sql->from('state', 's');
         $sql->where('s.id_country = ' . (int) $idCountry . ($active ? ' AND s.active = 1' : ''));
 
-        if (array_key_exists($orderBy, self::$definition['fields'])) {
+        if (array_key_exists($orderBy, static::$definition['fields'])) {
             $sql->orderBy($orderBy);
         }
 

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -119,7 +119,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     }
                 } elseif ($entity === 'State') {
                     if ($this->country->contains_states) {
-                        $states = State::getStatesByIdCountry($this->country->id, true, 'name');
+                        $states = State::getStatesByIdCountry($this->country->id, true, 'name', 'asc');
                         foreach ($states as $state) {
                             $formField->addAvailableValue(
                                 $state['id_state'],

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -119,7 +119,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     }
                 } elseif ($entity === 'State') {
                     if ($this->country->contains_states) {
-                        $states = State::getStatesByIdCountry($this->country->id, true);
+                        $states = State::getStatesByIdCountry($this->country->id, true, 'name');
                         foreach ($states as $state) {
                             $formField->addAvailableValue(
                                 $state['id_state'],

--- a/src/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CountryStateByIdChoiceProvider.php
@@ -56,7 +56,7 @@ final class CountryStateByIdChoiceProvider implements ConfigurableFormChoiceProv
                 return [];
             }
 
-            $states = State::getStatesByIdCountry($countryId, $resolvedOptions['only_active']);
+            $states = State::getStatesByIdCountry($countryId, $resolvedOptions['only_active'], 'name', 'asc');
 
             foreach ($states as $state) {
                 $choices[$state['name']] = $state['id_state'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Anywhere where Address field is displayed (in client are or during checkout), the drop down with States orders values by database ID and not name field.This makes the newly added States appear last in the list, thus confusing customer who will not see his State unless he will scroll to the bottom of the list
| Type?         | refacto 
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18731.
| How to test?  | See #18731 by @vitciobanu.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18736)
<!-- Reviewable:end -->
