### PR TITLE
Introduce CompilerPass to perform ControllerAwareTrait injection

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,9 +23,7 @@ services:
         exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
         tags:
           - 'controller.service_arguments'
-          - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS
-
-
+          - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG
 
 framework:
     assets:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -21,7 +21,11 @@ services:
     PrestaShopBundle\Controller\:
         resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
         exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
-        tags: ['prestashop.core.controllers', 'controller.service_arguments']
+        tags:
+          - 'controller.service_arguments'
+          - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS
+
+
 
 framework:
     assets:

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -49,7 +49,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class FrameworkBundleAdminController extends Controller
 {
-    const PRESTASHOP_CORE_CONTROLLERS = 'prestashop.core.controllers';
+    const PRESTASHOP_CORE_CONTROLLERS_TAG = 'prestashop.core.controllers';
 
     /**
      * @var ConfigurationInterface

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -49,6 +49,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class FrameworkBundleAdminController extends Controller
 {
+    const PRESTASHOP_CORE_CONTROLLERS = 'prestashop.core.controllers';
+
     /**
      * @var ConfigurationInterface
      */

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ContainerAwareControllersManualInjectionPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ContainerAwareControllersManualInjectionPass.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShopBundle\DependencyInjection\Compiler;
+
+use InvalidArgumentException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Decorated controllers using ControllerAwareTrait
+ * cannot be injected the container as the injection is performed by ControllerResolver.
+ *
+ * This pass injects the container into PrestaShop controllers to overcome this issue.
+ */
+class ContainerAwareControllersManualInjectionPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $controllers = $container->findTaggedServiceIds('prestashop.core.controllers');
+
+        foreach ($controllers as $id => $controller) {
+            $definition = $container->findDefinition($id);
+            $class = $definition->getClass();
+
+            if (!$r = $container->getReflectionClass($class)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Class "%s" used for service "%s" cannot be found.',
+                    $class,
+                    $id
+                ));
+            }
+            $isContainerAware = $r->implementsInterface(ContainerAwareInterface::class)
+                || is_subclass_of($class, AbstractController::class);
+
+            if ($isContainerAware) {
+                $definition->addMethodCall('setContainer', [new Reference('service_container')]);
+            }
+        }
+    }
+}

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/ContainerInjectionPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/ContainerInjectionPass.php
@@ -49,7 +49,7 @@ class ContainerInjectionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $controllers = $container->findTaggedServiceIds(FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS);
+        $controllers = $container->findTaggedServiceIds(FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG);
 
         foreach ($controllers as $id => $controller) {
             $definition = $container->findDefinition($id);

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle;
 
 use PrestaShopBundle\DependencyInjection\Compiler\CommandAndQueryCollectorPass;
-use PrestaShopBundle\DependencyInjection\Compiler\ContainerAwareControllersManualInjectionPass;
+use PrestaShopBundle\DependencyInjection\Compiler\ContainerInjectionPass;
 use PrestaShopBundle\DependencyInjection\Compiler\DynamicRolePass;
 use PrestaShopBundle\DependencyInjection\Compiler\GridDefinitionServiceIdsCollectorPass;
 use PrestaShopBundle\DependencyInjection\Compiler\IdentifiableObjectFormTypesCollectorPass;
@@ -72,6 +72,6 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new OptionsFormHookNameCollectorPass());
         $container->addCompilerPass(new GridDefinitionServiceIdsCollectorPass());
         $container->addCompilerPass(new IdentifiableObjectFormTypesCollectorPass());
-        $container->addCompilerPass(new ContainerAwareControllersManualInjectionPass());
+        $container->addCompilerPass(new ContainerInjectionPass());
     }
 }

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle;
 
 use PrestaShopBundle\DependencyInjection\Compiler\CommandAndQueryCollectorPass;
+use PrestaShopBundle\DependencyInjection\Compiler\ContainerAwareControllersManualInjectionPass;
 use PrestaShopBundle\DependencyInjection\Compiler\DynamicRolePass;
 use PrestaShopBundle\DependencyInjection\Compiler\GridDefinitionServiceIdsCollectorPass;
 use PrestaShopBundle\DependencyInjection\Compiler\IdentifiableObjectFormTypesCollectorPass;
@@ -71,5 +72,6 @@ class PrestaShopBundle extends Bundle
         $container->addCompilerPass(new OptionsFormHookNameCollectorPass());
         $container->addCompilerPass(new GridDefinitionServiceIdsCollectorPass());
         $container->addCompilerPass(new IdentifiableObjectFormTypesCollectorPass());
+        $container->addCompilerPass(new ContainerAwareControllersManualInjectionPass());
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -9,7 +9,7 @@ services:
             - [setLogger, ['@logger']]
             - [setContainer, ['@service_container']]
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.controller:
         alias: PrestaShopBundle\Controller\Api\ApiController
@@ -23,7 +23,7 @@ services:
             stockRepository: "@prestashop.core.api.stock.repository"
             queryParams: "@prestashop.core.api.query_stock_params_collection"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.stock.controller:
         alias: PrestaShopBundle\Controller\Api\StockController
@@ -36,7 +36,7 @@ services:
             stockMovementRepository: "@prestashop.core.api.stock_movement.repository"
             queryParams: "@prestashop.core.api.query_stock_movement_params_collection"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.stock_movement.controller:
         alias: PrestaShopBundle\Controller\Api\StockMovementController
@@ -48,7 +48,7 @@ services:
         properties:
             supplierRepository: "@prestashop.core.api.supplier.repository"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.supplier.controller:
         alias: PrestaShopBundle\Controller\Api\SupplierController
@@ -60,8 +60,8 @@ services:
         properties:
             manufacturerRepository: "@prestashop.core.api.manufacturer.repository"
         tags:
-          - { name: prestashop.core.controllers }
-          
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+
     prestashop.core.api.manufacturer.controller:
         alias: PrestaShopBundle\Controller\Api\ManufacturerController
 
@@ -72,7 +72,7 @@ services:
         properties:
             categoryRepository: "@prestashop.core.api.category.repository"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.category.controller:
         alias: PrestaShopBundle\Controller\Api\CategoryController
@@ -84,7 +84,7 @@ services:
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.attribute.controller:
         alias: PrestaShopBundle\Controller\Api\AttributeController
@@ -96,7 +96,7 @@ services:
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.feature.controller:
         alias: PrestaShopBundle\Controller\Api\FeatureController
@@ -106,7 +106,7 @@ services:
         parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.i18n.controller:
         alias: PrestaShopBundle\Controller\Api\I18nController
@@ -119,7 +119,7 @@ services:
             translationService: "@prestashop.service.translation"
             queryParams: "@prestashop.core.api.query_translation_params_collection"
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.translation.controller:
         alias: PrestaShopBundle\Controller\Api\TranslationController
@@ -129,7 +129,7 @@ services:
         parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         tags:
-          - { name: prestashop.core.controllers }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
 
     prestashop.core.api.improve.design.postions.controller:
         alias:  PrestaShopBundle\Controller\Api\Improve\Design\PositionsController

--- a/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/controller.yml
@@ -9,7 +9,7 @@ services:
             - [setLogger, ['@logger']]
             - [setContainer, ['@service_container']]
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.controller:
         alias: PrestaShopBundle\Controller\Api\ApiController
@@ -23,7 +23,7 @@ services:
             stockRepository: "@prestashop.core.api.stock.repository"
             queryParams: "@prestashop.core.api.query_stock_params_collection"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.stock.controller:
         alias: PrestaShopBundle\Controller\Api\StockController
@@ -36,7 +36,7 @@ services:
             stockMovementRepository: "@prestashop.core.api.stock_movement.repository"
             queryParams: "@prestashop.core.api.query_stock_movement_params_collection"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.stock_movement.controller:
         alias: PrestaShopBundle\Controller\Api\StockMovementController
@@ -48,7 +48,7 @@ services:
         properties:
             supplierRepository: "@prestashop.core.api.supplier.repository"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.supplier.controller:
         alias: PrestaShopBundle\Controller\Api\SupplierController
@@ -60,7 +60,7 @@ services:
         properties:
             manufacturerRepository: "@prestashop.core.api.manufacturer.repository"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.manufacturer.controller:
         alias: PrestaShopBundle\Controller\Api\ManufacturerController
@@ -72,7 +72,7 @@ services:
         properties:
             categoryRepository: "@prestashop.core.api.category.repository"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.category.controller:
         alias: PrestaShopBundle\Controller\Api\CategoryController
@@ -84,7 +84,7 @@ services:
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.attribute.controller:
         alias: PrestaShopBundle\Controller\Api\AttributeController
@@ -96,7 +96,7 @@ services:
         properties:
             featureAttributeRepository: "@prestashop.core.api.feature_attribute.repository"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.feature.controller:
         alias: PrestaShopBundle\Controller\Api\FeatureController
@@ -106,7 +106,7 @@ services:
         parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.i18n.controller:
         alias: PrestaShopBundle\Controller\Api\I18nController
@@ -119,7 +119,7 @@ services:
             translationService: "@prestashop.service.translation"
             queryParams: "@prestashop.core.api.query_translation_params_collection"
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.translation.controller:
         alias: PrestaShopBundle\Controller\Api\TranslationController
@@ -129,7 +129,7 @@ services:
         parent: PrestaShopBundle\Controller\Api\ApiController
         public: true
         tags:
-          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS }
+          - { name: !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG }
 
     prestashop.core.api.improve.design.postions.controller:
         alias:  PrestaShopBundle\Controller\Api\Improve\Design\PositionsController


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | As explained in https://github.com/symfony/symfony/issues/36567, ControllerAwareTrait requires injection of container and this is performed by Symfony ControllerResolver. If a controller is a decorated, it is not injected the container anymore. I avoid it by manually injecting it into all PrestaShop controllers.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

### How to test

Use attached demo module
[testdecorationcontrollers.zip](https://github.com/PrestaShop/PrestaShop/files/4645455/testdecorationcontrollers.zip)

1. Install module
2. Go on CMS listing page "Improve > Design > Pages"
3. You should see the green message
<img width="299" alt="Capture d’écran 2020-05-18 à 18 44 41" src="https://user-images.githubusercontent.com/3830050/82238650-edcb5c00-9937-11ea-8e53-6039d75eec3a.png">
4. You can check on `develop` the same module, you should see the red exception
<img width="526" alt="Capture d’écran 2020-05-18 à 18 44 17" src="https://user-images.githubusercontent.com/3830050/82238682-f7ed5a80-9937-11ea-9c5b-ff4abb89fe4d.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18811)
<!-- Reviewable:end -->
