### PR TITLE
Improvement - Theme hook only_pages

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1184,4 +1184,35 @@ class DispatcherCore
 
         return $controllers;
     }
+
+    /**
+     * Get names of all available FO controllers.
+     *
+     * @var mixed
+     *
+     * @return array
+     */
+    public static function getControllersNames($dirs)
+    {
+        if (!is_array($dirs)) {
+            $dirs = [$dirs];
+        }
+
+        $controllers = Dispatcher::getControllers($dirs);
+
+        $controllersNames = [];
+        foreach ($controllers as $controller) {
+            $reflectionClass = new \ReflectionClass($controller);
+
+            $reflectionClassProperties = $reflectionClass->getDefaultProperties();
+
+            if (empty($reflectionClassProperties['php_self'])) {
+                continue;
+            }
+
+            $controllersNames[] = $reflectionClassProperties['php_self'];
+        }
+
+        return $controllersNames;
+    }
 }

--- a/src/Core/Module/HookRepository.php
+++ b/src/Core/Module/HookRepository.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Module;
 
 use Db;
+use Dispatcher;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider;
 use Shop;
@@ -158,28 +159,15 @@ class HookRepository
 
                 if (!empty($extra_data['only_pages'])) {
                     $extra_data['except_pages'] = [];
-                    $pages = [];
 
-                    $controllers = \Dispatcher::getControllers(_PS_FRONT_CONTROLLER_DIR_);
+                    $controllersNames = Dispatcher::getControllersNames(_PS_FRONT_CONTROLLER_DIR_);
 
-                    foreach ($controllers as $controller) {
-                        $reflectionClass = new \ReflectionClass($controller);
-
-                        $reflectionClassProperties = $reflectionClass->getDefaultProperties();
-
-                        if (empty($reflectionClassProperties['php_self'])) {
+                    foreach ($controllersNames as $controllerName) {
+                        if (in_array($controllerName, $extra_data['only_pages'])) {
                             continue;
                         }
 
-                        $pages[] = $reflectionClassProperties['php_self'];
-                    }
-
-                    foreach ($pages as $key => $page) {
-                        if (in_array($page, $extra_data['only_pages'])) {
-                            continue;
-                        }
-
-                        $extra_data['except_pages'][] = $page;
+                        $extra_data['except_pages'][] = $controllerName;
                     }
                 }
 

--- a/src/Core/Module/HookRepository.php
+++ b/src/Core/Module/HookRepository.php
@@ -156,6 +156,33 @@ class HookRepository
 
                 $this->db->insert('hook_module', $row);
 
+                if (!empty($extra_data['only_pages'])) {
+                    $extra_data['except_pages'] = [];
+                    $pages = [];
+
+                    $controllers = \Dispatcher::getControllers(_PS_FRONT_CONTROLLER_DIR_);
+
+                    foreach ($controllers as $controller) {
+                        $reflectionClass = new \ReflectionClass($controller);
+
+                        $reflectionClassProperties = $reflectionClass->getDefaultProperties();
+
+                        if (empty($reflectionClassProperties['php_self'])) {
+                            continue;
+                        }
+
+                        $pages[] = $reflectionClassProperties['php_self'];
+                    }
+
+                    foreach ($pages as $key => $page) {
+                        if (in_array($page, $extra_data['only_pages'])) {
+                            continue;
+                        }
+
+                        $extra_data['except_pages'][] = $page;
+                    }
+                }
+
                 if (!empty($extra_data['except_pages'])) {
                     $this->setModuleHookExceptions(
                         $id_module,

--- a/tests-legacy/Unit/Core/Module/HookConfiguratorTest.php
+++ b/tests-legacy/Unit/Core/Module/HookConfiguratorTest.php
@@ -96,6 +96,12 @@ class HookConfiguratorTest extends UnitTestCase
                         "product",
                     ],
                 ],
+                "blockcurrencies" => [
+                    "only_pages" => [
+                        "category",
+                        "product",
+                    ],
+                ],
             ],
         ];
 
@@ -104,6 +110,12 @@ class HookConfiguratorTest extends UnitTestCase
                 null,
                 "blocklanguages" => [
                     "except_pages" => [
+                        "category",
+                        "product",
+                    ],
+                ],
+                "blockcurrencies" => [
+                    "only_pages" => [
                         "category",
                         "product",
                     ],


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In contrast to except_pages sequences in theme.yml who's not very handy, this PR add the posibility to limit hooks to load only on specified pages thanks to an "only_pages" sequence.<br>except_pages continue to work but if only_pages and except_pages are set on the same hook, only_pages has priority.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16420.
| How to test?  | Run tests, or add only_pages sequence in theme.yml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19146)
<!-- Reviewable:end -->
