### PR TITLE
Fix Missing required fields in import 

### DIFF
--- a/src/Core/Import/EntityField/Provider/CategoryFieldsProvider.php
+++ b/src/Core/Import/EntityField/Provider/CategoryFieldsProvider.php
@@ -56,7 +56,7 @@ final class CategoryFieldsProvider implements EntityFieldsProviderInterface
         $fields = [
             new EntityField('id', $this->trans('ID', 'Admin.Global')),
             new EntityField('active', $this->trans('Active (0/1)', 'Admin.Advparameters.Feature')),
-            new EntityField('name', $this->trans('Name', 'Admin.Global')),
+            new EntityField('name', $this->trans('Name', 'Admin.Global'), '', true),
             new EntityField('parent', $this->trans('Parent category', 'Admin.Catalog.Feature')),
             new EntityField(
                 'is_root_category',

--- a/src/Core/Import/EntityField/Provider/ProductFieldsProvider.php
+++ b/src/Core/Import/EntityField/Provider/ProductFieldsProvider.php
@@ -56,7 +56,7 @@ final class ProductFieldsProvider implements EntityFieldsProviderInterface
         $fields = [
             new EntityField('id', $this->trans('ID', 'Admin.Global')),
             new EntityField('active', $this->trans('Active (0/1)', 'Admin.Advparameters.Feature')),
-            new EntityField('name', $this->trans('Name', 'Admin.Global')),
+            new EntityField('name', $this->trans('Name', 'Admin.Global'), '', true),
             new EntityField('category', $this->trans('Categories (x,y,z...)', 'Admin.Advparameters.Feature')),
             new EntityField('price_tex', $this->trans('Price tax excluded', 'Admin.Advparameters.Feature')),
             new EntityField('price_tin', $this->trans('Price tax included', 'Admin.Advparameters.Feature')),

--- a/src/Core/Import/EntityField/Provider/SupplierFieldsProvider.php
+++ b/src/Core/Import/EntityField/Provider/SupplierFieldsProvider.php
@@ -56,7 +56,7 @@ final class SupplierFieldsProvider implements EntityFieldsProviderInterface
         $fields = [
             new EntityField('id', $this->trans('ID', 'Admin.Global')),
             new EntityField('active', $this->trans('Active (0/1)', 'Admin.Advparameters.Feature')),
-            new EntityField('name', $this->trans('Name', 'Admin.Global')),
+            new EntityField('name', $this->trans('Name', 'Admin.Global'), '', true),
             new EntityField('description', $this->trans('Description', 'Admin.Global')),
             new EntityField('short_description', $this->trans('Short description', 'Admin.Catalog.Feature')),
             new EntityField('meta_title', $this->trans('Meta title', 'Admin.Global')),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Prestashop 1.7.4.4 in the import section, it says "* Champs requis" (in french) but no field has a "" ....
| Type?         | bug fix
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/11334.
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/11334 by @grabelle and https://github.com/PrestaShop/PrestaShop/issues/11334#issuecomment-437358792 by @marionf .

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19510)
<!-- Reviewable:end -->
