### PR TITLE
Add API status block in webservice page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -69,7 +69,7 @@ class WebserviceController extends FrameworkBundleAdminController
         $configurationWarnings = $this->lookForWarnings();
 
         $webserviceConfiguration = $this->get('prestashop.admin.webservice.form_data_provider')->getData();
-        $webserviceIsEnabled = $webserviceConfiguration['webservice_configuration']['enable_webservice'];
+        $webserviceIsEnabled = $webserviceConfiguration['enable_webservice'];
         $webserviceStatus = [
             'enabled' => $webserviceIsEnabled,
             'isFunctional' => true,
@@ -77,11 +77,8 @@ class WebserviceController extends FrameworkBundleAdminController
         ];
 
         if ($webserviceIsEnabled) {
-            $expectedWebserviceEntryPoint = $request->getSchemeAndHttpHost() . self::WEBSERVICE_ENTRY_ENDPOINT;
-            $webServiceEntryPointIsReachable = $this->checkWebserviceEndpoint($expectedWebserviceEntryPoint);
-
-            $webserviceStatus['endpoint'] = $expectedWebserviceEntryPoint;
-            $webserviceStatus['isFunctional'] = $webServiceEntryPointIsReachable;
+            $webserviceStatus['endpoint'] = $request->getSchemeAndHttpHost() . self::WEBSERVICE_ENTRY_ENDPOINT;
+            $webserviceStatus['isFunctional'] = $this->checkWebserviceEndpoint($webserviceStatus['endpoint']);
         }
 
         return $this->render(
@@ -101,7 +98,7 @@ class WebserviceController extends FrameworkBundleAdminController
      *
      * @return bool
      */
-    private function checkWebserviceEndpoint($url): bool
+    private function checkWebserviceEndpoint(?string $url): bool
     {
         if ($url === null) {
             return false;
@@ -116,9 +113,9 @@ class WebserviceController extends FrameworkBundleAdminController
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
 
-        if ($httpCode >= 200 && $httpCode < 300) {
+        if ($httpCode >= Response::HTTP_OK && $httpCode < Response::HTTP_MULTIPLE_CHOICES) {
             return true;
-        } elseif ($httpCode == 401) {
+        } elseif ($httpCode == Response::HTTP_UNAUTHORIZED) {
             return true;
         }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -76,16 +76,16 @@
             </p>
             {% if webserviceStatus['isFunctional'] == true %}
               <p>
-                {{ "Developer documentation can be found [1]here[/1]."|trans({
+                {{ "Read the [1]developer documentation[/1] to learn more about it."|trans({
                   '[1]': '<a href="'~devdocUrl~'">', '[/1]': "</a>"
                 }, 'Admin.Advparameters.Feature')|raw }}
               </p>
             {% else %}
               <p>
-                {{ 'It seems webservice endpoint is not functional. If you are using httpd/apache2, you need to enable URL Rewriting.'|trans }}
+                {{ 'It seems that the webservice endpoint is not functional. If you are using httpd/apache2, you need to enable URL rewriting on your server.'|trans }}
               </p>
               <p>
-                {{ "Read the [1]developer documentation[/1] to find how."|trans({
+                {{ "Read the [1]developer documentation[/1] to learn more about it."|trans({
                   '[1]': '<a href="'~devdocUrl~'">', '[/1]': "</a>"
                 }, 'Admin.Advparameters.Feature')|raw }}
               </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -34,12 +34,12 @@
     'desc': 'Add new webservice key'|trans({}, 'Admin.Advparameters.Feature'),
     'icon': 'add_circle_outline'
   }
-  } %}
+} %}
 
 {% block content %}
 
   {% block webservice_list_notifications %}
-    {% if configurationWarnings is not empty %}
+    {% if configurationWarnings is not empty  %}
       <div class="row">
         <div class="col">
           <div class="alert alert-warning" role="alert">
@@ -52,7 +52,15 @@
     {% endif %}
   {% endblock %}
 
+  <div class="row">
+    <div class="col">
+      {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
+    </div>
+  </div>
+
   {% block webservice_api_status %}
+    {% set devdocUrl = 'https://devdocs.prestashop.com/1.7/development/webservice/' %}
+
     {% if webserviceStatus['enabled'] == true %}
       <div class="card">
         <h3 class="card-header">
@@ -61,28 +69,25 @@
         <div class="card-block">
           <div class="card-text">
             <p>
-              Webservice is enabled. Main entry point is
+              {{ 'Webservice is enabled. Main entry point is' |trans }}
               <a href="{{ webserviceStatus['endpoint'] }}">
                 {{ webserviceStatus['endpoint'] }}
               </a>
             </p>
             {% if webserviceStatus['isFunctional'] == true %}
               <p>
-                Developer documentation can be found <a
-                  href="https://devdocs.prestashop.com/1.7/development/webservice/">
-                  here
-                </a>.
+                {{ "Developer documentation can be found [1]here[/1]."|trans({
+                  '[1]': '<a href="'~devdocUrl~'">', '[/1]': "</a>"
+                }, 'Admin.Advparameters.Feature')|raw }}
               </p>
             {% else %}
               <p>
-                It seems webservice endpoint is not functional.
-                If you are using httpd/apache2, you need to enable URL Rewriting.
+                {{ 'It seems webservice endpoint is not functional. If you are using httpd/apache2, you need to enable URL Rewriting.'|trans }}
               </p>
               <p>
-                Read the <a
-                  href="https://devdocs.prestashop.com/1.7/development/webservice/">
-                  developer documentation
-                </a> to find how.
+                {{ "Read the [1]developer documentation[/1] to find how."|trans({
+                  '[1]': '<a href="'~devdocUrl~'">', '[/1]': "</a>"
+                }, 'Admin.Advparameters.Feature')|raw }}
               </p>
             {% endif %}
 
@@ -92,35 +97,20 @@
     {% endif %}
   {% endblock %}
 
-  <div class="row">
+  <div class="row justify-content-center">
     <div class="col">
-      {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
+      {{ form_start(webserviceConfigurationForm, {'action': path('admin_webservice_save_settings') ,'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
+
+      {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
+
+      {% block webservice_configuration_form_rest %}
+        {{ form_rest(webserviceConfigurationForm) }}
+      {% endblock %}
+
+      {{ form_end(webserviceConfigurationForm) }}
     </div>
   </div>
-
-  <div class="row justify-content-center">
-    <div class="row">
-      <div class="col">
-        {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
-      </div>
-    </div>
-
-    {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
-
-    <div class="row justify-content-center">
-      <div class="col">
-        {{ form_start(webserviceConfigurationForm, {'action': path('admin_webservice_save_settings') ,'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
-
-        {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
-
-        {% block webservice_configuration_form_rest %}
-          {{ form_rest(webserviceConfigurationForm) }}
-        {% endblock %}
-
-        {{ form_end(webserviceConfigurationForm) }}
-      </div>
-    </div>
-    {% endblock %}
+{% endblock %}
 
 {% block javascripts %}
   {{ parent() }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -39,13 +39,53 @@
 {% block content %}
 
   {% block webservice_list_notifications %}
-    {% if configurationWarnings is not empty  %}
+    {% if configurationWarnings is not empty %}
       <div class="row">
         <div class="col">
           <div class="alert alert-warning" role="alert">
             {% for warning in configurationWarnings %}
               <p class="alert-text">{{ warning }}</p>
             {% endfor %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  {% endblock %}
+
+  {% block webservice_api_status %}
+    {% if webserviceStatus['enabled'] == true %}
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">info_outline</i> {{ 'Webservice status'|trans }}
+        </h3>
+        <div class="card-block">
+          <div class="card-text">
+            <p>
+              Webservice is enabled. Main entry point is
+              <a href="{{ webserviceStatus['endpoint'] }}">
+                {{ webserviceStatus['endpoint'] }}
+              </a>
+            </p>
+            {% if webserviceStatus['isFunctional'] == true %}
+              <p>
+                Developer documentation can be found <a
+                  href="https://devdocs.prestashop.com/1.7/development/webservice/">
+                  here
+                </a>.
+              </p>
+            {% else %}
+              <p>
+                It seems webservice endpoint is not functional.
+                If you are using httpd/apache2, you need to enable URL Rewriting.
+              </p>
+              <p>
+                Read the <a
+                  href="https://devdocs.prestashop.com/1.7/development/webservice/">
+                  developer documentation
+                </a> to find how.
+              </p>
+            {% endif %}
+
           </div>
         </div>
       </div>
@@ -59,8 +99,17 @@
   </div>
 
   <div class="row justify-content-center">
-    <div class="col">
-      {{ form_start(webserviceConfigurationForm, {'action': path('admin_webservice_save_settings') ,'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
+    <div class="row">
+      <div class="col">
+        {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
+      </div>
+    </div>
+
+    {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
+
+    <div class="row justify-content-center">
+      <div class="col">
+        {{ form_start(webserviceConfigurationForm, {'action': path('admin_webservice_save_settings') ,'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
 
         {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
 
@@ -68,10 +117,10 @@
           {{ form_rest(webserviceConfigurationForm) }}
         {% endblock %}
 
-      {{ form_end(webserviceConfigurationForm) }}
+        {{ form_end(webserviceConfigurationForm) }}
+      </div>
     </div>
-  </div>
-{% endblock %}
+    {% endblock %}
 
 {% block javascripts %}
   {{ parent() }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Adds a block to indicate API endpoint URL, attempt to check whether it seems working and provide documentation link. Idea is to hep people struggling with API setup.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/19590
| How to test?  | Open webservice page and enable API. See new block, as displayed in https://github.com/PrestaShop/PrestaShop/pull/19335#issuecomment-648015337

### How it looks

See https://github.com/PrestaShop/PrestaShop/pull/19335#issuecomment-648015337

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19335)
<!-- Reviewable:end -->
