### PR TITLE
Remove _PS_MAGIC_QUOTES_GPC_ usage

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1825,10 +1825,6 @@ class ToolsCore
 
     public static function stripslashes($string)
     {
-        if (_PS_MAGIC_QUOTES_GPC_) {
-            $string = stripslashes($string);
-        }
-
         return $string;
     }
 
@@ -4219,15 +4215,8 @@ exit;
 
                 $purifier = new HTMLPurifier($config);
             }
-            if (_PS_MAGIC_QUOTES_GPC_) {
-                $html = stripslashes($html);
-            }
 
             $html = $purifier->purify($html);
-
-            if (_PS_MAGIC_QUOTES_GPC_) {
-                $html = addslashes($html);
-            }
         }
 
         return $html;

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -783,10 +783,6 @@ abstract class DbCore
      */
     public function escape($string, $html_ok = false, $bq_sql = false)
     {
-        if (_PS_MAGIC_QUOTES_GPC_) {
-            $string = stripslashes($string);
-        }
-
         if (!is_numeric($string)) {
             $string = $this->_escape($string);
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1664,11 +1664,6 @@ class AdminTranslationsControllerCore extends AdminController
                         $content = htmlspecialchars_decode($content);
                         // replace correct end of line
                         $content = str_replace("\r\n", PHP_EOL, $content);
-
-                        // Magic Quotes shall... not.. PASS!
-                        if (_PS_MAGIC_QUOTES_GPC_) {
-                            $content = stripslashes($content);
-                        }
                     }
 
                     if (Validate::isCleanHTML($content)) {
@@ -2962,10 +2957,6 @@ class AdminTranslationsControllerCore extends AdminController
             fwrite($fd, "<?php\n\nglobal \$_" . $tab . ";\n\$_" . $tab . " = array();\n");
 
             foreach ($sub as $key => $value) {
-                // Magic Quotes shall... not.. PASS!
-                if (_PS_MAGIC_QUOTES_GPC_) {
-                    $value = stripslashes($value);
-                }
                 fwrite($fd, '$_' . $tab . '[\'' . pSQL($key) . '\'] = \'' . pSQL($value) . '\';' . "\n");
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Because Magic_quotes_gpc has been removed in PHP 5.4 (https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-gpc). We also suppoirt PHP 7.1+ since the version 1.7.7.0, we don't need to keep dead code. Just keep the constant in defines.inc.php for BC.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | No need QA.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19154)
<!-- Reviewable:end -->
