### PR TITLE
Redirect to dashboard when employee default page is unauthorized

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -291,7 +291,10 @@ class DispatcherCore
                 if (null !== $employee) {
                     $tabClassName = $employee->getDefaultTabClassName();
                     if (null !== $tabClassName) {
-                        $defaultController = $tabClassName;
+                        $tabProfileAccess = Profile::getProfileAccess($employee->id_profile, Tab::getIdFromClassName($tabClassName));
+                        if (is_array($tabProfileAccess) && isset($tabProfileAccess['view']) && $tabProfileAccess['view'] === '1') {
+                            $defaultController = $tabClassName;
+                        }
                     }
                 }
 

--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -112,7 +112,7 @@ class ProfileCore extends ObjectModel
      * @param int $idProfile Profile ID
      * @param int $idTab Tab ID
      *
-     * @return bool
+     * @return array|bool
      */
     public static function getProfileAccess($idProfile, $idTab)
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Loop redirections when the employee default page is unauthorized for his profile. We check if the default page is authorized first, if not redirect to dashboard.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19075
| How to test?  | 1 - With Admin, go to BO > Advanced Parameters > Team > Add new Employee<br>2 - Create the employee, with "Orders" as Default Page, and Logistician as Profile<br>3 - Go to Permissions tab, change permissions of Logistician, remove all permissions in "Orders"<br>4 - Disconnect, and connect with the newly created employee<br>5 - Since his default page is Orders, and his profile has no access to this page, the employee will be redirected to his dashboard.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19103)
<!-- Reviewable:end -->
