### PR TITLE
Test install with localhost if 127.0.0.1 fails

### DIFF
--- a/install-dev/controllers/http/database.php
+++ b/install-dev/controllers/http/database.php
@@ -109,6 +109,18 @@ class InstallControllerHttpDatabase extends InstallControllerHttp implements Htt
 
         $errors = $this->model_database->testDatabaseSettings($server, $database, $login, $password, $prefix, $clear);
 
+        if (count($errors) > 0 && $server === '127.0.0.1') {
+            $errorsAgain = $this->model_database->testDatabaseSettings('localhost', $database, $login, $password, $prefix, $clear);
+
+            if (empty($errorsAgain)) {
+                $this->ajaxJsonAnswer(
+                    true,
+                    $this->translator->trans('Database can be reached if you use localhost for server name instead of 127.0.0.1', array(), 'Install')
+                );
+                return;
+            }
+        }
+
         $this->ajaxJsonAnswer(
             (count($errors)) ? false : true,
             (count($errors)) ? implode('<br />', $errors) : $this->translator->trans('Database is connected', array(), 'Install')


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Some webhosting dont route 127.0.0.1 but use localhost instead. This PR attempts to check if localhost works 127.0.01 fails and tells user if it works.
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | On localhost, configure your vhost to refuse 127.0.01 but accept localhost. Try to install prestashop, when you click on "test my database settings" it should tell you message 'Database can be reached if you use localhost for server name instead of 127.0.0.1'

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19714)
<!-- Reviewable:end -->
