### PR TITLE
Allow user to choose to install demo products or not even when not in dev mode

### DIFF
--- a/install-dev/theme/views/configure.php
+++ b/install-dev/theme/views/configure.php
@@ -53,7 +53,6 @@
 		<p class="userInfos aligned"><?php echo $this->translator->trans('Help us learn more about your store so we can offer you optimal guidance and the best features for your business!', array(), 'Install') ?></p>
 	</div>
 
-	<?php if (_PS_MODE_DEV_): ?>
 	<!-- Install type (with fixtures or not) -->
 	<div class="field clearfix">
 		<label class="aligned"><?php echo $this->translator->trans('Install demo products', array(), 'Install'); ?></label>
@@ -69,9 +68,6 @@
 		</div>
 		<p class="userInfos aligned"><?php echo $this->translator->trans('Demo products are a good way to learn how to use PrestaShop. You should install them if you are not familiar with it.', array(), 'Install'); ?></p>
 	</div>
-	<?php else: ?>
-		<input value="full" name="db_mode" type="hidden" />
-	<?php endif; ?>
 
 	<!-- Country list -->
 	<div class="field clearfix">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Since 1.5.5.0 (see commit https://github.com/PrestaShop/PrestaShop/commit/6191b928e6ae72dc34ee297c3b1204bd8311fc0f), users had to install PrestaShop in debug mode to be able to opt-out from demo products. This change displays this option regardless of whether you're in debug mode or not.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Install PS when not in debug mode, you should be able to install your shop without demo products.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19694)
<!-- Reviewable:end -->
