### PR TITLE
Allow modules to disable routing prefix with specific parameter

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -7,4 +7,3 @@ app_modules:
     # v1: only YAML format is supported for now.
     resource: .
     type: module
-    prefix: /modules

--- a/src/PrestaShopBundle/Routing/YamlModuleLoader.php
+++ b/src/PrestaShopBundle/Routing/YamlModuleLoader.php
@@ -93,10 +93,8 @@ class YamlModuleLoader extends Loader
     private function modifyRoutes(RouteCollection $routes)
     {
         foreach ($routes->getIterator() as $route) {
-            if ($route->hasDefault('_disable_module_prefix')) {
-                if ($route->getDefault('_disable_module_prefix') === true) {
-                    continue;
-                }
+            if ($route->hasDefault('_disable_module_prefix') && $route->getDefault('_disable_module_prefix') === true) {
+                continue;
             }
 
             $route->setPath('/modules' . $route->getPath());

--- a/src/PrestaShopBundle/Routing/YamlModuleLoader.php
+++ b/src/PrestaShopBundle/Routing/YamlModuleLoader.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Routing;
 
 use RuntimeException;
 use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -65,8 +66,9 @@ class YamlModuleLoader extends Loader
             $routingFile = $modulePath . '/config/routes.yml';
             if (file_exists($routingFile)) {
                 $loadedRoutes = $this->import($routingFile, 'yaml');
+                $modifiedRoutes = $this->modifyRoutes($loadedRoutes);
 
-                $routes->addCollection($loadedRoutes);
+                $routes->addCollection($modifiedRoutes);
             }
         }
 
@@ -81,5 +83,25 @@ class YamlModuleLoader extends Loader
     public function supports($resource, $type = null)
     {
         return 'module' === $type;
+    }
+
+    /**
+     * @param RouteCollection $routes
+     *
+     * @return RouteCollection
+     */
+    private function modifyRoutes(RouteCollection $routes)
+    {
+        foreach ($routes->getIterator() as $route) {
+            if ($route->hasDefault('_disable_module_prefix')) {
+                if ($route->getDefault('_disable_module_prefix') === true) {
+                    continue;
+                }
+            }
+
+            $route->setPath('/modules' . $route->getPath());
+        }
+
+        return $routes;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When a module declares Symfony routes, these routes automatically get the prefix `/modules`. <br/>This can be an issue if module wants to re-map a Core route to its custom controller. I introduce a new `default` parameter for PrestaShop module routes that allow modules to disable routing prefix with specific parameter `_disable_module_prefix`
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

## How to use it in a module

```
admin_orders_index:
  path: /sell/orders/orders/
  methods: [GET]
  defaults:
    _controller: Matks\TestDecoration\Controller\AController::aAction
    _legacy_controller: AdminOrders
    _legacy_link: AdminOrders
    _disable_module_prefix: true
```
=> if `_disable_module_prefix` is `true` the route is not prefixed

## How to test

Use following test module 
[testdecorationcontrollers.zip](https://github.com/PrestaShop/PrestaShop/files/4786683/testdecorationcontrollers.zip)

### On 1.7.7.x (without the PR)

Install the module on 1.7.7.x and look and click on Sell > Orders link. You arrive on a blank page with "ok". What is interesting is the URL: it should be `/admin-dev/index.php/modules/sell/orders/orders`
=> the module modified the URL of the "Orders" page 😢 


### On my branch (with the PR)

Install the module with my PR and look and click on Sell > Orders link. You arrive on a blank page with "ok". The URL is  `/admin-dev/index.php/sell/orders/orders`
=> fixed !

The snippet of code above allows a module developer to re-map the Orders page listing route `admin_orders_index` to its custom controller. Without the `_disable_module_prefix` option, the route is transformed by PrestaShop into `/modules/sell/orders/orders/`. So any link to the orders listing generated by PrestaShop will become `/modules/sell/orders/orders/` but external links and hardcoded links will fail.

With `_disable_module_prefix` set to true, the prefix is disabled and the route path remains `/sell/orders/orders/ ` which is the goal of this PR

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19782)
<!-- Reviewable:end -->
