### PR TITLE
BO - Catalog price rule - Currency sort and filter not working as expected #19014

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -159,9 +159,7 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                     (int) $this->context->language->id,
                     (int) $this->context->shop->id
                 );
-                if (Validate::isLoadedObject($currency)) {
-                    $this->_list[$k]['id_currency'] = $currency->getName();
-                }
+                $this->_list[$k]['id_currency'] = Validate::isLoadedObject($currency) ? $currency->getName() : null;
             }
 
             if ($list['reduction_type'] == 'amount') {

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -55,9 +55,9 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         $this->addRowAction('edit');
         $this->addRowAction('delete');
 
-        $this->_select = 's.name shop_name, cu.iso_code as currency_iso_code, cl.name country_name, gl.name group_name';
+        $this->_select = 's.name shop_name, cul.name as currency_name, cl.name country_name, gl.name group_name';
         $this->_join = 'LEFT JOIN ' . _DB_PREFIX_ . 'shop s ON (s.id_shop = a.id_shop)
-		LEFT JOIN ' . _DB_PREFIX_ . 'currency cu ON (cu.id_currency = a.id_currency)
+		LEFT JOIN ' . _DB_PREFIX_ . 'currency_lang cul ON (cul.id_currency = a.id_currency AND cul.id_lang=' . (int) $this->context->language->id . ')
 		LEFT JOIN ' . _DB_PREFIX_ . 'country_lang cl ON (cl.id_country = a.id_country AND cl.id_lang=' . (int) $this->context->language->id . ')
 		LEFT JOIN ' . _DB_PREFIX_ . 'group_lang gl ON (gl.id_group = a.id_group AND gl.id_lang=' . (int) $this->context->language->id . ')';
         $this->_use_found_rows = false;
@@ -85,10 +85,10 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 'title' => $this->trans('Shop', [], 'Admin.Global'),
                 'filter_key' => 's!name',
             ],
-            'currency_name' => [
+            'id_currency' => [
                 'title' => $this->trans('Currency', [], 'Admin.Global'),
                 'align' => 'center',
-                'filter_key' => 'cu!name',
+                'filter_key' => 'cul!name',
             ],
             'country_name' => [
                 'title' => $this->trans('Country', [], 'Admin.Global'),
@@ -153,9 +153,15 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
         parent::getList($id_lang, $order_by, $order_way, $start, $limit, $id_lang_shop);
 
         foreach ($this->_list as $k => $list) {
-            if (null !== $this->_list[$k]['currency_iso_code']) {
-                $currency = new Currency(Currency::getIdByIsoCode($this->_list[$k]['currency_iso_code']));
-                $this->_list[$k]['currency_name'] = $currency->name;
+            if (null !== $this->_list[$k]['id_currency']) {
+                $currency = new Currency(
+                    (int) $this->_list[$k]['id_currency'],
+                    (int) $this->context->language->id,
+                    (int) $this->context->shop->id
+                );
+                if (Validate::isLoadedObject($currency)) {
+                    $this->_list[$k]['id_currency'] = $currency->getName();
+                }
             }
 
             if ($list['reduction_type'] == 'amount') {


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | In BO => catalog => discount => catalog price rule the currency column filter always return null. And the sort fonctionnality doesn't sort correctly.
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19014
| How to test?  | See #19014 by @SD1982 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19020)
<!-- Reviewable:end -->
