### PR TITLE
Hide Product Details when no info available to show in tab

### DIFF
--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -153,15 +153,24 @@
                          {if $product.description} aria-selected="true"{/if}>{l s='Description' d='Shop.Theme.Catalog'}</a>
                     </li>
                   {/if}
-                  <li class="nav-item">
-                    <a
-                      class="nav-link{if !$product.description} active{/if}"
-                      data-toggle="tab"
-                      href="#product-details"
-                      role="tab"
-                      aria-controls="product-details"
-                      {if !$product.description} aria-selected="true"{/if}>{l s='Product Details' d='Shop.Theme.Catalog'}</a>
-                  </li>
+                  {if isset($product_manufacturer->id)
+                      || (isset($product.reference_to_display) && $product.reference_to_display neq '')
+                      || $product.show_quantities
+                      || $product.availability_date
+                      || $product.grouped_features
+                      || !empty($product.specific_references
+                      || $product.condition)
+                       }
+                    <li class="nav-item">
+                      <a
+                        class="nav-link{if !$product.description} active{/if}"
+                        data-toggle="tab"
+                        href="#product-details"
+                        role="tab"
+                        aria-controls="product-details"
+                        {if !$product.description} aria-selected="true"{/if}>{l s='Product Details' d='Shop.Theme.Catalog'}</a>
+                    </li>
+                  {/if}
                   {if $product.attachments}
                     <li class="nav-item">
                       <a


### PR DESCRIPTION
Hide Product Details when no info available to show in tab.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Changed the Theme Classic included in Presta Shop to not show the Product Details tab link when there is no information to be shown.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18916 
| How to test?  | Do the steps in the Issue and also change the product quantity to 0 to check if the tab become hidden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19165)
<!-- Reviewable:end -->
