### PR TITLE
Improve prestashop.core.query_bus service to use parent

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/core/command_bus.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/command_bus.yml
@@ -8,9 +8,7 @@ services:
             - '@tactician.commandbus.default'
 
     prestashop.core.query_bus:
-        class: 'PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter'
-        arguments:
-            - '@tactician.commandbus.default'
+        parent: 'prestashop.core.command_bus'
 
     prestashop.core.provider.command_definition_provider:
       class: 'PrestaShop\PrestaShop\Core\CommandBus\Parser\CommandDefinitionParser'

--- a/src/PrestaShopBundle/Resources/config/services/core/command_bus.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/command_bus.yml
@@ -9,6 +9,7 @@ services:
 
     prestashop.core.query_bus:
         parent: 'prestashop.core.command_bus'
+        public: true
 
     prestashop.core.provider.command_definition_provider:
       class: 'PrestaShop\PrestaShop\Core\CommandBus\Parser\CommandDefinitionParser'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  |  I found while working on another bug. Avoid service dependencies duplicate in ```src/PrestaShopBundle/Resources/config/services/core/command_bus.yml``` See : https://symfony.com/index.php/doc/3.3/service_container/parent_services.html.
| Type?         | improvement 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A.
| How to test?  | I do not really know 🤔

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18992)
<!-- Reviewable:end -->
