### PR TITLE
Synchronize cart_product and order_detail when quantity is changed

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1238,9 +1238,9 @@ class CartRuleCore extends ObjectModel
                     foreach ($context->cart->getProducts() as $product) {
                         if ($product['id_product'] == $this->reduction_product) {
                             if ($this->reduction_tax) {
-                                $max_reduction_amount = (float) $product['price_wt'];
+                                $max_reduction_amount = (int) $product['cart_quantity'] * (float) $product['price_wt'];
                             } else {
-                                $max_reduction_amount = (float) $product['price'];
+                                $max_reduction_amount = (int) $product['cart_quantity'] * (float) $product['price'];
                             }
                             $reduction_amount = min($reduction_amount, $max_reduction_amount);
                             break;

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Address;
 use Attribute;
+use Cache;
 use Carrier;
 use Cart;
 use CartRule;
@@ -221,6 +222,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
      */
     private function updateOrderCartRules(Order $order, ?OrderInvoice $invoice, array $cartCartRules)
     {
+        CartRule::resetStaticCache();
+        Cache::clean('getContextualValue_*');
+
         foreach ($cartCartRules as $cartCartRule) {
             $rule = new CartRule($cartCartRule['id_cart_rule']);
 

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -100,6 +100,7 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
                 $orderDetail,
                 $orderDetail->product_quantity,
                 0,
+                true,
                 $orderDetail->id_order_invoice != 0
             );
 

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -36,7 +36,7 @@ use OrderDetail;
 use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
-use PrestaShop\PrestaShop\Adapter\Order\OrderProductUpdater;
+use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand;
@@ -59,9 +59,9 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
      */
     private $orderAmountUpdater;
     /**
-     * @var OrderProductUpdater
+     * @var OrderProductQuantityUpdater
      */
-    private $orderProductUpdater;
+    private $orderProductQuantityUpdater;
 
     /**
      * @param ContextStateManager $contextStateManager
@@ -69,11 +69,11 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
     public function __construct(
         ContextStateManager $contextStateManager,
         OrderAmountUpdater $orderAmountUpdater,
-        OrderProductUpdater $orderProductUpdater
+        OrderProductQuantityUpdater $orderProductQuantityUpdater
     ) {
         $this->contextStateManager = $contextStateManager;
         $this->orderAmountUpdater = $orderAmountUpdater;
-        $this->orderProductUpdater = $orderProductUpdater;
+        $this->orderProductQuantityUpdater = $orderProductQuantityUpdater;
     }
 
     /**
@@ -94,7 +94,7 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
             ->setCustomer(new Customer($order->id_customer));
 
         try {
-            $order = $this->orderProductUpdater->update(
+            $order = $this->orderProductQuantityUpdater->update(
                 $order,
                 $orderDetail,
                 0,

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -97,7 +97,6 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
             $order = $this->orderProductUpdater->update(
                 $order,
                 $orderDetail,
-                $orderDetail->product_quantity,
                 0,
                 $orderDetail->id_order_invoice != 0 ? new OrderInvoice($orderDetail->id_order_invoice) : null
             );

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -99,13 +99,8 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
                 $orderDetail,
                 $orderDetail->product_quantity,
                 0,
-                true,
-                $orderDetail->id_order_invoice != 0
+                $orderDetail->id_order_invoice != 0 ? new OrderInvoice($orderDetail->id_order_invoice) : null
             );
-
-            if (!$this->updateOrderInvoice($orderDetail)) {
-                throw new OrderException('An error occurred while attempting to delete product from order.');
-            }
 
             Hook::exec('actionOrderEdited', ['order' => $order]);
         } catch (Exception $e) {
@@ -114,27 +109,6 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
         }
 
         $this->contextStateManager->restoreContext();
-    }
-
-    /**
-     * @param OrderDetail $orderDetail
-     *
-     * @return bool
-     */
-    private function updateOrderInvoice(OrderDetail $orderDetail)
-    {
-        if ($orderDetail->id_order_invoice != 0) {
-            $order_invoice = new OrderInvoice($orderDetail->id_order_invoice);
-            // @todo: use https://github.com/PrestaShop/decimal for price computations
-            $order_invoice->total_paid_tax_excl -= $orderDetail->total_price_tax_excl;
-            $order_invoice->total_paid_tax_incl -= $orderDetail->total_price_tax_incl;
-            $order_invoice->total_products -= $orderDetail->total_price_tax_excl;
-            $order_invoice->total_products_wt -= $orderDetail->total_price_tax_incl;
-
-            return $order_invoice->update();
-        }
-
-        return true;
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -108,8 +108,6 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
                 throw new OrderException('An error occurred while attempting to delete product from order.');
             }
 
-            $order = $order->refreshShippingCost();
-
             Hook::exec('actionOrderEdited', ['order' => $order]);
         } catch (Exception $e) {
             $this->contextStateManager->restoreContext();

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -160,6 +160,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
             $orderDetail,
             $old_quantity,
             $command->getQuantity(),
+            false,
             ($orderInvoice && !empty($orderInvoice->id))
         );
 

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -109,25 +109,8 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
             $res &= $order->update();
         }
 
-        $old_quantity = $orderDetail->product_quantity;
-
-        $orderDetail->product_quantity = $product_quantity;
-        $orderDetail->reduction_percent = 0;
-
-        // update taxes
-        $res &= $orderDetail->updateTaxAmount($order);
-
-        // Save order detail
-        $res &= $orderDetail->update();
-
         // Update quantity and amounts
-        $order = $this->orderProductUpdater->update(
-            $order,
-            $orderDetail,
-            $old_quantity,
-            $command->getQuantity(),
-            $orderInvoice
-        );
+        $order = $this->orderProductUpdater->update($order, $orderDetail, $product_quantity, $orderInvoice);
 
         if (!$res) {
             throw new OrderException('An error occurred while editing the product line.');

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -164,7 +164,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
 
         // Apply the changes on the cart
         $cart->updateQty(
-            $old_quantity - $orderDetail->product_quantity,
+            abs($old_quantity - $orderDetail->product_quantity),
             $orderDetail->product_id,
             $orderDetail->product_attribute_id,
             false,
@@ -276,6 +276,14 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         }
     }
 
+    /**
+     * @param Cart $cart
+     * @param Order $order
+     * @param OrderInvoice|null $invoice
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
     private function updateCartRules(Cart $cart, Order $order, ?OrderInvoice $invoice = null)
     {
         $computingPrecision = Context::getContext()->getComputingPrecision();
@@ -286,8 +294,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         CartRule::autoRemoveFromCart();
 
         $orderCartRulesData = $order->getCartRules();
-        /** @var OrderCartRule $orderCartRule */
-        foreach($orderCartRulesData as $orderCartRuleData) {
+        foreach ($orderCartRulesData as $orderCartRuleData) {
             $orderCartRule = new OrderCartRule((int) $orderCartRuleData['id_order_cart_rule']);
             $idCartRule = (int) $orderCartRule->id_cart_rule;
             $cartRule = new CartRule($idCartRule);
@@ -311,17 +318,23 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         $order->update();
     }
 
+    /**
+     * @param Order $order
+     * @param Cart $cart
+     *
+     * @return Cart
+     */
     private function syncCartOrderCartRules(Order $order, Cart $cart): Cart
     {
         $orderCartRulesData = $order->getCartRules();
         $orderCartRulesIds = array_map(
-            function(array $orderCartRuleData) { return (int)$orderCartRuleData['id_cart_rule']; },
+            function (array $orderCartRuleData) { return (int) $orderCartRuleData['id_cart_rule']; },
             $orderCartRulesData
         );
 
         $cartRules = $cart->getCartRules();
         $cartRulesIds = array_map(
-            function(array $cartRule) { return (int)$cartRule['id_cart_rule']; },
+            function (array $cartRule) { return (int) $cartRule['id_cart_rule']; },
             $cartRules
         );
 

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -32,7 +32,7 @@ use Order;
 use OrderDetail;
 use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
-use PrestaShop\PrestaShop\Adapter\Order\OrderProductUpdater;
+use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
@@ -47,13 +47,13 @@ use Validate;
 final class UpdateProductInOrderHandler extends AbstractOrderHandler implements UpdateProductInOrderHandlerInterface
 {
     /**
-     * @var OrderProductUpdater
+     * @var OrderProductQuantityUpdater
      */
-    private $orderProductUpdater;
+    private $orderProductQuantityUpdater;
 
-    public function __construct(OrderProductUpdater $orderProductUpdater)
+    public function __construct(OrderProductQuantityUpdater $orderProductQuantityUpdater)
     {
-        $this->orderProductUpdater = $orderProductUpdater;
+        $this->orderProductQuantityUpdater = $orderProductQuantityUpdater;
     }
 
     /**
@@ -110,7 +110,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         }
 
         // Update quantity and amounts
-        $order = $this->orderProductUpdater->update($order, $orderDetail, $product_quantity, $orderInvoice);
+        $order = $this->orderProductQuantityUpdater->update($order, $orderDetail, $product_quantity, $orderInvoice);
 
         if (!$res) {
             throw new OrderException('An error occurred while editing the product line.');

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use Address;
+use Cache;
 use Cart;
 use CartRule;
 use Configuration;
@@ -397,6 +398,8 @@ class OrderProductQuantityUpdater
     private function updateOrderCartRules(Order $order, Cart $cart): void
     {
         Context::getContext()->cart = $cart;
+        CartRule::resetStaticCache();
+        Cache::clean('getContextualValue_*');
         CartRule::autoAddToCart();
         CartRule::autoRemoveFromCart();
 

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -61,7 +61,7 @@ use Warehouse;
  * Increase or decrease quantity of an order's product.
  * Recalculate cart rules, order's prices and shipping infos.
  */
-class OrderProductUpdater
+class OrderProductQuantityUpdater
 {
     /**
      * @var OrderAmountUpdater

--- a/src/Adapter/Order/OrderProductUpdater.php
+++ b/src/Adapter/Order/OrderProductUpdater.php
@@ -91,10 +91,8 @@ class OrderProductUpdater
     /**
      * @param Order $order
      * @param OrderDetail $orderDetail
-     * @param int $oldQuantity
      * @param int $newQuantity
-     * @param bool|null $productDeletionMode
-     * @param bool|null $hasInvoice
+     * @param OrderInvoice|null $orderInvoice
      *
      * @return Order
      *
@@ -105,7 +103,6 @@ class OrderProductUpdater
     public function update(
         Order $order,
         OrderDetail $orderDetail,
-        int $oldQuantity,
         int $newQuantity,
         ?OrderInvoice $orderInvoice
     ): Order {
@@ -120,6 +117,15 @@ class OrderProductUpdater
         ;
 
         try {
+            $oldQuantity = $orderDetail->product_quantity;
+
+            $orderDetail->product_quantity = $newQuantity;
+            $orderDetail->reduction_percent = 0;
+            // update taxes
+            $orderDetail->updateTaxAmount($order);
+
+            $orderDetail->update();
+
             // Update quantity on the cart and stock
             $cart = $this->updateProductQuantity($cart, $order, $orderDetail, $oldQuantity, $newQuantity);
 

--- a/src/Adapter/Order/OrderProductUpdater.php
+++ b/src/Adapter/Order/OrderProductUpdater.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Adapter\Order;
+
+use Cart;
+use CartRule;
+use Configuration;
+use Context;
+use Order;
+use OrderCarrier;
+use OrderCartRule;
+use OrderDetail;
+use Product;
+use StockAvailable;
+use Validate;
+
+/**
+ * Increase or decrease quantity of an order's product.
+ * Recalculate cart rules, order's prices and shipping infos.
+ */
+class OrderProductUpdater
+{
+    /**
+     * @var OrderAmountUpdater
+     */
+    private $orderAmountUpdater;
+
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
+        $this->orderAmountUpdater = $orderAmountUpdater;
+    }
+
+    /**
+     * @param Order $order
+     * @param OrderDetail $orderDetail
+     * @param int $oldQuantity
+     * @param int $newQuantity
+     * @param bool $hasInvoice
+     *
+     * @return Order
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function update(
+        Order $order,
+        OrderDetail $orderDetail,
+        int $oldQuantity,
+        int $newQuantity,
+        bool $hasInvoice = false
+    ): Order {
+        $cart = new Cart($order->id_cart);
+
+        // Update quantity on the cart and stock
+        $cart = $this->updateCartProductQuantity($cart, $orderDetail, $oldQuantity, $newQuantity);
+
+        // Fix differences between cart's cartRules and order's cartRules
+        $cart = $this->syncCartAndOrderCartRules($cart, $order);
+
+        // Recalculate amounts of cartRules
+        $this->recalculateCartRules($cart, $order);
+
+        // Update prices on the order
+        $order = $this->updateOrderAmounts($cart, $order, $hasInvoice);
+
+        // Update weight and shipping infos
+        $order = $this->updateOrderShippingInfos($order, new Product((int) $orderDetail->product_id));
+
+        return $order;
+    }
+
+    /**
+     * @param Cart $cart
+     * @param OrderDetail $orderDetail
+     * @param int $oldQuantity
+     * @param int $newQuantity
+     *
+     * @return Cart
+     */
+    private function updateCartProductQuantity(
+        Cart $cart,
+        OrderDetail $orderDetail,
+        int $oldQuantity,
+        int $newQuantity
+    ): Cart {
+        $deltaQuantity = $oldQuantity - $newQuantity;
+
+        if (0 !== $deltaQuantity) {
+            $updateQuantityResult = $cart->updateQty(
+                abs($deltaQuantity),
+                $orderDetail->product_id,
+                $orderDetail->product_attribute_id,
+                false,
+                $deltaQuantity > 0 ? 'down' : 'up'
+            );
+
+            if (-1 === $updateQuantityResult) {
+                throw new \LogicException('Minimum quantity is not respected');
+            } elseif (true !== $updateQuantityResult) {
+                throw new \LogicException('Something went wrong');
+            }
+
+            // Update product available quantity
+            StockAvailable::updateQuantity(
+                $orderDetail->product_id,
+                $orderDetail->product_attribute_id,
+                $deltaQuantity,
+                $cart->id_shop
+            );
+        }
+
+        return $cart;
+    }
+
+    /**
+     * @param Cart $cart
+     * @param Order $order
+     *
+     * @return Cart
+     */
+    private function syncCartAndOrderCartRules(Cart $cart, Order $order): Cart
+    {
+        $orderCartRulesData = $order->getCartRules();
+        $orderCartRulesIds = array_map(
+            function (array $orderCartRuleData) { return (int) $orderCartRuleData['id_cart_rule']; },
+            $orderCartRulesData
+        );
+
+        $cartRules = $cart->getCartRules();
+        $cartRulesIds = array_map(
+            function (array $cartRule) { return (int) $cartRule['id_cart_rule']; },
+            $cartRules
+        );
+
+        if (count($orderCartRulesIds) === count($cartRulesIds)) {
+            return $cart;
+        }
+
+        if (count($orderCartRulesIds) > count($cartRulesIds)) {
+            sort($orderCartRulesIds);
+            sort($cartRulesIds);
+
+            foreach (array_diff($orderCartRulesIds, $cartRulesIds) as $cartRuleId) {
+                $cart->addCartRule($cartRuleId);
+            }
+        } else {
+            throw new \LogicException('Cart has more cart rules than order. This should never happen.');
+        }
+
+        return $cart;
+    }
+
+    private function recalculateCartRules(Cart $cart, Order $order)
+    {
+        $computingPrecision = Context::getContext()->getComputingPrecision();
+        Context::getContext()->cart = $cart;
+        CartRule::autoAddToCart();
+        CartRule::autoRemoveFromCart();
+
+        foreach ($order->getCartRules() as $orderCartRuleData) {
+            $orderCartRule = new OrderCartRule((int) $orderCartRuleData['id_order_cart_rule']);
+            $idCartRule = (int) $orderCartRule->id_cart_rule;
+            $cartRule = new CartRule($idCartRule);
+            $values = [
+                'tax_incl' => \Tools::ps_round($cartRule->getContextualValue(true), $computingPrecision),
+                'tax_excl' => \Tools::ps_round($cartRule->getContextualValue(false), $computingPrecision),
+            ];
+
+            if (
+                ($values['tax_incl'] !== \Tools::ps_round($orderCartRule->value, $computingPrecision)) ||
+                ($values['tax_excl'] !== \Tools::ps_round($orderCartRule->value_tax_excl, $computingPrecision))
+            ) {
+                $orderCartRule->value = $values['tax_incl'];
+                $orderCartRule->value_tax_excl = $values['tax_excl'];
+
+                $orderCartRule->update();
+            }
+        }
+    }
+
+    /**
+     * @param Cart $cart
+     * @param Order $order
+     * @param bool $hasInvoice
+     *
+     * @return Order
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    private function updateOrderAmounts(Cart $cart, Order $order, bool $hasInvoice): Order
+    {
+        $order = $this->orderAmountUpdater->update($order, $cart, $hasInvoice);
+        $order->update();
+
+        return $order;
+    }
+
+    /**
+     * @param Order $order
+     * @param Product $product
+     *
+     * @return Order
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    private function updateOrderShippingInfos(Order $order, Product $product): Order
+    {
+        $orderCarrier = new OrderCarrier((int) $order->getIdOrderCarrier());
+
+        if (Validate::isLoadedObject($orderCarrier)) {
+            $orderCarrier->weight = (float) $order->getTotalWeight();
+
+            if ($orderCarrier->update()) {
+                $order->weight = sprintf('%.3f ' . Configuration::get('PS_WEIGHT_UNIT'), $orderCarrier->weight);
+            }
+        }
+
+        if (!$product->is_virtual) {
+            $order = $order->refreshShippingCost();
+        }
+
+        return $order;
+    }
+}

--- a/src/Adapter/Order/OrderProductUpdater.php
+++ b/src/Adapter/Order/OrderProductUpdater.php
@@ -117,7 +117,7 @@ class OrderProductUpdater
         ;
 
         try {
-            $oldQuantity = $orderDetail->product_quantity;
+            $oldQuantity = (int) $orderDetail->product_quantity;
 
             $orderDetail->product_quantity = $newQuantity;
             $orderDetail->reduction_percent = 0;

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -126,7 +126,12 @@ class CartRuleCalculator
             if ($cartRule->reduction_product == 0) {
                 foreach ($this->cartRows as $cartRow) {
                     $product = $cartRow->getRowData();
-                    if ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
+                    if (
+                        array_key_exists('product_quantity', $product) &&
+                        0 === (int) $product['product_quantity']
+                    ) {
+                        $cartRuleData->addDiscountApplied(new AmountImmutable(0.0, 0.0));
+                    } elseif ((($cartRule->reduction_exclude_special && !$product['reduction_applies'])
                         || !$cartRule->reduction_exclude_special)) {
                         $amount = $cartRow->applyPercentageDiscount($cartRule->reduction_percent);
                         $cartRuleData->addDiscountApplied($amount);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -37,7 +37,7 @@ services:
   prestashop.adapter.order.command_handler.update_product_in_order_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\UpdateProductInOrderHandler
     arguments:
-      - '@prestashop.adapter.order.product.updater'
+      - '@prestashop.adapter.order.product_quantity.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand
@@ -161,7 +161,7 @@ services:
     arguments:
       - '@prestashop.adapter.context_state_manager'
       - '@prestashop.adapter.order.amount.updater'
-      - '@prestashop.adapter.order.product.updater'
+      - '@prestashop.adapter.order.product_quantity.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand
@@ -239,8 +239,8 @@ services:
   prestashop.adapter.order.amount.updater:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater
 
-  prestashop.adapter.order.product.updater:
-    class: PrestaShop\PrestaShop\Adapter\Order\OrderProductUpdater
+  prestashop.adapter.order.product_quantity.updater:
+    class: PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater
     arguments:
       - '@prestashop.adapter.order.amount.updater'
       - '@prestashop.adapter.order.product.remover'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -36,6 +36,8 @@ services:
 
   prestashop.adapter.order.command_handler.update_product_in_order_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\UpdateProductInOrderHandler
+    arguments:
+      - '@prestashop.adapter.order.amount.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -161,6 +161,7 @@ services:
     arguments:
       - '@prestashop.adapter.context_state_manager'
       - '@prestashop.adapter.order.amount.updater'
+      - '@prestashop.adapter.order.product.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand
@@ -242,4 +243,5 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderProductUpdater
     arguments:
       - '@prestashop.adapter.order.amount.updater'
+      - '@prestashop.adapter.order.product.remover'
       - '@prestashop.adapter.context_state_manager'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -242,3 +242,4 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderProductUpdater
     arguments:
       - '@prestashop.adapter.order.amount.updater'
+      - '@prestashop.adapter.context_state_manager'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -37,7 +37,7 @@ services:
   prestashop.adapter.order.command_handler.update_product_in_order_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\UpdateProductInOrderHandler
     arguments:
-      - '@prestashop.adapter.order.amount.updater'
+      - '@prestashop.adapter.order.product.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand
@@ -237,3 +237,8 @@ services:
 
   prestashop.adapter.order.amount.updater:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater
+
+  prestashop.adapter.order.product.updater:
+    class: PrestaShop\PrestaShop\Adapter\Order\OrderProductUpdater
+    arguments:
+      - '@prestashop.adapter.order.amount.updater'

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -109,8 +109,14 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         $this->createCartRule($cartRuleName, 0, $amount, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser);
     }
 
-    protected function createCartRule($cartRuleName, $percent, $amount, $priority, $cartRuleQuantity, $cartRuleQuantityPerUser)
-    {
+    protected function createCartRule(
+        $cartRuleName,
+        $percent,
+        $amount,
+        $priority,
+        $cartRuleQuantity,
+        $cartRuleQuantityPerUser
+    ) {
         $cartRule = new CartRule();
         $cartRule->reduction_percent = $percent;
         $cartRule->reduction_amount = $amount;

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -63,6 +63,7 @@ use Product;
 use RuntimeException;
 use stdClass;
 use Tax;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 class OrderFeatureContext extends AbstractDomainFeatureContext
@@ -1063,6 +1064,12 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
      */
     private function getOrderDiscountByName(int $orderId, string $cartRuleName): ?OrderDiscountForViewing
     {
+        $cartRuleName = CommonFeatureContext::getContainer()->get('translator')->trans(
+            $cartRuleName,
+            [],
+            'Admin.Orderscustomers.Feature'
+        );
+
         /** @var OrderDiscountForViewing[] $orderDiscountsForViewing */
         $orderDiscountsForViewing = $this->getOrderDiscounts($orderId);
 

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -127,7 +127,7 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have 5 products in total
     Then order "bo_order1" should contain 3 products "Test Product Cart Rule On Select Product"
     Then order "bo_order1" should have 1 cart rule
-    Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct" with amount "$15.00"
+    Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct" with amount "$45.00"
     Then order "bo_order1" should have following details:
       | total_products           | 68.800 |
       | total_products_wt        | 72.930 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -80,6 +80,66 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
+  Scenario: Add product linked to a cart rule to an existing Order without invoice with free shipping and new invoice And update the product quantity
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should have 0 invoices
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a product in the catalog named "Test Product Cart Rule On Select Product" with a price of 15.0 and 100 items in stock
+    And there is a cart rule named "CartRuleAmountOnSelectedProduct" that applies an amount discount of 500.0 with priority 1, quantity of 100 and quantity per user 100
+    And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
+    And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product Cart Rule On Select Product"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product Cart Rule On Select Product  |
+      | amount        | 1                                         |
+      | price         | 15                                        |
+      | free_shipping | true                                      |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product Cart Rule On Select Product"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct" with amount "$15.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 38.800 |
+      | total_products_wt        | 41.130 |
+      | total_discounts_tax_excl | 15.000 |
+      | total_discounts_tax_incl | 15.900 |
+      | total_paid_tax_excl      | 30.8   |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I edit product "Test Product Cart Rule On Select Product" to order "bo_order1" with following products details:
+      | amount        | 3                       |
+      | price         | 15                      |
+    Then order "bo_order1" should have 5 products in total
+    Then order "bo_order1" should contain 3 products "Test Product Cart Rule On Select Product"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct" with amount "$15.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 68.800 |
+      | total_products_wt        | 72.930 |
+      | total_discounts_tax_excl | 45.000 |
+      | total_discounts_tax_incl | 47.7 |
+      | total_paid_tax_excl      | 30.8   |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+
   Scenario: Add product linked to a cart rule to an existing Order without invoice with free shipping and new invoice And add this same product a second time
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | 2 assertions : <br>When a product is deleted, the existing cart_product is decreased by the quantity setted on order_detail.<br>When a cart_product already exist and the quantity is increased minimum quantity is not checked<br><br>And On an order, when quantity is updated, cart_product is not updated aswell<br><br>... led to this issue<br>The fix is to update quantity on cart_product when the order's product quantity is updated 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19607 and fixes #19592 
| How to test?  | See the before and after videos<br>*Before* : https://drive.google.com/file/d/1qTSkNfmmrjPhAkY9VDPy4sbhcWFdY6Ui/view<br>*After* : https://drive.google.com/file/d/1pRolBU_UH_xDRl8BcR2Yv7XMddPKtSyj/view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19646)
<!-- Reviewable:end -->
