### PR TITLE
Added missing required_once for Datas class

### DIFF
--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -70,6 +70,7 @@ if (!defined('__PS_BASE_URI__')) {
             )
         );
     } else {
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'classes/datas.php';
         define('__PS_BASE_URI__', '/' . trim(Datas::getInstance()->base_uri, '/') . '/');
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | When using the upgrade script in CLI, an error was thrown preventing the upgrade.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18723
| How to test?  | With an up-to-date shop, in CLI, the command `php install-dev/upgrade/upgrade.php` should return a [code 28](https://devdocs.prestashop.com/1.7/basics/keeping-up-to-date/upgrade/#error-codes) without a PHP Fatal error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/18996)
<!-- Reviewable:end -->
