### PR TITLE
Remove MBO-related api calls from core

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2205,7 +2205,7 @@ class AdminControllerCore extends Controller
      */
     protected function initTabModuleList()
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**
@@ -2213,7 +2213,7 @@ class AdminControllerCore extends Controller
      */
     protected function addPageHeaderToolBarModulesListButton()
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**
@@ -2221,7 +2221,7 @@ class AdminControllerCore extends Controller
      */
     protected function addToolBarModulesListButton()
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     protected function getAdminModulesUrl()
@@ -2234,7 +2234,7 @@ class AdminControllerCore extends Controller
      */
     protected function filterTabModuleList()
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2183,7 +2183,6 @@ class AdminControllerCore extends Controller
         $this->getLanguages();
 
         $this->initToolbar();
-        $this->initTabModuleList();
         $this->initPageHeaderToolbar();
 
         $this->context->smarty->assign([
@@ -2201,54 +2200,28 @@ class AdminControllerCore extends Controller
 
     /**
      * Init tab modules list and add button in toolbar.
+     *
+     * @deprecated since 1.7.7.0
      */
     protected function initTabModuleList()
     {
-        if (!$this->isFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, 86400)) {
-            @file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'));
-        }
-        if (!$this->isFresh(Module::CACHE_FILE_TAB_MODULES_LIST, 604800)) {
-            $this->refresh(Module::CACHE_FILE_TAB_MODULES_LIST, _PS_TAB_MODULE_LIST_URL_);
-        }
-
-        $this->tab_modules_list = Tab::getTabModulesList($this->id);
-
-        if (is_array($this->tab_modules_list['default_list']) && count($this->tab_modules_list['default_list'])) {
-            $this->filter_modules_list = $this->tab_modules_list['default_list'];
-        } elseif (is_array($this->tab_modules_list['slider_list']) && count($this->tab_modules_list['slider_list'])) {
-            $this->addToolBarModulesListButton();
-            $this->addPageHeaderToolBarModulesListButton();
-            $this->context->smarty->assign([
-                'tab_modules_list' => implode(',', $this->tab_modules_list['slider_list']),
-                'admin_module_ajax_url' => $this->context->link->getAdminLink('AdminModules'),
-                'back_tab_modules_list' => $this->context->link->getAdminLink(Tools::getValue('controller')),
-                'tab_modules_open' => (int) Tools::getValue('tab_modules_open'),
-            ]);
-        }
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
+    /**
+     * @deprecated since 1.7.7.0
+     */
     protected function addPageHeaderToolBarModulesListButton()
     {
-        $this->filterTabModuleList();
-
-        if (is_array($this->tab_modules_list['slider_list']) && count($this->tab_modules_list['slider_list'])) {
-            $this->page_header_toolbar_btn['modules-list'] = [
-                'href' => $this->getAdminModulesUrl(),
-                'desc' => $this->trans('Recommended Modules'),
-            ];
-        }
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
+    /**
+     * @deprecated since 1.7.7.0
+     */
     protected function addToolBarModulesListButton()
     {
-        $this->filterTabModuleList();
-
-        if (is_array($this->tab_modules_list['slider_list']) && count($this->tab_modules_list['slider_list'])) {
-            $this->toolbar_btn['modules-list'] = [
-                'href' => $this->getAdminModulesUrl(),
-                'desc' => $this->trans('Recommended Modules'),
-            ];
-        }
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     protected function getAdminModulesUrl()
@@ -2256,65 +2229,12 @@ class AdminControllerCore extends Controller
         return $this->context->link->getAdminLink('AdminModulesCatalog');
     }
 
+    /**
+     * @deprecated since 1.7.7.0
+     */
     protected function filterTabModuleList()
     {
-        static $list_is_filtered = null;
-
-        if ($list_is_filtered !== null) {
-            return;
-        }
-
-        if (!$this->isFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 86400)) {
-            file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'));
-        }
-
-        if (!$this->isFresh(Module::CACHE_FILE_ALL_COUNTRY_MODULES_LIST, 86400)) {
-            file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_ALL_COUNTRY_MODULES_LIST, Tools::addonsRequest('native_all'));
-        }
-
-        if (!$this->isFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, 86400)) {
-            @file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'));
-        }
-
-        libxml_use_internal_errors(true);
-
-        $country_module_list = file_get_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST);
-        $must_have_module_list = file_get_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_MUST_HAVE_MODULES_LIST);
-        $all_module_list = [];
-
-        if (!empty($country_module_list) && $country_module_list_xml = @simplexml_load_string($country_module_list)) {
-            $country_module_list_array = [];
-            if (is_object($country_module_list_xml->module)) {
-                foreach ($country_module_list_xml->module as $k => $m) {
-                    $all_module_list[] = (string) $m->name;
-                }
-            }
-        } else {
-            foreach (libxml_get_errors() as $error) {
-                $this->errors[] = $this->trans('Error found : %1$s in country_module_list.xml file.', [$error->message], 'Admin.Modules.Notification');
-            }
-        }
-
-        libxml_clear_errors();
-
-        if (!empty($must_have_module_list) && $must_have_module_list_xml = @simplexml_load_string($must_have_module_list)) {
-            $must_have_module_list_array = [];
-            if (is_object($country_module_list_xml->module)) {
-                foreach ($must_have_module_list_xml->module as $l => $mo) {
-                    $all_module_list[] = (string) $mo->name;
-                }
-            }
-        } else {
-            foreach (libxml_get_errors() as $error) {
-                $this->errors[] = $this->trans('Error found : %1$s in must_have_module_list.xml file.', [$error->message], 'Admin.Modules.Notification');
-            }
-        }
-
-        libxml_clear_errors();
-
-        $this->tab_modules_list['slider_list'] = array_intersect($this->tab_modules_list['slider_list'], $all_module_list);
-
-        $list_is_filtered = true;
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Synchronous http calls were made in the BO without any network issue handling system, making the BO access dependent of internet and addons server availability. Since MBO is now in charge of these calls, we can remove them from the core.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes #12833 #12831 #12826 #12825
| How to test?  | With MBO v2 installed, cleared cache, **no internet connection** and the following files deleted : <br><br><ul><li>config/xml/default_country_modules_list.xml</li><li>config/xml/modules_native_addons.xml</li><li>config/xml/must_have_modules_list.xml</li><li>config/xml/tab_modules_list.xml</li></ul><br>Try to access any page of the BO. Despite some style & font issues, you should be able to navigate everywhere without any error/exception.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19461)
<!-- Reviewable:end -->
