### PR TITLE
Add tag controller.service_arguments to PrestaShop controllers

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -21,7 +21,7 @@ services:
     PrestaShopBundle\Controller\:
         resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
         exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
-        tags: ['prestashop.core.controllers']
+        tags: ['prestashop.core.controllers', 'controller.service_arguments']
 
 framework:
     assets:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add tag controller.service_arguments to PrestaShop controllers. I forgot to add it when I enabled autowiring for PrestaShop controllers. This tag enablse autowiring arguments for controller action methods (see https://symfony.com/doc/3.4/service_container/3.3-di-changes.html#controllers-are-registered-as-services) thanks @mickaelandrieu 
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No need for QA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18845)
<!-- Reviewable:end -->
