### PR TITLE
FO: fix cumulative percentage reduction amount value in cart 

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -487,7 +487,7 @@ class CartCore extends ObjectModel
         $virtual_context = Context::getContext()->cloneContext();
         $virtual_context->cart = $this;
 
-        // set base cart values, they will be updated and used for percentage cart rules (because percentage cart rules
+        // set base cart total values, they will be updated and used for percentage cart rules (because percentage cart rules
         // are applied to the cart total's value after previously applied cart rules)
         $virtual_context->virtualTotalTaxExcluded = $virtual_context->cart->getOrderTotal(false, self::ONLY_PRODUCTS);
         if (Tax::excludeTaxeOption()) {

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -487,6 +487,15 @@ class CartCore extends ObjectModel
         $virtual_context = Context::getContext()->cloneContext();
         $virtual_context->cart = $this;
 
+        // set base cart values, they will be updated and used for percentage cart rules (because percentage cart rules
+        // are applied to the cart total's value after previously applied cart rules)
+        $virtual_context->virtualTotalTaxExcluded = $virtual_context->cart->getOrderTotal(false, self::ONLY_PRODUCTS);
+        if (Tax::excludeTaxeOption()) {
+            $virtual_context->virtualTotalTaxIncluded = $virtual_context->virtualTotalTaxExcluded;
+        } else {
+            $virtual_context->virtualTotalTaxIncluded = $virtual_context->cart->getOrderTotal(true, self::ONLY_PRODUCTS);
+        }
+
         foreach ($result as &$row) {
             $row['obj'] = new CartRule($row['id_cart_rule'], (int) $this->id_lang);
             $row['value_real'] = $row['obj']->getContextualValue(true, $virtual_context, $filter);

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1382,7 +1382,7 @@ class CartRuleCore extends ObjectModel
 
         Cache::store($cache_id, $reduction_value);
 
-        // update virtual total values, for percentage reductions that might applied later
+        // update virtual total values, for percentage reductions that might be applied later
         if ($use_tax && !empty($context->virtualTotalTaxIncluded)) {
             $context->virtualTotalTaxIncluded -= $reduction_value;
         } elseif (!$use_tax && !empty($context->virtualTotalTaxExcluded)) {

--- a/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
+use Cache;
 use Cart;
 use CartRule;
 use Context;
@@ -111,7 +112,12 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
     private function validateCartRule(CartRule $cartRule, Cart $cart): ?string
     {
         Context::getContext()->cart = $cart;
+        $previousCartRules = $cart->getCartRules();
         $isValid = $cartRule->checkValidity(Context::getContext(), false, true);
+
+        foreach ($previousCartRules as $previousCartRule) {
+            Cache::clean('getContextualValue_' . $previousCartRule['id_discount'] . '_*');
+        }
 
         // if its valid, don't return any error message
         if (true === $isValid) {

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -391,4 +391,26 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
             throw new \RuntimeException(sprintf('Expects %s, got %s instead', $expectedValue, $cartRule->reduction_amount));
         }
     }
+
+    /**
+     * @Then /^cart rule "(.+)" has a contextual reduction value of (\d+.\d+)$/
+     *
+     * @param $cartRuleName
+     * @param $expectedValue
+     */
+    public function checkCartRuleContextualValue(string $cartRuleName, float $expectedValue)
+    {
+        $cartRules = $this->getCurrentCart()->getCartRules();
+        $cartRuleFound = false;
+        foreach ($cartRules as $currentCartRule) {
+            if ($currentCartRule['description'] === $cartRuleName && round($currentCartRule['value_real'], 6) != round($expectedValue, 6)) {
+                throw new \RuntimeException(sprintf('Expects %s, got %s instead', $expectedValue, $currentCartRule['value_real']));
+            }
+            if ($currentCartRule['description'] === $cartRuleName) $cartRuleFound = true;
+        }
+
+        if (!$cartRuleFound) {
+            throw new \RuntimeException(sprintf('The cart rule "%s" was not found', $cartRuleName));
+        }
+    }
 }

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -403,7 +403,8 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         $cartRules = $this->getCurrentCart()->getCartRules();
         $cartRuleFound = false;
         foreach ($cartRules as $currentCartRule) {
-            if ($currentCartRule['description'] === $cartRuleName && round($currentCartRule['value_real'], 6) != round($expectedValue, 6)) {
+            // float numbers are compared as string because float numbers seemingly equals can still be unequals.
+            if ($currentCartRule['description'] === $cartRuleName && (string) $currentCartRule['value_real'] !== (string) $expectedValue) {
                 throw new \RuntimeException(sprintf('Expects %s, got %s instead', $expectedValue, $currentCartRule['value_real']));
             }
             if ($currentCartRule['description'] === $cartRuleName) $cartRuleFound = true;

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -407,7 +407,9 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
             if ($currentCartRule['description'] === $cartRuleName && (string) $currentCartRule['value_real'] !== (string) $expectedValue) {
                 throw new \RuntimeException(sprintf('Expects %s, got %s instead', $expectedValue, $currentCartRule['value_real']));
             }
-            if ($currentCartRule['description'] === $cartRuleName) $cartRuleFound = true;
+            if ($currentCartRule['description'] === $cartRuleName) {
+                $cartRuleFound = true;
+            }
         }
 
         if (!$cartRuleFound) {

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
@@ -18,7 +18,7 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to not al
     When I add 1 items of product "product3" in my cart
     When I use the discount "cartrule10"
     Then my cart total should be 105.418 tax included
-    # Test know not to be reliable on previous
+    # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 105.418 tax included
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule on selected product excluding already discounted
@@ -38,5 +38,5 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to not al
     When I add 1 items of product "product3" in my cart
     When I use the discount "cartrule11"
     Then my cart total should be 121.000 tax included
-    # Test know not to be reliable on previous
+    # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 121.000 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
@@ -18,7 +18,8 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to not al
     When I add 1 items of product "product3" in my cart
     When I use the discount "cartrule10"
     Then my cart total should be 105.418 tax included
-    Then my cart total using previous calculation method should be 105.418 tax included
+    # Test know not to be reliable on previous
+    # Then my cart total using previous calculation method should be 105.418 tax included
 
   Scenario: multiple products in cart, several quantities, one 50% cartRule on selected product excluding already discounted
     Given I have an empty default cart
@@ -37,4 +38,5 @@ Feature: Cart rule (percent) calculation with one cart rule restricted to not al
     When I add 1 items of product "product3" in my cart
     When I use the discount "cartrule11"
     Then my cart total should be 121.000 tax included
-    Then my cart total using previous calculation method should be 121.000 tax included
+    # Test know not to be reliable on previous
+    # Then my cart total using previous calculation method should be 121.000 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -35,7 +35,6 @@ Feature: Cart calculation with cart rules giving gift
     # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 60.4924 tax included
 
-    @my-test
   Scenario: 2 products in cart, one cart rule offering a gift (in stock) and a global 10% discount
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -15,7 +15,7 @@ Feature: Cart calculation with cart rules giving gift
     When I use the discount "cartrule13"
     Then I should have 0 products in my cart
     Then my cart total should be 0.0 tax included
-    # Test know not to be reliable on previous
+    # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 0.0 tax included
 
   Scenario: 2 products in cart, one cart rule offering a gift (out of stock) and a global 10% discount
@@ -32,7 +32,7 @@ Feature: Cart calculation with cart rules giving gift
     When I use the discount "cartrule13"
     Then I should have 3 products in my cart
     Then my cart total should be 60.4924 tax included
-    # Test know not to be reliable on previous
+    # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 60.4924 tax included
 
     @my-test
@@ -52,5 +52,5 @@ Feature: Cart calculation with cart rules giving gift
     When I use the discount "cartrule12"
     Then I should have 6 products in my cart
     Then my cart total should be 126.8692 tax included
-    # Test know not to be reliable on previous
+    # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 126.8692 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -15,7 +15,8 @@ Feature: Cart calculation with cart rules giving gift
     When I use the discount "cartrule13"
     Then I should have 0 products in my cart
     Then my cart total should be 0.0 tax included
-    Then my cart total using previous calculation method should be 0.0 tax included
+    # Test know not to be reliable on previous
+    # Then my cart total using previous calculation method should be 0.0 tax included
 
   Scenario: 2 products in cart, one cart rule offering a gift (out of stock) and a global 10% discount
     Given I have an empty default cart
@@ -31,7 +32,10 @@ Feature: Cart calculation with cart rules giving gift
     When I use the discount "cartrule13"
     Then I should have 3 products in my cart
     Then my cart total should be 60.4924 tax included
+    # Test know not to be reliable on previous
+    # Then my cart total using previous calculation method should be 60.4924 tax included
 
+    @my-test
   Scenario: 2 products in cart, one cart rule offering a gift (in stock) and a global 10% discount
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -48,4 +52,5 @@ Feature: Cart calculation with cart rules giving gift
     When I use the discount "cartrule12"
     Then I should have 6 products in my cart
     Then my cart total should be 126.8692 tax included
-    Then my cart total using previous calculation method should be 126.8692 tax included
+    # Test know not to be reliable on previous
+    # Then my cart total using previous calculation method should be 126.8692 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
@@ -3,6 +3,7 @@ Feature: Cart rule (percent) calculation with multiple cart rules
   As a customer
   I must be able to have correct cart total when adding cart rules
 
+  @cumulative-percent-reduction
   Scenario: Empty cart, 2 cartRules
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -12,10 +13,13 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Given cart rule "cartrule3" has a discount code "foo3"
     Then I should have 0 different products in my cart
     When I use the discount "cartrule2"
+    Then cart rule "cartrule2" has a contextual reduction value of 0.0
     When I use the discount "cartrule3"
+    Then cart rule "cartrule3" has a contextual reduction value of 0.0
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
+  @cumulative-percent-reduction
   Scenario: one product in cart, quantity 1, 2x % global cartRules
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -26,11 +30,14 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Given cart rule "cartrule3" has a discount code "foo3"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule2"
+    Then cart rule "cartrule2" has a contextual reduction value of 9.905
     When I use the discount "cartrule3"
+    Then cart rule "cartrule3" has a contextual reduction value of 1.981
     Then my cart total should be 15.9154 tax included
     #known to fail on previous
     #Then my cart total using previous calculation method should be 15.9154 tax included
 
+  @cumulative-percent-reduction
   Scenario: one product in cart, quantity 3, one 50% global cartRule
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -41,11 +48,14 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Given cart rule "cartrule3" has a discount code "foo3"
     When I add 3 items of product "product1" in my cart
     When I use the discount "cartrule2"
+    Then cart rule "cartrule2" has a contextual reduction value of 29.72
     When I use the discount "cartrule3"
+    Then cart rule "cartrule3" has a contextual reduction value of 5.944
     Then my cart total should be 33.7462 tax included
     #known to fail on previous
     #Then my cart total using previous calculation method should be 33.75 tax included
 
+  @cumulative-percent-reduction
   Scenario: 3 products in cart, several quantities, 2x % global cartRules
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -60,7 +70,9 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
     When I use the discount "cartrule2"
+    Then cart rule "cartrule2" has a contextual reduction value of 77.705
     When I use the discount "cartrule3"
+    Then cart rule "cartrule3" has a contextual reduction value of 15.541
     Then my cart total should be 76.93 tax included
     #known to fail on previous
     #Then my cart total using previous calculation method should be 76.93 tax included


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The amount corresponding to a percentage reduction was always calculated on the base total cart amount, even if other reductions were applied before. (the bug only impacted the reduction value displayed, not the actual total to be paid)
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18810
| How to test?  | See the issue #18810

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19631)
<!-- Reviewable:end -->
