### PR TITLE
Allow developers to use their own tinymce config

### DIFF
--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -72,8 +72,8 @@ function tinySetup(config) {
     rel_list: [{title: 'nofollow', value: 'nofollow'}]
   };
 
-  if (typeof defaultTinyMceConfig !== 'undefined') {
-    Object.assign(default_config, defaultTinyMceConfig);
+  if (typeof window.defaultTinyMceConfig !== 'undefined') {
+    Object.assign(default_config, window.defaultTinyMceConfig);
   }
 
   $.each(default_config, function(index, el) {

--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -45,37 +45,35 @@ function tinySetup(config) {
     config.selector = '.' + config.editor_selector;
   }
 
-  var default_config = {};
+  var default_config = {
+    selector: '.rte',
+    plugins: 'align colorpicker link image filemanager table media placeholder advlist code table autoresize',
+    browser_spellcheck: true,
+    toolbar1:
+      'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
+    toolbar2: '',
+    external_filemanager_path: baseAdminDir + 'filemanager/',
+    filemanager_title: 'File manager',
+    external_plugins: {
+      filemanager: baseAdminDir + 'filemanager/plugin.min.js'
+    },
+    language: iso_user,
+    content_style: lang_is_rtl === '1' ? 'body {direction:rtl;}' : '',
+    skin: 'prestashop',
+    menubar: false,
+    statusbar: false,
+    relative_urls: false,
+    convert_urls: false,
+    entity_encoding: 'raw',
+    extended_valid_elements: 'em[class|name|id],@[role|data-*|aria-*]',
+    valid_children: '+*[*]',
+    valid_elements: '*[*]',
+    init_instance_callback: 'changeToMaterial',
+    rel_list: [{title: 'nofollow', value: 'nofollow'}]
+  };
 
-  if (defaultTinyMceConfig) {
-    default_config = defaultTinyMceConfig;
-  } else {
-    default_config = {
-      selector: '.rte',
-      plugins: 'align colorpicker link image filemanager table media placeholder advlist code table autoresize',
-      browser_spellcheck: true,
-      toolbar1:
-        'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
-      toolbar2: '',
-      external_filemanager_path: baseAdminDir + 'filemanager/',
-      filemanager_title: 'File manager',
-      external_plugins: {
-        filemanager: baseAdminDir + 'filemanager/plugin.min.js'
-      },
-      language: iso_user,
-      content_style: lang_is_rtl === '1' ? 'body {direction:rtl;}' : '',
-      skin: 'prestashop',
-      menubar: false,
-      statusbar: false,
-      relative_urls: false,
-      convert_urls: false,
-      entity_encoding: 'raw',
-      extended_valid_elements: 'em[class|name|id],@[role|data-*|aria-*]',
-      valid_children: '+*[*]',
-      valid_elements: '*[*]',
-      init_instance_callback: 'changeToMaterial',
-      rel_list: [{title: 'nofollow', value: 'nofollow'}]
-    };
+  if (typeof defaultTinyMceConfig !== 'undefined') {
+    Object.assign(default_config, defaultTinyMceConfig);
   }
 
   $.each(default_config, function(index, el) {

--- a/js/admin/tinymce.inc.js
+++ b/js/admin/tinymce.inc.js
@@ -45,31 +45,38 @@ function tinySetup(config) {
     config.selector = '.' + config.editor_selector;
   }
 
-  var default_config = {
-    selector: '.rte',
-    plugins: 'align colorpicker link image filemanager table media placeholder advlist code table autoresize',
-    browser_spellcheck: true,
-    toolbar1: 'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
-    toolbar2: '',
-    external_filemanager_path: baseAdminDir + 'filemanager/',
-    filemanager_title: 'File manager',
-    external_plugins: {
-      filemanager: baseAdminDir + 'filemanager/plugin.min.js'
-    },
-    language: iso_user,
-    content_style: lang_is_rtl === '1' ? 'body {direction:rtl;}' : '',
-    skin: 'prestashop',
-    menubar: false,
-    statusbar: false,
-    relative_urls: false,
-    convert_urls: false,
-    entity_encoding: 'raw',
-    extended_valid_elements: 'em[class|name|id],@[role|data-*|aria-*]',
-    valid_children: '+*[*]',
-    valid_elements: '*[*]',
-    init_instance_callback: 'changeToMaterial',
-    rel_list: [{title: 'nofollow', value: 'nofollow'}]
-  };
+  var default_config = {};
+
+  if (defaultTinyMceConfig) {
+    default_config = defaultTinyMceConfig;
+  } else {
+    default_config = {
+      selector: '.rte',
+      plugins: 'align colorpicker link image filemanager table media placeholder advlist code table autoresize',
+      browser_spellcheck: true,
+      toolbar1:
+        'code,colorpicker,bold,italic,underline,strikethrough,blockquote,link,align,bullist,numlist,table,image,media,formatselect',
+      toolbar2: '',
+      external_filemanager_path: baseAdminDir + 'filemanager/',
+      filemanager_title: 'File manager',
+      external_plugins: {
+        filemanager: baseAdminDir + 'filemanager/plugin.min.js'
+      },
+      language: iso_user,
+      content_style: lang_is_rtl === '1' ? 'body {direction:rtl;}' : '',
+      skin: 'prestashop',
+      menubar: false,
+      statusbar: false,
+      relative_urls: false,
+      convert_urls: false,
+      entity_encoding: 'raw',
+      extended_valid_elements: 'em[class|name|id],@[role|data-*|aria-*]',
+      valid_children: '+*[*]',
+      valid_elements: '*[*]',
+      init_instance_callback: 'changeToMaterial',
+      rel_list: [{title: 'nofollow', value: 'nofollow'}]
+    };
+  }
 
   $.each(default_config, function(index, el) {
     if (config[index] === undefined) config[index] = el;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Currently, there was no way of using our own TinyMCE configuration, now developers can use the actionAdminControllerSetMedia hook to create a defaultTinyMceConfig global var to use their own config.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19408.
| How to test?  | Add a defaultTinyMceConfig global var using a test module and see if the tinymce configuration changed and if it's working properly on pages

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19776)
<!-- Reviewable:end -->
