### PR TITLE
Number extractor service

### DIFF
--- a/src/Core/Util/Number/NumberExtractor.php
+++ b/src/Core/Util/Number/NumberExtractor.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Util\Number;
+
+use PrestaShop\Decimal\Number;
+use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
+use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * Extracts @var Number from given array/object
+ */
+class NumberExtractor
+{
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * @param $objectOrArray
+     * @param string $propertyPath
+     *
+     * @return Number
+     */
+    public function extract($objectOrArray, string $propertyPath): Number
+    {
+        try {
+            $plainValue = $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
+
+        } catch (InvalidArgumentException $e) {
+            throw new NumberExtractorException(
+                sprintf('Invalid property path "%s" provided', $propertyPath),
+                NumberExtractorException::INVALID_PROPERTY_PATH,
+                $e
+            );
+
+        } catch (AccessException $e) {
+            throw new NumberExtractorException(
+                sprintf(
+                    'Cannot access property "%s". It doesn\'t exist or is not public',
+                    $propertyPath
+                ),
+                NumberExtractorException::NOT_ACCESSIBLE,
+                $e
+            );
+
+        } catch (UnexpectedTypeException $e) {
+            throw new NumberExtractorException(
+                'Invalid type of resource within a path given. Expected array or object',
+                NumberExtractorException::INVALID_RESOURCE_TYPE,
+                $e
+            );
+        }
+
+        return $this->toNumber($plainValue);
+    }
+
+    /**
+     * @param $value
+     *
+     * @return Number
+     *
+     * @throws NumberExtractorException
+     */
+    private function toNumber($value): Number
+    {
+        if (!is_numeric($value)) {
+            throw new NumberExtractorException(
+                sprintf(
+                    'Only numeric values can be converted to Number. Got "%s"',
+                    $value
+                ),
+                NumberExtractorException::NON_NUMERIC_PROPERTY
+            );
+        }
+
+        return new Number((string) $value);
+    }
+}

--- a/src/Core/Util/Number/NumberExtractor.php
+++ b/src/Core/Util/Number/NumberExtractor.php
@@ -59,14 +59,12 @@ class NumberExtractor
     {
         try {
             $plainValue = $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
-
         } catch (InvalidArgumentException $e) {
             throw new NumberExtractorException(
                 sprintf('Invalid property path "%s" provided', $propertyPath),
                 NumberExtractorException::INVALID_PROPERTY_PATH,
                 $e
             );
-
         } catch (AccessException $e) {
             throw new NumberExtractorException(
                 sprintf(
@@ -76,7 +74,6 @@ class NumberExtractor
                 NumberExtractorException::NOT_ACCESSIBLE,
                 $e
             );
-
         } catch (UnexpectedTypeException $e) {
             throw new NumberExtractorException(
                 'Invalid type of resource within a path given. Expected array or object',

--- a/src/Core/Util/Number/NumberExtractor.php
+++ b/src/Core/Util/Number/NumberExtractor.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Util\Number;
 
 use PrestaShop\Decimal\Number;
+use stdClass;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
@@ -50,15 +51,28 @@ class NumberExtractor
     }
 
     /**
-     * @param $objectOrArray
+     * If provided resource is array, access its values using brackets e.g. '[one_property][another_level_property]'
+     * If provided resource is object, access its properties using dots e.g. 'myProperty.anotherProperty'
+     * You can also simply provide the name of property/key to reach the value if it is not multidimensional.
+     *
+     * e.g:
+     * ->extract($myMultiDimensionalArray, '[firstDimensionKey][secondDimensionKey]')
+     *
+     * ->extract($productForEditing, 'priceInformation.price')
+     *
+     * ->extract($productEntity, 'price')
+     *
+     * ->extract($simpleArray, 'someKey')
+     *
+     * @param array|stdClass $resource
      * @param string $propertyPath
      *
      * @return Number
      */
-    public function extract($objectOrArray, string $propertyPath): Number
+    public function extract($resource, string $propertyPath): Number
     {
         try {
-            $plainValue = $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
+            $plainValue = $this->propertyAccessor->getValue($resource, $propertyPath);
         } catch (InvalidArgumentException $e) {
             throw new NumberExtractorException(
                 sprintf('Invalid property path "%s" provided', $propertyPath),

--- a/src/Core/Util/Number/NumberExtractor.php
+++ b/src/Core/Util/Number/NumberExtractor.php
@@ -35,7 +35,7 @@ use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
- * Extracts @var Number from given array/object
+ * Extracts numeric value as @var Number from given resource
  */
 class NumberExtractor
 {

--- a/src/Core/Util/Number/NumberExtractor.php
+++ b/src/Core/Util/Number/NumberExtractor.php
@@ -62,7 +62,7 @@ class NumberExtractor
      *
      * ->extract($productEntity, 'price')
      *
-     * ->extract($simpleArray, 'someKey')
+     * ->extract($simpleArray, '[someKey]')
      *
      * @param array|stdClass $resource
      * @param string $propertyPath

--- a/src/Core/Util/Number/NumberExtractorException.php
+++ b/src/Core/Util/Number/NumberExtractorException.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Util\Number;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+/**
+ * Exception thrown when something goes wrong in @var NumberExtractor service
+ */
+class NumberExtractorException extends CoreException
+{
+    /**
+     * When provided property path is not valid
+     */
+    const INVALID_PROPERTY_PATH = 10;
+
+    /**
+     * When the resource/property from which value is being extracted is of invalid type
+     */
+    const INVALID_RESOURCE_TYPE = 20;
+
+    /**
+     * When property is not accessible or doesn't exist
+     */
+    const NOT_ACCESSIBLE = 30;
+
+    /**
+     * When property type is not numeric therefore it cannot be converted to number
+     */
+    const NON_NUMERIC_PROPERTY = 40;
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/util/number.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/number.yml
@@ -5,4 +5,4 @@ services:
   prestashop.core.util.number.number_extractor:
     class: 'PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor'
     arguments:
-      '@property_accessor'
+      - '@property_accessor'

--- a/src/PrestaShopBundle/Resources/config/services/core/util/number.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/number.yml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.core.util.number.number_extractor:
+    class: 'PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor'
+    arguments:
+      '@property_accessor'

--- a/tests/Unit/Core/Util/Number/NumberExtractorTest.php
+++ b/tests/Unit/Core/Util/Number/NumberExtractorTest.php
@@ -46,7 +46,7 @@ class NumberExtractorTest extends TestCase
     }
 
     /**
-     * @dataProvider getValidDataForArrayExtractions
+     * @dataProvider getValidDataForArrayAndObjectExtractions
      *
      * @param $resource
      * @param $path
@@ -62,7 +62,7 @@ class NumberExtractorTest extends TestCase
     /**
      * @return Generator
      */
-    public function getValidDataForArrayExtractions(): Generator
+    public function getValidDataForArrayAndObjectExtractions(): Generator
     {
         $obj = new stdClass();
         $obj->test = 17;

--- a/tests/Unit/Core/Util/Number/NumberExtractorTest.php
+++ b/tests/Unit/Core/Util/Number/NumberExtractorTest.php
@@ -32,6 +32,7 @@ use Generator;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
+use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractorException;
 use stdClass;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
@@ -49,7 +50,7 @@ class NumberExtractorTest extends TestCase
     }
 
     /**
-     * @dataProvider getValidDataForArrayAndObjectExtractions
+     * @dataProvider getValidData
      *
      * @param $resource
      * @param $path
@@ -63,9 +64,23 @@ class NumberExtractorTest extends TestCase
     }
 
     /**
+     * @dataProvider getDataWithInvalidResourcePropertyType
+     *
+     * @param $resource
+     * @param string $path
+     */
+    public function testItThrowsExceptionWhenNonNumericValueIsProvidedInAccessedProperty($resource, string $path)
+    {
+        $this->expectException(NumberExtractorException::class);
+        $this->expectExceptionCode(NumberExtractorException::NON_NUMERIC_PROPERTY);
+
+        $this->numberExtractor->extract($resource, $path);
+    }
+
+    /**
      * @return Generator
      */
-    public function getValidDataForArrayAndObjectExtractions(): Generator
+    public function getValidData(): Generator
     {
         $obj = new stdClass();
         $obj->test = 17;
@@ -103,6 +118,29 @@ class NumberExtractorTest extends TestCase
             $obj,
             'obj2.test2',
             new Number('19.5'),
+        ];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getDataWithInvalidResourcePropertyType(): Generator
+    {
+        $obj = new stdClass();
+        $obj->test = 'this is not a numeric value';
+        $obj->test2 = null;
+
+        yield [
+            ['test' => 'this is not a numeric value'],
+            '[test]',
+        ];
+        yield [
+            $obj,
+            'test',
+        ];
+        yield [
+            $obj,
+            'test2',
         ];
     }
 }

--- a/tests/Unit/Core/Util/Number/NumberExtractorTest.php
+++ b/tests/Unit/Core/Util/Number/NumberExtractorTest.php
@@ -37,6 +37,9 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class NumberExtractorTest extends TestCase
 {
+    /**
+     * @var NumberExtractor
+     */
     private $numberExtractor;
 
     public function setUp()

--- a/tests/Unit/Core/Util/Number/NumberExtractorTest.php
+++ b/tests/Unit/Core/Util/Number/NumberExtractorTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Util\Number;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Decimal\Number;
+use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
+use stdClass;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class NumberExtractorTest extends TestCase
+{
+    private $numberExtractor;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->numberExtractor = new NumberExtractor(PropertyAccess::createPropertyAccessor());
+    }
+
+    /**
+     * @dataProvider getValidDataForArrayExtractions
+     *
+     * @param $resource
+     * @param $path
+     * @param $expectedResult
+     */
+    public function testItExtractsNumberFromArrayOrObject($resource, string $path, Number $expectedResult)
+    {
+        $actualResult = $this->numberExtractor->extract($resource, $path);
+
+        $this->assertTrue($expectedResult->equals($actualResult));
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getValidDataForArrayExtractions(): Generator
+    {
+        $obj = new stdClass();
+        $obj->test = 17;
+
+        $obj2 = new stdClass();
+        $obj2->test2 = 19.5;
+
+        $obj3 = new stdClass();
+        $obj3->test3 = '300.03';
+
+        $obj->obj2 = $obj2;
+        $obj->obj3 = $obj3;
+
+        yield [
+            ['test' => 15],
+            '[test]',
+            new Number('15'),
+        ];
+        yield [
+            ['test' => ['hello' => '13']],
+            '[test][hello]',
+            new Number('13'),
+        ];
+        yield [
+            ['test' => ['hello' => [1 => 17.3]]],
+            '[test][hello][1]',
+            new Number('17.3'),
+        ];
+        yield [
+            $obj,
+            'test',
+            new Number('17'),
+        ];
+        yield [
+            $obj,
+            'obj2.test2',
+            new Number('19.5'),
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | A service to extract Number() object from any given object or array. It uses symfony property accessor inside to reach the properties by passing path as string. We need to use Number in many calculations, this should save some time on the convertion of ObjectModel floats to Number().
| Type?         |  refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | There is nothing to test in UI. Added couple unit tests that should pass with CI

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19648)
<!-- Reviewable:end -->
