### PR TITLE
Retrieve the good stock when shop context changed in the same script

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -425,6 +425,12 @@ class StockAvailableCore extends ObjectModel
             $id_product_attribute = 0;
         }
 
+        // When the first call is done, the query will retrieve the quantity of the current shop
+        // If a second call is done but the shop context changed, we do not want to return the same value …
+        if (null === $id_shop) {
+            // If null, getting the context shop id
+            $id_shop = Shop::getContextShopID(true);
+        }
         $key = 'StockAvailable::getQuantityAvailableByProduct_' . (int) $id_product . '-' . (int) $id_product_attribute . '-' . (int) $id_shop;
         if (!Cache::isStored($key)) {
             $query = new DbQuery();

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -35,6 +35,11 @@ Context::getContext()->cart = new Cart();
 Context::getContext()->container = ContainerBuilder::getContainer('webservice', _PS_MODE_DEV_);
 Context::getContext()->currency = Context::getContext()->currency ?? new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
 
+// If the currency is not defined in the context, initialize with the default one !
+if (null === Context::getContext()->currency) {
+    Context::getContext()->currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+}
+
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {
     list($name, $password) = explode(':', base64_decode($matches[1]));

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -35,11 +35,6 @@ Context::getContext()->cart = new Cart();
 Context::getContext()->container = ContainerBuilder::getContainer('webservice', _PS_MODE_DEV_);
 Context::getContext()->currency = Context::getContext()->currency ?? new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
 
-// If the currency is not defined in the context, initialize with the default one !
-if (null === Context::getContext()->currency) {
-    Context::getContext()->currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
-}
-
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {
     list($name, $password) = explode(':', base64_decode($matches[1]));


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the shop context changed during a script and we try to know if a pack is in stock, we always have the value of the first shop because the cache key do not change between the two calls.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19649 .
| How to test?  | Have a pack product with no stock in a shop. For the same product put some stock on a second shop. Make a script wich connect to the first shop, call the method Pack::isInStock. There is no stock (it's ok). In the same script, switch to the second shop and call the same method. There is no stock … Here it's not ok..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19651)
<!-- Reviewable:end -->
