### PR TITLE
Add modal actions to attribute and attribute actions

### DIFF
--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -24,8 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-declare(strict_types=1);
-
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\AttributeGroup\AttributeGroupViewDataProviderInterface;

--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -55,8 +55,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
-    use BulkDeleteActionTrait;
-
     use DeleteActionTrait;
 
     const GRID_ID = 'attribute';

--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -35,7 +35,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -172,9 +171,8 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
                             'id_attribute_group',
                             Request::METHOD_DELETE,
                              [
-                                    'attributeId' => 'id_attribute',
+                                 'attributeId' => 'id_attribute',
                              ]
-
                         )
                     ),
             ])
@@ -284,19 +282,19 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
     {
         return (new BulkActionCollection())
             ->add((new SubmitBulkAction('delete_selection'))
-                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                ->setOptions([
-                    'submit_route' => 'admin_attributes_bulk_delete',
-                    'route_params' => [
-                        'attributeGroupId' => $this->attributeGroupId,
-                    ],
-                    'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
-                    'modal_options' => new ModalOptions([
-                        'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
-                        'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
-                        'confirm_button_class' => 'btn-danger',
-                    ]),
-                ])
+            ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
+            ->setOptions([
+                'submit_route' => 'admin_attributes_bulk_delete',
+                'route_params' => [
+                    'attributeGroupId' => $this->attributeGroupId,
+                ],
+                'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
+                'modal_options' => new ModalOptions([
+                    'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
+                    'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                    'confirm_button_class' => 'btn-danger',
+                ]),
+            ])
             );
     }
 }

--- a/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGridDefinitionFactory.php
@@ -24,12 +24,15 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\AttributeGroup\AttributeGroupViewDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
@@ -46,12 +49,17 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Defines grid for attributes group > attributes list
  */
 final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
+
+    use DeleteActionTrait;
+
     const GRID_ID = 'attribute';
 
     /**
@@ -157,22 +165,17 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
                         ],
                     ])
                     )
-                    ->add((new SubmitRowAction('delete'))
-                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                    ->setIcon('delete')
-                    ->setOptions([
-                        'route' => 'admin_attributes_delete',
-                        'route_param_name' => 'attributeGroupId',
-                        'route_param_field' => 'id_attribute_group',
-                        'extra_route_params' => [
-                            'attributeId' => 'id_attribute',
-                        ],
-                        'confirm_message' => $this->trans(
-                            'Delete selected item?',
-                            [],
-                            'Admin.Notifications.Warning'
-                        ),
-                    ])
+                    ->add(
+                        $this->buildDeleteAction(
+                            'admin_attributes_delete',
+                            'attributeGroupId',
+                            'id_attribute_group',
+                            Request::METHOD_DELETE,
+                             [
+                                    'attributeId' => 'id_attribute',
+                             ]
+
+                        )
                     ),
             ])
         );
@@ -280,16 +283,20 @@ final class AttributeGridDefinitionFactory extends AbstractFilterableGridDefinit
     protected function getBulkActions()
     {
         return (new BulkActionCollection())
-            ->add(
-                (new SubmitBulkAction('delete_selection'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_attributes_bulk_delete',
-                        'route_params' => [
-                            'attributeGroupId' => $this->attributeGroupId,
-                        ],
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
+            ->add((new SubmitBulkAction('delete_selection'))
+                ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_route' => 'admin_attributes_bulk_delete',
+                    'route_params' => [
+                        'attributeGroupId' => $this->attributeGroupId,
+                    ],
+                    'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
+                    'modal_options' => new ModalOptions([
+                        'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
+                        'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                        'confirm_button_class' => 'btn-danger',
+                    ]),
+                ])
             );
     }
 }

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -228,7 +228,7 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
     protected function getBulkActions()
     {
         return (new BulkActionCollection())
-              ->add(
+            ->add(
                 $this->buildBulkDeleteAction('admin_attribute_groups_bulk_delete')
               );
     }

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -24,14 +24,14 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Defines attribute groups grid
@@ -50,6 +51,10 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
     const GRID_ID = 'attribute_group';
+
+    use BulkDeleteActionTrait;
+
+    use DeleteActionTrait;
 
     /**
      * {@inheritdoc}
@@ -128,19 +133,13 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
                         'route_param_field' => 'id_attribute_group',
                     ])
                     )
-                    ->add((new SubmitRowAction('delete'))
-                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                    ->setIcon('delete')
-                    ->setOptions([
-                        'route' => 'admin_attribute_groups_delete',
-                        'route_param_name' => 'attributeGroupId',
-                        'route_param_field' => 'id_attribute_group',
-                        'confirm_message' => $this->trans(
-                            'Delete selected item?',
-                            [],
-                            'Admin.Notifications.Warning'
-                        ),
-                    ])
+                    ->add(
+                        $this->buildDeleteAction(
+                            'admin_attribute_groups_delete',
+                            'attributeGroupId',
+                            'id_attribute_group',
+                            Request::METHOD_DELETE
+                        )
                     ),
             ])
             );
@@ -229,13 +228,8 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
     protected function getBulkActions()
     {
         return (new BulkActionCollection())
-            ->add(
-                (new SubmitBulkAction('delete_selection'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_attribute_groups_bulk_delete',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
-            );
+              ->add(
+                $this->buildBulkDeleteAction('admin_attribute_groups_bulk_delete')
+              );
     }
 }

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -24,7 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -24,7 +24,6 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 

--- a/src/Core/Search/Filters/AttributeFilters.php
+++ b/src/Core/Search/Filters/AttributeFilters.php
@@ -45,7 +45,7 @@ final class AttributeFilters extends Filters
         return [
             'limit' => 50,
             'offset' => 0,
-            'orderBy' => 'id_attribute',
+            'orderBy' => 'position',
             'sortOrder' => 'asc',
             'filters' => [],
         ];

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute.yml
@@ -52,7 +52,7 @@ admin_attributes_edit:
 
 admin_attributes_delete:
   path: /{attributeId}/delete
-  methods: DELETE
+  methods: [POST, DELETE]
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:delete'
     _legacy_controller: AdminAttributesGroups

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute.yml
@@ -52,7 +52,7 @@ admin_attributes_edit:
 
 admin_attributes_delete:
   path: /{attributeId}/delete
-  methods: POST
+  methods: DELETE
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Attribute:delete'
     _legacy_controller: AdminAttributesGroups

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute_group.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute_group.yml
@@ -52,7 +52,7 @@ admin_attribute_groups_edit:
 
 admin_attribute_groups_delete:
   path: /{attributeGroupId}/delete
-  methods: POST
+  methods: [POST, DELETE]
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/AttributeGroup:delete'
     _legacy_controller: AdminAttributesGroups


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add modal actions to attribute and attribute actions
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10511.
| How to test?  | Attributes and attribute group deletion (bulk and single) should have modals

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19838)
<!-- Reviewable:end -->
