### PR TITLE
Add missing breadcrumb links in order pages: confirmation/return/follow, cart and addresses pages

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -138,12 +138,10 @@ class AddressControllerCore extends FrontController
             'url' => $this->context->link->getPageLink('addresses'),
         ];
 
-        $title = $this->trans('New address', [], 'Shop.Theme.Customeraccount');
-
         $id_address = Tools::getValue('id_address');
-        if ($id_address) {
-            $title = $this->trans('Update your address', [], 'Shop.Theme.Customeraccount');
-        }
+        $title = $id_address
+            ? $this->trans('Update your address', [], 'Shop.Theme.Customeraccount')
+            : $this->trans('New address', [], 'Shop.Theme.Customeraccount');
 
         $breadcrumb['links'][] = [
             'title' => $title,

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -138,6 +138,18 @@ class AddressControllerCore extends FrontController
             'url' => $this->context->link->getPageLink('addresses'),
         ];
 
+        $title = $this->trans('New address', [], 'Shop.Theme.Customeraccount');
+
+        $id_address = Tools::getValue('id_address');
+        if ($id_address) {
+            $title = $this->trans('Update your address', [], 'Shop.Theme.Customeraccount');
+        }
+
+        $breadcrumb['links'][] = [
+            'title' => $title,
+            'url' => '#',
+        ];
+
         return $breadcrumb;
     }
 

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -680,16 +680,4 @@ class CartControllerCore extends FrontController
             }
         }
     }
-
-    public function getBreadcrumbLinks()
-    {
-        $breadcrumb = parent::getBreadcrumbLinks();
-
-        $breadcrumb['links'][] = [
-            'title' => $this->trans('Cart', [], 'Shop.Theme.Checkout'),
-            'url' => $this->context->link->getPageLink('cart'),
-        ];
-
-        return $breadcrumb;
-    }
 }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -680,4 +680,16 @@ class CartControllerCore extends FrontController
             }
         }
     }
+
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Cart', [], 'Shop.Theme.Checkout'),
+            'url' => $this->context->link->getPageLink('cart'),
+        ];
+
+        return $breadcrumb;
+    }
 }

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -159,4 +159,16 @@ class OrderConfirmationControllerCore extends FrontController
             $cart->secure_key
         );
     }
+
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Order confirmation', [], 'Shop.Theme.Checkout'),
+            'url' => $this->context->link->getPageLink('order-confirmation'),
+        ];
+
+        return $breadcrumb;
+    }
 }

--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -134,6 +134,10 @@ class OrderFollowControllerCore extends FrontController
         $breadcrumb = parent::getBreadcrumbLinks();
 
         $breadcrumb['links'][] = $this->addMyAccountToBreadcrumb();
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('Merchandise returns', [], 'Shop.Theme.Global'),
+            'url' => $this->context->link->getPageLink('order-follow'),
+        ];
 
         return $breadcrumb;
     }

--- a/controllers/front/OrderReturnController.php
+++ b/controllers/front/OrderReturnController.php
@@ -24,6 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderReturnLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderReturnPresenter;
 
 class OrderReturnControllerCore extends FrontController
@@ -175,6 +176,17 @@ class OrderReturnControllerCore extends FrontController
             $breadcrumb['links'][] = [
                 'title' => $this->trans('Merchandise returns', [], 'Shop.Theme.Global'),
                 'url' => $this->context->link->getPageLink('order-follow'),
+            ];
+
+            $prefix = Configuration::get('PS_RETURN_PREFIX', $this->context->language->id);
+            $orderReturn = new OrderReturn($id_order_return);
+            $orderReturn->id_order_return = $id_order_return;
+            $orderReturnLazyArray = new OrderReturnLazyArray($prefix, $this->context->link, (array) $orderReturn);
+            $orderReturnNumber = $orderReturnLazyArray->getReturnNumber();
+
+            $breadcrumb['links'][] = [
+                'title' => $orderReturnNumber,
+                'url' => '#',
             ];
         }
 


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add breadcrumb links to pages: cart, order confirmation, customer merchandise returns, return details, 4th breadcrumb level for addresses: update address, create new address
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17131.
| How to test?  | 

Go to following pages to reproduce:
- /index.php?controller=OrderFollow > added 'Merchandise returns' link
- /index.php?controller=OrderReturn > : added Return number as 4th level of breadcrumb
- /index.php?controller=OrderConfirmation > : added 'Order confirmation' link
- /index.php?controller=Address > : added 'Update your address' or 'New address' as 4th level

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19298)
<!-- Reviewable:end -->
