### PR TITLE
Allow user to choose to enable SSL or not in install process

### DIFF
--- a/install-dev/controllers/http/configure.php
+++ b/install-dev/controllers/http/configure.php
@@ -43,6 +43,7 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
             $this->session->shop_name = trim(Tools::getValue('shop_name'));
             $this->session->shop_activity = Tools::getValue('shop_activity');
             $this->session->install_type = Tools::getValue('db_mode');
+            $this->session->enable_ssl = Tools::getValue('enable_ssl');
             $this->session->shop_country = Tools::getValue('shop_country');
             $this->session->shop_timezone = Tools::getValue('shop_timezone');
 

--- a/install-dev/controllers/http/database.php
+++ b/install-dev/controllers/http/database.php
@@ -56,6 +56,7 @@ class InstallControllerHttpDatabase extends InstallControllerHttp implements Htt
         $this->session->database_prefix = trim(Tools::getValue('db_prefix'));
         $this->session->database_clear = Tools::getValue('database_clear');
 
+        $this->session->enable_ssl = Tools::getValue('enable_ssl');
         $this->session->rewrite_engine = Tools::getValue('rewrite_engine');
     }
 

--- a/install-dev/controllers/http/database.php
+++ b/install-dev/controllers/http/database.php
@@ -55,8 +55,6 @@ class InstallControllerHttpDatabase extends InstallControllerHttp implements Htt
         $this->session->database_password = trim(Tools::getValue('dbPassword'));
         $this->session->database_prefix = trim(Tools::getValue('db_prefix'));
         $this->session->database_clear = Tools::getValue('database_clear');
-
-        $this->session->enable_ssl = Tools::getValue('enable_ssl');
         $this->session->rewrite_engine = Tools::getValue('rewrite_engine');
     }
 

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -198,16 +198,17 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         $this->initializeContext();
 
         $success = $this->model_install->configureShop(array(
-            'shop_name' =>                $this->session->shop_name,
-            'shop_activity' =>            $this->session->shop_activity,
-            'shop_country' =>            $this->session->shop_country,
-            'shop_timezone' =>            $this->session->shop_timezone,
+            'shop_name' =>              $this->session->shop_name,
+            'shop_activity' =>          $this->session->shop_activity,
+            'shop_country' =>           $this->session->shop_country,
+            'shop_timezone' =>          $this->session->shop_timezone,
             'admin_firstname' =>        $this->session->admin_firstname,
-            'admin_lastname' =>            $this->session->admin_lastname,
-            'admin_password' =>            $this->session->admin_password,
+            'admin_lastname' =>         $this->session->admin_lastname,
+            'admin_password' =>         $this->session->admin_password,
             'admin_email' =>            $this->session->admin_email,
-            'configuration_agrement' =>    $this->session->configuration_agrement,
-            'rewrite_engine' =>            $this->session->rewrite_engine,
+            'configuration_agrement' => $this->session->configuration_agrement,
+            'enable_ssl' =>             $this->session->enable_ssl,
+            'rewrite_engine' =>         $this->session->rewrite_engine,
         ));
 
         if (!$success || $this->model_install->getErrors()) {

--- a/install-dev/theme/views/configure.php
+++ b/install-dev/theme/views/configure.php
@@ -101,7 +101,7 @@
 
     <!-- Enable SSL -->
     <div class="field clearfix">
-        <label class="aligned"><?php echo $this->translator->trans('Enable SSL', array(), 'Admin.Shopparameters.Feature'); ?></label>
+        <label class="aligned"><?php echo $this->translator->trans('Enable SSL', array(), 'Install'); ?></label>
         <div class="contentinput">
             <label>
                 <input value="1" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '1'): ?>checked="checked"<?php endif; ?> autocomplete="off" />

--- a/install-dev/theme/views/configure.php
+++ b/install-dev/theme/views/configure.php
@@ -99,6 +99,21 @@
 		<?php echo $this->displayError('shop_timezone') ?>
 	</div>
 
+    <!-- Enable SSL -->
+    <div class="field clearfix">
+        <label class="aligned"><?php echo $this->translator->trans('Enable SSL', array(), 'Admin.Shopparameters.Feature'); ?></label>
+        <div class="contentinput">
+            <label>
+                <input value="1" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '1'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
+                <?php echo $this->translator->trans('Yes', array(), 'Install'); ?>
+            </label>
+            <label>
+                <input value="0" type="radio" name="enable_ssl" style="vertical-align: middle;" <?php if ($this->session->enable_ssl == '0'): ?>checked="checked"<?php endif; ?> autocomplete="off" />
+                <?php echo $this->translator->trans('No', array(), 'Install'); ?>
+            </label>
+        </div>
+    </div>
+
 	<h2 style="margin-top:20px"><?php echo $this->translator->trans('Your Account', array(), 'Install'); ?></h2>
 
 	<!-- Admin firstname -->


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow user to choose to enable SSL or not in install process
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18525 & Fixes #10482
| How to test?  | In install process,<br>* Choose YES for enable SSL : `PS_SSL_ENABLED` & `PS_SSL_ENABLED_EVERYWHERE` must be at `1` in database<br>* Choose NO for enable SSL : `PS_SSL_ENABLED` & `PS_SSL_ENABLED_EVERYWHERE` must be at `0` in database
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19791)
<!-- Reviewable:end -->
