### PR TITLE
FO: show browser-native error messages during payment selection step in checkout

### DIFF
--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -53,9 +53,7 @@ class Payment {
   }
 
   haveTermsBeenAccepted() {
-    let termsCheckbox = $(this.termsCheckboxSelector);
-
-    return termsCheckbox.prop('checked');
+    return $(this.termsCheckboxSelector).prop('checked');
   }
 
   hideConfirmation() {
@@ -114,11 +112,8 @@ class Payment {
   }
 
   showNativeFormErrors () {
-    let termsCheckbox = $(this.termsCheckboxSelector)
-    termsCheckbox.get(0).reportValidity();
-
-    let paymentOptionsGroup = $('input[name=payment-option]')
-    paymentOptionsGroup.get(0).reportValidity();
+    $(this.termsCheckboxSelector).get(0).reportValidity();
+    $('input[name=payment-option]').get(0).reportValidity();
   }
 
   confirm() {

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -37,15 +37,15 @@ class Payment {
   init() {
     let $body = $('body');
 
-    $body.on('change', this.conditionsSelector + ' input[type="checkbox"]', $.proxy(this.toggleOrderButton, this));
+    $body.on('change', `${this.conditionsSelector} input[type="checkbox"]`, $.proxy(this.toggleOrderButton, this));
     $body.on('change', 'input[name="payment-option"]', $.proxy(this.toggleOrderButton, this));
-    $body.on('click', this.confirmationSelector + ' button', $.proxy(this.confirm, this));
+    $body.on('click', `${this.confirmationSelector} button`, $.proxy(this.confirm, this));
 
     this.collapseOptions();
   }
 
   collapseOptions() {
-    $(this.additionalInformatonSelector + ', ' + this.optionsForm).hide();
+    $(`${this.additionalInformatonSelector}, ${this.optionsForm}`).hide();
   }
 
   getSelectedOption() {
@@ -66,7 +66,7 @@ class Payment {
 
   toggleOrderButton() {
     var show = true;
-    $(this.conditionsSelector + ' input[type="checkbox"]').each((_, checkbox) => {
+    $(`${this.conditionsSelector} input[type="checkbox"]`).each((_, checkbox) => {
       if (!checkbox.checked) {
         show = false;
       }
@@ -79,11 +79,11 @@ class Payment {
       show = false;
     }
 
-    $('#' + selectedOption + '-additional-information').show();
-    $('#pay-with-' + selectedOption + '-form').show();
+    $(`#${selectedOption}-additional-information`).show();
+    $(`#pay-with-${selectedOption}-form`).show();
 
     $('.js-payment-binary').hide();
-    if ($('#' + selectedOption).hasClass('binary')) {
+    if ($(`#${selectedOption}`).hasClass('binary')) {
       var paymentOption = this.getPaymentOptionSelector(selectedOption);
       this.hideConfirmation();
       $(paymentOption).show();
@@ -95,7 +95,7 @@ class Payment {
       }
     } else {
       this.showConfirmation();
-      $(this.confirmationSelector + ' button').toggleClass('disabled', !show);
+      $(`${this.confirmationSelector} button`).toggleClass('disabled', !show);
 
       if (show) {
         $(this.conditionAlertSelector).hide();
@@ -126,8 +126,8 @@ class Payment {
       return;
     }
 
-    $(this.confirmationSelector + ' button').addClass('disabled');
-    $('#pay-with-' + option + '-form form').submit();
+    $(`${this.confirmationSelector} button`).addClass('disabled');
+    $(`#pay-with-${option}-form form`).submit();
   }
 }
 

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -112,13 +112,14 @@ class Payment {
   }
 
   showNativeFormErrors () {
-    $(this.termsCheckboxSelector).get(0).reportValidity();
-    $('input[name=payment-option]').get(0).reportValidity();
+    $(`input[name=payment-option], ${this.termsCheckboxSelector}`).each(function() {
+      this.reportValidity();
+    });
   }
 
   confirm() {
-    let option = this.getSelectedOption();
-    let termsAccepted = this.haveTermsBeenAccepted();
+    const option = this.getSelectedOption();
+    const termsAccepted = this.haveTermsBeenAccepted();
 
     if (option === undefined || termsAccepted === false) {
       this.showNativeFormErrors();

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -127,7 +127,7 @@
 
   <div id="payment-confirmation">
     <div class="ps-shown-by-js">
-      <button type="submit" {if !$selected_payment_option} disabled {/if} class="btn btn-primary center-block">
+      <button type="submit" class="btn btn-primary center-block{if !$selected_payment_option} disabled{/if}">
         {l s='Place order' d='Shop.Theme.Checkout'}
       </button>
       {if $show_final_summary}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Cf **What this change is about**
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no (I think)
| Deprecations? | no
| Fixed ticket? | Fixes #17812
| How to test?  | Cf **How to test**

### What this change is about

During the checkout process, in the payment step (the final step), the confirmation button "place order" was disabled.
It was only enabled when 

- a payment method was chosen, and
- the terms and conditions checkbox were accepted (checkbox checked)

If the user tried to click the button before doing so, nothing happened.
I found that there there should be an error message popping up, informing that some action was still required by the user in order to proceed.
I even could track some users that had trouble finding the missing step, scrolling up and down, clicking the disabled submit button repeatedly.

### How to test

In the Payment-stage of the checkout flow...

Click the submit button with no payment-method selected.  
-> There should be an error message next to the input element, informing that it is needed to chose one to proceed.

Click the submit button without having agreed to the terms and conditions
-> There should be an error message next to the checkbox, informing that it is needed to check the box in order to proceed.


### How it was done

Since other steps in the checkout, e.g. the "personal information" step makes use of the native browser form validation, the same method for displaying errors should be used. 

Since said elements are not in the same form DOM-wise, this was a little tricky.
I traversed the input elements and called the reportValidity() method on them.

Also, the button for submitting the form had the "disabled" attribute, prventing and events to be catched on it. So I used the "disabled" class from bootstrap instead. Still, there is a proper check of the input element's state before the submit is fired.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18904)
<!-- Reviewable:end -->
