### PR TITLE
Add order sources in Order View page

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -30,6 +30,7 @@ use Address;
 use Carrier;
 use CartRule;
 use Configuration;
+use ConnectionsSource;
 use Context;
 use Country;
 use Currency;
@@ -71,6 +72,8 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderReturnForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderReturnsForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderShippingAddressForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderShippingForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderSourceForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderSourcesForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderStatusForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 use PrestaShop\PrestaShop\Core\Image\Parser\ImageTagSourceParserInterface;
@@ -189,7 +192,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->getOrderPayments($order),
             $this->getOrderMessages($order),
             $this->getOrderPrices($order),
-            $this->getOrderDiscounts($order)
+            $this->getOrderDiscounts($order),
+            $this->getOrderSources($order)
         );
     }
 
@@ -755,6 +759,28 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         }
 
         return new OrderDiscountsForViewing($discountsForViewing);
+    }
+
+    /**
+     * @param Order $order
+     *
+     * @return OrderSourcesForViewing
+     */
+    private function getOrderSources(Order $order): OrderSourcesForViewing
+    {
+        $sourcesData = ConnectionsSource::getOrderSources($order->id);
+        $sources = [];
+
+        foreach ($sourcesData as $sourceItem) {
+            $sources[] = new OrderSourceForViewing(
+                $sourceItem['http_referer'],
+                $sourceItem['request_uri'],
+                new DateTimeImmutable($sourceItem['date_add']),
+                $sourceItem['keywords']
+            );
+        }
+
+        return new OrderSourcesForViewing($sources);
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -174,6 +174,11 @@ class OrderForViewing
     private $invoiceManagementIsEnabled;
 
     /**
+     * @var OrderSourcesForViewing
+     */
+    private $sources;
+
+    /**
      * @param int $orderId
      * @param int $currencyId
      * @param int $carrierId
@@ -202,6 +207,7 @@ class OrderForViewing
      * @param OrderMessagesForViewing $messages
      * @param OrderPricesForViewing $prices
      * @param OrderDiscountsForViewing $discounts
+     * @param OrderSourcesForViewing $sources
      */
     public function __construct(
         int $orderId,
@@ -231,7 +237,8 @@ class OrderForViewing
         OrderPaymentsForViewing $payments,
         OrderMessagesForViewing $messages,
         OrderPricesForViewing $prices,
-        OrderDiscountsForViewing $discounts
+        OrderDiscountsForViewing $discounts,
+        OrderSourcesForViewing $sources
     ) {
         $this->reference = $reference;
         $this->customer = $customer;
@@ -261,6 +268,7 @@ class OrderForViewing
         $this->carrierName = $carrierName;
         $this->shopId = $shopId;
         $this->invoiceManagementIsEnabled = $invoiceManagementIsEnabled;
+        $this->sources = $sources;
     }
 
     /**
@@ -490,6 +498,14 @@ class OrderForViewing
     public function isInvoiceManagementIsEnabled(): bool
     {
         return $this->invoiceManagementIsEnabled;
+    }
+
+    /**
+     * @return OrderSourcesForViewing
+     */
+    public function getSources(): OrderSourcesForViewing
+    {
+        return $this->sources;
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderSourceForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderSourceForViewing.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
+
+use DateTimeImmutable;
+
+class OrderSourceForViewing
+{
+    /**
+     * @var string
+     */
+    private $httpReferer;
+
+    /**
+     * @var string
+     */
+    private $requestUri;
+
+    /**
+     * @var DateTimeImmutable
+     */
+    private $addedAt;
+
+    /**
+     * @var string
+     */
+    private $keywords;
+
+    /**
+     * @param string $httpReferer
+     * @param string $requestUri
+     * @param DateTimeImmutable $addedAt
+     * @param string $keywords
+     */
+    public function __construct(string $httpReferer, string $requestUri, DateTimeImmutable $addedAt, string $keywords)
+    {
+        $this->httpReferer = $httpReferer;
+        $this->requestUri = $requestUri;
+        $this->addedAt = $addedAt;
+        $this->keywords = $keywords;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpReferer(): string
+    {
+        return $this->httpReferer;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestUri(): string
+    {
+        return $this->requestUri;
+    }
+
+    /**
+     * @return DateTimeImmutable
+     */
+    public function getAddedAt(): DateTimeImmutable
+    {
+        return $this->addedAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeywords(): string
+    {
+        return $this->keywords;
+    }
+}

--- a/src/Core/Domain/Order/QueryResult/OrderSourceForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderSourceForViewing.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
 
 use DateTimeImmutable;

--- a/src/Core/Domain/Order/QueryResult/OrderSourcesForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderSourcesForViewing.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
+
+class OrderSourcesForViewing
+{
+    /** @var OrderSourceForViewing[] */
+    private $sources = [];
+
+    /**
+     * @param OrderSourceForViewing[] $sources
+     */
+    public function __construct(array $sources)
+    {
+        foreach ($sources as $source) {
+            $this->addSource($source);
+        }
+    }
+
+    /**
+     * @return OrderSourceForViewing[]
+     */
+    public function getSources(): array
+    {
+        return $this->sources;
+    }
+
+    /**
+     * @param OrderSourceForViewing $source
+     */
+    private function addSource(OrderSourceForViewing $source): void
+    {
+        $this->sources[] = $source;
+    }
+}

--- a/src/Core/Domain/Order/QueryResult/OrderSourcesForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderSourcesForViewing.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
 
 class OrderSourcesForViewing

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
@@ -30,6 +30,7 @@
           <div class="col-md-6">
             <i class="material-icons">public</i>
             {{ 'Sources'|trans({}, 'Admin.Orderscustomers.Feature') }}
+            <span class="badge badge-primary rounded">{{ orderForViewing.sources.sources|length }}</span>
           </div>
 
           <ul id="order-sources-list">
@@ -48,7 +49,7 @@
                 <a href="http://{{ source.requestUri }}">{{ source.requestUri | slice(0,100) }}</a>
                 <br/>
                 {% if source.keywords != '' %}
-                  <b>{{ 'Keywords'|trans({}) }}</b>
+                  <b>{{ 'Keywords'|trans({}, 'Admin.Global') }}</b>
                   <br/>
                   {{ source.keywords }}
                 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
@@ -1,0 +1,62 @@
+{#**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *#}
+
+  {% if orderForViewing.sources.sources is not empty %}
+    <div class="card mt-2 d-print-none">
+      <div class="card-header">
+        <div class="row">
+          <div class="col-md-6">
+            <i class="material-icons">public</i>
+            {{ 'Sources'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          </div>
+
+          <ul id="order-sources-list">
+            {% for source in orderForViewing.sources.sources %}
+              <li>
+                {{ source.addedAt|date_format_full }}
+                <br/>
+                <b>{{ 'From'|trans({}, 'Admin.Orderscustomers.Feature') }}</b>
+                {% if source.httpReferer != '' %}
+                  <a href="{{ source.httpReferer }}">{{ source.httpReferer }}</a>
+                {% else %}
+                  -
+                {% endif %}
+                <br/>
+                <b>{{ 'To'|trans({}, 'Admin.Orderscustomers.Feature') }}</b>
+                <a href="http://{{ source.requestUri }}">{{ source.requestUri | slice(0,100) }}</a>
+                <br/>
+                {% if source.keywords != '' %}
+                  <b>{{ 'Keywords'|trans({}) }}</b>
+                  <br/>
+                  {{ source.keywords }}
+                {% endif %}
+                <br/>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -32,15 +32,16 @@
 
 
 {% block content %}
-  <div id="order-view-page" data-order-title="{{ 'Order'|trans({}, 'Admin.Global') }} #{{ orderForViewing.id }} {{ orderForViewing.reference }}">
+  <div id="order-view-page"
+       data-order-title="{{ 'Order'|trans({}, 'Admin.Global') }} #{{ orderForViewing.id }} {{ orderForViewing.reference }}">
     <div class="row d-print-none">
-    {% set displayAdminOrderTopHookContent = renderhook('displayAdminOrderTop', {'id_order': orderForViewing.id}) %}
+      {% set displayAdminOrderTopHookContent = renderhook('displayAdminOrderTop', {'id_order': orderForViewing.id}) %}
 
-    {% if displayAdminOrderTopHookContent != '' %}
-      <div class="col-md-12">
-        {{ displayAdminOrderTopHookContent|raw }}
-      </div>
-    {% endif %}
+      {% if displayAdminOrderTopHookContent != '' %}
+        <div class="col-md-12">
+          {{ displayAdminOrderTopHookContent|raw }}
+        </div>
+      {% endif %}
       <div class="order-actions col-md-12">
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig' %}
       </div>
@@ -84,6 +85,14 @@
         {{ renderhook('displayAdminOrderMainBottom', {'id_order': orderForViewing.id}) }}
       </div>
     </div>
+
+    {% if orderForViewing.sources.sources is not empty %}
+      <div class="product-row row">
+        <div class="col-md-12 left-column">
+          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/sources.html.twig' %}
+        </div>
+      </div>
+    {% endif %}
 
     {{ renderhook('displayAdminOrder', {'id_order': orderForViewing.id}) }}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig' %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add order sources in Order View page
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18966
| How to test?  | See ticket

This is how it looks after migration:
<img width="1208" alt="Capture d’écran 2020-06-10 à 16 19 47" src="https://user-images.githubusercontent.com/3830050/84279577-7a7fc900-ab36-11ea-99c0-ce893e937e0d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19697)
<!-- Reviewable:end -->
