### PR TITLE
Fixed error when no Memcached servers are available.

### DIFF
--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -79,7 +79,10 @@ class CacheMemcachedCore extends Cache
             $this->memcached->addServer($server['ip'], $server['port'], (int) $server['weight']);
         }
 
-        $this->is_connected = in_array('255.255.255', $this->memcached->getVersion(), true) === false;
+        $versions = $this->memcached->getVersion();
+        $this->is_connected = is_array($versions)
+            ? in_array('255.255.255', $versions, true) === false
+            : false;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed error when no Memcached servers are available while there are servers in database
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18523
| How to test?  | 1. Install Memcached extension (On ubuntu, `sudo apt-get install php7.2-memcached` && `service apache2 restart`)<br>2. In database, add a memcached server (`INSERT INTO ps_memcached_servers ( ip, port, weight) VALUES('127.0.0.1', 12345, 1);`) while I don't have one.<br>3. Go to Configure > Advanced Parameters > Performances<br>4. Enable Cache<br>5. **BEFORE:** Eroor in bottom<br>![image](https://user-images.githubusercontent.com/1533248/84122411-ae74c480-aa38-11ea-9372-c99c5460dd6d.png)<br>5.**AFTER:** No errors<br>![image](https://user-images.githubusercontent.com/1533248/84122520-d82deb80-aa38-11ea-961f-1242bc5a201e.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19102)
<!-- Reviewable:end -->
