### PR TITLE
BO Product Controller: Virtual product download link will not download the active file.

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
@@ -104,6 +104,7 @@ class VirtualProductController extends FrameworkBundleAdminController
             ->getRepository('PrestaShopBundle:ProductDownload')
             ->findOneBy([
                 'idProduct' => $idProduct,
+                'active' => 1
             ]);
 
         $response = new BinaryFileResponse(

--- a/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
@@ -104,7 +104,7 @@ class VirtualProductController extends FrameworkBundleAdminController
             ->getRepository('PrestaShopBundle:ProductDownload')
             ->findOneBy([
                 'idProduct' => $idProduct,
-                'active' => 1
+                'active' => 1,
             ]);
 
         $response = new BinaryFileResponse(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The bug is at the backoffice products detail page at virtual products. You edit a virtual product and add a new download file to this product, you are able to download this file (see screenshot) ![image](https://user-images.githubusercontent.com/63242596/81045831-5259d600-8eb7-11ea-859a-3b8b24f6da80.png)<br>but if there are more than one file downloads available for this product. this download link will only get the first file and not the active one.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19553 
| How to test?  | - Add a virtual product (0€)<br>- Add a File download to this product<br>- The first file is downloadable on the frontoffice<br>- Add another file download to this product to replace the first one<br>- Disable the first<br>- Try to download the file with the link. you will get the first download file and not the last (active) download.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18972)
<!-- Reviewable:end -->
