### PR TITLE
Front side validation problem on the number of characters in a password

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -140,9 +140,9 @@ class CustomerFormCore extends AbstractForm
         }
 
         $passwordField = $this->getField('password');
-        if(!Validate::isPasswd($passwordField->getValue())) {
+        if (Validate::isPasswd($passwordField->getValue()) === false) {
             $passwordField->AddError($this->translator->trans(
-                'The password should be at least 5 characters long',
+                'Password must be between 5 and 72 characters long',
                 [],
                 'Shop.Notifications.Error'
             ));

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -140,7 +140,7 @@ class CustomerFormCore extends AbstractForm
         }
 
         $passwordField = $this->getField('password');
-        if(Validate::isPasswd($passwordField->getValue())) {
+        if(!Validate::isPasswd($passwordField->getValue())) {
             $passwordField->AddError($this->translator->trans(
                 'The password should be at least 5 characters long',
                 [],

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -138,6 +138,15 @@ class CustomerFormCore extends AbstractForm
             );
             $birthdayField->setValue($dateBuilt->format('Y-m-d'));
         }
+
+        $passwordField = $this->getField('password');
+        if(Validate::isPasswd($passwordField->getValue())) {
+            $passwordField->AddError($this->translator->trans(
+                'The password should be at least 5 characters long',
+                [],
+                'Shop.Notifications.Error'
+            ));
+        }
         $this->validateFieldsLengths();
         $this->validateByModules();
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | There is only a HTML validation of the password when creating an account. This is problematic if a theme does not add this check because it is impossible for the user to connect later, see also #19505 
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19505.
| How to test?  | - Delete the validation from the template form-fields.tpl <br> - Go on the registration form <br> - Create an account with a password under 5 characters long <br> - Log out and try to log in

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19534)
<!-- Reviewable:end -->
