### PR TITLE
Hooks displayAdminOrderTabLink or displayAdminOrderTabContent displayed not escaped to allow raw HTML

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -117,12 +117,12 @@
   <div class="mt-2" id="order_hook_tabs">
     <ul class="nav nav nav-tabs" role="tablist">
       {# Rendering of hook displayAdminOrderTabLink, we expect tab links #}
-      {{ displayAdminOrderTabLink }}
+      {{ displayAdminOrderTabLink|raw }}
     </ul>
 
     <div class="tab-content">
       {# Rendering of hook displayAdminOrderTabContent, we expect tab contents #}
-      {{ displayAdminOrderTabContent }}
+      {{ displayAdminOrderTabContent|raw }}
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When you want to use dispalyAdminOrderTabLink or dispalyAdminOrderTabContent, HTML content is escape.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19822
| How to test?  | You can use https://github.com/PrestaShop/PrestaShop/files/4695351/tottesthooks.zip you reproduce the bug ![image](https://user-images.githubusercontent.com/52157233/84899489-0353b300-b0a9-11ea-9f0c-3a51c31810eb.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19820)
<!-- Reviewable:end -->
