### PR TITLE
Fix not found feature value in FeatureValueCore::addFeatureValueImport

### DIFF
--- a/classes/FeatureValue.php
+++ b/classes/FeatureValue.php
@@ -167,8 +167,9 @@ class FeatureValueCore extends ObjectModel
         }
 
         if (!$custom) {
-            if(!$idLang)
+            if (null === $idLang) {
                 $idLang = Context::getContext()->language->id;
+            }
 
             $idFeatureValue = Db::getInstance()->getValue('
 				SELECT fv.`id_feature_value`

--- a/classes/FeatureValue.php
+++ b/classes/FeatureValue.php
@@ -167,6 +167,9 @@ class FeatureValueCore extends ObjectModel
         }
 
         if (!$custom) {
+            if(!$idLang)
+                $idLang = Context::getContext()->language->id;
+
             $idFeatureValue = Db::getInstance()->getValue('
 				SELECT fv.`id_feature_value`
 				FROM '._DB_PREFIX_.'feature_value fv


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When FeatureValueCore::addFeatureValueImport is used in specific development, the $idLang can not be set. The search is done with idLang = 0 and so never found. So it will create multiple feature value with same name.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19773.
| How to test?  | Use : FeatureValue::addFeatureValueImport($id_feature, $value); or FeatureValue::addFeatureValueImport($id_feature, $value, $id_product); in a loop of items with the same feature value. In admin panel you'll see multiple values with same name.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19774)
<!-- Reviewable:end -->
