### PR TITLE
Fixed BackOffice Notification when Settings disable it

### DIFF
--- a/src/Adapter/Notification/QueryHandler/GetNotificationLastElementsHandler.php
+++ b/src/Adapter/Notification/QueryHandler/GetNotificationLastElementsHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Notification\QueryHandler;
 
 use Notification;
+use PrestaShop\PrestaShop\Adapter\Admin\NotificationsConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements;
 use PrestaShop\PrestaShop\Core\Domain\Notification\QueryHandler\GetNotificationLastElementsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Notification\QueryResult\NotificationResult;
@@ -41,6 +42,20 @@ use PrestaShop\PrestaShop\Core\Domain\Notification\QueryResult\NotificationsResu
 final class GetNotificationLastElementsHandler implements GetNotificationLastElementsHandlerInterface
 {
     /**
+     * @var array
+     */
+    protected $configuration;
+
+    /**
+     * @param NotificationsConfiguration $notificationsConfiguration
+     */
+    public function __construct(
+        NotificationsConfiguration $notificationsConfiguration
+    ) {
+        $this->configuration = $notificationsConfiguration->getConfiguration();
+    }
+
+    /**
      * @param GetNotificationLastElements $query
      *
      * @return NotificationsResults
@@ -53,25 +68,51 @@ final class GetNotificationLastElementsHandler implements GetNotificationLastEle
         $results = [];
         foreach ($elements as $type => $notifications) {
             $notificationsResult = [];
-            foreach ($notifications['results'] as $notification) {
-                $notificationsResult[] = new NotificationResult(
-                    $notification['id_order'],
-                    $notification['id_customer'],
-                    $notification['customer_name'],
-                    $notification['id_customer_message'],
-                    $notification['id_customer_thread'],
-                    $notification['customer_view_url'],
-                    $notification['total_paid'],
-                    $notification['carrier'],
-                    $notification['iso_code'],
-                    $notification['company'],
-                    $notification['status'],
-                    $notification['date_add']
-                );
+            $totalNotifications = 0;
+            if ($this->isDisplayed($type)) {
+                $totalNotifications = $notifications['total'];
+                foreach ($notifications['results'] as $notification) {
+                    $notificationsResult[] = new NotificationResult(
+                        $notification['id_order'],
+                        $notification['id_customer'],
+                        $notification['customer_name'],
+                        $notification['id_customer_message'],
+                        $notification['id_customer_thread'],
+                        $notification['customer_view_url'],
+                        $notification['total_paid'],
+                        $notification['carrier'],
+                        $notification['iso_code'],
+                        $notification['company'],
+                        $notification['status'],
+                        $notification['date_add']
+                    );
+                }
             }
-            $results[] = new NotificationsResult($type, $notifications['total'], $notificationsResult);
+            $results[] = new NotificationsResult($type, $totalNotifications, $notificationsResult);
         }
 
         return new NotificationsResults($results);
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    protected function isDisplayed(string $type): bool
+    {
+        switch ($type) {
+            case 'customer':
+                return $this->configuration['show_notifs_new_customers'] ?: false;
+                break;
+            case 'customer_message':
+                return $this->configuration['show_notifs_new_messages'] ?: false;
+                break;
+            case 'order':
+                return $this->configuration['show_notifs_new_orders'] ?: false;
+                break;
+        }
+
+        return false;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/notification.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/notification.yml
@@ -11,6 +11,8 @@ services:
 
   prestashop.adapter.notification.query_handler.get_notification_last_elements_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Notification\QueryHandler\GetNotificationLastElementsHandler'
+    arguments:
+      - '@prestashop.adapter.notifications.configuration'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed BackOffice Notification number when Settings disable it
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #18938 
| How to test?  | 1. Menu - Configure -> Advanced Parameters -> Administration<br>2. Define Notifications On for new Messages, but Off for new Customers and Orders.<br>3. On FO, make a new order<br>4. **BEFORE** The number increase<br>4. **AFTER** The number take settings for displaying notifications
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19037)
<!-- Reviewable:end -->
