### PR TITLE
Handle AbstractGridDefinitionFactory compatibility

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -359,15 +359,14 @@ class CommonController extends FrameworkBundleAdminController
         $gridDefinitionFactoryServiceId,
         $redirectRoute,
         array $redirectQueryParamsToKeep = []
-    )
-    {
-        /** @var ResponseBuilder $responseBuilder */
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
+    ) {
         /** @var GridDefinitionFactoryInterface $definitionFactory */
         $definitionFactory = $this->get($gridDefinitionFactoryServiceId);
 
         if ($definitionFactory instanceof FilterableGridDefinitionFactoryInterface) {
+            /** @var ResponseBuilder $responseBuilder */
+            $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
+
             return $responseBuilder->buildSearchResponse(
                 $definitionFactory,
                 $request,
@@ -376,9 +375,13 @@ class CommonController extends FrameworkBundleAdminController
                 $redirectQueryParamsToKeep
             );
         }
+
         // for backward compatibility with AbstractGridDefinitionFactory
         // replaced by AbstractFilterableGridDefinitionFactory
         if ($definitionFactory instanceof AbstractGridDefinitionFactory) {
+            /** @var ResponseBuilder $responseBuilder */
+            $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
+
             return $responseBuilder->buildSearchResponse(
                 $definitionFactory,
                 $request,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because of https://github.com/PrestaShop/PrestaShop/pull/18228, if you use CommonController::searchGridAction with a AbstractGridDefinitionFactory it does not work.<br> This is because https://github.com/PrestaShop/PrestaShop/pull/18228 only handles 2 cases: AbstractFilterableGridDefinitionFactory and controller/action filter keys
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19506)
<!-- Reviewable:end -->
