### PR TITLE
Fix FrontController names in modules hook-exceptions

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -1184,4 +1184,52 @@ class DispatcherCore
 
         return $controllers;
     }
+
+    /**
+     * Get the default php_self value of a controller.
+     *
+     * @param string $controller The controller class name
+     *
+     * @return string|null
+     */
+    public static function getControllerPhpself($controller)
+    {
+        if (!class_exists($controller)) {
+            return;
+        }
+
+        $reflectionClass = new ReflectionClass($controller);
+        $controllerDefaultProperties = $reflectionClass->getDefaultProperties();
+
+        return isset($controllerDefaultProperties['php_self']) ? $controllerDefaultProperties['php_self'] : null;
+    }
+
+    /**
+     * Get list of all php_self property values of each available controller in the specified dir.
+     *
+     * @param string $dir Directory to scan (recursively)
+     * @param bool $base_name_otherwise Return the controller base name if no php_self is found
+     *
+     * @return array
+     */
+    public static function getControllersPhpself($dirs, $base_name_otherwise = true)
+    {
+        $controllers = Dispatcher::getControllers($dirs);
+
+        $controllersPhpself = [];
+
+        foreach ($controllers as $controllerBaseName => $controllerClassName) {
+            $controllerPhpself = Dispatcher::getControllerPhpself($controllerClassName);
+
+            if ($base_name_otherwise) {
+                $controllerPhpself = $controllerPhpself ? $controllerPhpself : $controllerBaseName;
+            }
+
+            if ($controllerPhpself) {
+                $controllersPhpself[] = $controllerPhpself;
+            }
+        }
+
+        return $controllersPhpself;
+    }
 }

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -446,12 +446,11 @@ class AdminModulesPositionsControllerCore extends AdminController
                     . $this->trans('___________ CUSTOM ___________', [], 'Admin.Design.Feature')
                     . '</option>';
 
-        /** @todo do something better with controllers */
-        $controllers = Dispatcher::getControllers(_PS_FRONT_CONTROLLER_DIR_);
-        ksort($controllers);
+        $controllers = Dispatcher::getControllersPhpself(_PS_FRONT_CONTROLLER_DIR_);
+        asort($controllers);
 
         foreach ($file_list as $k => $v) {
-            if (!array_key_exists($v, $controllers)) {
+            if (!in_array($v, $controllers)) {
                 $content .= '<option value="' . $v . '">' . $v . '</option>';
             }
         }
@@ -459,7 +458,7 @@ class AdminModulesPositionsControllerCore extends AdminController
         $content .= '<option disabled="disabled">' . $this->trans('____________ CORE ____________', [], 'Admin.Design.Feature') . '</option>';
 
         foreach ($controllers as $k => $v) {
-            $content .= '<option value="' . $k . '">' . $k . '</option>';
+            $content .= '<option value="' . $v . '">' . $v . '</option>';
         }
 
         $modules_controllers_type = ['admin' => $this->trans('Admin modules controller', [], 'Admin.Design.Feature'), 'front' => $this->trans('Front modules controller', [], 'Admin.Design.Feature')];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Previously, AdminModulesPositionsController used Dispatcher::getControllers(_PS_FRONT_CONTROLLER_DIR_) to suggest hook-exceptions for every module in every Core FrontController, however, this method returns a list of FrontControllers base names (such as myaccount, newproducts, bestsales ...), but in the other side, whenever the the Hook::exec() tries to check the exceptions, it uses the controller_name and php_self (such as my-account, new-products, best-sales ...) to compare, but never uses the base names.<br><br>This new code implements two new public static methods in the Dispatcher class, which work together to extract a list of all php_self property values of each available controller. Thus, AdminModulesPositionsController will suggest hook-exceptions based on php_self, and if php_self don't exist in a controller, then it will suggest the controller base name.
| Type?         | bug fix 
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no.
| How to test?  | **Making the Exception** : Go to back-office, chose an arbitrary module (ps_emailsubscription for example), and try to make this module disappear from the displayFooterBefore hook in some Core FrontController which have a $php_self thant contain a dash (exeple : 'my-account').<br><br> **Testing The exception** : now you should go to your front-office (after clearing the cache), navigate to the desired Core FrontController (http://something.com/mon-compte in my case) : The module (ps_emailsubscription) should not show up in this page. ![image](https://user-images.githubusercontent.com/39015823/82111516-3c190900-9746-11ea-8eee-8be7b6b7ef40.png)
|Explanation| When you go to chose an exception from the Core FrontControllers list, you have to notice that this list is generated based on Core FrontController files names : <br>**examples** : <br>- controllers/front/**MyAccount**Controller.php ==> myaccount<br> - controllers/front/**ChangeCurrency**Controller.php ==> changecurrency<br>So if you select **myaccount** for example, it will be stored in the DB (${prefix}_hook_module_exceptions table) as it is (**myaccount**). Then, in the rendering phase (precisely in **Hook::excec()**), the algorithm was comparing this DB value (**myaccount**) to current context controller **php_self** (**my-account**) <br>(**myaccount** ?= **my-account**)==> BUG !
|Solution| Replace the suggestion list filling method by anothoer one based on php_self properties default values.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19163)
<!-- Reviewable:end -->
