### PR TITLE
Multistore: Fix error when viewing an order with custom product made on secondary shop

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -655,9 +655,7 @@ class OrderCore extends ObjectModel
 
             // Backward compatibility 1.4 -> 1.5
             $this->setProductPrices($row);
-
-            $customized_datas = Product::getAllCustomizedDatas($this->id_cart, null, true, null, (int) $row['id_customization']);
-
+            $customized_datas = Product::getAllCustomizedDatas($this->id_cart, null, true, $this->id_shop, (int) $row['id_customization']);
             $this->setProductCustomizedDatas($row, $customized_datas);
 
             // Add information for virtual product


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The shop id was not given when fetching for products customization data, so the current shop would be used instead of the shop from which the order was made.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18913
| How to test?  | See reproduction steps in issue #18913

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18923)
<!-- Reviewable:end -->
