### PR TITLE
Return 404 in frontoffice if return merchandise is disabed

### DIFF
--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -93,6 +93,11 @@ class OrderFollowControllerCore extends FrontController
      */
     public function initContent()
     {
+        if ((bool) Configuration::get('PS_ORDER_RETURN') === false) {
+            $this->redirect_after = '404';
+            $this->redirect();
+        }
+
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Return page should not be avalaible if returns is disabled 
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19199
| How to test?  |-  Go to BO Customer Service > Merchandise Returns<br>- Set "enable return " to "no"<br>- Go to https://yourshop.tld/index.php?controller=orderfollow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19395)
<!-- Reviewable:end -->
