### PR TITLE
Docker-compose is failing due to missing build assets

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,4 +7,7 @@ RUN groupmod -g 1000 www-data \
 COPY /wait-for-it.sh /tmp/
 COPY /docker_run_git.sh /tmp/
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt install -y nodejs
+
 CMD ["/tmp/docker_run_git.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -7,6 +7,9 @@ RUN groupmod -g 1000 www-data \
 COPY /wait-for-it.sh /tmp/
 COPY /docker_run_git.sh /tmp/
 
+RUN mkdir -p /var/www/.npm
+RUN chown -R www-data:www-data /var/www/.npm
+
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt install -y nodejs
 

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-if [ ! -f ./vendor/autoload.php  ]; then
-	echo "\n* Vendor autoloader not found, running composer ...";
-	runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
-fi
+echo "\n* Running composer ...";
+runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
+
+echo "\n* Build assets ...";
+runuser -g www-data -u www-data -- /usr/bin/make assets
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since we removed assets from the source, we must add `make assets` in the docker_run_git.sh file when using `docker-compose`. Also, remove the check for autoload.php, we need to rerun the `composer install` command each time in case of we change the branch. Otherwise you have to remove manually the `vendor` directory which is unproductive.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Rebuild the container`docker-compose build --no-cache`, remove old volumes `docker-compose down -v` and run `docker-compose up`. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19188)
<!-- Reviewable:end -->
