### PR TITLE
Improve convertPrice function in Tools.php

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -871,7 +871,7 @@ class ToolsCore
         }
 
         if (gettype($price) === 'string' && is_numeric($price)) {
-            $price = (float)$price;
+            $price = (float) $price;
         } else if (!is_numeric($price)) {
             throw new PrestaShopException('Invalid price');
         }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -872,8 +872,10 @@ class ToolsCore
 
         if (gettype($price) === 'string' && is_numeric($price)) {
             $price = (float) $price;
-        } elseif (!is_numeric($price)) {
-            throw new PrestaShopException('Invalid price');
+        }
+
+        if (!is_numeric($price)) {
+            return $price;
         }
 
         $c_id = (is_array($currency) ? $currency['id_currency'] : $currency->id);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -849,8 +849,6 @@ class ToolsCore
     /**
      * Return price converted.
      *
-     * @deprecated since 1.7.4 use convertPriceToCurrency()
-     *
      * @param float $price Product price
      * @param object|array $currency Current currency object
      * @param bool $to_currency convert to currency or from currency to default currency
@@ -865,10 +863,17 @@ class ToolsCore
         if (!$context) {
             $context = Context::getContext();
         }
+
         if ($currency === null) {
             $currency = $context->currency;
         } elseif (is_numeric($currency)) {
             $currency = Currency::getCurrencyInstance($currency);
+        }
+
+        if (gettype($price) === 'string' && is_numeric($price)) {
+            $price = (float)$price;
+        } else if (!is_numeric($price)) {
+            throw new PrestaShopException('Invalid price');
         }
 
         $c_id = (is_array($currency) ? $currency['id_currency'] : $currency->id);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -872,7 +872,7 @@ class ToolsCore
 
         if (gettype($price) === 'string' && is_numeric($price)) {
             $price = (float) $price;
-        } else if (!is_numeric($price)) {
+        } elseif (!is_numeric($price)) {
             throw new PrestaShopException('Invalid price');
         }
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -33,6 +33,8 @@ use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
+use PrestaShop\Decimal\Number;
+use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -849,6 +851,8 @@ class ToolsCore
     /**
      * Return price converted.
      *
+     * @deprecated since 1.7.4 use convertPriceToCurrency()
+     *
      * @param float $price Product price
      * @param object|array $currency Current currency object
      * @param bool $to_currency convert to currency or from currency to default currency
@@ -870,8 +874,9 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance($currency);
         }
 
-        if (gettype($price) === 'string' && is_numeric($price)) {
-            $price = (float) $price;
+        if (gettype($price) === "string") {
+            $price = (new Number($price))
+                ->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
         }
 
         if (!is_numeric($price)) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -880,7 +880,7 @@ class ToolsCore
         }
 
         if (!is_numeric($price)) {
-            throw new PrestaShopException('Invalid price');
+            return $price;
         }
 
         $c_id = (is_array($currency) ? $currency['id_currency'] : $currency->id);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -875,8 +875,7 @@ class ToolsCore
         }
 
         if (gettype($price) === 'string') {
-            $price = (new Number($price))
-                ->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
+            $price = (new Number($price))->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
         }
 
         if (!is_numeric($price)) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -25,6 +25,7 @@
  */
 use Composer\CaBundle\CaBundle;
 use PHPSQLParser\PHPSQLParser;
+use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
@@ -33,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
-use PrestaShop\Decimal\Number;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
@@ -875,11 +875,12 @@ class ToolsCore
         }
 
         if (gettype($price) === 'string') {
-            $price = (new Number($price))->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
+            $price = (new Number($price))
+                ->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
         }
 
         if (!is_numeric($price)) {
-            return $price;
+            throw new PrestaShopException('Invalid price');
         }
 
         $c_id = (is_array($currency) ? $currency['id_currency'] : $currency->id);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -874,7 +874,7 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance($currency);
         }
 
-        if (gettype($price) === "string") {
+        if (gettype($price) === 'string') {
             $price = (new Number($price))
                 ->toPrecision(CommonAbstractType::PRESTASHOP_DECIMALS);
         }


### PR DESCRIPTION
I've had to resort to this function to be able to format a price and compare it. Unlike other similar functions like displayPrice, here it doesn't  validate if a price is numeric but it comes as a string (something that happens on many occasions). With this little validation we make sure that whenever we enter a valid value, the result will be returned correctly.

On the other hand, I have removed the comment from @deprecated, I understand that until the function is available, this comment should not be displayed because it misleads the developer.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improve the operation of the displayPrice function in Tools.php
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/14956
| How to test?  | Using Tools :: displayPrice with a numeric value in string.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19078)
<!-- Reviewable:end -->
