### PR TITLE
Use the appropriate exception in BulkToggleLanguagesStatusCommand

### DIFF
--- a/src/Core/Domain/Language/Command/BulkToggleLanguagesStatusCommand.php
+++ b/src/Core/Domain/Language/Command/BulkToggleLanguagesStatusCommand.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Language\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 
@@ -79,7 +78,7 @@ class BulkToggleLanguagesStatusCommand
     private function setLanguages(array $languageIds)
     {
         if (empty($languageIds)) {
-            throw new CategoryConstraintException('Languages must be provided in order to toggle their status');
+            throw new LanguageConstraintException('Languages must be provided in order to toggle their status');
         }
 
         foreach ($languageIds as $languageId) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This change fixes minor code issues I found while working on another bug.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  N/A.
| How to test?  | N/A (Maybe just make sure that `BO > International > Localization > Languages` work )



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19837)
<!-- Reviewable:end -->
