### PR TITLE
BO - Save button design change if an error message is displayed

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -609,6 +609,11 @@ class AdminCartRulesControllerCore extends AdminController
     public function renderForm()
     {
         $limit = 40;
+        $this->toolbar_btn['save'] = [
+            'href' => '#',
+            'desc' => $this->trans('Save', [], 'Admin.Actions'),
+        ];
+
         $this->toolbar_btn['save-and-stay'] = [
             'href' => '#',
             'desc' => $this->trans('Save and stay', [], 'Admin.Actions'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In cart rule page if an error message is displayed the "save" button design change.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    |no
| Deprecations? | no
| Fixed ticket? | Fixes #19005.
| How to test?  | See ##19005 by @SD1982 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19021)
<!-- Reviewable:end -->
