### PR TITLE
Handle 'no combination' specific price submit

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -268,7 +268,7 @@ class AdminProductWrapper
     public function processProductSpecificPrice($id_product, $specificPriceValues, $idSpecificPrice = null)
     {
         // ---- data formatting ----
-        $id_product_attribute = $specificPriceValues['sp_id_product_attribute'];
+        $id_product_attribute = isset($specificPriceValues['sp_id_product_attribute']) ? $specificPriceValues['sp_id_product_attribute'] : 0;
         $id_shop = $specificPriceValues['sp_id_shop'] ? $specificPriceValues['sp_id_shop'] : 0;
         $id_currency = $specificPriceValues['sp_id_currency'] ? $specificPriceValues['sp_id_currency'] : 0;
         $id_country = $specificPriceValues['sp_id_country'] ? $specificPriceValues['sp_id_country'] : 0;

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -268,7 +268,7 @@ class AdminProductWrapper
     public function processProductSpecificPrice($id_product, $specificPriceValues, $idSpecificPrice = null)
     {
         // ---- data formatting ----
-        $id_product_attribute = isset($specificPriceValues['sp_id_product_attribute']) ? $specificPriceValues['sp_id_product_attribute'] : 0;
+        $id_product_attribute = $specificPriceValues['sp_id_product_attribute'] ?? 0;
         $id_shop = $specificPriceValues['sp_id_shop'] ? $specificPriceValues['sp_id_shop'] : 0;
         $id_currency = $specificPriceValues['sp_id_currency'] ? $specificPriceValues['sp_id_currency'] : 0;
         $id_country = $specificPriceValues['sp_id_country'] ? $specificPriceValues['sp_id_country'] : 0;

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -269,9 +269,9 @@ class AdminProductWrapper
     {
         // ---- data formatting ----
         $id_product_attribute = $specificPriceValues['sp_id_product_attribute'] ?? 0;
-        $id_shop = $specificPriceValues['sp_id_shop'] ? $specificPriceValues['sp_id_shop'] : 0;
-        $id_currency = $specificPriceValues['sp_id_currency'] ? $specificPriceValues['sp_id_currency'] : 0;
-        $id_country = $specificPriceValues['sp_id_country'] ? $specificPriceValues['sp_id_country'] : 0;
+        $id_shop = $specificPriceValues['sp_id_shop'] ?? 0;
+        $id_currency = $specificPriceValues['sp_id_currency'] ?? 0;
+        $id_country = $specificPriceValues['sp_id_country'] ?? 0;
         $id_group = $specificPriceValues['sp_id_group'] ? $specificPriceValues['sp_id_group'] : 0;
         $id_customer = !empty($specificPriceValues['sp_id_customer']['data']) ? $specificPriceValues['sp_id_customer']['data'][0] : 0;
         $price = isset($specificPriceValues['leave_bprice']) ? '-1' : $this->floatParser->fromString($specificPriceValues['sp_price']);

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -272,7 +272,7 @@ class AdminProductWrapper
         $id_shop = $specificPriceValues['sp_id_shop'] ?? 0;
         $id_currency = $specificPriceValues['sp_id_currency'] ?? 0;
         $id_country = $specificPriceValues['sp_id_country'] ?? 0;
-        $id_group = $specificPriceValues['sp_id_group'] ? $specificPriceValues['sp_id_group'] : 0;
+        $id_group = $specificPriceValues['sp_id_group'] ?? 0;
         $id_customer = !empty($specificPriceValues['sp_id_customer']['data']) ? $specificPriceValues['sp_id_customer']['data'][0] : 0;
         $price = isset($specificPriceValues['leave_bprice']) ? '-1' : $this->floatParser->fromString($specificPriceValues['sp_price']);
         $from_quantity = $specificPriceValues['sp_from_quantity'];


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When creating a specific price in Product BO page, if "apply to all combinations" was selected it would not work. I fixed it by using default value zero.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/18751
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19845)
<!-- Reviewable:end -->
