### PR TITLE
Add composer update --dry-run roave/security-advisories into CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,8 @@ install:
     fi
 
 script:
+  - composer update --dry-run roave/security-advisories
+
   - if [ "$PRESTASHOP_TEST_TYPE" = "unit" ]; then
         bash tests/check_file_syntax.sh;
     fi


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `composer update --dry-run roave/security-advisories` is a nice check to make sure no dependencies with known vulnerabilities are used
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | CI should pass, excluding usecase where not secure dependency is used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19721)
<!-- Reviewable:end -->
