### PR TITLE
Update ps_themecusto to the latest version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4931,16 +4931,16 @@
         },
         {
             "name": "prestashop/ps_themecusto",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_themecusto.git",
-                "reference": "6f25e80e1374549254cf1f703b971088a5e228c7"
+                "reference": "69482091a23a68caa19aedc89f04f01fa997db77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_themecusto/zipball/6f25e80e1374549254cf1f703b971088a5e228c7",
-                "reference": "6f25e80e1374549254cf1f703b971088a5e228c7",
+                "url": "https://api.github.com/repos/PrestaShop/ps_themecusto/zipball/69482091a23a68caa19aedc89f04f01fa997db77",
+                "reference": "69482091a23a68caa19aedc89f04f01fa997db77",
                 "shasum": ""
             },
             "require": {
@@ -4969,7 +4969,7 @@
             ],
             "description": "PrestaShop module ps_themecusto",
             "homepage": "https://github.com/PrestaShop/ps_themecusto",
-            "time": "2019-11-22T11:44:15+00:00"
+            "time": "2020-04-29T06:18:04+00:00"
         },
         {
             "name": "prestashop/ps_wirepayment",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | It was impossible to upload a child theme in Appearance -> Theme & logo -> Advanced customization. Using the latest version of ps_themecusto solve this problem.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18914 
| How to test?  | 1. Go to Appearance -> Theme & logo -> Advanced customization<br>2. Click on upload a theme child<br>3. You should be able to upload this [child theme](https://github.com/PrestaShop/PrestaShop/files/4558401/child_classic.zip) without any error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19032)
<!-- Reviewable:end -->
