### PR TITLE
Fix Product object model default values

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -242,7 +242,7 @@ class ProductCore extends ObjectModel
     /**
      * @var int TaxRulesGroup identifier
      */
-    public $id_tax_rules_group = 1;
+    public $id_tax_rules_group;
 
     /**
      * @var int

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -112,7 +112,7 @@ class ProductCore extends ObjectModel
     public $unity = null;
 
     /** @var float price for product's unity */
-    public $unit_price;
+    public $unit_price = 0;
 
     /** @var float price for product's unity ratio */
     public $unit_price_ratio = 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | see bellow
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | CI must pass. Nothing to test manually

**classes/Product.php contains some strange default values which seems just to be a mistake according to other similar properties.**
- The `unit_price doesn't have a default value "0"` as other price values which makes it abit confusing when dealing with Number
-  `id_tax_rules_group has a default value of 1`. It is a reference to tax rules group, so it doesn't make sense to have default static id which in some case might not even exist.

**So with this PR i suggest** 
- making `unit_price default value 0` (as in other price numbers like price, ecotax, wholesale_price etc.) 
- `remove the default value from id_tax_rules_group` (as in other relations identifiers like id_manufacturer, id_supplier etc.)

Personally I am not aware of any strict comparisons that could break something, but If anyone is concerned please tell in comments.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19598)
<!-- Reviewable:end -->
