### PR TITLE
Functional tests - Increase timeout after disabling a category

### DIFF
--- a/tests/UI/pages/BO/catalog/categories/index.js
+++ b/tests/UI/pages/BO/catalog/categories/index.js
@@ -141,13 +141,14 @@ module.exports = class Categories extends BOBasePage {
   async updateToggleColumnValue(row, column, valueWanted = true) {
     await this.waitForVisibleSelector(this.categoriesListTableColumn(row, column), 2000);
     if (await this.getToggleColumnValue(row, column) !== valueWanted) {
-      this.page.click(this.categoriesListTableColumn(row, column));
+      await this.page.click(this.categoriesListTableColumn(row, column));
       await this.waitForVisibleSelector(
         (
           valueWanted
             ? this.categoriesListColumnValidIcon(row, column)
             : this.categoriesListColumnNotValidIcon(row, column)
         ),
+        15000,
       );
       return true;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Increase timeout after disabling a category (improve function due to nightly error)
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/03_catalog/02_categories/01_filterAndQuickEditCategories" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19725)
<!-- Reviewable:end -->
