### PR TITLE
Don't try to translate using domain unless the "d" parameter is present

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -175,7 +175,7 @@ function smartyTranslate($params, $smarty)
         $params['d'] = null;
     }
 
-    if (null !== $params['d']) {
+    if (!empty($params['d'])) {
         if (isset($params['tags'])) {
             $backTrace = debug_backtrace();
 
@@ -209,15 +209,12 @@ function smartyTranslate($params, $smarty)
                 return $params['s'];
             }
         }
-    }
 
-    if (($translation = Context::getContext()->getTranslator()->trans($params['s'], $params['sprintf'], $params['d'])) !== $params['s']
-        && $params['mod'] === false) {
-        return $translation;
+        return Context::getContext()->getTranslator()->trans($params['s'], $params['sprintf'], $params['d']);
     }
 
     $string = str_replace('\'', '\\\'', $params['s']);
-    
+
     // fix inheritance template filename in case of includes from different cross sources between theme, modules, ...
     $filename = $smarty->template_resource;
     if (!isset($smarty->inheritance->sourceStack[0]) || $filename === $smarty->inheritance->sourceStack[0]->resource) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The Smarty translation was trying to translate using the context translator even when the `d` parameter of the `{l}` function wasn't provided. This should provide a small performance improvement when translating third party modules using the legacy translation system and when a wording is not translated. This change only applies to FO.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Install a module that uses the legacy translation system, like https://github.com/PrestaShopCorp/psgdpr. See that its wordings in FO appear translated as before in any page. See that the rest of the page appears translated as before in any page.

Note: this change makes the behavior of FO closer to BO, where we don't try other translation methods as soon as the `d` parameter is provided: https://github.com/PrestaShop/PrestaShop/blob/1.7.7.x/config/smartyadmin.config.inc.php#L78-L114

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19706)
<!-- Reviewable:end -->
