### PR TITLE
Wrong call prefix for Congo (CG/CD)

### DIFF
--- a/install-dev/data/xml/country.xml
+++ b/install-dev/data/xml/country.xml
@@ -82,8 +82,8 @@
     <country id="CL" id_zone="South_America" iso_code="CL" call_prefix="56" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNN-NNNN" display_tax_label="1"/>
     <country id="CO" id_zone="South_America" iso_code="CO" call_prefix="57" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNNN" display_tax_label="1"/>
     <country id="KM" id_zone="Africa" iso_code="KM" call_prefix="269" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
-    <country id="CD" id_zone="Africa" iso_code="CD" call_prefix="242" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
-    <country id="CG" id_zone="Africa" iso_code="CG" call_prefix="243" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
+    <country id="CD" id_zone="Africa" iso_code="CD" call_prefix="243" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
+    <country id="CG" id_zone="Africa" iso_code="CG" call_prefix="242" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>
     <country id="CR" id_zone="Central_America_Antilla" iso_code="CR" call_prefix="506" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNN" display_tax_label="1"/>
     <country id="HR" id_zone="Europe" iso_code="HR" call_prefix="385" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="NNNNN" display_tax_label="1"/>
     <country id="CU" id_zone="Central_America_Antilla" iso_code="CU" call_prefix="53" active="1" contains_states="0" need_identification_number="0" need_zip_code="1" zip_code_format="" display_tax_label="1"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There was a confusion on call prefix for the two Congo : Congo Rep. (CG) is +242 ans Congo Democratic Rep. (CD) is +243<br>Just a simple update on the countries XML file due to confusion on call prefix for the two Congo
| Type?         |  refacto 
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | none.
| How to test?  | I'm in the Congo Rep, you can contact me on my phone (call/whatsapp) on +242 05 xxx xx xx.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19599)
<!-- Reviewable:end -->
