### PR TITLE
Fix simplfied url not properly set for multilang categories

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -117,7 +117,7 @@ class CategoryCore extends ObjectModel
                 'type' => self::TYPE_STRING,
                 'lang' => true,
                 'validate' => 'isLinkRewrite',
-                'required' => false,
+                'required' => true,
                 'size' => 128,
                 'ws_modifier' => [
                     'http_method' => WebserviceRequest::HTTP_POST,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The simplfied url field in category creation form was made optional, which made it broken in multilingual mode
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18763
| How to test?  | See how to test in the issue: #18763

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19063)
<!-- Reviewable:end -->
