### PR TITLE
Minimal value of minimal_quantity set to 1

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1089,7 +1089,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             $minimal_quantity = $this->product->minimal_quantity;
         }
 
-        return $minimal_quantity;
+        return max($minimal_quantity, 1);
     }
 
     /**

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -34,6 +34,11 @@ require_once dirname(__FILE__).'/../config/config.inc.php';
 Context::getContext()->cart = new Cart();
 Context::getContext()->container = ContainerBuilder::getContainer('webservice', _PS_MODE_DEV_);
 
+// If the currency is not defined in the context, initialize with the default one !
+if (null === Context::getContext()->currency) {
+    Context::getContext()->currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+}
+
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {
     list($name, $password) = explode(':', base64_decode($matches[1]));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a minimal_quantity on a product is set to 0, the add to cart quantity will be 1 (and not 0)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18850 
| How to test?  | Set a minimal quantity of 0 on a product and display the product detail in Front Office.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18853)
<!-- Reviewable:end -->
