### PR TITLE
Refacto AddProductCommand and introduce GetEditableProduct query

### DIFF
--- a/src/Adapter/Product/AbstractProductHandler.php
+++ b/src/Adapter/Product/AbstractProductHandler.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShopException;
+use Product;
+
+/**
+ * Provides reusable methods for product handlers
+ */
+abstract class AbstractProductHandler
+{
+    /**
+     * @param ProductId $productId
+     *
+     * @return Product
+     *
+     * @throws ProductException
+     * @throws ProductNotFoundException
+     */
+    protected function getProduct(ProductId $productId): Product
+    {
+        $productIdValue = $productId->getValue();
+
+        try {
+            $product = new Product($productIdValue);
+
+            if ((int) $product->id !== $productIdValue) {
+                throw new ProductNotFoundException(sprintf(
+                    'Product #%s was not found',
+                    $productIdValue
+                ));
+            }
+        } catch (PrestaShopException $e) {
+            throw new ProductException(
+                sprintf('Error occurred when trying to get product #%s', $productId),
+                0,
+                $e
+            );
+        }
+
+        return $product;
+    }
+}

--- a/src/Adapter/Product/CommandHandler/AddProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/AddProductHandler.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\AddProductHandlerIn
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShopException;
 use Product;
 
@@ -98,7 +97,7 @@ final class AddProductHandler implements AddProductHandlerInterface
         $product->active = false;
         $product->category = Category::getLinkRewrite($this->defaultCategoryId, $this->defaultLangId);
         $product->id_category_default = $this->defaultCategoryId;
-        $product->is_virtual = $command->getType() === ProductType::TYPE_VIRTUAL;
+        $product->is_virtual = $command->isVirtual();
 
         foreach ($product->name as $langId => $name) {
             if (true !== $product->validateField('name', $name, $langId)) {

--- a/src/Adapter/Product/QueryHandler/GetEditableProductHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetEditableProductHandler.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
+
+use Pack;
+use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetEditableProductHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\EditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
+use Product;
+
+/**
+ * Handles the query GetEditableProduct using legacy ObjectModel
+ */
+class GetEditableProductHandler extends AbstractProductHandler implements GetEditableProductHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ProductConstraintException
+     * @throws ProductException
+     * @throws ProductNotFoundException
+     */
+    public function handle(GetEditableProduct $query): EditableProduct
+    {
+        $product = $this->getProduct($query->getProductId());
+
+        return new EditableProduct(
+            $product->id,
+            $product->name,
+            $this->getProductType($product)
+        );
+    }
+
+    /**
+     * @param Product $product
+     *
+     * @return ProductType
+     *
+     * @throws ProductConstraintException
+     */
+    private function getProductType(Product $product): ProductType
+    {
+        if ($product->is_virtual) {
+            $productTypeValue = ProductType::TYPE_VIRTUAL;
+        } elseif (Pack::isPack($product->id)) {
+            $productTypeValue = ProductType::TYPE_PACK;
+        } elseif (!empty($product->getAttributeCombinations())) {
+            $productTypeValue = ProductType::TYPE_COMBINATION;
+        } else {
+            $productTypeValue = ProductType::TYPE_STANDARD;
+        }
+
+        return new ProductType($productTypeValue);
+    }
+}

--- a/src/Core/Domain/Product/Command/AddProductCommand.php
+++ b/src/Core/Domain/Product/Command/AddProductCommand.php
@@ -28,8 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
-
 /**
  * Command for creating product with basic information
  */
@@ -41,20 +39,20 @@ class AddProductCommand
     private $localizedNames;
 
     /**
-     * @var ProductType
+     * @var bool
      */
-    private $type;
+    private $isVirtual;
 
     /**
      * @param array $localizedNames
-     * @param int $type
+     * @param bool $isVirtual
      */
     public function __construct(
         array $localizedNames,
-        int $type
+        bool $isVirtual
     ) {
         $this->localizedNames = $localizedNames;
-        $this->type = new ProductType($type);
+        $this->isVirtual = $isVirtual;
     }
 
     /**
@@ -66,10 +64,10 @@ class AddProductCommand
     }
 
     /**
-     * @return ProductType
+     * @return bool
      */
-    public function getType(): ProductType
+    public function isVirtual(): bool
     {
-        return $this->type;
+        return $this->isVirtual;
     }
 }

--- a/src/Core/Domain/Product/Query/GetEditableProduct.php
+++ b/src/Core/Domain/Product/Query/GetEditableProduct.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+/**
+ * Get Product data necessary for edition
+ */
+class GetEditableProduct
+{
+    /**
+     * @var ProductId
+     */
+    private $productId;
+
+    /**
+     * GetEditableProduct constructor.
+     *
+     * @param int $productId
+     */
+    public function __construct(int $productId)
+    {
+        $this->productId = new ProductId($productId);
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+}

--- a/src/Core/Domain/Product/QueryHandler/GetEditableProductHandlerInterface.php
+++ b/src/Core/Domain/Product/QueryHandler/GetEditableProductHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\EditableProduct;
+
+interface GetEditableProductHandlerInterface
+{
+    /**
+     * @param GetEditableProduct $query
+     *
+     * @return EditableProduct
+     */
+    public function handle(GetEditableProduct $query): EditableProduct;
+}

--- a/src/Core/Domain/Product/QueryResult/EditableProduct.php
+++ b/src/Core/Domain/Product/QueryResult/EditableProduct.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
+
+/**
+ * DTO for product that needs to be edited
+ */
+class EditableProduct
+{
+    /**
+     * @var int
+     */
+    private $productId;
+
+    /**
+     * @var string[]
+     */
+    private $localizedNames;
+
+    /**
+     * @var ProductType
+     */
+    private $type;
+
+    public function __construct(
+        int $productId,
+        array $localizedNames,
+        ProductType $type
+    ) {
+        $this->productId = $productId;
+        $this->localizedNames = $localizedNames;
+        $this->type = $type;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductId(): int
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedNames(): array
+    {
+        return $this->localizedNames;
+    }
+
+    /**
+     * @return ProductType
+     */
+    public function getType(): ProductType
+    {
+        return $this->type;
+    }
+}

--- a/src/Core/Domain/Product/QueryResult/ProductType.php
+++ b/src/Core/Domain/Product/QueryResult/ProductType.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\ValueObject;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 
@@ -38,23 +38,23 @@ class ProductType
     /**
      * Standard product
      */
-    const TYPE_STANDARD = 0;
+    const TYPE_STANDARD = 'standard';
 
     /**
      * A pack consists multiple units of product.
      */
-    const TYPE_PACK = 1;
+    const TYPE_PACK = 'pack';
 
     /**
      * Items that are not in physical form and can be sold without requiring any shipping
      * E.g. downloadable photos, videos, software, services etc.
      */
-    const TYPE_VIRTUAL = 2;
+    const TYPE_VIRTUAL = 'virtual';
 
     /**
      * Product containing combinations of different attributes
      */
-    const TYPE_COMBINATION = 3;
+    const TYPE_COMBINATION = 'combination';
 
     /**
      * A list of available types
@@ -67,35 +67,35 @@ class ProductType
     ];
 
     /**
-     * @var int
+     * @var string
      */
     private $value;
 
     /**
-     * @param int $value
+     * @param string $value
      *
      * @throws ProductConstraintException
      */
-    public function __construct(int $value)
+    public function __construct(string $value)
     {
         $this->assertProductType($value);
         $this->value = $value;
     }
 
     /**
-     * @return int
+     * @return string
      */
-    public function getValue(): int
+    public function getValue(): string
     {
         return $this->value;
     }
 
     /**
-     * @param int $value
+     * @param string $value
      *
      * @throws ProductConstraintException
      */
-    private function assertProductType(int $value): void
+    private function assertProductType(string $value): void
     {
         if (!in_array($value, self::AVAILABLE_TYPES, true)) {
             throw new ProductConstraintException(

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -66,6 +66,12 @@ services:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled
 
+    prestashop.adapter.product.command_handler.get_editable_product_handler:
+      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetEditableProductHandler
+      tags:
+        - name: tactician.handler
+          command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct
+
     prestashop.adapter.product.command_handler.add_product_handler:
       class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductHandler
       arguments:

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -76,7 +76,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $productId = $this->getCommandBus()->handle(new AddProductCommand(
                 $this->parseLocalizedArray($data['name']),
-                $this->getProductTypeValueByName($data['type']) ?? -1
+                PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual'])
             ));
 
             $this->getSharedStorage()->set($productReference, $productId->getValue());

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -7,8 +7,8 @@ Feature: Add basic product from Back Office (BO)
   @add
   Scenario: I add a product with basic information
     When I add product "product1" with following basic information:
-      | name | en-US:bottle of beer |
-      | type | standard             |
+      | name       | en-US:bottle of beer |
+      | is_virtual | false                |
     Then product "product1" should have following values:
       | active           | false          |
       | condition        | new            |
@@ -17,16 +17,21 @@ Feature: Add basic product from Back Office (BO)
     And product "product1" should be assigned to default category
 
   @add
-  Scenario: I add a product with invalid type
-    When I add product "product2" with following basic information:
-    | name | en-US:empty box |
-    | type | undefined       |
-  Then I should get error that product type is invalid
+  Scenario: I add a product with basic information
+    When I add product "product1" with following basic information:
+      | name       | en-US:bottle of beer |
+      | is_virtual | true                 |
+    Then product "product1" should have following values:
+      | active           | false          |
+      | condition        | new            |
+    And product "product1" type should be virtual
+    And product "product1" localized "name" should be "en-US:bottle of beer"
+    And product "product1" should be assigned to default category
 
   @add
   Scenario: I add a product with invalid characters in name
     When I add product "product2" with following basic information:
-      | name | en-US: T-shirt #1    |
-      | type | standard             |
+      | name       | en-US: T-shirt #1 |
+      | is_virtual | false             |
     Then I should get error that product name is invalid
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The `AddProductCommand` command contract changes: it only needs a boolean `isVirtual` as input The product type interpreation has been moved into the `GetEditableProduct` query so the behat tests use this query
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Technical PR, only green tests on Travis are enough

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19529)
<!-- Reviewable:end -->
