### PR TITLE
Help on textarea (twig) show 2 times

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -39,7 +39,6 @@
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
     {{- parent() -}}
 
-    {{ block('form_help') }}
 {%- endblock textarea_widget %}
 
 {% block button_widget -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -38,7 +38,6 @@
 {% block textarea_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
     {{- parent() -}}
-
 {%- endblock textarea_widget %}
 
 {% block button_widget -%}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | {{ block('form_help') }} is already in {{- parent() -}} 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes ...
| How to test?  | ![image](https://user-images.githubusercontent.com/52157233/83241686-7e593600-a19b-11ea-9e1c-e2bae08db9f6.png)<br>Create a Symfony Form Type and add a TextareaType::class on build form method for instance to manage a configuration parameter. Don't forget 

Sample code:
```php
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('Myfield', TextareaType::class, [
                'label' => $this->trans('My label', 'Module.__Module__.Admin'),
                'help' => $this->trans('My help', 'Module.__Module__.Admin'),
            ]);
    }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19453)
<!-- Reviewable:end -->
