### PR TITLE
Fix webservice id_shop_group parameter

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -908,17 +908,17 @@ class WebserviceRequestCore
      */
     protected function groupShopExists($params)
     {
-        if (isset($params['id_group_shop']) && is_numeric($params['id_group_shop'])) {
-            Shop::setContext(Shop::CONTEXT_GROUP, (int) $params['id_group_shop']);
-            self::$shopIDs = Shop::getShops(true, (int) $params['id_group_shop'], true);
+        if (isset($params['id_shop_group']) && is_numeric($params['id_shop_group'])) {
+            Shop::setContext(Shop::CONTEXT_GROUP, (int) $params['id_shop_group']);
+            self::$shopIDs = Shop::getShops(true, (int) $params['id_shop_group'], true);
             if (!is_countable(self::$shopIDs) || count(self::$shopIDs) == 0) {
                 // @FIXME Set ErrorCode !
-                $this->setError(500, 'This group shop doesn\'t have shops', 999);
+                $this->setError(500, 'This shop group doesn\'t have shops', 999);
 
                 return false;
             }
         }
-        // id_group_shop isn't mandatory
+        // id_shop_group isn't mandatory
         return true;
     }
 

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -911,7 +911,7 @@ class WebserviceRequestCore
         $idShopGroup = null;
         if (isset($params['id_shop_group']) && is_numeric($params['id_shop_group'])) {
             $idShopGroup = (int) $params['id_shop_group'];
-        } else if (isset($params['id_group_shop']) && is_numeric($params['id_group_shop'])) {
+        } elseif (isset($params['id_group_shop']) && is_numeric($params['id_group_shop'])) {
             $idShopGroup = (int) $params['id_group_shop'];
         }
 

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -908,9 +908,16 @@ class WebserviceRequestCore
      */
     protected function groupShopExists($params)
     {
+        $idShopGroup = null;
         if (isset($params['id_shop_group']) && is_numeric($params['id_shop_group'])) {
-            Shop::setContext(Shop::CONTEXT_GROUP, (int) $params['id_shop_group']);
-            self::$shopIDs = Shop::getShops(true, (int) $params['id_shop_group'], true);
+            $idShopGroup = (int) $params['id_shop_group'];
+        } else if (isset($params['id_group_shop']) && is_numeric($params['id_group_shop'])) {
+            $idShopGroup = (int) $params['id_group_shop'];
+        }
+
+        if (null !== $idShopGroup) {
+            Shop::setContext(Shop::CONTEXT_GROUP, $idShopGroup);
+            self::$shopIDs = Shop::getShops(true, $idShopGroup, true);
             if (!is_countable(self::$shopIDs) || count(self::$shopIDs) == 0) {
                 // @FIXME Set ErrorCode !
                 $this->setError(500, 'This shop group doesn\'t have shops', 999);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Fix typo in the name of id_shop_group parameter for webservice, see official doc: https://devdocs.prestashop.com/1.7/development/webservice/tutorials/advanced-use/manage-multishop/#define-shop-specific-override)
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #19566
| How to test?  | Activate multishop, with 2 groups (eg: "Default" and "Stores"), with at least 1 shop in each group. Activate webservices and create a key with full access (all resources and all shops). Create a product for the second groups's shop. Get products from /api/products?id_shop_group=2. Without this fix, you won't see the product you previously create.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19565)
<!-- Reviewable:end -->
