### PR TITLE
Use target="_blank" instead of class="_blank"

### DIFF
--- a/admin-dev/filemanager/ajax_calls.php
+++ b/admin-dev/filemanager/ajax_calls.php
@@ -186,7 +186,7 @@ if (isset($_GET['action'])) {
 					<div class="jp-no-solution">
 						<span>Update Required</span>
 						To play the media you will need to either update your browser to a recent version or update your
-						<a href="http://get.adobe.com/flashplayer/" class="_blank">Flash plugin</a>.
+						<a href="http://get.adobe.com/flashplayer/" target="_blank" rel="noopener noreferrer nofollow">Flash plugin</a>.
 					</div>
 				</div>
 			</div>

--- a/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
@@ -119,7 +119,7 @@
 									    <ul style="margin: 0; padding: 0; list-style-type: none;">
 									    {foreach from=$datas key='index' item='data'}
 											    <li style="display: inline; margin: 2px;">
-												    <a href="{$link->getAdminLink('AdminCarts', true, [], ['ajax' => 1, 'action' => 'customizationImage', 'img' => $data.value, 'name' => $order->id|intval|cat:'-file'|cat:$index])}" class="_blank">
+												    <a href="{$link->getAdminLink('AdminCarts', true, [], ['ajax' => 1, 'action' => 'customizationImage', 'img' => $data.value, 'name' => $order->id|intval|cat:'-file'|cat:$index])}" target="_blank" rel="noopener noreferrer nofollow">
 												    <img src="{$pic_dir}{$data.value}_small" alt="" /></a>
 											    </li>
 									    {/foreach}

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl
@@ -53,8 +53,8 @@
 			</h4>
 		{/if}
 		<span class="message-date">&nbsp;<i class="icon-calendar"></i> - {dateFormat date=$message.date_add full=0} - <i class="icon-time"></i> {$message.date_add|substr:11:5}</span>
-		{if isset($message.file_name)} <span class="message-product">&nbsp;<i class="icon-link"></i> <a href="{$message.file_name|escape:'html':'UTF-8'}" class="_blank">{l s="Attachment" d='Admin.Catalog.Feature'}</a></span>{/if}
-		{if isset($message.product_name)} <span class="message-attachment">&nbsp;<i class="icon-book"></i> <a href="{$message.product_link|escape:'html':'UTF-8'}" class="_blank">{l s="Product" d='Admin.Global'} {$message.product_name|escape:'html':'UTF-8'} </a></span>{/if}
+		{if isset($message.file_name)} <span class="message-product">&nbsp;<i class="icon-link"></i> <a href="{$message.file_name|escape:'html':'UTF-8'}" target="_blank" rel="noopener noreferrer nofollow">{l s="Attachment" d='Admin.Catalog.Feature'}</a></span>{/if}
+		{if isset($message.product_name)} <span class="message-attachment">&nbsp;<i class="icon-book"></i> <a href="{$message.product_link|escape:'html':'UTF-8'}" target="_blank" rel="noopener noreferrer nofollow">{l s="Product" d='Admin.Global'} {$message.product_name|escape:'html':'UTF-8'} </a></span>{/if}
 		<p class="message-item-text">{$message.message|escape:'html':'UTF-8'|nl2br}</p>
 	</div>
 </div>

--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -90,7 +90,7 @@
 		<div class="col-md-8 col-lg-7" id="hookDashboardZoneTwo">
 			{$hookDashboardZoneTwo}
 			<div id="dashaddons" class="row-margin-bottom">
-				<a href="https://addons.prestashop.com/en/209-dashboards?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">
+				<a href="https://addons.prestashop.com/en/209-dashboards?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow">
 					<i class="icon-plus"></i> {l s='Add more dashboard modules' d='Admin.Dashboard.Feature'}
 				</a>
 			</div>
@@ -107,11 +107,11 @@
 			<section class="dash_links panel">
 				<h3><i class="icon-link"></i> {l s="We stay by your side!" d='Admin.Dashboard.Feature'}</h3>
 					<dl>
-						<dt><a href="{$help_center_link}" class="_blank">{l s="Help Center" d='Admin.Global'}</a></dt>
+						<dt><a href="{$help_center_link}" target="_blank" rel="noopener noreferrer nofollow">{l s="Help Center" d='Admin.Global'}</a></dt>
 						<dd>{l s="Documentation, support, experts, training... PrestaShop and all of its community are here to guide you" d='Admin.Dashboard.Feature'}</dd>
 					</dl>
 					<dl>
-						<dt><a href="https://addons.prestashop.com?utm_source=back-office&amp;utm_medium=links&amp;utm_campaign=addons-{$lang_iso}&amp;utm_content=download17" class="_blank">{l s="PrestaShop Marketplace" d='Admin.Dashboard.Feature'}</a></dt>
+						<dt><a href="https://addons.prestashop.com?utm_source=back-office&amp;utm_medium=links&amp;utm_campaign=addons-{$lang_iso}&amp;utm_content=download17" target="_blank" rel="noopener noreferrer nofollow">{l s="PrestaShop Marketplace" d='Admin.Dashboard.Feature'}</a></dt>
 						<dd>{l s="Traffic, conversion rate, customer loyalty... Increase your sales with all of the PrestaShop modules and themes" d='Admin.Dashboard.Feature'}</dd>
 					</dl>
 			</section>

--- a/admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl
@@ -40,7 +40,7 @@
 	</p>
 	<p>
 		{l s='If you are unsure about this module, you can look for similar modules on the official marketplace.'}
-		<a class="_blank" href="https://addons.prestashop.com/">{l s='Click here to browse PrestaShop Addons.'}</a>
+		<a target="_blank" rel="noopener noreferrer nofollow" href="https://addons.prestashop.com/">{l s='Click here to browse PrestaShop Addons.'}</a>
 	</p>
 </div>
 

--- a/admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl
@@ -82,7 +82,7 @@
 											<div class="form-group">
 												<span class="col-lg-3 control-label"><strong>{l s='Attachment'}</strong></span>
 												<div class="col-lg-9">
-													<a href="{$link->getAdminLink('AdminCarts', true, [], ['ajax' => 1, 'action' => 'customizationImage', 'img' => $data['value'], 'name' => $returnedCustomization['id_order_detail']|intval|cat:'-file'|cat:$smarty.foreach.data.iteration.iteration])}" class="_blank"><img class="img-thumbnail" src="{$picture_folder}{$data['value']}_small" alt="" /></a>
+													<a href="{$link->getAdminLink('AdminCarts', true, [], ['ajax' => 1, 'action' => 'customizationImage', 'img' => $data['value'], 'name' => $returnedCustomization['id_order_detail']|intval|cat:'-file'|cat:$smarty.foreach.data.iteration.iteration])}" target="_blank" rel="noopener noreferrer nofollow"><img class="img-thumbnail" src="{$picture_folder}{$data['value']}_small" alt="" /></a>
 												</div>
 											</div>
 										{/foreach}

--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -163,14 +163,14 @@ $(function() {
             <tbody>
             {foreach $addons key=key item=addon}
                 <tr>
-                    <td><a href="{$addon.href|escape:'html':'UTF-8'}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank"><strong><i class="icon-external-link-sign"></i> {$addon.title|escape:'html':'UTF-8'}</strong></a></td>
-                    <td><a href="{$addon.href|escape:'html':'UTF-8'}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank">{if is_string($addon.description)}{$addon.description|truncate:256:'...'|escape:'html':'UTF-8'}{/if}</a></td>
+                    <td><a href="{$addon.href|escape:'html':'UTF-8'}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow"><strong><i class="icon-external-link-sign"></i> {$addon.title|escape:'html':'UTF-8'}</strong></a></td>
+                    <td><a href="{$addon.href|escape:'html':'UTF-8'}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow">{if is_string($addon.description)}{$addon.description|truncate:256:'...'|escape:'html':'UTF-8'}{/if}</a></td>
                 </tr>
             {/foreach}
         </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="2" class="text-center"><a href="https://addons.prestashop.com/search.php?search_query={$query|urlencode}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="_blank"><strong>{l s='Show more results...' d='Admin.Navigation.Search'}</strong></a></td>
+                    <td colspan="2" class="text-center"><a href="https://addons.prestashop.com/search.php?search_query={$query|urlencode}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow"><strong>{l s='Show more results...' d='Admin.Navigation.Search'}</strong></a></td>
                 </tr>
             </tfoot>
         </table>

--- a/admin-dev/themes/default/template/controllers/shop/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/controllers/shop/helpers/list/list_content.tpl
@@ -36,7 +36,7 @@
 {block name="td_content"}
 	{if $key == 'url'}
 		{if isset($tr.$key)}
-			<a href="{$tr.$key}" onmouseover="$(this).css('text-decoration', 'underline')" onmouseout="$(this).css('text-decoration', 'none')" class="_blank">{$tr.$key}</a>
+			<a href="{$tr.$key}" onmouseover="$(this).css('text-decoration', 'underline')" onmouseout="$(this).css('text-decoration', 'none')" target="_blank" rel="noopener noreferrer nofollow">{$tr.$key}</a>
 		{else}
 			<a href="{$link->getAdminLink('AdminShopUrl', true, [], ['addshop_url' => 1, 'shop_id' => $tr.$identifier|intval])|escape:'html':'UTF-8'}" class="multishop_warning">{l s='Click here to set a URL for this shop.' d='Admin.Shopparameters.Notification'}</a>
 		{/if}

--- a/admin-dev/themes/default/template/controllers/shop_url/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/controllers/shop_url/helpers/list/list_content.tpl
@@ -27,7 +27,7 @@
 
 {block name="td_content"}
 	{if $key == 'url'}
-		<a href="{$tr.$key}" onmouseover="$(this).css('text-decoration', 'underline')" onmouseout="$(this).css('text-decoration', 'none')" class="_blank">{$tr.$key}</a>
+		<a href="{$tr.$key}" onmouseover="$(this).css('text-decoration', 'underline')" onmouseout="$(this).css('text-decoration', 'none')" target="_blank" rel="noopener noreferrer nofollow">{$tr.$key}</a>
 	{else}
 		{$smarty.block.parent}
 	{/if}

--- a/admin-dev/themes/default/template/footer.tpl
+++ b/admin-dev/themes/default/template/footer.tpl
@@ -29,7 +29,7 @@
 <div id="footer" class="bootstrap hide">
 
 	<div class="col-sm-2 hidden-xs">
-		<a href="https://www.prestashop.com/" class="_blank">PrestaShop&trade;</a>
+		<a href="https://www.prestashop.com/" target="_blank" rel="noopener noreferrer nofollow">PrestaShop&trade;</a>
 		-
 		<span id="footer-load-time"><i class="icon-time" title="{l s='Load time:' d='Admin.Navigation.Footer'}"></i> {number_format(microtime(true) - $timer_start, 3, '.', '')}s</span>
 	</div>

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -371,7 +371,7 @@
             <li><a href="{l s='https://addons.prestashop.com?utm_source=back-office&utm_medium=profile&utm_campaign=addons-en&utm_content=download17' d='Admin.Navigation.Header'}" target="_blank"><i class="material-icons">extension</i> {l s='PrestaShop Marketplace' d='Admin.Navigation.Header'}</a></li>
             <li><a href="{l s='https://www.prestashop.com/en/contact?utm_source=back-office&utm_medium=profile&utm_campaign=help-center-en&utm_content=download17' d='Admin.Navigation.Header'}" target="_blank"><i class="material-icons">help</i> {l s='Help Center' d='Admin.Global'}</a></li>
             {if $host_mode}
-              <li><a href="https://www.prestashop.com/cloud/" class="_blank"><i class="material-icons">settings_applications</i> {l s='My PrestaShop account' d='Admin.Navigation.Header'}</a></li>
+              <li><a href="https://www.prestashop.com/cloud/" target="_blank" rel="noopener noreferrer nofollow"><i class="material-icons">settings_applications</i> {l s='My PrestaShop account' d='Admin.Navigation.Header'}</a></li>
             {/if}
             <li class="divider"></li>
             <li class="signout text-center" data-mobile="true" data-from="employee_links" data-target="menu" data-after="true"><a id="header_logout" href="{$logout_link|escape:'html':'UTF-8'}"><i class="material-icons visible-xs">power_settings_new</i> {l s='Sign out' d='Admin.Navigation.Header'}</a></li>

--- a/admin-dev/themes/default/template/helpers/modules_list/list.tpl
+++ b/admin-dev/themes/default/template/helpers/modules_list/list.tpl
@@ -54,7 +54,7 @@
 							<div class="alert alert-warning">
 							{if $controller_name == 'AdminPayment'}
 							{l s='It seems there are no recommended payment solutions for your country.'}<br />
-							<a class="_blank" href="https://www.prestashop.com/en/contact-us">{l s='Do you think there should be one? Let us know!'}</a>
+							<a target="_blank" rel="noopener noreferrer nofollow" href="https://www.prestashop.com/en/contact-us">{l s='Do you think there should be one? Let us know!'}</a>
 							{else}{l s='No modules available in this section.'}{/if}</div>
 						</td>
 					</tr>

--- a/js/admin/dashboard.js
+++ b/js/admin/dashboard.js
@@ -201,7 +201,7 @@ function getBlogRss() {
 		success : function(jsonData) {
 			if (typeof jsonData !== 'undefined' && jsonData !== null && !jsonData.has_errors) {
 				for (var article in jsonData.rss) {
-					var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" class="_blank" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+read_more+'</a><p></article><hr/>';
+					var article_html = '<article><h4><a href="'+jsonData.rss[article].link+'" target="_blank" rel="noopener noreferrer nofollow" onclick="return !window.open(this.href);">'+jsonData.rss[article].title+'</a></h4><span class="dash-news-date text-muted">'+jsonData.rss[article].date+'</span><p>'+jsonData.rss[article].short_desc+' <a href="'+jsonData.rss[article].link+'">'+read_more+'</a><p></article><hr/>';
 					$('.dash_news .dash_news_content').append(article_html);
 				}
 			}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig
@@ -27,7 +27,7 @@
   <div class="alert alert-info" role="alert">
     {% if isHostMode %}
       <h4>{{ 'How to restore a database backup'|trans({}, 'Admin.Advparameters.Notification') }}</h4>
-      <p>{{ 'If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].'|trans({'[1]': '<strong>',  '[/1]': '</strong>', '[2]': '<a class="_blank" href="https://addons.prestashop.com/support/16298-support-essentiel-plan.html">', '[/2]': '</a>'}, 'Admin.Advparameters.Notification')|raw }}</p>
+      <p>{{ 'If you need to restore a database backup, we invite you to subscribe to a [1][2]technical support plan[/2][/1].'|trans({'[1]': '<strong>',  '[/1]': '</strong>', '[2]': '<a target="_blank" rel="noopener noreferrer nofollow" href="https://addons.prestashop.com/support/16298-support-essentiel-plan.html">', '[/2]': '</a>'}, 'Admin.Advparameters.Notification')|raw }}</p>
       <p>{{ 'Our team will take care of restoring your database safely.'|trans({}, 'Admin.Advparameters.Notification') }}</p>
       <br>
       <p>{{ 'Why can\'t I restore it by myself?'|trans({}, 'Admin.Advparameters.Notification') }}</p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -35,13 +35,13 @@
     <div class="alert alert-info" role="alert">
       <p class="alert-text">
         {{ 'You can read information on import at:'|trans({}, 'Admin.Advparameters.Help') }}
-        <a href="{{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}" class="_blank">
+        <a href="{{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
           {{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}
         </a>
       </p>
       <p class="alert-text">
         {{ 'Read more about the CSV format at:'|trans({}, 'Admin.Advparameters.Help') }}
-        <a href="{{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}" class="_blank">
+        <a href="{{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
           {{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}
         </a>
       </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
@@ -63,7 +63,7 @@
     <div class="alert alert-warning" role="alert">
       <p class="alert-text">
         {{ 'It seems there are no recommended payment solutions for your country.'|trans({}, 'Admin.Payment.Notification') }} <br>
-        <a class="_blank" href="https://www.prestashop.com/en/contact-us">{{ 'Do you think there should be one? Let us know!'|trans({}, 'Admin.Shipping.Feature') }}</a>
+        <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.prestashop.com/en/contact-us">{{ 'Do you think there should be one? Let us know!'|trans({}, 'Admin.Shipping.Feature') }}</a>
       </p>
     </div>
   {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -46,7 +46,7 @@
           {{ form_widget(categoryForm.active) }}
           <small class="form-text">
             {{ 'If you want a category to appear in the menu of your shop, go to [1]Modules > Module Manager[/1] and configure your menu module.'|trans({
-              '[1]': '<a href="' ~ path('admin_module_manage') ~ '" class="_blank">',
+              '[1]': '<a href="' ~ path('admin_module_manage') ~ '" target="_blank" rel="noopener noreferrer nofollow">',
               '[/1]': '</a>'
             }, 'Admin.Catalog.Help')|raw }}
           </small>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -61,13 +61,13 @@
         </td>
         <td>
           {% if document.type == 'invoice' %}
-            <a class="_blank"
+            <a target="_blank" rel="noopener noreferrer nofollow"
                href="{{ getAdminLink('AdminPdf', true, {'submitAction': 'generateInvoicePDF', 'id_order_invoice': document.id}) }}"
             >
               {{ document.referenceNumber }}
             </a>
           {% elseif document.type == 'delivery_slip' %}
-            <a class="_blank"
+            <a target="_blank" rel="noopener noreferrer nofollow"
                href="{{ getAdminLink('AdminPdf', true, {'submitAction': 'generateDeliverySlipPDF', 'id_order_invoice': document.id}) }}"
             >
               {{ document.referenceNumber }}

--- a/themes/classic/templates/_partials/footer.tpl
+++ b/themes/classic/templates/_partials/footer.tpl
@@ -45,7 +45,7 @@
       <div class="col-md-12">
         <p class="text-sm-center">
           {block name='copyright_link'}
-            <a class="_blank" href="https://www.prestashop.com" target="_blank" rel="nofollow">
+            <a href="https://www.prestashop.com" target="_blank" rel="nofollow">
               {l s='%copyright% %year% - Ecommerce software by %prestashop%' sprintf=['%prestashop%' => 'PrestaShop™', '%year%' => 'Y'|date, '%copyright%' => '©'] d='Shop.Theme.Global'}
             </a>
           {/block}

--- a/themes/classic/templates/_partials/footer.tpl
+++ b/themes/classic/templates/_partials/footer.tpl
@@ -45,7 +45,7 @@
       <div class="col-md-12">
         <p class="text-sm-center">
           {block name='copyright_link'}
-            <a href="https://www.prestashop.com" target="_blank" rel="nofollow">
+            <a href="https://www.prestashop.com" target="_blank" rel="noopener noreferrer nofollow">
               {l s='%copyright% %year% - Ecommerce software by %prestashop%' sprintf=['%prestashop%' => 'PrestaShop™', '%year%' => 'Y'|date, '%copyright%' => '©'] d='Shop.Theme.Global'}
             </a>
           {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Currently both `class="_blank"` and `target="_blank"` are proper. This is because https://github.com/PrestaShop/PrestaShop/blob/develop/js/tools.js#L761. But today `target` attribute is compatible with most browsers  ![target_black_compatiility](https://user-images.githubusercontent.com/16455155/84367052-fda32c80-abd3-11ea-9271-24f40386f91f.png) See :  https://developer.mozilla.org/fr/docs/Web/HTML/Element/a#Compatibilit%C3%A9_des_navigateurs and https://www.w3schools.com/tags/tag_a.asp
| Type?         |  improvement 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A.
| How to test?  | N/A ??.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19710)
<!-- Reviewable:end -->
