### PR TITLE
Fix logic for adding anchor to URL

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -127,8 +127,9 @@ class LinkCore
      * @param int|null $ipa ID product attribute
      * @param bool $force_routes
      * @param bool $relativeProtocol
-     * @param bool $addAnchor
+     * @param bool $addAnchor Either add or not # with combination informations after an URL
      * @param array $extraParams
+     * @param bool $withIdInAnchor Add or not id_attribute in combination anchor
      *
      * @return string
      */

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -142,8 +142,9 @@ class LinkCore
         $ipa = null,
         $force_routes = false,
         $relativeProtocol = false,
-        $addAnchor = false,
-        $extraParams = []
+        $addAnchor = true,
+        $extraParams = [],
+        $withIdInAnchor = false
     ) {
         $dispatcher = Dispatcher::getInstance();
 
@@ -237,7 +238,11 @@ class LinkCore
         if ($ipa) {
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
-        $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $addAnchor) : '';
+        
+        $anchor = '';
+        if ($addAnchor) {
+             $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $withIdInAnchor) : '';
+        }
 
         return $url . $dispatcher->createUrl('product_rule', $idLang, array_merge($params, $extraParams), $force_routes, $anchor, $idShop);
     }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -241,7 +241,7 @@ class LinkCore
         
         $anchor = '';
         if ($addAnchor) {
-             $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $withIdInAnchor) : '';
+            $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $withIdInAnchor) : '';
         }
 
         return $url . $dispatcher->createUrl('product_rule', $idLang, array_merge($params, $extraParams), $force_routes, $anchor, $idShop);

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -238,7 +238,6 @@ class LinkCore
         if ($ipa) {
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
-        
         $anchor = '';
         if ($addAnchor) {
             $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $withIdInAnchor) : '';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | as you can see in code, we couldn't remove anchor from URL at all, this PR fixes this issue and make sure that param $addAnchor is indeed used, to prevent this PR to be a "breaking change" i set "addAnchor" to true and added new new param to be provided for getAnchor method
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | try to get URL for a product with "addAnchor" set to `false` before and after this change

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19400)
<!-- Reviewable:end -->
