### PR TITLE
Prefix parameter in CLI is not interpreted if it's empty

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -206,6 +206,8 @@ class Datas
 
             if ($res[1] == 'license' && !isset($res[2])) {
                 $res[2] = 1;
+            } elseif ($res[1] == 'prefix' && !isset($res[2])) {
+                $res[2] = '';
             } elseif (!isset($res[2])) {
                 continue;
             }

--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -206,7 +206,7 @@ class Datas
 
             if ($res[1] == 'license' && !isset($res[2])) {
                 $res[2] = 1;
-            } elseif ($res[1] == 'prefix' && !isset($res[2])) {
+            } elseif ($res[1] == 'prefix' && empty($res[2])) {
                 $res[2] = '';
             } elseif (!isset($res[2])) {
                 continue;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When using `--prefix=""` with `index_cli.php` the database prefix fallbacks to `ps_` contrary to the classic installer.
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19201
| How to test?  | Run `./install-dev/index_cli.php --prefix=""` or in `docker-compose.yml` add in `environment` this line: `DB_PREFIX: ''`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19213)
<!-- Reviewable:end -->
