### PR TITLE
Check if the module exists on Addons

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -67,6 +67,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         // Clean all cache values
         Cache::clean('*');
 
+        Shop::initialize();
         Context::getContext()->shop = new Shop(1);
         Shop::setContext(Shop::CONTEXT_SHOP, 1);
         Configuration::loadConfiguration();

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -294,7 +294,9 @@ class ModuleManager implements AddonManagerInterface
         if (!empty($source)) {
             $this->moduleZipManager->storeInModulesFolder($source);
         } elseif (!$this->moduleProvider->isOnDisk($name)) {
-            $this->moduleUpdater->setModuleOnDiskFromAddons($name);
+            if (!$this->moduleUpdater->setModuleOnDiskFromAddons($name)) {
+                throw new Exception($this->translator->trans('The module %name% has not been found on Addons.', ['%name%' => $name]));
+            }
         }
 
         $module = $this->moduleRepository->getModule($name);

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Addon\Module\Exception\UnconfirmedModuleActionException;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShopBundle\Event\ModuleManagementEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -295,7 +296,14 @@ class ModuleManager implements AddonManagerInterface
             $this->moduleZipManager->storeInModulesFolder($source);
         } elseif (!$this->moduleProvider->isOnDisk($name)) {
             if (!$this->moduleUpdater->setModuleOnDiskFromAddons($name)) {
-                throw new Exception($this->translator->trans('The module %name% could not be found on Addons.', ['%name%' => $name], 'Admin.Modules.Notification'));
+                throw new FailedToEnableThemeModuleException(
+                    $name,
+                    $this->translator->trans(
+                        'The module %name% could not be found on Addons.',
+                        ['%name%' => $name],
+                        'Admin.Modules.Notification'
+                    )
+                );
             }
         }
 

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -295,7 +295,7 @@ class ModuleManager implements AddonManagerInterface
             $this->moduleZipManager->storeInModulesFolder($source);
         } elseif (!$this->moduleProvider->isOnDisk($name)) {
             if (!$this->moduleUpdater->setModuleOnDiskFromAddons($name)) {
-                throw new Exception($this->translator->trans('The module %name% has not been found on Addons.', ['%name%' => $name]));
+                throw new Exception($this->translator->trans('The module %name% could not be found on Addons.', ['%name%' => $name], 'Admin.Modules.Notification'));
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Before this PR, the CLI trigger a mystic error when a module was not found on Addons
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18499
| How to test?  | 1. set-up a proper environment to install PrestaShop (mysql, apache,...)<br>2. work on `develop` branch<br>3. unzip [classic-rocket](https://github.com/PrestaShop/classic-rocket/releases)  into themes/classic-rocket<br>4. launch the silent installation : `php install-dev/index_cli.php --language=en --country=fr --domaine='127.0.0.1' --base_uri='/PrestaShop/' --db_server=127.0.0.1 --db_user=root --db_password=root --db_name=prestashop --step=database,theme,modules,addons_modules --theme=classic-rocket`<br>5. **BEFORE**: "Cannot install module ps_searchbarjqauto. The module is invalid and cannot be loaded."<br>5. **AFTER**: "Module ps_searchbarjqauto not found on Addons."
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19744)
<!-- Reviewable:end -->
