### PR TITLE
Cast changelogs to array for twig

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
@@ -35,7 +35,7 @@
 {% block addon_description %}
   {% if module.attributes.changeLog is defined %}
     <ul>
-      {% for version, lines in module.attributes.changeLog %}
+      {% for version, lines in module.attributes.changeLog|arrayCast %}
         <li><b>{{ version }}:</b>
           {% for line in lines %}
             {{ line }}<br/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Even if the `changeLog` key of the api-addons was send, the actual implementation would be unable to show it. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18450
| How to test?  | 1. Clear cache with `rm -rf var/cache/*`<br>2. Go to `Improve > Modules > Module manager`<br>3. Uninstall the MBO module<br>4. Upload an [outdated version of the MBO module](https://github.com/PrestaShopCorp/ps_mbo/releases/download/v2.0.0/ps_mbo.zip)<br>5. In the `Updates` tab, you should see the changelog for a new MBO module version available

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19778)
<!-- Reviewable:end -->
