### PR TITLE
Fix voucher display for single customer - backport of #19443 to 1.7.7.x

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -448,7 +448,8 @@ class CartPresenter implements PresenterInterface
         $discounts = array_filter($discounts, function ($discount) use ($cartRulesIds, $cart) {
             $voucherCustomerId = (int) $discount['id_customer'];
             $voucherIsRestrictedToASingleCustomer = ($voucherCustomerId !== 0);
-            if ($voucherIsRestrictedToASingleCustomer && $cart->id_customer !== $voucherCustomerId) {
+            $voucherIsEmptyCode = empty($discount['code']);
+            if ($voucherIsRestrictedToASingleCustomer && $cart->id_customer !== $voucherCustomerId && $voucherIsEmptyCode) {
                 return false;
             }
 


### PR DESCRIPTION
Backport of https://github.com/PrestaShop/PrestaShop/pull/19443

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Voucher not displayed if it is linked to a customer, see also #19442 
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19442 .
| How to test?  | - Open a PS1.7.7 <br> - create a new voucher limited to 1 person with code code <br>- Add some product to the cart (you should be logged into account of the person selected for voucher) <br>- Check voucher in the cart summary <br> <br> Please check also that https://github.com/PrestaShop/PrestaShop/issues/13002#issuecomment-476516323 is still fixed as this PR modifies it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19456)
<!-- Reviewable:end -->
