### PR TITLE
Change buttons in modal bulk of module page to avoid black color

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -49,8 +49,8 @@
           </div>
       </div>
       <div class="modal-footer">
-          <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
-          <a class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</a>
+          <input type="button" class="btn btn-outline-secondary uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
+          <button class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</button>
       </div>
 
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Buttons had black colors instead of white and cancel button didn't have the same style than other modals on this page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9699.
| How to test?  | Go on module page, select some module, do a bulk action and see if buttons are same as other modals on the page (without black color)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19814)
<!-- Reviewable:end -->
