### PR TITLE
Disable payment button if term checkbox is unchecked

### DIFF
--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -85,7 +85,9 @@ class Payment {
       var paymentOption = this.getPaymentOptionSelector(selectedOption);
       this.hideConfirmation();
       $(paymentOption).show();
-      $(paymentOption + ' button').attr('disabled', !show);
+      document.querySelectorAll(`${paymentOption} button, ${paymentOption} input`).forEach(element => {
+        element.setAttribute('disabled', !show);
+      });
 
       if (show) {
         $(paymentOption).removeClass('disabled');

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -85,8 +85,13 @@ class Payment {
       var paymentOption = this.getPaymentOptionSelector(selectedOption);
       this.hideConfirmation();
       $(paymentOption).show();
+      console.log(show);
       document.querySelectorAll(`${paymentOption} button, ${paymentOption} input`).forEach(element => {
-        element.setAttribute('disabled', !show);
+        if (show) {
+          element.removeAttribute('disabled');
+        } else {
+          element.setAttribute('disabled', !show);
+        }
       });
 
       if (show) {

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -22,7 +22,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
-import $ from 'jquery'
+import $ from 'jquery';
 
 class Payment {
   constructor() {
@@ -85,6 +85,7 @@ class Payment {
       var paymentOption = this.getPaymentOptionSelector(selectedOption);
       this.hideConfirmation();
       $(paymentOption).show();
+      $(paymentOption + ' button').attr('disabled', !show);
 
       if (show) {
         $(paymentOption).removeClass('disabled');
@@ -118,7 +119,7 @@ class Payment {
   }
 }
 
-export default function () {
+export default function() {
   let payment = new Payment();
   payment.init();
 

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -85,7 +85,7 @@ class Payment {
       var paymentOption = this.getPaymentOptionSelector(selectedOption);
       this.hideConfirmation();
       $(paymentOption).show();
-      console.log(show);
+
       document.querySelectorAll(`${paymentOption} button, ${paymentOption} input`).forEach(element => {
         if (show) {
           element.removeAttribute('disabled');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Binary payment button was enabled while terms checkbox was unchecked, it's a problem
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19161.
| How to test?  | Install the module example provided by @Matt75 in #19161, and then go to checkout page, select binary, the "Pay binary" button shouldn't be clickable, also test this with Atos module as you need to verify that inputs are disabled too instead of buttons

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19438)
<!-- Reviewable:end -->
