### PR TITLE
Functional tests - Add ids to forms in payment preferences page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig
@@ -45,7 +45,7 @@
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
+          <button class="btn btn-primary" id="form-currency-restrictions-save-button">
             {{ 'Save'|trans({}, 'Admin.Actions') }}
           </button>
         </div>
@@ -72,7 +72,7 @@
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
+          <button class="btn btn-primary" id="form-group-restrictions-save-button">
             {{ 'Save'|trans({}, 'Admin.Actions') }}
           </button>
         </div>
@@ -99,7 +99,7 @@
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
+          <button class="btn btn-primary" id="form-country-restrictions-save-button">
             {{ 'Save'|trans({}, 'Admin.Actions') }}
           </button>
         </div>
@@ -125,7 +125,7 @@
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
+          <button class="btn btn-primary" id="form-carrier-restrictions-save-button">
             {{ 'Save'|trans({}, 'Admin.Actions') }}
           </button>
         </div>

--- a/tests/UI/pages/BO/payment/preferences/index.js
+++ b/tests/UI/pages/BO/payment/preferences/index.js
@@ -10,13 +10,13 @@ module.exports = class Preferences extends BOBasePage {
     // Selectors for currency restrictions
     this.euroCurrencyRestrictionsCheckbox = paymentModule => '#form_payment_module_preferences_currency_restrictions_'
       + `${paymentModule}_0`;
-    this.currencyRestrictionsSaveButton = '#main-div div:nth-child(1) > div.card-footer button';
+    this.currencyRestrictionsSaveButton = '#form-currency-restrictions-save-button';
     // Selectors for group restrictions
     this.paymentModuleCheckbox = (paymentModule, groupID) => '#form_payment_module_preferences_group_restrictions_'
       + `${paymentModule}_${groupID}`;
     this.countryRestrictionsCheckbox = (paymentModule, countryID) => '#form_payment_module_preferences_country_'
       + `restrictions_${paymentModule}_${countryID}`;
-    this.groupRestrictionsSaveButton = '#main-div div:nth-child(2) > div.card-footer button';
+    this.groupRestrictionsSaveButton = '#form-group-restrictions-save-button';
   }
 
   /*


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add ids to payment preferences forms save buttons
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | No tests needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19826)
<!-- Reviewable:end -->
