### PR TITLE
Replaced h2 title by h1 in the product listing of the catalog

### DIFF
--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -28,7 +28,7 @@
   <section id="main">
 
     {block name='product_list_header'}
-      <h2 id="js-product-list-header" class="h2">{$listing.label}</h2>
+      <h1 id="js-product-list-header" class="h2">{$listing.label}</h1>
     {/block}
 
     {block name='subcategory_list'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Replaced h2 title by h1 in the product listing of the catalog
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17878
| How to test?  | 1. Go on front office.<br>2. On pages Catalog (Best Sales, New Products, Prices Drop, Listing, Search) :<br>2.1 **BEFORE** Title is an `<h2>`<br>2.1 **AFTER** Title is an `<h1>`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19384)
<!-- Reviewable:end -->
