### PR TITLE
Fix discount display on multicurrency context

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -605,7 +605,7 @@ class CartPresenter implements PresenterInterface
             } else {
                 // In all other cases, the value displayed should be the total of applied reductions for the current voucher
                 $totalCartVoucherReduction = $shippingReduction + $amountReduction + $percentageReduction;
-                $cartVoucher['reduction_formatted'] = '-' . $this->priceFormatter->convertAndFormat($totalCartVoucherReduction);
+                $cartVoucher['reduction_formatted'] = '-' . $this->priceFormatter->format($totalCartVoucherReduction);
             }
 
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_formatted'] = $cartVoucher['reduction_formatted'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Front - Fix cart rule discount amount when currency is a secondary one.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18900
| How to test?  | 1 - Go to BO => international => localisation and add USD currency<br>2 - GO to BO => catalog => discount and create a 10% discount<br>3 - Go to FO set the currency to EUR and create a cart with some items<br>4 - Apply the previuously created discount check the detail discount and the total discount they should be identical<br>5 - Switch currency to USD the discounts should be the same too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18993)
<!-- Reviewable:end -->
