### PR TITLE
Add a condition to avoid currency name repeat

### DIFF
--- a/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
+++ b/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
@@ -33,13 +33,13 @@
     <ul class="dropdown-menu hidden-sm-down" aria-labelledby="currency-selector-label">
       {foreach from=$currencies item=currency}
         <li {if $currency.current} class="current" {/if}>
-          <a title="{$currency.name}" rel="nofollow" href="{$currency.url}" class="dropdown-item">{$currency.iso_code} {$currency.sign}</a>
+          <a title="{$currency.name}" rel="nofollow" href="{$currency.url}" class="dropdown-item">{$currency.iso_code}{if $currency.sign !== $currency.iso_code} {$currency.sign}{/if}</a>
         </li>
       {/foreach}
     </ul>
     <select class="link hidden-md-up" aria-labelledby="currency-selector-label">
       {foreach from=$currencies item=currency}
-        <option value="{$currency.url}"{if $currency.current} selected="selected"{/if}>{$currency.iso_code} {$currency.sign}</option>
+        <option value="{$currency.url}"{if $currency.current} selected="selected"{/if}>{$currency.iso_code}{if $currency.sign !== $currency.iso_code} {$currency.sign}{/if}</option>
       {/foreach}
     </select>
   </div>

--- a/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
+++ b/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
@@ -27,7 +27,7 @@
   <div class="currency-selector dropdown js-dropdown">
     <span id="currency-selector-label">{l s='Currency:' d='Shop.Theme.Global'}</span>
     <button data-target="#" data-toggle="dropdown" class="hidden-sm-down btn-unstyle" aria-haspopup="true" aria-expanded="false" aria-label="{l s='Currency dropdown' d='Shop.Theme.Global'}">
-      <span class="expand-more _gray-darker">{$current_currency.iso_code} {$current_currency.sign}</span>
+      <span class="expand-more _gray-darker">{$current_currency.iso_code} {if $current_currency.iso_code !== $current_currency.sign}{$current_currency.sign}{/if}</span>
       <i class="material-icons expand-more">&#xE5C5;</i>
     </button>
     <ul class="dropdown-menu hidden-sm-down" aria-labelledby="currency-selector-label">

--- a/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
+++ b/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
@@ -27,7 +27,7 @@
   <div class="currency-selector dropdown js-dropdown">
     <span id="currency-selector-label">{l s='Currency:' d='Shop.Theme.Global'}</span>
     <button data-target="#" data-toggle="dropdown" class="hidden-sm-down btn-unstyle" aria-haspopup="true" aria-expanded="false" aria-label="{l s='Currency dropdown' d='Shop.Theme.Global'}">
-      <span class="expand-more _gray-darker">{$current_currency.iso_code} {if $current_currency.iso_code !== $current_currency.sign}{$current_currency.sign}{/if}</span>
+      <span class="expand-more _gray-darker">{$current_currency.iso_code}{if $current_currency.iso_code !== $current_currency.sign} {$current_currency.sign}{/if}</span>
       <i class="material-icons expand-more">&#xE5C5;</i>
     </button>
     <ul class="dropdown-menu hidden-sm-down" aria-labelledby="currency-selector-label">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On currency which has the same ISO Code as their sign, we see a duplicate name on the top selector
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9692.
| How to test?  | Create a currency which as TEST as iso code and TEST as sign, see if it's duplicate on FO

https://github.com/PrestaShop/ps_currencyselector/pull/17 Should also be merged

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18739)
<!-- Reviewable:end -->
