### PR TITLE
Refactor EditableProduct to ProductForEditing

### DIFF
--- a/src/Adapter/Product/QueryHandler/GetProductForEditingForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingForEditingHandler.php
@@ -29,10 +29,9 @@ namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
 use Pack;
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetProductForEditingHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductBasicInformation;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 use Product;
@@ -44,19 +43,30 @@ class GetProductForEditingForEditingHandler extends AbstractProductHandler imple
 {
     /**
      * {@inheritdoc}
-     *
-     * @throws ProductConstraintException
-     * @throws ProductException
-     * @throws ProductNotFoundException
      */
     public function handle(GetProductForEditing $query): ProductForEditing
     {
         $product = $this->getProduct($query->getProductId());
 
         return new ProductForEditing(
-            $product->id,
+            (int) $product->id,
+            (bool) $product->active,
+            $this->getBasicInformation($product)
+        );
+    }
+
+    /**
+     * @param Product $product
+     *
+     * @return ProductBasicInformation
+     */
+    private function getBasicInformation(Product $product): ProductBasicInformation
+    {
+        return new ProductBasicInformation(
+            $this->getProductType($product),
             $product->name,
-            $this->getProductType($product)
+            $product->description,
+            $product->description_short
         );
     }
 

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingForEditingHandler.php
@@ -31,16 +31,16 @@ use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetEditableProductHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\EditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetProductForEditingHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 use Product;
 
 /**
  * Handles the query GetEditableProduct using legacy ObjectModel
  */
-class GetEditableProductHandler extends AbstractProductHandler implements GetEditableProductHandlerInterface
+class GetProductForEditingForEditingHandler extends AbstractProductHandler implements GetProductForEditingHandlerInterface
 {
     /**
      * {@inheritdoc}
@@ -49,11 +49,11 @@ class GetEditableProductHandler extends AbstractProductHandler implements GetEdi
      * @throws ProductException
      * @throws ProductNotFoundException
      */
-    public function handle(GetEditableProduct $query): EditableProduct
+    public function handle(GetProductForEditing $query): ProductForEditing
     {
         $product = $this->getProduct($query->getProductId());
 
-        return new EditableProduct(
+        return new ProductForEditing(
             $product->id,
             $product->name,
             $this->getProductType($product)

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetProductForEditingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductBasicInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCategoriesInformation;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 use Product;
@@ -51,7 +52,8 @@ class GetProductForEditingHandler extends AbstractProductHandler implements GetP
         return new ProductForEditing(
             (int) $product->id,
             (bool) $product->active,
-            $this->getBasicInformation($product)
+            $this->getBasicInformation($product),
+            $this->getCategoriesInformation($product)
         );
     }
 
@@ -68,6 +70,19 @@ class GetProductForEditingHandler extends AbstractProductHandler implements GetP
             $product->description,
             $product->description_short
         );
+    }
+
+    /**
+     * @param Product $product
+     *
+     * @return ProductCategoriesInformation
+     */
+    private function getCategoriesInformation(Product $product): ProductCategoriesInformation
+    {
+        $categoryIds = array_map('intval', $product->getCategories());
+        $defaultCategoryId = (int) $product->id_category_default;
+
+        return new ProductCategoriesInformation($categoryIds, $defaultCategoryId);
     }
 
     /**

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -39,7 +39,7 @@ use Product;
 /**
  * Handles the query GetEditableProduct using legacy ObjectModel
  */
-class GetProductForEditingForEditingHandler extends AbstractProductHandler implements GetProductForEditingHandlerInterface
+class GetProductForEditingHandler extends AbstractProductHandler implements GetProductForEditingHandlerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Core/Domain/Product/Query/GetProductForEditing.php
+++ b/src/Core/Domain/Product/Query/GetProductForEditing.php
@@ -24,17 +24,35 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Query;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\EditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
-interface GetEditableProductHandlerInterface
+/**
+ * Get Product data necessary for editing
+ */
+class GetProductForEditing
 {
     /**
-     * @param GetEditableProduct $query
-     *
-     * @return EditableProduct
+     * @var ProductId
      */
-    public function handle(GetEditableProduct $query): EditableProduct;
+    private $productId;
+
+    /**
+     * GetEditableProduct constructor.
+     *
+     * @param int $productId
+     */
+    public function __construct(int $productId)
+    {
+        $this->productId = new ProductId($productId);
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
 }

--- a/src/Core/Domain/Product/QueryHandler/GetProductForEditingHandlerInterface.php
+++ b/src/Core/Domain/Product/QueryHandler/GetProductForEditingHandlerInterface.php
@@ -24,35 +24,20 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\Query;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 
 /**
- * Get Product data necessary for edition
+ * Defines contract for GetProductForEditingHandler
  */
-class GetEditableProduct
+interface GetProductForEditingHandlerInterface
 {
     /**
-     * @var ProductId
-     */
-    private $productId;
-
-    /**
-     * GetEditableProduct constructor.
+     * @param GetProductForEditing $query
      *
-     * @param int $productId
+     * @return ProductForEditing
      */
-    public function __construct(int $productId)
-    {
-        $this->productId = new ProductId($productId);
-    }
-
-    /**
-     * @return ProductId
-     */
-    public function getProductId(): ProductId
-    {
-        return $this->productId;
-    }
+    public function handle(GetProductForEditing $query): ProductForEditing;
 }

--- a/src/Core/Domain/Product/QueryResult/ProductBasicInformation.php
+++ b/src/Core/Domain/Product/QueryResult/ProductBasicInformation.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
+
+/**
+ * Contains some basic information about product
+ */
+class ProductBasicInformation
+{
+    /**
+     * @var ProductType
+     */
+    private $type;
+
+    /**
+     * @var string[]
+     */
+    private $localizedNames;
+
+    /**
+     * @var string[]
+     */
+    private $localizedDescriptions;
+
+    /**
+     * @var string[]
+     */
+    private $localizedShortDescriptions;
+
+    /**
+     * @param ProductType $type
+     * @param string[] $localizedNames
+     * @param string[] $localizedDescriptions
+     * @param string[] $localizedShortDescriptions
+     */
+    public function __construct(
+        ProductType $type,
+        array $localizedNames,
+        array $localizedDescriptions,
+        array $localizedShortDescriptions
+    ) {
+        $this->type = $type;
+        $this->localizedNames = $localizedNames;
+        $this->localizedDescriptions = $localizedDescriptions;
+        $this->localizedShortDescriptions = $localizedShortDescriptions;
+    }
+
+    /**
+     * @return ProductType
+     */
+    public function getType(): ProductType
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedNames(): array
+    {
+        return $this->localizedNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedDescriptions(): array
+    {
+        return $this->localizedDescriptions;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedShortDescriptions(): array
+    {
+        return $this->localizedShortDescriptions;
+    }
+}

--- a/src/Core/Domain/Product/QueryResult/ProductCategoriesInformation.php
+++ b/src/Core/Domain/Product/QueryResult/ProductCategoriesInformation.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
+
+/**
+ * Contains information about product categories
+ */
+class ProductCategoriesInformation
+{
+    /**
+     * @var int[]
+     */
+    private $categoryIds;
+
+    /**
+     * @var int
+     */
+    private $defaultCategoryId;
+
+    /**
+     * @param int[] $categoryIds
+     * @param int $defaultCategoryId
+     */
+    public function __construct(array $categoryIds, int $defaultCategoryId)
+    {
+        $this->categoryIds = $categoryIds;
+        $this->defaultCategoryId = $defaultCategoryId;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getCategoryIds(): array
+    {
+        return $this->categoryIds;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDefaultCategoryId(): int
+    {
+        return $this->defaultCategoryId;
+    }
+}

--- a/src/Core/Domain/Product/QueryResult/ProductForEditing.php
+++ b/src/Core/Domain/Product/QueryResult/ProductForEditing.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
 
 /**
- * DTO for product that needs to be edited
+ * Product information for editing
  */
 class ProductForEditing
 {
@@ -37,23 +37,28 @@ class ProductForEditing
     private $productId;
 
     /**
-     * @var string[]
+     * @var bool
      */
-    private $localizedNames;
+    private $active;
 
     /**
-     * @var ProductType
+     * @var ProductBasicInformation
      */
-    private $type;
+    private $basicInformation;
 
+    /**
+     * @param int $productId
+     * @param bool $active
+     * @param ProductBasicInformation $basicInformation
+     */
     public function __construct(
         int $productId,
-        array $localizedNames,
-        ProductType $type
+        bool $active,
+        ProductBasicInformation $basicInformation
     ) {
         $this->productId = $productId;
-        $this->localizedNames = $localizedNames;
-        $this->type = $type;
+        $this->active = $active;
+        $this->basicInformation = $basicInformation;
     }
 
     /**
@@ -65,18 +70,18 @@ class ProductForEditing
     }
 
     /**
-     * @return string[]
+     * @return bool
      */
-    public function getLocalizedNames(): array
+    public function isActive(): bool
     {
-        return $this->localizedNames;
+        return $this->active;
     }
 
     /**
-     * @return ProductType
+     * @return ProductBasicInformation
      */
-    public function getType(): ProductType
+    public function getBasicInformation(): ProductBasicInformation
     {
-        return $this->type;
+        return $this->basicInformation;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/ProductForEditing.php
+++ b/src/Core/Domain/Product/QueryResult/ProductForEditing.php
@@ -47,18 +47,26 @@ class ProductForEditing
     private $basicInformation;
 
     /**
+     * @var ProductCategoriesInformation
+     */
+    private $categoriesInformation;
+
+    /**
      * @param int $productId
      * @param bool $active
      * @param ProductBasicInformation $basicInformation
+     * @param ProductCategoriesInformation $categoriesInformation
      */
     public function __construct(
         int $productId,
         bool $active,
-        ProductBasicInformation $basicInformation
+        ProductBasicInformation $basicInformation,
+        ProductCategoriesInformation $categoriesInformation
     ) {
         $this->productId = $productId;
         $this->active = $active;
         $this->basicInformation = $basicInformation;
+        $this->categoriesInformation = $categoriesInformation;
     }
 
     /**
@@ -83,5 +91,13 @@ class ProductForEditing
     public function getBasicInformation(): ProductBasicInformation
     {
         return $this->basicInformation;
+    }
+
+    /**
+     * @return ProductCategoriesInformation
+     */
+    public function getCategoriesInformation(): ProductCategoriesInformation
+    {
+        return $this->categoriesInformation;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/ProductForEditing.php
+++ b/src/Core/Domain/Product/QueryResult/ProductForEditing.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
 /**
  * DTO for product that needs to be edited
  */
-class EditableProduct
+class ProductForEditing
 {
     /**
      * @var int

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -66,11 +66,11 @@ services:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled
 
-    prestashop.adapter.product.command_handler.get_editable_product_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetEditableProductHandler
+    prestashop.adapter.product.command_handler.get_product_for_editing_handler:
+      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductForEditingHandler
       tags:
         - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct
+          command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing
 
     prestashop.adapter.product.command_handler.add_product_handler:
       class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductHandler

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -309,18 +309,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     /**
      * @param string $reference
      *
-     * @return Product
-     */
-    private function getProductByReference(string $reference): Product
-    {
-        $productId = $this->getSharedStorage()->get($reference);
-
-        return $this->getProductById($productId);
-    }
-
-    /**
-     * @param string $reference
-     *
      * @return ProductForEditing
      */
     private function getProductForEditing(string $reference): ProductForEditing
@@ -330,21 +318,5 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         return $this->getQueryBus()->handle(new GetProductForEditing(
             $productId
         ));
-    }
-
-    /**
-     * @param int $productId
-     *
-     * @return Product
-     */
-    private function getProductById(int $productId): Product
-    {
-        $product = new Product($productId);
-
-        if (!$product->id) {
-            throw new RuntimeException('Product with id "%s" was not found');
-        }
-
-        return $product;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -100,8 +100,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         $command = new UpdateProductBasicInformationCommand($productId);
 
         if (isset($data['name'])) {
-            $localizedNames = $this->parseLocalizedArray($data['name']);
-            $command->setLocalizedNames($localizedNames);
+            $command->setLocalizedNames($this->parseLocalizedArray($data['name']));
         }
 
         if (isset($data['is_virtual'])) {
@@ -268,6 +267,8 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * Extracts corresponding field value from ProductForEditing DTO
+     *
      * @param ProductForEditing $productForEditing
      * @param string $propertyName
      *

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -34,9 +34,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetEditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\EditableProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use Product;
 use RuntimeException;
@@ -309,13 +309,13 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     /**
      * @param string $reference
      *
-     * @return EditableProduct
+     * @return ProductForEditing
      */
-    private function getEditableProductByReference(string $reference): EditableProduct
+    private function getEditableProductByReference(string $reference): ProductForEditing
     {
         $productId = $this->getSharedStorage()->get($reference);
 
-        return $this->getQueryBus()->handle(new GetEditableProduct(
+        return $this->getQueryBus()->handle(new GetProductForEditing(
             $productId
         ));
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -36,8 +36,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use Product;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -148,7 +148,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
                         $fieldName,
                         $langIso,
                         $expectedValue,
-                        $productForEditing->{$fieldName}[$langId]
+                        $actualValue
                     )
                 );
             }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -219,12 +219,12 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     public function assertProductType(string $productReference, string $productTypeName)
     {
         $editableProduct = $this->getEditableProductByReference($productReference);
-        if ($productTypeName !== $editableProduct->getType()->getValue()) {
+        if ($productTypeName !== $editableProduct->getBasicInformation()->getType()->getValue()) {
             throw new RuntimeException(
                 sprintf(
                     'Product type is not as expected. Expected %s but go %s instead',
                     $productTypeName,
-                    $editableProduct->getType()->getValue()
+                    $editableProduct->getBasicInformation()->getType()->getValue()
                 )
             );
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -11,7 +11,6 @@ Feature: Add basic product from Back Office (BO)
       | is_virtual | false                |
     Then product "product1" should have following values:
       | active           | false          |
-      | condition        | new            |
     And product "product1" type should be standard
     And product "product1" localized "name" should be "en-US:bottle of beer"
     And product "product1" should be assigned to default category


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Renamed EditableProduct and its query/handlers to ProductForEditing (for  consistency). Also added some more structure to this DTO similarly as with OrderForViewing. keep in mind that It will evolve during the product migration. Also adjusted some behats to use ProductForEditing instead of legacy object model for assertions. Finally, removed assertions for product condition, because it doesn't give any value now and it should be done when time comes for Options tab/commands.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Not testable. CI must pass.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19577)
<!-- Reviewable:end -->
