### PR TITLE
Enable drag-and-drop for Grid listings in both directions

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
@@ -90,6 +90,8 @@ export default class PositionExtension {
 
     let trData;
 
+    // retrieve dragAndDropOffset offset to have all needed data
+    // for positions mapping evolution over time
     for (let i = 0; i < rowsData.length; i++) {
       trData = this.grid.getContainer()
         .find('#' + rowsData[i]);
@@ -194,7 +196,7 @@ export default class PositionExtension {
     const positionsAfterDragAndDrop = {};
     const mapping = [];
 
-    let rowData;
+    let rowDataMarker;
     let rowDataParsedData;
     let i;
     let rowID;
@@ -202,9 +204,12 @@ export default class PositionExtension {
     let rowOldOffset;
     let rowNewOffset;
 
+    // first, compute for each position,
+    // where they were before the drag-and-drop
+    // and where they are after the drag-and-drop
     for (i = 0; i < rowsNb; i += 1) {
-      rowData = rowsData[i].rowMarker;
-      rowDataParsedData = regex.exec(rowData);
+      rowDataMarker = rowsData[i].rowMarker;
+      rowDataParsedData = regex.exec(rowDataMarker);
 
       rowID = rowDataParsedData[1];
       rowOldPosition = parseInt(rowDataParsedData[2], 10);
@@ -217,9 +222,12 @@ export default class PositionExtension {
 
     let previousRowPositionWithThisOffset;
 
+    // for each row in table, we look at before the drag-and-drop
+    // and find what other rows was there, this is the new position
+    // of current row
     for (i = 0; i < rowsNb; i += 1) {
-      rowData = rowsData[i].rowMarker;
-      rowDataParsedData = regex.exec(rowData);
+      rowDataMarker = rowsData[i].rowMarker;
+      rowDataParsedData = regex.exec(rowDataMarker);
       rowID = rowDataParsedData[1];
       rowOldPosition = parseInt(rowDataParsedData[2], 10);
 

--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
@@ -71,8 +71,7 @@ export default class PositionExtension {
     const $rowPositionContainer = $(row).find(`.js-${this.grid.getId()}-position:first`);
     const updateUrl = $rowPositionContainer.data('update-url');
     const method = $rowPositionContainer.data('update-method');
-    const paginationOffset = parseInt($rowPositionContainer.data('pagination-offset'), 10);
-    const positions = this.getRowsPositions(paginationOffset);
+    const positions = this.getRowsPositions();
     const params = {positions};
 
     this.updatePosition(updateUrl, params, method);
@@ -83,7 +82,7 @@ export default class PositionExtension {
    * @returns {Array}
    * @private
    */
-  getRowsPositions(paginationOffset) {
+  getRowsPositions() {
     const tableData = JSON.parse($.tableDnD.jsonize());
     const rowsData = tableData[`${this.grid.getId()}_grid_table`];
     const completeRowsData = [];
@@ -92,14 +91,14 @@ export default class PositionExtension {
 
     // retrieve dragAndDropOffset offset to have all needed data
     // for positions mapping evolution over time
-    for (let i = 0; i < rowsData.length; i++) {
+    for (let i = 0; i < rowsData.length; i += 1) {
       trData = this.grid.getContainer()
-        .find('#' + rowsData[i]);
+        .find(`#${rowsData[i]}`);
 
       completeRowsData.push({
         rowMarker: rowsData[i],
-        offset: trData.data('dragAndDropOffset')
-      })
+        offset: trData.data('dragAndDropOffset'),
+      });
     }
 
     return this.computeMappingBetweenOldAndNewPositions(completeRowsData);
@@ -111,7 +110,6 @@ export default class PositionExtension {
    * @private
    */
   addIdsToGridTableRows() {
-
     let counter = 0;
 
     this.grid.getContainer()
@@ -125,7 +123,7 @@ export default class PositionExtension {
         $positionWrapper.closest('td').addClass('js-drag-handle');
         $positionWrapper.closest('tr').data('dragAndDropOffset', counter);
 
-        counter++;
+        counter += 1;
       });
   }
 
@@ -223,7 +221,7 @@ export default class PositionExtension {
     let previousRowPositionWithThisOffset;
 
     // for each row in table, we look at before the drag-and-drop
-    // and find what other rows was there, this is the new position
+    // and find what other row was there, this is the new position
     // of current row
     for (i = 0; i < rowsNb; i += 1) {
       rowDataMarker = rowsData[i].rowMarker;

--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -137,8 +137,7 @@ final class GridPresenter implements GridPresenterInterface
         /** @var ColumnInterface $column */
         foreach ($grid->getDefinition()->getColumns() as $column) {
             if ($column instanceof PositionColumn &&
-                strtolower($column->getId()) == strtolower($searchCriteria->getOrderBy()) &&
-                'asc' == strtolower($searchCriteria->getOrderWay())
+                strtolower($column->getId()) == strtolower($searchCriteria->getOrderBy())
             ) {
                 return $column;
             }

--- a/src/PrestaShopBundle/Twig/Extension/GridExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/GridExtension.php
@@ -168,8 +168,7 @@ class GridExtension extends AbstractExtension
     {
         if (empty($grid['columns'])
             || empty($grid['sorting']['order_by'])
-            || empty($grid['sorting']['order_way'])
-            || 'asc' != strtolower($grid['sorting']['order_way'])) {
+            || empty($grid['sorting']['order_way'])) {
             return false;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Drag-and-drop on grid listings needed the listing to be sorted by ascending positions. I modified the behavior of the Javascript to be able to work whether rows are ordered by ASC or DESC, so it works in both cases. See below for insights
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/19008
| How to test?  | See ticket. The bug should be fixed.

## Insights

Previous implementation was considering that, since rows were ordered following ASC, it could guess the new position (after drag-and-drop was done by user) by counting rows numbers. So it would consider 1st row (from top) would be position 0, next would be position 1, and so on ... It could handle pagination by adding the page offset.

This did not work if rows were ordered DESC.

So I changed the logic. When the page loads, I record, for all rows, in a dedicated jQuery data attribute, its offset in the grid. If the grid has 10 items it will number them 0, 1, 2, etc ...

After drag-and-drop has been done by user, I check all rows and find which rows have moved. Since moved row still has its offset, I can find where they are now and where they used to be.

Now, what about positions ? If I know that row number 3 has moved from position 2 to position 5, I can guess that the new "position" of row number 3 is _the position of the row that was, before it, in position 2_. The idea is to find "what row used to be where I am now" and this is the new "position" of the row.

As it's a complex logic, the code does not look good. I tried to make it more maintainable by adding comments and lot and lot of variable assignments (to use variable names as indicators of what they are).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19026)
<!-- Reviewable:end -->
