### PR TITLE
Delivery and billing address were displayed wrong.

### DIFF
--- a/mails/themes/classic/core/order_conf.html.twig
+++ b/mails/themes/classic/core/order_conf.html.twig
@@ -274,18 +274,17 @@
               <td>
                 <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
                   {% if templateType == 'html' %}
-
                     <p style="border-bottom:1px solid #D6D4D4;">
                       {{ 'Delivery address'|trans({}, 'Emails.Body', locale)|raw }}
                     </p>
                     <span>
                       {delivery_block_html}
                     </span>
-                  
-{% endif %}
-                  <span data-text-only="1">
-                    {delivery_block_txt}
-                  </span>
+                  {% endif %}
+                  {% if templateType == 'txt' %} 
+										{{ 'Delivery address'|trans({}, 'Emails.Body', locale)|raw }} 
+										{delivery_block_txt} 
+									{% endif %} 
                 </font>
               </td>
               <td width="10">&nbsp;</td>
@@ -300,18 +299,17 @@
               <td>
                 <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
                   {% if templateType == 'html' %}
-
                     <p style="border-bottom:1px solid #D6D4D4;">
                       {{ 'Billing address'|trans({}, 'Emails.Body', locale)|raw }}
                     </p>
                     <span>
                       {invoice_block_html}
                     </span>
-                  
-{% endif %}
-                  <span data-text-only="1">
-                    {invoice_block_txt}
-                  </span>
+                  {% endif %}
+									{% if templateType == 'txt' %} 
+										{{ 'Billing address'|trans({}, 'Emails.Body', locale)|raw }} 
+										{invoice_block_txt} 
+									{% endif %} 
                 </font>
               </td>
               <td width="10">&nbsp;</td>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | With this small fix, the HTML and text-only version of the Order confirmation mail get fixed. Without this fix, both addresses have been shown twice in HTML version and "Billing address:" and "Delivery address:" have been missing in the plain text version. There might be a solution with less code, but this one works
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19064
| How to test?  | Disable Caching, test the new file with Design -> "Email Themes" preview function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19050)
<!-- Reviewable:end -->
