### PR TITLE
Check whether subcategories are empty before displaying them

### DIFF
--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -32,7 +32,9 @@
     {/block}
 
     {block name='subcategory_list'}
-      {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
+      {if isset($subcategories) && $subcategories|@count > 0}
+        {include file='catalog/_partials/subcategories.tpl' subcategories=$subcategories}
+      {/if}
     {/block}
 
     <section id="products">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Check whether subcategories are empty before displaying them in product-list.tpl
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/19451
| How to test?  | See ticket

Initial issue was introduced in https://github.com/PrestaShop/PrestaShop/pull/16928 . Since the modified template is used by multiple controllers, a new variable can be used in the template if all controllers are updated or add the small check I introduced

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19501)
<!-- Reviewable:end -->
