### PR TITLE
Added possibility to set force_id when post an object

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1552,12 +1552,14 @@ class WebserviceRequestCore
                     $object = new $this->resourceConfiguration['retrieveData']['className']((int) $attributes->id);
                     if ($object->id) {
                         $this->setError(400, 'id is already used', 92);
+
                         return false;
                     }
-                    if((int) $attributes->force_id>0 ) {
+                    if ((int) $attributes->force_id > 0) {
                         $object->force_id = true;
                     } else {
                         $this->setError(400, 'id is forbidden when adding a new resource', 91);
+
                         return false;
                     }
                 } else {

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1510,14 +1510,14 @@ class WebserviceRequestCore
         $object = null;
 
         $ids = [];
-        $ids2 = [];
+        $forceIds = [];
         foreach ($xmlEntities as $entity) {
             // To cast in string allow to check null values
             if ((string) $entity->id != '') {
                 $ids[] = (int) $entity->id;
             }
             if ((int) $entity->force_id > 0) {
-                $ids2[] = (int) $entity->force_id;
+                $forceIds[] = (int) $entity->force_id;
             }
         }
         if ($this->method == 'PUT') {
@@ -1534,7 +1534,7 @@ class WebserviceRequestCore
                 return false;
             }
         } elseif ($this->method == 'POST' && count($ids) > 0) {
-            if (count($ids2) < count($ids)) {
+            if (count($forceIds) < count($ids)) {
                 $this->setError(400, 'id is forbidden when adding a new resource', 91);
 
                 return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Added possibilty to force_id when using webService, it is already possibile using php classes
| Type?         | improvement
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  #19847
| How to test?  | Do some posts specifing id with force_id = 0 and 1, with multiple entitities too

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19841)
<!-- Reviewable:end -->
