### PR TITLE
Rename and deprecate confusing method in classes/Configuration.php

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -255,6 +255,14 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
+     * @deprecated use Configuration::getConfigInMultipleLangs() instead.
+     */
+    public static function getInt($key, $idShopGroup = null, $idShop = null)
+    {
+        return self::getConfigInMultipleLangs($key, $idShopGroup, $idShop);
+    }
+
+    /**
      * Get a single configuration value (in multiple languages).
      *
      * @param string $key Configuration Key
@@ -263,13 +271,13 @@ class ConfigurationCore extends ObjectModel
      *
      * @return array Values in multiple languages
      */
-    public static function getInt($key, $idShopGroup = null, $idShop = null)
+    public static function getConfigInMultipleLangs($key, $idShopGroup = null, $idShop = null)
     {
         $resultsArray = [];
         foreach (Language::getIDs() as $idLang) {
             $resultsArray[$idLang] = Configuration::get($key, $idLang, $idShopGroup, $idShop);
         }
-
+        
         return $resultsArray;
     }
 

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -255,7 +255,7 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
-     * @deprecated use Configuration::getConfigInMultipleLangs() instead.
+     * @deprecated use Configuration::getConfigInMultipleLangs() instead
      */
     public static function getInt($key, $idShopGroup = null, $idShop = null)
     {

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -277,7 +277,7 @@ class ConfigurationCore extends ObjectModel
         foreach (Language::getIDs() as $idLang) {
             $resultsArray[$idLang] = Configuration::get($key, $idLang, $idShopGroup, $idShop);
         }
-        
+
         return $resultsArray;
     }
 

--- a/classes/ConfigurationKPI.php
+++ b/classes/ConfigurationKPI.php
@@ -126,7 +126,7 @@ class ConfigurationKPICore extends Configuration
     public static function getInt($key, $idShopGroup = null, $idShop = null)
     {
         ConfigurationKPI::setKpiDefinition();
-        $values = parent::getInt($key, $idShopGroup, $idShop);
+        $values = parent::getConfigInMultipleLangs($key, $idShopGroup, $idShop);
         ConfigurationKPI::unsetKpiDefinition();
 
         return $values;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | classes/Configuration.php had a method `getInt()` which was returning `array`. As the name suggests developer might expect it to return int and it is easy to confuse with adapter/Configuration::getInt(). Deprecated the method and added a new one with a more suitable name to avoid confusion and mistakes in future.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | 
| How to test?  | nothing to test. If CI passes, we are good.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19402)
<!-- Reviewable:end -->
