### PR TITLE
Allow user to choose to drop existing tables or not even when not in dev mode

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -114,7 +114,14 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
                 $this->model_database->createDatabase($this->datas->database_server, $this->datas->database_name, $this->datas->database_login, $this->datas->database_password);
             }
 
-            if (!$this->model_database->testDatabaseSettings($this->datas->database_server, $this->datas->database_name, $this->datas->database_login, $this->datas->database_password, $this->datas->database_prefix, $this->datas->database_engine, $this->datas->database_clear)) {
+            if (!$this->model_database->testDatabaseSettings(
+                $this->datas->database_server,
+                $this->datas->database_name,
+                $this->datas->database_login,
+                $this->datas->database_password,
+                $this->datas->database_prefix,
+                $this->datas->database_clear
+            )) {
                 $this->printErrors();
             }
             if (!$this->processInstallDatabase()) {

--- a/install-dev/theme/views/database.php
+++ b/install-dev/theme/views/database.php
@@ -64,12 +64,10 @@
 			<label for="db_prefix"><?php echo $this->translator->trans('Tables prefix', array(), 'Install'); ?></label>
 			<input class="text" type="text" id="db_prefix" name="db_prefix" value="<?php echo htmlspecialchars($this->database_prefix) ?>" />
 		</p>
-		<?php if (_PS_MODE_DEV_): ?>
-			<p>
-				<label for="db_clear"><?php echo $this->translator->trans('Drop existing tables (mode dev)', array(), 'Install'); ?></label>
-				<input type="checkbox" name="database_clear" id="db_clear" value="1" <?php if ($this->database_clear): ?>checked="checked"<?php endif; ?> />
-			</p>
-		<?php endif; ?>
+        <p>
+            <label for="db_clear"><?php echo $this->translator->trans('Drop existing tables', array(), 'Install'); ?></label>
+            <input type="checkbox" name="database_clear" id="db_clear" value="1" <?php if ($this->database_clear): ?>checked="checked"<?php endif; ?> />
+        </p>
 		<p class="aligned last">
 			<input id="btTestDB" class="button" type="button" value="<?php echo $this->translator->trans('Test your database connection now!', array(), 'Install'); ?>"/>
 		</p>

--- a/src/PrestaShopBundle/Install/Database.php
+++ b/src/PrestaShopBundle/Install/Database.php
@@ -39,7 +39,6 @@ class Database extends AbstractInstall
      * @param string $login
      * @param string $password
      * @param string $prefix
-     * @param string $engine
      * @param bool $clear
      *
      * @return array List of errors


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Allow user to choose to drop existing tables or not even when not in dev mode
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19754
| How to test?  | 0. "Debug mode" : ON or OFF<br>1. Install PS, with demo products and with drop existing tables<br>2. **BEFORE** : An error occurs at "Create database tables" step<br>2. **BEFORE** : Restart install. A new error occurs at "Create default shop and languages" step<br>3. **AFTER**: Now we can drop existing tables

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19788)
<!-- Reviewable:end -->
