### PR TITLE
Fix wrong image path in the colorPicker when using renderOptions

### DIFF
--- a/admin-dev/themes/default/template/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/helpers/options/options.tpl
@@ -387,3 +387,6 @@
 </script>
 {/if}
 {/block}
+<script type="text/javascript">
+  $.fn.mColorPicker.defaults.imageFolder = baseDir + 'img/admin/';
+</script>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix wrong image path in the colorPicker when using renderOptions
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18766
| How to test?  | 1. Generate a new module that has adminController<br>2. Add fields_options with at least one field of "color" type in the adminController and then install module<br>3. See wrong image in the colorPicker of moduleAdminController 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18757)
<!-- Reviewable:end -->
