### PR TITLE
Cart rule is applied even is disabled in specific conditions

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2130,11 +2130,11 @@ class CartCore extends ObjectModel
     protected function getTotalCalculationCartRules($type, $withShipping)
     {
         if ($withShipping || $type == Cart::ONLY_DISCOUNTS) {
-            $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_ALL);
+            $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_ALL, true, true);
         } else {
-            $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_REDUCTION, false);
+            $cartRules = $this->getCartRules(CartRule::FILTER_ACTION_REDUCTION, false, true);
             // Cart Rules array are merged manually in order to avoid doubles
-            foreach ($this->getCartRules(CartRule::FILTER_ACTION_GIFT, false) as $cartRuleCandidate) {
+            foreach ($this->getCartRules(CartRule::FILTER_ACTION_GIFT, false, true) as $cartRuleCandidate) {
                 $alreadyAddedCartRule = false;
                 foreach ($cartRules as $cartRule) {
                     if ($cartRuleCandidate['id_cart_rule'] == $cartRule['id_cart_rule']) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -463,7 +463,7 @@ class CartCore extends ObjectModel
             CartRule::autoAddToCart($virtual_context);
         }
 
-        $cache_key = 'Cart::getCartRules_' . $this->id . '-' . $filter. '-' . $active;
+        $cache_key = 'Cart::getCartRules_' . $this->id . '-' . $filter . '-' . $active;
         if (!Cache::isStored($cache_key)) {
             $result = Db::getInstance()->executeS(
                 'SELECT cr.*, crl.`id_lang`, crl.`name`, cd.`id_cart`

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -445,10 +445,11 @@ class CartCore extends ObjectModel
      *                    - FILTER_ACTION_GIFT
      *                    - FILTER_ACTION_ALL_NOCAP
      * @param bool $autoAdd automaticaly adds cart ruls without code to cart
+     * @param bool $active true if the cart ruls must be active
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null Database result
      */
-    public function getCartRules($filter = CartRule::FILTER_ACTION_ALL, $autoAdd = true)
+    public function getCartRules($filter = CartRule::FILTER_ACTION_ALL, $autoAdd = true, $active = false)
     {
         // Define virtual context to prevent case where the cart is not the in the global context
         $virtual_context = Context::getContext()->cloneContext();
@@ -473,6 +474,7 @@ class CartCore extends ObjectModel
                     AND crl.id_lang = ' . (int) $this->id_lang . '
                 )
                 WHERE `id_cart` = ' . (int) $this->id . '
+                ' . ($active ? ' AND cr.active = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -463,7 +463,7 @@ class CartCore extends ObjectModel
             CartRule::autoAddToCart($virtual_context);
         }
 
-        $cache_key = 'Cart::getCartRules_' . $this->id . '-' . $filter;
+        $cache_key = 'Cart::getCartRules_' . $this->id . '-' . $filter. '-' . $active;
         if (!Cache::isStored($cache_key)) {
             $result = Db::getInstance()->executeS(
                 'SELECT cr.*, crl.`id_lang`, crl.`name`, cd.`id_cart`

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -502,7 +502,7 @@ class CartPresenter implements PresenterInterface
         $shippingDisplayValue = '';
 
         // if one of the applied cart rules have free shipping, then the shipping display value is 'Free'
-        foreach ($cart->getCartRules() as $rule) {
+        foreach ($cart->getCartRules(CartRule::FILTER_ACTION_ALL, true, true) as $rule) {
             if ($rule['free_shipping'] && !$rule['carrier_restriction']) {
                 return $this->translator->trans('Free', [], 'Shop.Theme.Checkout');
             }
@@ -536,7 +536,7 @@ class CartPresenter implements PresenterInterface
 
     private function getTemplateVarVouchers(Cart $cart)
     {
-        $cartVouchers = $cart->getCartRules();
+        $cartVouchers = $cart->getCartRules(CartRule::FILTER_ACTION_ALL, true, true);
         $vouchers = [];
 
         $cartHasTax = null === $cart->id ? false : $cart::getTaxesAverageUsed($cart);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | If a Cart rule for cheapest product is created but not enabled and if a second cart rule is created and enabled the first one is displayed and enabled in the FO.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19393.
| How to test?  | See #19393 By @SD1982 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19399)
<!-- Reviewable:end -->
