### PR TITLE
Allow deprecation notices to be caught nicely even in dev mode

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -31,8 +31,12 @@ if (!defined('_PS_MODE_DEV_')) {
 /* Compatibility warning */
 define('_PS_DISPLAY_COMPATIBILITY_WARNING_', true);
 if (_PS_MODE_DEV_ === true) {
+    $errorReportingLevel = E_ALL | E_STRICT;
+    if (_PS_DISPLAY_COMPATIBILITY_WARNING_ === false) {
+        $errorReportingLevel = $errorReportingLevel & ~E_DEPRECATED & ~E_USER_DEPRECATED;
+    }
     @ini_set('display_errors', 'on');
-    @error_reporting(E_ALL | E_STRICT);
+    @error_reporting($errorReportingLevel);
     define('_PS_DEBUG_SQL_', true);
 } else {
     @ini_set('display_errors', 'off');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | With newer version of our operating systems, the version of PHP being installed is sometimes not fully compatible with PrestaShop as it trigger many deprecation notices. They may prevent the shop to be installed. With this change, we can make our shop usable anyway.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | Nope
| Deprecations? | Nope
| Fixed ticket? | N/A
| How to test?  | Install PrestaShop on a server running PHP 7.4. More details below:

## Current state

Without this PR, even with the constant `_PS_DISPLAY_COMPATIBILITY_WARNING_` set to `false`, the backoffice is unusable:

![image](https://user-images.githubusercontent.com/6768917/81072447-0e2dfc00-8ede-11ea-9dca-cd4430345ce7.png)

## With the pull-request

With the PR and the `_PS_DISPLAY_COMPATIBILITY_WARNING_` set to `false`, we find these erreors in the Symfony debugger and the legacy error handler:

### Legacy error handler
![Capture d’écran du 2020-05-05 14-35-41](https://user-images.githubusercontent.com/6768917/81072701-6cf37580-8ede-11ea-9d2b-1f5a1f4bad60.png)

### Symfony debugger
![Capture d’écran du 2020-05-05 14-36-20](https://user-images.githubusercontent.com/6768917/81072731-7a106480-8ede-11ea-9c2a-ab275afbacbb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18985)
<!-- Reviewable:end -->
