### PR TITLE
Fix order payment duplication depending on order state configuration

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -716,6 +716,7 @@ class OrderInvoiceCore extends ObjectModel
      */
     public function getRestPaid()
     {
+        if (!$this->number) return 0;
         return round($this->total_paid_tax_incl + $this->getSiblingTotal() - $this->getTotalPaid(), 2);
     }
 

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -716,7 +716,10 @@ class OrderInvoiceCore extends ObjectModel
      */
     public function getRestPaid()
     {
-        if (!$this->number) return 0;
+        if (!$this->number) {
+            return 0;
+        }
+        
         return round($this->total_paid_tax_incl + $this->getSiblingTotal() - $this->getTotalPaid(), 2);
     }
 

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -719,7 +719,7 @@ class OrderInvoiceCore extends ObjectModel
         if (!$this->number) {
             return 0;
         }
-        
+
         return round($this->total_paid_tax_incl + $this->getSiblingTotal() - $this->getTotalPaid(), 2);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Avoid considering "dummy" invoices with number 0 to miss payments
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12588.
| How to test?  | Place an order that is paid and invoice is not yet generated. Change order state to Preparation (previously configured with paid = true, invoice = false). Without the fix a "double" payment is automatically created.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19260)
<!-- Reviewable:end -->
