### PR TITLE
Put back prefix for filter name inside CustomerQueryBuilder

### DIFF
--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -222,7 +222,7 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
-            $qb->andWhere('c.`' .  $filterName . '` LIKE :' . $filterName);
+            $qb->andWhere('c.`' . $filterName . '` LIKE :' . $filterName);
             $qb->setParameter($filterName, '%' . $filterValue . '%');
         }
     }

--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -222,7 +222,7 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
                 continue;
             }
 
-            $qb->andWhere('`' . $filterName . '` LIKE :' . $filterName);
+            $qb->andWhere('c.`' .  $filterName . '` LIKE :' . $filterName);
             $qb->setParameter($filterName, '%' . $filterValue . '%');
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The filter name must to have a table prefix<br/>in my case, i add a filter phone on customer grid. the lastname field exist on customer and address table.<br/>I have a sql error
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Customer listing page should work as before

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19404)
<!-- Reviewable:end -->
