### PR TITLE
Fix empty email subject in the translation interface

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,6 +2191,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
+    
     /**
      * @param $directory : name of directory
      *
@@ -2200,9 +2201,9 @@ class AdminTranslationsControllerCore extends AdminController
     {
         $subject_mail_content = [];
 
-        if (Tools::file_exists_cache($directory.'/lang.php')) {
+        if (Tools::file_exists_cache($directory . '/lang.php')) {
             // we need to include this even if already included (no include once)
-            include($directory . '/lang.php');
+            include $directory . '/lang.php';
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
                 ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);
@@ -2214,6 +2215,7 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
+        
         return $subject_mail_content;
     }
     

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2204,7 +2204,7 @@ class AdminTranslationsControllerCore extends AdminController
             // we need to include this even if already included (no include once)
             include($directory . '/lang.php');
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
-                $this->total_expression++;
+                ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);
                 $subject = str_replace("\\'", "\'", $subject);
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,7 +2191,6 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
-    
     /**
      * @param $directory : name of directory
      *

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2193,33 +2193,6 @@ class AdminTranslationsControllerCore extends AdminController
     }
     
     /**
-     * @param $directory : name of directory
-     *
-     * @return array
-     */
-    protected function getSubjectMailContent($directory)
-    {
-        $subject_mail_content = [];
-
-        if (Tools::file_exists_cache($directory . '/lang.php')) {
-            // we need to include this even if already included (no include once)
-            include $directory . '/lang.php';
-            foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
-                ++$this->total_expression;
-                $subject = str_replace('\n', ' ', $subject);
-                $subject = str_replace("\\'", "\'", $subject);
-
-                $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
-                $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
-            }
-        } else {
-            $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
-        }
-        
-        return $subject_mail_content;
-    }
-    
-    /**
      * This method generate the form for errors translations.
      */
     public function initFormErrors()
@@ -3336,5 +3309,32 @@ class AdminTranslationsControllerCore extends AdminController
         $this->ajaxRender(
             AdminTranslationsController::getEmailHTML($email)
         );
+    }
+    
+    /**
+     * @param $directory : name of directory
+     *
+     * @return array
+     */
+    protected function getSubjectMailContent($directory)
+    {
+        $subject_mail_content = [];
+
+        if (Tools::file_exists_cache($directory . '/lang.php')) {
+            // we need to include this even if already included (no include once)
+            include $directory . '/lang.php';
+            foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
+                ++$this->total_expression;
+                $subject = str_replace('\n', ' ', $subject);
+                $subject = str_replace("\\'", "\'", $subject);
+
+                $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
+                $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
+            }
+        } else {
+            $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
+        }
+        
+        return $subject_mail_content;
     }
 }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3310,7 +3310,6 @@ class AdminTranslationsControllerCore extends AdminController
             AdminTranslationsController::getEmailHTML($email)
         );
     }
-    
     /**
      * @param $directory : name of directory
      *

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2194,6 +2194,7 @@ class AdminTranslationsControllerCore extends AdminController
     
     /**
      * @param $directory : name of directory
+     *
      * @return array
      */
     protected function getSubjectMailContent($directory)

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3319,23 +3319,19 @@ class AdminTranslationsControllerCore extends AdminController
     protected function getSubjectMailContent($directory)
     {
         $subject_mail_content = [];
-
         if (Tools::file_exists_cache($directory . '/lang.php')) {
             // we need to include this even if already included (no include once)
-            include $directory . '/lang.php';
-            
+            include $directory . '/lang.php';          
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
                 ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);
                 $subject = str_replace("\\'", "\'", $subject);
-
                 $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
                 $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
             }
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
-        
         return $subject_mail_content;
     }
 }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,7 +2191,6 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
-    
     /**
      * This method generate the form for errors translations.
      */

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3321,7 +3321,6 @@ class AdminTranslationsControllerCore extends AdminController
         if (Tools::file_exists_cache($directory . '/lang.php')) {
             // we need to include this even if already included (no include once)
             include $directory . '/lang.php';
-            
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
                 ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3330,7 +3330,7 @@ class AdminTranslationsControllerCore extends AdminController
                 $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
             }
         } else {
-            $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
+            $this->errors[] = $this->trans('Email subject translation file not found in %path%', ['%path%' => $directory], 'Admin.International.Notification');
         }
 
         return $subject_mail_content;

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3331,6 +3331,7 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
+
         return $subject_mail_content;
     }
 }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3323,6 +3323,7 @@ class AdminTranslationsControllerCore extends AdminController
         if (Tools::file_exists_cache($directory . '/lang.php')) {
             // we need to include this even if already included (no include once)
             include $directory . '/lang.php';
+            
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
                 ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,7 +2191,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
-    
+
     /**
      * This method generate the form for errors translations.
      */

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3324,7 +3324,6 @@ class AdminTranslationsControllerCore extends AdminController
                 ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);
                 $subject = str_replace("\\'", "\'", $subject);
-                
                 $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
                 $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
             }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3319,7 +3319,6 @@ class AdminTranslationsControllerCore extends AdminController
     protected function getSubjectMailContent($directory)
     {
         $subject_mail_content = [];
-        
         if (Tools::file_exists_cache($directory . '/lang.php')) {
             // we need to include this even if already included (no include once)
             include $directory . '/lang.php';

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3319,19 +3319,23 @@ class AdminTranslationsControllerCore extends AdminController
     protected function getSubjectMailContent($directory)
     {
         $subject_mail_content = [];
+        
         if (Tools::file_exists_cache($directory . '/lang.php')) {
             // we need to include this even if already included (no include once)
-            include $directory . '/lang.php';          
+            include $directory . '/lang.php';
+            
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
                 ++$this->total_expression;
                 $subject = str_replace('\n', ' ', $subject);
                 $subject = str_replace("\\'", "\'", $subject);
+                
                 $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
                 $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
             }
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
+        
         return $subject_mail_content;
     }
 }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,6 +2191,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
+    
     /**
      * @param $directory : name of directory
      *
@@ -2214,8 +2215,10 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
+        
         return $subject_mail_content;
     }
+    
     /**
      * This method generate the form for errors translations.
      */

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3330,7 +3330,6 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
-        
         return $subject_mail_content;
     }
 }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2198,7 +2198,7 @@ class AdminTranslationsControllerCore extends AdminController
      */
     protected function getSubjectMailContent($directory)
     {
-        $subject_mail_content = array();
+        $subject_mail_content = [];
 
         if (Tools::file_exists_cache($directory.'/lang.php')) {
             // we need to include this even if already included (no include once)

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2202,7 +2202,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         if (Tools::file_exists_cache($directory.'/lang.php')) {
             // we need to include this even if already included (no include once)
-            include($directory.'/lang.php');
+            include($directory . '/lang.php');
             foreach ($GLOBALS[$this->translations_informations[$this->type_selected]['var']] as $key => $subject) {
                 $this->total_expression++;
                 $subject = str_replace('\n', ' ', $subject);

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,6 +2191,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
+    
     /**
      * This method generate the form for errors translations.
      */

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -3309,6 +3309,7 @@ class AdminTranslationsControllerCore extends AdminController
             AdminTranslationsController::getEmailHTML($email)
         );
     }
+
     /**
      * @param $directory : name of directory
      *

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2191,7 +2191,6 @@ class AdminTranslationsControllerCore extends AdminController
 
         return $modules;
     }
-    
     /**
      * @param $directory : name of directory
      *
@@ -2215,10 +2214,8 @@ class AdminTranslationsControllerCore extends AdminController
         } else {
             $this->errors[] = sprintf($this->l('Email subject translation file not found in "%s".'), $directory);
         }
-        
         return $subject_mail_content;
     }
-    
     /**
      * This method generate the form for errors translations.
      */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Subject's translation is not displayed in the input field when I saved it from the email translation section check this screenshot ![image](https://user-images.githubusercontent.com/1533248/82785946-dc1c1400-9e63-11ea-8454-81753b97ab11.png)
| Type?         | bug fix 
| Category?     | BO
| Fixed ticket? | Fixes #19288 and #15381
| How to test?  | Please install our test module from this link [wktestmodule](https://github.com/Amit-Kumar-Tiwari-Webkul/wktestmodule/blob/master/wktestmodule.zip)<br>and install it and follow the steps as mention in issue #19288

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19289)
<!-- Reviewable:end -->
