### PR TITLE
Fix : "update address" page title is changed when an error is triggered

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -76,8 +76,6 @@ class AddressControllerCore extends FrontController
 
                 $this->should_redirect = true;
             }
-
-            return;
         }
 
         // There is no id_adress, no need to continue


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | The main title of the "edit address" page is changed when a error is triggered in the form.
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18283.
| How to test?  | See #18283 by @SD1982 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19434)
<!-- Reviewable:end -->
