### PR TITLE
Avoid showing 0 in Quantity field when the minimal quantity is 0

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -33,9 +33,16 @@
             type="number"
             name="qty"
             id="quantity_wanted"
+            {if $product.quantity_wanted}
             value="{$product.quantity_wanted}"
-            class="input-group"
             min="{$product.minimal_quantity}"
+            {else}
+            value="1"
+            min="1"
+            {/if}
+            
+            class="input-group"
+            
             aria-label="{l s='Quantity' d='Shop.Theme.Actions'}"
           >
         </div>

--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -34,15 +34,13 @@
             name="qty"
             id="quantity_wanted"
             {if $product.quantity_wanted}
-            value="{$product.quantity_wanted}"
-            min="{$product.minimal_quantity}"
+              value="{$product.quantity_wanted}"
+              min="{$product.minimal_quantity}"
             {else}
-            value="1"
-            min="1"
+              value="1"
+              min="1"
             {/if}
-            
             class="input-group"
-            
             aria-label="{l s='Quantity' d='Shop.Theme.Actions'}"
           >
         </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  |  when minimal_quantity =0 it show 0 in quantity field on product page, but add product to cart when you click, this fix, will show 1 when minimal quantity =0
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| related issue    | Fixes #19233 
| Deprecations? | no
| How to test?  | edit product, set minimal quantity = 0, then go to product page on front you should see 0 in quantity field

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![image](https://user-images.githubusercontent.com/22837086/81834499-86c13800-9530-11ea-9bf1-ca11e9d372bf.png)
![image](https://user-images.githubusercontent.com/22837086/81834572-a193ac80-9530-11ea-93f4-8f0d58edcb4b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19116)
<!-- Reviewable:end -->
