### PR TITLE
Add breadcrumb to Stores & Sitemap front controllers

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -186,4 +186,16 @@ class SitemapControllerCore extends FrontController
 
         return $links;
     }
+
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Sitemap', [], 'Shop.Theme.Global'),
+            'url' => $this->context->link->getPageLink('sitemap', true)
+        ];
+
+        return $breadcrumb;
+    }
 }

--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -193,7 +193,7 @@ class SitemapControllerCore extends FrontController
 
         $breadcrumb['links'][] = [
             'title' => $this->trans('Sitemap', [], 'Shop.Theme.Global'),
-            'url' => $this->context->link->getPageLink('sitemap', true)
+            'url' => $this->context->link->getPageLink('sitemap', true),
         ];
 
         return $breadcrumb;

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -240,7 +240,7 @@ class StoresControllerCore extends FrontController
 
         $breadcrumb['links'][] = [
             'title' => $this->trans('Our stores', [], 'Shop.Theme.Global'),
-            'url' => $this->context->link->getPageLink('stores', true)
+            'url' => $this->context->link->getPageLink('stores', true),
         ];
         
         return $breadcrumb;

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -242,6 +242,7 @@ class StoresControllerCore extends FrontController
             'title' => $this->trans('Our stores', [], 'Shop.Theme.Global'),
             'url' => $this->context->link->getPageLink('stores', true),
         ];
+
         return $breadcrumb;
     }
 }

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -233,4 +233,16 @@ class StoresControllerCore extends FrontController
 
         return $stores;
     }
+
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Our stores', [], 'Shop.Theme.Global'),
+            'url' => $this->context->link->getPageLink('stores', true)
+        ];
+        
+        return $breadcrumb;
+    }
 }

--- a/controllers/front/StoresController.php
+++ b/controllers/front/StoresController.php
@@ -242,7 +242,6 @@ class StoresControllerCore extends FrontController
             'title' => $this->trans('Our stores', [], 'Shop.Theme.Global'),
             'url' => $this->context->link->getPageLink('stores', true),
         ];
-        
         return $breadcrumb;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add missing breadcrumbs in Stores and Sitemap pages in Front-office
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17131.
| How to test? | It partially fix #17131<br><br>So go to page :<br>* /index.php?controller=stores > Now there is a breadcrumb<br>* /index.php?controller=sitemap > Now there is a breadcrumb

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19195)
<!-- Reviewable:end -->
