### PR TITLE
Separated Symfony cache per HTTP_HOST

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -90,7 +90,8 @@ if ((defined('_PS_IN_TEST_') && _PS_IN_TEST_)
 }
 
 if (!defined('_PS_CACHE_DIR_')) {
-    define('_PS_CACHE_DIR_', _PS_ROOT_DIR_.'/var/cache/' . _PS_ENV_ . DIRECTORY_SEPARATOR);
+    $cache_dir_host_suffix = (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] . DIRECTORY_SEPARATOR : '');
+    define('_PS_CACHE_DIR_', _PS_ROOT_DIR_.'/var/cache/' . _PS_ENV_ . DIRECTORY_SEPARATOR . $cache_dir_host_suffix);
 }
 
 define('_PS_CONFIG_DIR_', _PS_CORE_DIR_.'/config/');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When multistore is active and different stores has same translation key with different value it should show different value fore each store. See in #15346.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15346.
| How to test?  | Enable multistore and modify translations.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19018)
<!-- Reviewable:end -->
