### PR TITLE
Handle empty states for category grids

### DIFF
--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -86,18 +86,12 @@ final class GridPresenter implements GridPresenterInterface
             ],
             'filters' => $searchCriteria->getFilters(),
             'attributes' => [
-                'is_empty_state' => empty($filterForm->getData()) && $data->getRecords()->count() === 0,
+                'is_empty_state' => $this->isEmptyState($grid),
             ],
         ];
 
         if ($searchCriteria instanceof Filters) {
             $presentedGrid['form_prefix'] = $searchCriteria->getFilterId();
-        }
-
-        if (isset($searchCriteria->getFilters()['is_search_request'])
-            && false === $searchCriteria->getFilters()['is_search_request']
-            && 0 === $data->getRecordsTotal()) {
-            $presentedGrid['attributes']['is_empty_state'] = true;
         }
 
         $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridPresenterModifier', [
@@ -171,5 +165,27 @@ final class GridPresenter implements GridPresenterInterface
         }
 
         return $columnFiltersMapping;
+    }
+
+    /**
+     * @param GridInterface $grid
+     *
+     * @return bool
+     */
+    private function isEmptyState(GridInterface $grid)
+    {
+        $filterFormData = $grid->getFilterForm()->getData();
+        if (empty($filterFormData) && 0 === $grid->getData()->getRecordsTotal()) {
+            return true;
+        }
+
+        $definitionFiltersKeys = array_keys($grid->getDefinition()->getFilters()->all());
+        foreach ($filterFormData as $key => $value) {
+            if (in_array($key, $definitionFiltersKeys, true)) {
+                return false;
+            }
+        }
+
+        return 0 === $grid->getData()->getRecordsTotal();
     }
 }

--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -94,6 +94,12 @@ final class GridPresenter implements GridPresenterInterface
             $presentedGrid['form_prefix'] = $searchCriteria->getFilterId();
         }
 
+        if (isset($searchCriteria->getFilters()['is_search_request'])
+            && false === $searchCriteria->getFilters()['is_search_request']
+            && 0 === $data->getRecordsTotal()) {
+            $presentedGrid['attributes']['is_empty_state'] = true;
+        }
+
         $this->hookDispatcher->dispatchWithParameters('action' . Container::camelize($definition->getId()) . 'GridPresenterModifier', [
             'presented_grid' => &$presentedGrid,
         ]);

--- a/src/Core/Grid/Presenter/GridPresenter.php
+++ b/src/Core/Grid/Presenter/GridPresenter.php
@@ -175,7 +175,8 @@ final class GridPresenter implements GridPresenterInterface
     private function isEmptyState(GridInterface $grid)
     {
         $filterFormData = $grid->getFilterForm()->getData();
-        if (empty($filterFormData) && 0 === $grid->getData()->getRecordsTotal()) {
+        $dataRecordsTotal = $grid->getData()->getRecordsTotal();
+        if (empty($filterFormData) && 0 === $dataRecordsTotal) {
             return true;
         }
 
@@ -186,6 +187,6 @@ final class GridPresenter implements GridPresenterInterface
             }
         }
 
-        return 0 === $grid->getData()->getRecordsTotal();
+        return 0 === $dataRecordsTotal;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -90,6 +90,7 @@ class CmsPageController extends FrameworkBundleAdminController
     public function indexAction(CmsPageCategoryFilters $categoryFilters, CmsPageFilters $cmsFilters, Request $request)
     {
         $cmsCategoryParentId = (int) $categoryFilters->getFilters()['id_cms_category_parent'];
+        $categoryFilters->addFilter(['is_search_request' => $this->requestHasSearchParameters($request)]);
         $viewData = [];
 
         try {
@@ -1209,5 +1210,15 @@ class CmsPageController extends FrameworkBundleAdminController
                 ),
             ],
         ];
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function requestHasSearchParameters(Request $request)
+    {
+        return !empty($request->query->get(CmsPageCategoryDefinitionFactory::GRID_ID)['filters']);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -90,7 +90,6 @@ class CmsPageController extends FrameworkBundleAdminController
     public function indexAction(CmsPageCategoryFilters $categoryFilters, CmsPageFilters $cmsFilters, Request $request)
     {
         $cmsCategoryParentId = (int) $categoryFilters->getFilters()['id_cms_category_parent'];
-        $categoryFilters->addFilter(['is_search_request' => $this->requestHasSearchParameters($request)]);
         $viewData = [];
 
         try {
@@ -1210,15 +1209,5 @@ class CmsPageController extends FrameworkBundleAdminController
                 ),
             ],
         ];
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return bool
-     */
-    private function requestHasSearchParameters(Request $request)
-    {
-        return !empty($request->query->get(CmsPageCategoryDefinitionFactory::GRID_ID)['filters']);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -853,6 +853,6 @@ class CategoryController extends FrameworkBundleAdminController
      */
     private function requestHasSearchParameters(Request $request)
     {
-        return !empty($request->query->get('category')['filters']);
+        return !empty($request->query->get(CategoryGridDefinitionFactory::GRID_ID)['filters']);
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/Table/filters_row.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<tr class="column-filters {% if 0 == grid.data.records_total and grid.filters is empty %}d-none{% endif %}">
+<tr class="column-filters{% if grid.attributes.is_empty_state %} d-none{% endif %}">
   {% for column in grid.columns %}
     <td>
       {% if loop.first and grid.actions.bulk|length > 0 %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When table with no data and no filter selected was displayed, the filter form was still shown. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17597
| How to test?  | With a clean install of PrestaShop (without fixtures), check all pages listed in #17597, you should not see the filter form if the table is empty.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19703)
<!-- Reviewable:end -->
