### PR TITLE
Make product image in list overridable

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5028,9 +5028,11 @@ class ProductCore extends ObjectModel
 
         $row['ecotax_rate'] = (float) Tax::getProductEcotaxRate($context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
 
-        $cover = static::getCover($row['id_product']);
-        if (isset($cover['id_image'])) {
-            $row['cover_image_id'] = $cover['id_image'];
+        if (!isset($row['cover_image_id'])) {
+            $cover = static::getCover($row['id_product']);
+            if (isset($cover['id_image'])) {
+                $row['cover_image_id'] = $cover['id_image'];
+            }
         }
 
         Hook::exec('actionGetProductPropertiesAfter', [

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5028,6 +5028,11 @@ class ProductCore extends ObjectModel
 
         $row['ecotax_rate'] = (float) Tax::getProductEcotaxRate($context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
 
+        $cover = static::getCover($row['id_product']);
+        if (isset($cover['id_image'])) {
+            $row['cover_image_id'] = $cover['id_image'];
+        }
+
         Hook::exec('actionGetProductPropertiesAfter', [
             'id_lang' => $id_lang,
             'product' => &$row,

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -23,6 +23,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
+
+/**
+ * @deprecated This const is deprecated you should use the configuration variable instead Configuration::get('PS_SEARCH_MAX_WORD_LENGTH')
+ */
+define('PS_SEARCH_MAX_WORD_LENGTH', 30);
+
 /* Copied from Drupal search module, except for \x{0}-\x{2f} that has been replaced by \x{0}-\x{2c}\x{2e}-\x{2f} in order to keep the char '-' */
 define(
     'PREG_CLASS_SEARCH_EXCLUDE',

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -199,6 +199,7 @@ class ImageRetriever
             'medium' => $medium,
             'large' => $large,
             'legend' => isset($object->meta_title) ? $object->meta_title : $object->name,
+            'id_image' => $id_image,
         ];
     }
 

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -54,9 +54,8 @@ class ImageRetriever
      *
      * @return array
      */
-    public function getProductImages(array $product, Language $language)
+    public function getAllProductImages(array $product, Language $language)
     {
-        $productAttributeId = $product['id_product_attribute'];
         $productInstance = new Product(
             $product['id_product'],
             false,
@@ -99,6 +98,20 @@ class ImageRetriever
             return $image;
         }, $images);
 
+        return $images;
+    }
+
+    /**
+     * @param array $product
+     * @param Language $language
+     *
+     * @return array
+     */
+    public function getProductImages(array $product, Language $language)
+    {
+        $images = $this->getAllProductImages($product, $language);
+
+        $productAttributeId = $product['id_product_attribute'];
         $filteredImages = [];
 
         foreach ($images as $image) {

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -594,6 +594,18 @@ class ProductLazyArray extends AbstractLazyArray
         // Get filtered product images matching the specified id_product_attribute
         $this->product['images'] = $this->filterImagesForCombination($productImages, $product['id_product_attribute']);
 
+        // Get default image for selected combination (used for product page, cart details, ...)
+        $this->product['default_image'] = reset($this->product['images']);
+        foreach ($this->product['images'] as $image) {
+            // If one of the image is a cover it is used as such
+            if (isset($image['cover']) && null !== $image['cover']) {
+                $this->product['default_image'] = $image;
+
+                break;
+            }
+        }
+
+        // Get generic product image, used for product listing
         if (isset($product['cover_image_id'])) {
             // First try to find cover in product images
             foreach ($productImages as $productImage) {
@@ -612,21 +624,9 @@ class ProductLazyArray extends AbstractLazyArray
             }
         }
 
+        // If no cover fallback on default image
         if (!isset($this->product['cover'])) {
-            $this->product['cover'] = null;
-            foreach ($this->product['images'] as $image) {
-                // At least select the first product image
-                if (null === $this->product['cover']) {
-                    $this->product['cover'] = $image;
-                }
-
-                // If one of the image is a cover it is used as such
-                if (isset($image['cover']) && null !== $image['cover']) {
-                    $this->product['cover'] = $image;
-
-                    break;
-                }
-            }
+            $this->product['cover'] = $this->product['default_image'];
         }
     }
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -586,7 +586,7 @@ class ProductLazyArray extends AbstractLazyArray
         Language $language
     ) {
         // Get all product images, including potential cover
-        $productImages = $this->imageRetriever->getProductImages(
+        $productImages = $this->imageRetriever->getAllProductImages(
             $product,
             $language
         );
@@ -605,9 +605,9 @@ class ProductLazyArray extends AbstractLazyArray
 
             // If the cover is not associated to the product images it is fetched manually
             if (!isset($this->product['cover'])) {
-                $coverImage = $this->imageRetriever->getImage(new Product($product['id_product']), $product['cover_image_id']);
+                $coverImage = $this->imageRetriever->getImage(new Product($product['id_product'], false, $language->getId()), $product['cover_image_id']);
                 $this->product['cover'] = array_merge($coverImage, [
-                    'legend' => $coverImage['legend'][$language->getId()],
+                    'legend' => $coverImage['legend'],
                 ]);
             }
         }

--- a/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
+++ b/tests-legacy/Unit/Core/Business/Product/ProductPresenterTest.php
@@ -92,7 +92,7 @@ class ProductPresenterTest extends UnitTestCase
         Phake::when($link)->getAddToCartURL(Phake::anyParameters())->thenReturn('http://add-to-cart.url');
 
         $imageRetriever = Phake::mock('PrestaShop\PrestaShop\Adapter\Image\ImageRetriever');
-        Phake::when($imageRetriever)->getProductImages(Phake::anyParameters())->thenReturn([
+        Phake::when($imageRetriever)->getAllProductImages(Phake::anyParameters())->thenReturn([
             ['id_image' => 0, 'associatedVariants' => []],
         ]);
 

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -29,11 +29,9 @@
     <div class="thumbnail-container">
       {block name='product_thumbnail'}
         {if $product.cover}
-          {assign var='coverImage' value=Product::getCover($product->id)}
-          {assign var='coverImageId' value="{$product->id}-{$coverImage.id_image}"}
           <a href="{$product.url}" class="thumbnail product-thumbnail">
             <img
-              src="{$link->getImageLink($product.link_rewrite, $coverImageId)}"
+              src="{$product.cover.bySize.home_default.url}"
               alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
               data-full-size-image-url="{$product.cover.large.url}"
               />

--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -25,8 +25,8 @@
 <div class="images-container">
   {block name='product_cover'}
     <div class="product-cover">
-      {if $product.cover}
-        <img class="js-qv-product-cover" src="{$product.cover.bySize.large_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" style="width:100%;" itemprop="image">
+      {if $product.default_image}
+        <img class="js-qv-product-cover" src="{$product.default_image.bySize.large_default.url}" alt="{$product.default_image.legend}" title="{$product.default_image.legend}" style="width:100%;" itemprop="image">
         <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">search</i>
         </div>
@@ -42,7 +42,7 @@
         {foreach from=$product.images item=image}
           <li class="thumb-container">
             <img
-              class="thumb js-thumb {if $image.id_image == $product.cover.id_image} selected {/if}"
+              class="thumb js-thumb {if $image.id_image == $product.default_image.id_image} selected {/if}"
               data-image-medium-src="{$image.bySize.medium_default.url}"
               data-image-large-src="{$image.bySize.large_default.url}"
               src="{$image.bySize.home_default.url}"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | A top watcher bug has been fixed in 177 that allowed to display the Product cover in the list instead of the combination images Though it didn't allow to customize this image any more This PR changes the way the cover is selected, so the default behaviour is still to use the cover but now it is possible to override the image used as cover thanks to the `actionGetProductPropertiesAfter` A documentation is being written to complete this PR
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19029
| How to test?  | On a product with combination add a new image and set it as cover (one that is not used by any combination so that it's easier to see the difference) In the different product list the cover is used, but when you are on the product page and select a combination the images are those for the selected combination (the first one displayed is still the cover though)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19437)
<!-- Reviewable:end -->
