### PR TITLE
Fix AdminModulesController fatal error

### DIFF
--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -1415,7 +1415,13 @@ class AdminModulesControllerCore extends AdminController
         $translateLinks = [];
 
         if (Tools::getIsset('configure')) {
+            /** @var Module|false $module */
             $module = Module::getInstanceByName(Tools::getValue('configure'));
+
+            if (false === $module) {
+                return;
+            }
+
             $isNewTranslateSystem = $module->isUsingNewTranslationSystem();
             $link = Context::getContext()->link;
             foreach ($languages as $lang) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | If requested Module is not found when trying to access module configuration page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/19447
| How to test?  | Follow "How to test" described in related issue.

You should see
![fix-AdminModulesController](https://user-images.githubusercontent.com/5262628/83196238-d6f8e680-a13b-11ea-8452-cfaf459c5011.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19448)
<!-- Reviewable:end -->
