### PR TITLE
Fix partial refund display issues in order page (BO)

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_orders.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_orders.scss
@@ -269,22 +269,13 @@ td .editProductInvoice {
 }
 
 .partial-refund {
-  display: none;
-
   .shipping-price-container {
     display: flex;
     margin-top: 8px;
   }
   .form-group {
-    display: inline-flex;
     width: max-content;
   }
-}
-
-.partial-refund label {
-  height: 30px;
-  padding: 0;
-  line-height: 30px;
 }
 
 .cancel-product-element,
@@ -302,7 +293,6 @@ td .editProductInvoice {
 .refund-checkboxes-container {
   display: none;
   width: fit-content;
-  max-width: 90px;
   margin: 16px auto;
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Css issues prevented the partial refund feature to be displayed properly in the BO (in order page)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18478
| How to test?  | See steps in the issue #18478

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19140)
<!-- Reviewable:end -->
