### PR TITLE
Fix problem with set accesses by tabs

### DIFF
--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -226,7 +226,7 @@ class ProfileCore extends ObjectModel
         $accessPerTab = [];
         foreach ($rolesGiven as $role) {
             preg_match(
-                '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z][A-Z0-9]*)_[A-Z]+/',
+                '/ROLE_MOD_[A-Z]+_(?P<classname>[A-Z][A-Z0-9\_]*)_(CREATE|DELETE|READ|UPDATE)+/',
                 $role['slug'],
                 $matches
             );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix problem with set accesses by tabs
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/19759.
| How to test?  | Create tab module in section More. Go to accesses by tabs. Set access this tab module. Update page, access not setted
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19760)
<!-- Reviewable:end -->
