### PR TITLE
Fixed the SMTP Configuration Toggler

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/email/smtp-configuration-toggler.js
+++ b/admin-dev/themes/new-theme/js/pages/email/smtp-configuration-toggler.js
@@ -31,7 +31,7 @@ const {$} = window;
 class SmtpConfigurationToggler {
   constructor() {
     $('.js-email-method').on('change', 'input[type="radio"]', (event) => {
-      const mailMethod = $(event.currentTarget).val();
+      const mailMethod = Number($(event.currentTarget).val());
 
       if (this.getSmtpMailMethodOption() === mailMethod) {
         this.showSmtpConfiguration();
@@ -64,7 +64,7 @@ class SmtpConfigurationToggler {
    *
    * @private
    *
-   * @returns {String}
+   * @returns {Number}
    */
   getSmtpMailMethodOption() {
     return $('.js-email-method').data('smtp-mail-method');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed the SMTP Configuration Toggler
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18549
| How to test?  | 0. Build assets <br>1.  Go to BO > Advanced Parameters => Emails page<br>2. Select the option "Set my own SMTP parameters (for advanced users ONLY)".<br>3. **BEFORE**: The SMTP configuration card is not opened<br>3. **AFTER** The SMTP Configuration card is opened

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19361)
<!-- Reviewable:end -->
