### PR TITLE
Missing location for nginx pretty-urls

### DIFF
--- a/docs/server_config/nginx.conf.dist
+++ b/docs/server_config/nginx.conf.dist
@@ -162,6 +162,10 @@ server {
             deny all;
         }
     }
+    
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
 
     # PHP FPM part
     location ~ \.php$ {


### PR DESCRIPTION
Default nginx.conf.dist is missing a location definition to make pretty-urls fully working

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | develop / 1.7.7.x
| Description  | Fix missing location in nginx config to make rewrite work correctly
| Type         | improvement
| Category     | FO
| BC breaks    | no
| Deprecations | no
| How to test  | Make a clean install and use only the provided config. Products were not browsable, all catalog requests responded with a 404 Error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18746)
<!-- Reviewable:end -->
