### PR TITLE
FO: Display 'free' as shipping cost in the cart when a cart rule grants free shipping

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -495,6 +495,13 @@ class CartPresenter implements PresenterInterface
     {
         $shippingDisplayValue = '';
 
+        // if one of the applied cart rules have free shipping, then the shipping display value is 'Free'
+        foreach ($cart->getCartRules() as $rule) {
+            if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
+                return $this->translator->trans('Free', [], 'Shop.Theme.Checkout');
+            }
+        }
+
         if ($shippingCost != 0) {
             $shippingDisplayValue = $this->priceFormatter->format($shippingCost);
         } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In the cart (FO), in the right column, the value of the shipping cost should be 'free' when there is a cart rule offering free shipping. This PR takes count of cart rules when defining the display value of shipping cost. (see issue for screen captures)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18533
| How to test?  | See issue #18533

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18884)
<!-- Reviewable:end -->
