### PR TITLE
Remove i18n access restrictions

### DIFF
--- a/src/PrestaShopBundle/Controller/Api/I18nController.php
+++ b/src/PrestaShopBundle/Controller/Api/I18nController.php
@@ -37,7 +37,7 @@ class I18nController extends ApiController
     /**
      * Show translation for page-app build with vue-js.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * No access restrictions because it is require for VueJs translations
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Api/I18nController.php
+++ b/src/PrestaShopBundle/Controller/Api/I18nController.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Controller\Api;
 
 use Exception;
-use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

--- a/src/PrestaShopBundle/Controller/Api/I18nController.php
+++ b/src/PrestaShopBundle/Controller/Api/I18nController.php
@@ -36,7 +36,7 @@ class I18nController extends ApiController
     /**
      * Show translation for page-app build with vue-js.
      *
-     * No access restrictions because it is require for VueJs translations
+     * No access restrictions because it is required for VueJs translations
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Resources/config/routing/api/i18n.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/api/i18n.yml
@@ -3,6 +3,5 @@ api_i18n_translations_list:
     methods: [GET]
     defaults:
         _controller: prestashop.core.api.i18n.controller:listTranslationAction
-        _legacy_controller: AdminTranslations
     requirements:
         page: \w+


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | This controller action is needed for some VueJs pages. We can remove the access restrictions.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19713 
| How to test?  | - Install 1.7.6.5<br>- Modify "Logistician' employee profile, give him all accesses to "Stock" page<br>- Create new employee, assign him the "Logistician" profile<br>- Login as new employee, try to access 'Stock page'<br>- on first attempt: blank page<br>- if you refresh, you see a hundred of "access denied" messages
.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19718)
<!-- Reviewable:end -->
