### PR TITLE
When new webservice key is created, add log

### DIFF
--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -53,7 +53,23 @@ class WebserviceKeyCore extends ObjectModel
             return false;
         }
 
-        return parent::add($autodate = true, $nullValues = false);
+        $result = parent::add($autodate = true, $nullValues = false);
+
+        if ($result) {
+            PrestaShopLogger::addLog(
+                Context::getContext()->getTranslator()->trans(
+                    'Webservice key created by employee %s %s (%s)',
+                    [
+                        Context::getContext()->employee->firstname,
+                        Context::getContext()->employee->lastname,
+                        Context::getContext()->employee->email,
+                    ],
+                    'Admin.Advparameters.Notification'
+                )
+            );
+        }
+
+        return $result;
     }
 
     public static function keyExists($key)

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -64,7 +64,7 @@ class WebserviceKeyCore extends ObjectModel
                         Context::getContext()->employee->lastname,
                         Context::getContext()->employee->email,
                     ],
-                    'Admin.Advparameters.Notification'
+                    'Admin.Advparameters.Feature'
                 )
             );
         }

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -58,8 +58,9 @@ class WebserviceKeyCore extends ObjectModel
         if ($result) {
             PrestaShopLogger::addLog(
                 Context::getContext()->getTranslator()->trans(
-                    'Webservice key created by employee %s %s (%s)',
+                    'Webservice key created by employee "%d" %s %s (%s)',
                     [
+                        Context::getContext()->employee->id,
                         Context::getContext()->employee->firstname,
                         Context::getContext()->employee->lastname,
                         Context::getContext()->employee->email,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I add a call to PrestaShopLogger in webservice key creation so it's logged. I think for security it's important BO Admin can know who create keys. Keys can provide access to critical data.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a new Webservice Key then go in Logs page and see latest log which says "Webservice key created by employee Ksaan Ami (ksaan.ami@gmail.com)"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19831)
<!-- Reviewable:end -->
