### PR TITLE
Fix options in CustomerAddressType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -334,8 +334,8 @@ class CustomerAddressType extends AbstractType
             ])
             ->add('id_country', CountryChoiceType::class, [
                 'required' => true,
-                'withDniAttr' => true,
-                'withPostcodeAttr' => true,
+                'with_dni_attr' => true,
+                'with_postcode_attr' => true,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->translator->trans(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | options `with_dni_attr` and `with_postcode_attr` were passed with wrong camel case instead of snake case after one of the pr got merged in develop branch. This led to error when trying to edit address in order view page. ![Screenshot from 2020-05-25 17-31-39](https://user-images.githubusercontent.com/31609858/82822253-2629e780-9eae-11ea-98d4-4647d396fa6e.png)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | Go to orders, select any order for viewing, press `three dots` in addresses tab -> `edit existing address` -> `see a form loaded without any errors`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19338)
<!-- Reviewable:end -->
