### PR TITLE
Add caching on Theme Yaml parsing

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 use AbstractAssetManager;
 use PrestaShop\PrestaShop\Core\Addon\AddonInterface;
 use Shudrum\Component\ArrayFinder\ArrayFinder;
-use Symfony\Component\Yaml\Yaml;
+use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
 
 class Theme implements AddonInterface
 {
@@ -38,7 +38,8 @@ class Theme implements AddonInterface
     public function __construct(array $attributes)
     {
         if (isset($attributes['parent'])) {
-            $parentAttributes = Yaml::parse(file_get_contents(_PS_ALL_THEMES_DIR_ . '/' . $attributes['parent'] . '/config/theme.yml'));
+            $yamlParser = new YamlParser((new \Configuration())->get('_PS_CACHE_DIR_'));
+            $parentAttributes = $yamlParser->parse(_PS_ALL_THEMES_DIR_ . '/' . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -27,9 +27,10 @@
 namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 
 use AbstractAssetManager;
+use Configuration;
 use PrestaShop\PrestaShop\Core\Addon\AddonInterface;
-use Shudrum\Component\ArrayFinder\ArrayFinder;
 use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
+use Shudrum\Component\ArrayFinder\ArrayFinder;
 
 class Theme implements AddonInterface
 {
@@ -38,7 +39,7 @@ class Theme implements AddonInterface
     public function __construct(array $attributes)
     {
         if (isset($attributes['parent'])) {
-            $yamlParser = new YamlParser((new \Configuration())->get('_PS_CACHE_DIR_'));
+            $yamlParser = new YamlParser((new Configuration())->get('_PS_CACHE_DIR_'));
             $parentAttributes = $yamlParser->parse(_PS_ALL_THEMES_DIR_ . '/' . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add caching on Theme Yaml parsing by using PrestaShop PrestaShop\PrestaShop\Core\Util\File\YamlParser (with built-in cache) instead of Symfony Yaml parser directly. This helps avoiding multiple `file_get_content()` and YAML to PHP array conversions.<br><br>This YAML file parsing happens _when there is a child theme using parents configuration_.<br><br>So in current implementation, if we have 10 children themes on the disk and they all use Classic as parent, this will load the YAML configuration file of Classic Theme 10 times.<br/>This PR puts this config file in cache to avoid that.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | with xhprof / blackfireIO, no more Yaml classes loaded (once in cache)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19231)
<!-- Reviewable:end -->
