### PR TITLE
Wrong shop id at creating new specific price rules in BO

### DIFF
--- a/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
@@ -139,7 +139,7 @@
 		</div>
 	</div>
 {if !$is_multishop}
-	<input type="hidden" name="id_shop" value="1" />
+	<input type="hidden" name="id_shop" value="{$shop->id}" />
 {/if}
 </div>
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | At a standard prestashop installation in non-multishop context the shop id is 1. But if you have a non-multishop installation where the shop id is not 1 this will not work. The static shop id has to be replaced to the real shop id from the shop context
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Possible test szenario:<br>let's say we have individual prestashops on individual servers. every shop itself has the shop id 1. we now want to combine the individual shops with a merchandise management system. the merchandise management system should now be able to differentiate between shops based on shop id. So we have to change the shop id for all shops. the first shop has the shop id 1, the second one gets the shop id 2, and so on... You can achieve this by changing all database fields that contain a shop ID.<br><br>Another way to test it:<br>Make a prestashop release where all fixtures for the installation have the shop id 2 (or 3...)<br><br>Here is a example of the shop table with a different shop id. please note that it is not a multishop:<br>![image](https://user-images.githubusercontent.com/63096826/81269222-4e5dbd80-9049-11ea-85ea-02ce8d84521d.png)<br><br>all in all, there should be no static shop id in the source code, but the shop id should either come from the context or the configuration PS_SHOP_DEFAULT.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18960)
<!-- Reviewable:end -->
