### PR TITLE
Specific price condition - Use the same rounding to compare

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -48,6 +48,7 @@ use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Cart\AmountImmutable;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\Precision;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\AddProductToOrderHandlerInterface;
@@ -387,7 +388,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $product->id,
             true,
             $combination ? $combination->id : null,
-            2,
+            Precision::DEFAULT_PRECISION,
             null,
             false,
             true,
@@ -399,7 +400,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         );
 
         // Use the same rounding decimals used to call Product::getPriceStatic
-        $amountTaxIncluded = Tools::ps_round($amount->getTaxIncluded(), 2);
+        $amountTaxIncluded = Tools::ps_round($amount->getTaxIncluded(), Precision::DEFAULT_PRECISION);
         if (!(new Number((string) $amountTaxIncluded))->equals(new Number((string) $initialProductPriceTaxIncl))) {
             // @todo: use private method to create specific price object
             $specificPrice = new SpecificPrice();

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -398,7 +398,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
         );
 
-        if (!(new Number((string) $amount->getTaxIncluded()))->equals(new Number((string) $initialProductPriceTaxIncl))) {
+        // Use the same rounding decimals used to call Product::getPriceStatic
+        $amountTaxIncluded = Tools::ps_round($amount->getTaxIncluded(), 2);
+        if (!(new Number((string) $amountTaxIncluded))->equals(new Number((string) $initialProductPriceTaxIncl))) {
             // @todo: use private method to create specific price object
             $specificPrice = new SpecificPrice();
             $specificPrice->id_shop = 0;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | To know if we have to create a specific price for the product, the price received is compared to the one defined previously for the product, And to know if the previous order products must have specific prices, we compare the price in order_detail to the one defined for the product.<br>prices in order detail are 6 decimals rounded, and the one used to compare is 2 digits rounded.<br>Now we round the price in order_detail before the comparison 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18695
| How to test?  | Create a productA with Quantity=0 and minimal quantity=10 and Allow orders<br><br>Go to `admin-dev/sell/orders/orders/{orderId}/view<br><br>Make sure order status is not "delivered" and you can add products.<br><br>Click Add product, search and select the last product created productA with quantity=10<br><br>In a buggy version, it displays "Error!<br>An unexpected error occurred. [PrestaShopDatabaseException code 0]: Duplicate entry '19-0-2-0-0000-00-00 00:00:00-0000-00-00 00:00:00-0-0-1-0-0-1-0' for key 'id_product_2'"<br><br>Now, the product is added to the order

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19629)
<!-- Reviewable:end -->
