### PR TITLE
Better performance for manufacturer's admin query

### DIFF
--- a/src/Core/Grid/Query/ManufacturerQueryBuilder.php
+++ b/src/Core/Grid/Query/ManufacturerQueryBuilder.php
@@ -70,7 +70,8 @@ final class ManufacturerQueryBuilder extends AbstractDoctrineQueryBuilder
         $addressesQb = $this->connection->createQueryBuilder();
         $addressesQb->select('COUNT(a.`id_manufacturer`) AS `addresses_count`')
             ->from($this->dbPrefix . 'address', 'a')
-            ->where('m.`id_manufacturer` = a.`id_manufacturer`')
+            ->where('a.`id_manufacturer` != 0')
+            ->andWhere('m.`id_manufacturer` = a.`id_manufacturer`')
             ->andWhere('a.`deleted` = 0')
             ->groupBy('a.`id_manufacturer`')
         ;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently, the query for the admin section of the manufacturers also fetches the address count for each manufacturer, with a subquery. In some of our shops, with 500k+ products, this query takes 300s+ to run. We backtraced this to the subquery itself, which doesn't have a way to filter using an index properly, and matches each single address (which in a big shop could be a VERY large table) to match with in id of the manufacturer. Since most of the addresses usually are not for a manufacturer, we found that simply filtering first by ```id_manufacturer != 0``` take the query time down to 30ms. I still think this query can be improved in its general construction, but in the meantime, this fixes the big issue.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Just seed a lot of manufacturers and addresses (not linked to the manufacturers) and see the query time results.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19570)
<!-- Reviewable:end -->
