### PR TITLE
Fix to show the Modules tab in the product editor - backport of #19216 to 1.7.7.x

### DIFF
--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -175,6 +175,6 @@ class HookExtension extends \Twig_Extension
      */
     public function hookCount($hookName)
     {
-        return count($this->hookDispatcher->getListeners($hookName));
+        return count($this->hookDispatcher->getListeners(strtolower($hookName)));
     }
 }


### PR DESCRIPTION
Backport of https://github.com/PrestaShop/PrestaShop/pull/19216

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix to show the Modules tab in the product editor in the Back Office.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #19246
| How to test?  | No need QA, already validated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19452)
<!-- Reviewable:end -->
