### PR TITLE
BO - Customer View page - Added Green alert when editing a voucher

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -266,7 +266,9 @@ class CustomerController extends AbstractAdminController
             'note' => $customerInformation->getGeneralInformation()->getPrivateNote(),
         ]);
 
-        $this->manageLegacyFlashes($request->query->get('conf'));
+        if ($request->query->has('conf')) {
+            $this->manageLegacyFlashes($request->query->get('conf'));
+        }
 
         return $this->render('@PrestaShop/Admin/Sell/Customer/view.html.twig', [
             'enableSidebar' => true,
@@ -844,17 +846,13 @@ class CustomerController extends AbstractAdminController
     }
 
     /**
-     * Manage legacy flashes, this code must be removed
-     * when legacy edit will be migrated.
+     * Manage legacy flashes
+     * @todo Remove this code when legacy edit will be migrated.
      *
      * @param int $messageId The message id from legacy context
      */
     private function manageLegacyFlashes($messageId)
     {
-        if (empty($messageId)) {
-            return;
-        }
-
         $messages = [
             4 => $this->trans('Update successful.', 'Admin.Notifications.Success'),
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -266,6 +266,8 @@ class CustomerController extends AbstractAdminController
             'note' => $customerInformation->getGeneralInformation()->getPrivateNote(),
         ]);
 
+        $this->manageLegacyFlashes($request->query->get('conf'));
+
         return $this->render('@PrestaShop/Admin/Sell/Customer/view.html.twig', [
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
@@ -839,5 +841,29 @@ class CustomerController extends AbstractAdminController
                 ]
             ),
         ];
+    }
+
+    /**
+     * Manage legacy flashes, this code must be removed
+     * when legacy edit will be migrated.
+     *
+     * @param int $messageId The message id from legacy context
+     */
+    private function manageLegacyFlashes($messageId)
+    {
+        if (empty($messageId)) {
+            return;
+        }
+
+        $messages = [
+            4 => $this->trans('Update successful.', 'Admin.Notifications.Success'),
+        ];
+
+        if (isset($messages[$messageId])) {
+            $this->addFlash(
+                'success',
+                $messages[$messageId]
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | BO - Customer View page - Added Green alert when editing a voucher.
| Type?         |  bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18842
| How to test?  | 1. Go to BO => Catalog => Discounts page<br>2. Add new cart rule for the "John DOE" customer<br>3. Go to BO => Customers => Customer view page "John DOE"<br>4. Try to edit a voucher<br>5. Click save<br>6. No alert displayed
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18975)
<!-- Reviewable:end -->
