### PR TITLE
enhance phone number display and handling

### DIFF
--- a/themes/classic/modules/ps_contactinfo/nav.tpl
+++ b/themes/classic/modules/ps_contactinfo/nav.tpl
@@ -29,8 +29,8 @@
       {l
         s='Call us: [1]%phone%[/1]'
         sprintf=[
-          '[1]' => '<span>',
-          '[/1]' => '</span>',
+        '[1]' => '<a href="tel:'|cat:$contact_infos.phone|cat:'">',
+        '[/1]' => '</a>',
           '%phone%' => $contact_infos.phone
         ]
         d='Shop.Theme.Global'

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -29,7 +29,7 @@
     <div class="icon"><i class="material-icons">&#xE55F;</i></div>
     <div class="data">{$contact_infos.address.formatted nofilter}</div>
   </div>
-  {if $contact_infos.phone}
+  {if $contact_infos.phone && $display_phone}
     <hr/>
     <div class="block">
       <div class="icon"><i class="material-icons">&#xE0CD;</i></div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -27,7 +27,7 @@
   <div class="hidden-sm-down">
     <p class="h4 text-uppercase block-contact-title">{l s='Store information' d='Shop.Theme.Global'}</p>
       {$contact_infos.address.formatted nofilter}
-      {if $contact_infos.phone}
+      {if $contact_infos.phone && $display_phone}
         <br>
         {* [1][/1] is for a HTML tag. *}
         {l s='Call us: [1]%phone%[/1]'

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -32,8 +32,8 @@
         {* [1][/1] is for a HTML tag. *}
         {l s='Call us: [1]%phone%[/1]'
           sprintf=[
-          '[1]' => '<span>',
-          '[/1]' => '</span>',
+          '[1]' => '<a href="tel:'|cat:$contact_infos.phone|cat:'">',
+          '[/1]' => '</a>',
           '%phone%' => $contact_infos.phone
           ]
           d='Shop.Theme.Global'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.7.x
| Description?  | Make the display of phone number in footer and contact page's left column configurable and make phone number clickable.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#18928.
| How to test?  |  - back office open Shop parameters > Contact > Stores > Contact details and add phone number <br> - Open front office and click on the phone number in nav bar at top of the page <br> - Open front office and click on the phone number in the footer at the bottom of the page <br> - Open front office, navigate to contact us page and click on the phone number <br> - on mobile devices the dialer interface should open<br><br> - Open Modules > Module Manager > ps_contactinfo > Configure and set Display phone number to "no" <br> - Open front office and the phone number in the footer at the bottom of the page should be gone <br> - Open front office, navigate to contact us page and the phone number should be gone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19843)
<!-- Reviewable:end -->
