### PR TITLE
Use setFieldsToUpdate() in UpdateProductBasicInformationHandler

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -60,6 +60,10 @@ final class UpdateProductBasicInformationHandler extends AbstractProductHandler 
         $this->fillUpdatableFieldsWithCommandData($product, $command);
         $product->setFieldsToUpdate($this->fieldsToUpdate);
 
+        if (empty($this->fieldsToUpdate)) {
+            return;
+        }
+
         $this->performUpdate($product);
     }
 

--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -43,7 +43,7 @@ final class UpdateProductBasicInformationHandler extends AbstractProductHandler 
 {
     /**
      * Only fields defined in this array will be updated.
-     * Its necessary to avoid resetting some of product properties (which are not loaded by default) during partial update
+     * It is necessary to avoid resetting some of product properties (which are not loaded by default) during partial update
      *
      * @var array
      */
@@ -57,7 +57,7 @@ final class UpdateProductBasicInformationHandler extends AbstractProductHandler 
     public function handle(UpdateProductBasicInformationCommand $command): void
     {
         $product = $this->getProduct($command->getProductId());
-        $this->fillUpdatableFields($product, $command);
+        $this->fillUpdatableFieldsWithCommandData($product, $command);
         $product->setFieldsToUpdate($this->fieldsToUpdate);
 
         $this->performUpdate($product);
@@ -67,8 +67,10 @@ final class UpdateProductBasicInformationHandler extends AbstractProductHandler 
      * @param Product $product
      * @param UpdateProductBasicInformationCommand $command
      */
-    private function fillUpdatableFields(Product $product, UpdateProductBasicInformationCommand $command): void
-    {
+    private function fillUpdatableFieldsWithCommandData(
+        Product $product,
+        UpdateProductBasicInformationCommand $command
+    ): void {
         if (null !== $command->isVirtual()) {
             $product->is_virtual = $command->isVirtual();
             $this->fieldsToUpdate['is_virtual'] = true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Product entity is not fully loaded by default, meaning some values are null in object, but actually it exists in database. During partial update we don't want to reset such values when updating some other fields. This is achieved by using ObjectModel->setFieldsToUpdate() method, which allows specifically define which fields should be updated.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No UI to test. If travis passes its ok.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19655)
<!-- Reviewable:end -->
