### PR TITLE
Deprecate hookcount and add missing hook in hook.xml

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -751,6 +751,11 @@
       <title>Display new elements in back office product page, Shipping tab</title>
       <description>This hook launches modules when the back office product page is displayed</description>
     </hook>
+    <hook id="displayAdminProductsExtra">
+      <name>displayAdminProductsExtra</name>
+      <title>Admin Product Extra Module Tab</title>
+      <description>This hook displays extra content in the Module tab on the product edit page</description>
+    </hook>
     <hook id="displayAdminProductsCombinationBottom">
       <name>displayAdminProductsCombinationBottom</name>
       <title>Display new elements in back office product page, Combination tab</title>

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -545,6 +545,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayBackOfficeOrderActions', 'Admin Order Actions', 'This hook displays content in the order view page after action buttons (or aliased to side column in migrated page)', '1'),
   (NULL, 'actionAdminAdminPreferencesControllerPostProcessBefore', 'On post-process in Admin Preferences', 'This hook is called on Admin Preferences post-process before processing the form', '1'),
   (NULL, 'displayAdditionalCustomerAddressFields', 'Display additional customer address fields', 'This hook allows to display extra field values added in an address form using hook ''additionalCustomerAddressFields''', '1')
+  (NULL, 'displayAdminProductsExtra', 'Admin Product Extra Module Tab', 'This hook displays extra content in the Module tab on the product edit page', '1')
 ;
 
 INSERT INTO `PREFIX_hook_alias` (`name`, `alias`) VALUES

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/tabs.html.twig
@@ -34,7 +34,7 @@
     <li id="tab_step2" class="nav-item"><a href="#step2" role="tab" data-toggle="tab" class="nav-link">{{ 'Pricing'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
     <li id="tab_step5" class="nav-item"><a href="#step5" role="tab" data-toggle="tab" class="nav-link">{{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
     <li id="tab_step6" class="nav-item"><a href="#step6" role="tab" data-toggle="tab" class="nav-link">{{ 'Options'|trans({}, 'Admin.Global') }}</a></li>
-    {% if hookcount('displayAdminProductsExtra') > 0 %}
+    {% if hooksarraycontent(hooks) is not empty %}
       <li id="tab_hooks" class="nav-item"><a href="#hooks" role="tab" data-toggle="tab" class="nav-link">{{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}</a></li>
     {% endif %}
   </ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -24,9 +24,9 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
-
 {% block content %}
+
+  {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
 
   <form name="form" id="form" method="post" class="form-horizontal product-page row justify-content-md-center" novalidate="novalidate">
 
@@ -53,7 +53,7 @@
     <div id="form-loading" class="col-xxl-10">
       {# FORM TABS CONTAINER #}
       {% block product_tabs_container %}
-        {{ include('@Product/ProductPage/Blocks/tabs.html.twig') }}
+        {{ include('@Product/ProductPage/Blocks/tabs.html.twig', { 'hooks': hooks }) }}
       {% endblock %}
       <div id="form_content" class="tab-content">
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -24,6 +24,8 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
+
 {% block content %}
 
   <form name="form" id="form" method="post" class="form-horizontal product-page row justify-content-md-center" novalidate="novalidate">
@@ -150,7 +152,7 @@
 
         {# PANEL HOOKED MODULES #}
         {% block product_panel_modules %}
-          {% if hookcount('displayAdminProductsExtra') > 0 %}
+          {% if hooksarraycontent(hooks) is not empty %}
             <div role="tabpanel" class="form-contenttab tab-pane" id="hooks">
               <div class="row">
                 <div class="col-md-12">
@@ -159,8 +161,6 @@
 
                       {# LEFT #}
                       <div class="col-md-12">
-                        {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
-
                         <div class="row module-selection" style="display: none;">
                           <div class="col-md-12 col-lg-7">
                             {% for module in hooks %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -111,16 +111,18 @@
   </div>
 </div>
 
-{% if hookcount('displayAdminOrderTabLink') > 0 or hookcount('displayAdminOrderTabContent') > 0 %}
+{% set displayAdminOrderTabLink = renderhook('displayAdminOrderTabLink', {'id_order': orderForViewing.id}) %}
+{% set displayAdminOrderTabContent = renderhook('displayAdminOrderTabContent', {'id_order': orderForViewing.id}) %}
+{% if displayAdminOrderTabLink is not empty or displayAdminOrderTabContent is not empty%}
   <div class="mt-2" id="order_hook_tabs">
     <ul class="nav nav nav-tabs" role="tablist">
       {# Rendering of hook displayAdminOrderTabLink, we expect tab links #}
-      {{ renderhook('displayAdminOrderTabLink', {'id_order': orderForViewing.id}) }}
+      {{ displayAdminOrderTabLink }}
     </ul>
 
     <div class="tab-content">
       {# Rendering of hook displayAdminOrderTabContent, we expect tab contents #}
-      {{ renderhook('displayAdminOrderTabContent', {'id_order': orderForViewing.id}) }}
+      {{ displayAdminOrderTabContent }}
     </div>
   </div>
 {% endif %}

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -176,15 +176,14 @@ class HookExtension extends \Twig_Extension
      */
     public function hooksArrayContent($hooksArray)
     {
-        $content = '';
         if (!is_array($hooksArray)) {
-            return $content;
+            return '';
         }
 
+        $content = '';
+
         foreach ($hooksArray as $hook) {
-            if (isset($hook['content'])) {
-                $content .= $hook['content'];
-            }
+            $content .= $hook['content'] ?? '';
         }
 
         return $content;

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -76,6 +76,7 @@ class HookExtension extends \Twig_Extension
         return [
             new \Twig_SimpleFilter('renderhook', [$this, 'renderHook'], ['is_safe' => ['html']]),
             new \Twig_SimpleFilter('renderhooksarray', [$this, 'renderHooksArray'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFilter('hooksarraycontent', [$this, 'hooksArrayContent']),
         ];
     }
 
@@ -90,6 +91,7 @@ class HookExtension extends \Twig_Extension
             new \Twig_SimpleFunction('renderhook', [$this, 'renderHook'], ['is_safe' => ['html']]),
             new \Twig_SimpleFunction('renderhooksarray', [$this, 'renderHooksArray'], ['is_safe' => ['html']]),
             new \Twig_SimpleFunction('hookcount', [$this, 'hookCount']),
+            new \Twig_SimpleFunction('hooksarraycontent', [$this, 'hooksArrayContent']),
         ];
     }
 
@@ -166,8 +168,33 @@ class HookExtension extends \Twig_Extension
     }
 
     /**
+     * Return the concatenated content of a renderHooksArray response
+     *
+     * @param array $hooksArray the array returned by the renderHooksArray function
+     *
+     * @return string
+     */
+    public function hooksArrayContent($hooksArray)
+    {
+        $content = '';
+        if (!is_array($hooksArray)) {
+            return $content;
+        }
+
+        foreach ($hooksArray as $hook) {
+            if (isset($hook['content'])) {
+                $content .= $hook['content'];
+            }
+        }
+
+        return $content;
+    }
+
+    /**
      * Count how many listeners will respond to the hook name.
      * Does not trigger the hook, so maybe some listeners could not add a response to the result.
+     *
+     * @deprecated since 1.7.7.0
      *
      * @param string $hookName
      *
@@ -175,6 +202,8 @@ class HookExtension extends \Twig_Extension
      */
     public function hookCount($hookName)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 1.7.7.0.', E_USER_DEPRECATED);
+
         return count($this->hookDispatcher->getListeners(strtolower($hookName)));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The function `hookcount` returns 1 even when no module subscribed to the hook when the hook is present in `hook.xml`. It also does not take into account programmatically subscribed hooks. Therefore, this function should be deprecated and we should look for the content returned by `renderhook` or `renderhookarray` instead.<br>Also, the `displayAdminProductsExtra` hook was missing form `hook.xml`.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | N/A
| How to test?  | 1. Go on the order view page, no empty rectangle below the tabs (status, transport...) should be displayed.<br>2. Go on the product view page, no "Module" tab should be displayed.<br>3. Install @Matt75's [module](https://github.com/Matt75/testhookdisplayadminproductsextra/releases), go back on the product view page, you should see the "Module" tab.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19657)
<!-- Reviewable:end -->
