### PR TITLE
Manage UpdateProductTagsCommand in separate command / handler

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductOptionsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductOptionsHandler.php
@@ -36,7 +36,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductTagsHa
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShopException;
 use Product;

--- a/src/Adapter/Product/CommandHandler/UpdateProductOptionsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductOptionsHandler.php
@@ -30,13 +30,10 @@ namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductOptionsHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductTagsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShopException;
 use Product;
 
@@ -45,19 +42,6 @@ use Product;
  */
 final class UpdateProductOptionsHandler extends AbstractProductHandler implements UpdateProductOptionsHandlerInterface
 {
-    /**
-     * @var UpdateProductTagsHandlerInterface
-     */
-    private $updateProductTagsHandler;
-
-    /**
-     * @param UpdateProductTagsHandlerInterface $updateProductTagsHandler
-     */
-    public function __construct(UpdateProductTagsHandlerInterface $updateProductTagsHandler)
-    {
-        $this->updateProductTagsHandler = $updateProductTagsHandler;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -70,11 +54,6 @@ final class UpdateProductOptionsHandler extends AbstractProductHandler implement
         $product->setFieldsToUpdate($this->fieldsToUpdate);
 
         $this->performUpdate($product);
-
-        // don't do anything with tags if its null. (It means it is a partial update and tags aren't changed)
-        if (null !== $command->getLocalizedTags()) {
-            $this->updateTags($productId, $command->getLocalizedTags());
-        }
     }
 
     /**
@@ -164,19 +143,5 @@ final class UpdateProductOptionsHandler extends AbstractProductHandler implement
                 $e
             );
         }
-    }
-
-    /**
-     * Invokes the handler to update product tags
-     *
-     * @param ProductId $productId
-     * @param array $localizedTagsList
-     */
-    private function updateTags(ProductId $productId, array $localizedTagsList)
-    {
-        $this->updateProductTagsHandler->handle(new UpdateProductTagsCommand(
-            $productId->getValue(),
-            $localizedTagsList
-        ));
     }
 }

--- a/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
@@ -93,7 +93,7 @@ class UpdateProductTagsHandler extends AbstractProductHandler implements UpdateP
             if (false === Tag::deleteProductTagsInLang($productId, $langId)) {
                 throw new CannotUpdateProductException(
                     sprintf('Failed to delete product #%s previous tags in lang #%s', $productId, $langId),
-                    CannotUpdateProductException::FAILED_UPDATE_OPTIONS
+                    CannotUpdateProductException::FAILED_UPDATE_TAGS
                 );
             }
 
@@ -106,7 +106,7 @@ class UpdateProductTagsHandler extends AbstractProductHandler implements UpdateP
             if (false === Tag::addTags($langId, $productId, $localizedTags->getTags())) {
                 throw new CannotUpdateProductException(
                     sprintf('Failed to update product #%s tags in lang #%s', $productId, $langId),
-                    CannotUpdateProductException::FAILED_UPDATE_OPTIONS
+                    CannotUpdateProductException::FAILED_UPDATE_TAGS
                 );
             }
         }

--- a/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
@@ -38,6 +38,9 @@ use PrestaShopException;
 use Product;
 use Tag;
 
+/**
+ * Handles UpdateProductTagsCommand using legacy object model
+ */
 class UpdateProductTagsHandler extends AbstractProductHandler implements UpdateProductTagsHandlerInterface
 {
     /**

--- a/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
@@ -41,7 +41,7 @@ use Tag;
 class UpdateProductTagsHandler extends AbstractProductHandler implements UpdateProductTagsHandlerInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function handle(UpdateProductTagsCommand $command): void
     {

--- a/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductTagsHandler.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductTagsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
+use PrestaShopException;
+use Product;
+use Tag;
+
+class UpdateProductTagsHandler extends AbstractProductHandler implements UpdateProductTagsHandlerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(UpdateProductTagsCommand $command): void
+    {
+        $product = $this->getProduct($command->getProductId());
+
+        try {
+            $this->updateTags($product, $command->getLocalizedTagsList());
+        } catch (PrestaShopException $e) {
+            throw new ProductException(
+                sprintf(
+                    'Error occurred during product #%s tags update',
+                    $product->id
+                ),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * Due to this method it is possible to partially update tags in separate languages.
+     *
+     * If all localizedTags array is empty, all previous tags will be deleted.
+     * If tags in some language are null, it will be skipped.
+     * If tags in some language has any values, all previous tags will be deleted and new ones inserted instead
+     * If tags in some language are empty, then all previous tags will be deleted and none inserted.
+     *
+     * @param Product $product
+     * @param LocalizedTags[] $localizedTagsList
+     *
+     * @throws CannotUpdateProductException
+     * @throws PrestaShopException
+     */
+    private function updateTags(Product $product, array $localizedTagsList)
+    {
+        $productId = (int) $product->id;
+
+        // delete all tags for product if array is empty
+        if (empty($localizedTagsList)) {
+            $this->deleteAllTagsForProduct($productId);
+
+            return;
+        }
+
+        foreach ($localizedTagsList as $localizedTags) {
+            $langId = $localizedTags->getLanguageId()->getValue();
+
+            // delete all this product tags for this lang
+            if (false === Tag::deleteProductTagsInLang($productId, $langId)) {
+                throw new CannotUpdateProductException(
+                    sprintf('Failed to delete product #%s previous tags in lang #%s', $productId, $langId),
+                    CannotUpdateProductException::FAILED_UPDATE_OPTIONS
+                );
+            }
+
+            // empty tags means to delete all previous tags, which is already done above.
+            if ($localizedTags->isEmpty()) {
+                continue;
+            }
+
+            // assign new tags to product
+            if (false === Tag::addTags($langId, $productId, $localizedTags->getTags())) {
+                throw new CannotUpdateProductException(
+                    sprintf('Failed to update product #%s tags in lang #%s', $productId, $langId),
+                    CannotUpdateProductException::FAILED_UPDATE_OPTIONS
+                );
+            }
+        }
+    }
+
+    /**
+     * @param int $productId
+     *
+     * @throws CannotUpdateProductException
+     * @throws PrestaShopException
+     */
+    private function deleteAllTagsForProduct(int $productId): void
+    {
+        if (false === Tag::deleteTagsForProduct($productId)) {
+            throw new CannotUpdateProductException(
+                sprintf('Failed to delete all tags for product #%s', $productId),
+                CannotUpdateProductException::FAILED_UPDATE_TAGS
+            );
+        }
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;

--- a/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
@@ -30,8 +30,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Mpn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
@@ -64,11 +62,6 @@ class UpdateProductOptionsCommand
      * @var bool|null
      */
     private $showPrice;
-
-    /**
-     * @var LocalizedTags[]|null
-     */
-    private $localizedTags;
 
     /**
      * @var ProductCondition|null
@@ -122,18 +115,6 @@ class UpdateProductOptionsCommand
     public function getVisibility(): ?ProductVisibility
     {
         return $this->visibility;
-    }
-
-    /**
-     * @param ProductVisibility $visibility
-     *
-     * @return UpdateProductOptionsCommand
-     */
-    public function setVisibility(string $visibility): UpdateProductOptionsCommand
-    {
-        $this->visibility = new ProductVisibility($visibility);
-
-        return $this;
     }
 
     /**
@@ -192,26 +173,6 @@ class UpdateProductOptionsCommand
     public function setShowPrice(bool $showPrice): UpdateProductOptionsCommand
     {
         $this->showPrice = $showPrice;
-
-        return $this;
-    }
-
-    /**
-     * @return array[]|null
-     */
-    public function getLocalizedTags(): ?array
-    {
-        return $this->localizedTags;
-    }
-
-    /**
-     * @param string[] $localizedTagsList key value pairs where key is language id and value is the array of tags
-     *
-     * @return UpdateProductOptionsCommand
-     */
-    public function setLocalizedTagsList(array $localizedTagsList): UpdateProductOptionsCommand
-    {
-        $this->localizedTags = $localizedTagsList;
 
         return $this;
     }

--- a/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
@@ -126,6 +126,18 @@ class UpdateProductOptionsCommand
     }
 
     /**
+     * @param string $visibility
+     *
+     * @return UpdateProductOptionsCommand
+     */
+    public function setVisibility(string $visibility): UpdateProductOptionsCommand
+    {
+        $this->visibility = new ProductVisibility($visibility);
+
+        return $this;
+    }
+
+    /**
      * @param bool $availableForOrder
      *
      * @return UpdateProductOptionsCommand

--- a/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductOptionsCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
@@ -197,7 +198,7 @@ class UpdateProductOptionsCommand
     }
 
     /**
-     * @return string[]|null
+     * @return array[]|null
      */
     public function getLocalizedTags(): ?array
     {
@@ -205,13 +206,13 @@ class UpdateProductOptionsCommand
     }
 
     /**
-     * @param string[] $localizedTags key value pairs where key is language id and value is the array of tags
+     * @param string[] $localizedTagsList key value pairs where key is language id and value is the array of tags
      *
      * @return UpdateProductOptionsCommand
      */
-    public function setLocalizedTags(array $localizedTags): UpdateProductOptionsCommand
+    public function setLocalizedTagsList(array $localizedTagsList): UpdateProductOptionsCommand
     {
-        $this->localizedTags = $localizedTags;
+        $this->localizedTags = $localizedTagsList;
 
         return $this;
     }

--- a/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+class UpdateProductTagsCommand
+{
+    /**
+     * @var ProductId
+     */
+    private $productId;
+
+    /**
+     * @var LocalizedTags[]
+     */
+    private $localizedTagsList;
+
+    /**
+     * @param int $productId
+     * @param array $localizedTags
+     */
+    public function __construct(int $productId, array $localizedTags)
+    {
+        $this->productId = new ProductId($productId);
+        $this->setLocalizedTagsList($localizedTags);
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return LocalizedTags[]
+     */
+    public function getLocalizedTagsList(): array
+    {
+        return $this->localizedTagsList;
+    }
+
+    /**
+     * @param array $localizedTags
+     * @throws ProductConstraintException
+     */
+    private function setLocalizedTagsList(array $localizedTags): void
+    {
+        foreach ($localizedTags as $langId => $tags) {
+            $this->localizedTagsList[] = new LocalizedTags($langId, $tags);
+        }
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
@@ -74,7 +74,7 @@ class UpdateProductTagsCommand
     }
 
     /**
-     * @param array $localizedTags
+     * @param array[] $localizedTags key-value pairs where each key represents language id and value is the array of tags
      *
      * @throws ProductConstraintException
      */

--- a/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
@@ -72,6 +72,7 @@ class UpdateProductTagsCommand
 
     /**
      * @param array $localizedTags
+     *
      * @throws ProductConstraintException
      */
     private function setLocalizedTagsList(array $localizedTags): void

--- a/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
@@ -32,6 +32,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
+/**
+ * Updates product tags in provided languages
+ */
 class UpdateProductTagsCommand
 {
     /**

--- a/src/Core/Domain/Product/CommandHandler/UpdateProductTagsHandlerInterface.php
+++ b/src/Core/Domain/Product/CommandHandler/UpdateProductTagsHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand;
+
+/**
+ * Defines contract for UpdateProductTagsHandler
+ */
+interface UpdateProductTagsHandlerInterface
+{
+    /**
+     * @param UpdateProductTagsCommand $command
+     */
+    public function handle(UpdateProductTagsCommand $command): void;
+}

--- a/src/Core/Domain/Product/Exception/CannotUpdateProductException.php
+++ b/src/Core/Domain/Product/Exception/CannotUpdateProductException.php
@@ -45,4 +45,9 @@ class CannotUpdateProductException extends ProductException
      * When product options update fails
      */
     const FAILED_UPDATE_OPTIONS = 30;
+
+    /**
+     * When product tags update fails
+     */
+    const FAILED_UPDATE_TAGS = 40;
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -105,8 +105,6 @@ services:
 
     prestashop.adapter.product.command_handler.update_product_options_handler:
       class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductOptionsHandler
-      arguments:
-        - '@prestashop.adapter.product.command_handler.update_product_tags_handler'
       tags:
         - name: tactician.handler
           command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -97,8 +97,16 @@ services:
         - name: tactician.handler
           command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand
 
+    prestashop.adapter.product.command_handler.update_product_tags_handler:
+      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductTagsHandler
+      tags:
+        - name: tactician.handler
+          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand
+
     prestashop.adapter.product.command_handler.update_product_options_handler:
       class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductOptionsHandler
+      arguments:
+        - '@prestashop.adapter.product.command_handler.update_product_tags_handler'
       tags:
         - name: tactician.handler
           command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -135,7 +135,7 @@ abstract class AbstractDomainFeatureContext implements Context
      */
     protected function parseLocalizedArray(string $parsedArray): array
     {
-        $arrayValues = explode(';', $parsedArray);
+        $arrayValues = array_map('trim', explode(';', $parsedArray));
         $localizedArray = [];
         foreach ($arrayValues as $arrayValue) {
             $data = explode(':', $arrayValue);

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -349,10 +349,10 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
 
             foreach ($localizedTagStrings as $langId => $localizedTagString) {
                 $tags = explode(',', $localizedTagString);
-                $localizedTagsList[] = new LocalizedTags($langId, $tags);
+                $localizedTagsList[$langId] = $tags;
             }
 
-            $command->setLocalizedTags($localizedTagsList);
+            $command->setLocalizedTagsList($localizedTagsList);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -231,7 +231,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
             }
 
             // convert filled tags to array
-            $expectedTags = explode(',', $tagsString);
+            $expectedTags = array_map('trim', explode(',', $tagsString));
             $valueInLangExists = false;
             foreach ($actualLocalizedTagsList as $actualLocalizedTags) {
                 if ($actualLocalizedTags->getLanguageId() !== $langId) {
@@ -347,8 +347,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
             $localizedTagsList = [];
 
             foreach ($localizedTagStrings as $langId => $localizedTagString) {
-                $tags = explode(',', $localizedTagString);
-                $localizedTagsList[$langId] = $tags;
+                $localizedTagsList[$langId] = explode(',', $localizedTagString);
             }
 
             $command->setLocalizedTagsList($localizedTagsList);

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -44,7 +44,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags as LocalizedTagsDto;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
 use Product;
 use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
@@ -96,28 +96,3 @@ Feature: Update product options from Back Office (BO)
       | reference   | invalid chars like ^;{ |
     Then I should get error that product reference is invalid
 
-    Scenario: I update product tags in multiple languages
-      Given language "language1" with locale "en-US" exists
-      And language with iso code "en" is the default one
-      And language "language2" with locale "fr-FR" exists
-      And I add product "product3" with following information:
-        | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
-        | is_virtual | false                                         |
-      And product "product3" should have following values:
-        | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
-      And product "product3" localized "tags" should be "en-US: ;fr-FR:"
-      When I update product "product3" options with following values:
-        | tags       | en-US:mechanic,watch; fr-FR:montre,mécanique |
-      And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre,mécanique"
-      When I update product "product3" options with following values:
-        | tags       | en-US:mechanic,watch; fr-FR: |
-      And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:"
-      When I update product "product3" options with following values:
-        | tags       | fr-FR:montre |
-      And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
-
-    Scenario: Update product tags with invalid values
-      Given product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
-      When I update product "product3" options with following values:
-        | tags       | en-US:#<{ |
-      Then I should get error that product tag is invalid

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
@@ -101,24 +101,23 @@ Feature: Update product options from Back Office (BO)
       And language with iso code "en" is the default one
       And language "language2" with locale "fr-FR" exists
       And I add product "product3" with following information:
-        | name       | en-US:Mechanical watch;fr-FR:montre mécanique |
+        | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
         | is_virtual | false                                         |
       And product "product3" should have following values:
-        | name       | en-US:Mechanical watch;fr-FR:montre mécanique |
-      And product "product3" localized "tags" should be "en-US:;fr-FR:"
+        | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
+      And product "product3" localized "tags" should be "en-US: ;fr-FR:"
       When I update product "product3" options with following values:
-        | tags       | en-US:mechanic,watch;fr-FR:montre,mécanique |
-      And product "product3" localized "tags" should be "en-US:mechanic,watch;fr-FR:montre,mécanique"
+        | tags       | en-US:mechanic,watch; fr-FR:montre,mécanique |
+      And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre,mécanique"
       When I update product "product3" options with following values:
-        | tags       | en-US:mechanic,watch;fr-FR: |
-      And product "product3" localized "tags" should be "en-US:mechanic,watch;fr-FR:"
+        | tags       | en-US:mechanic,watch; fr-FR: |
+      And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:"
       When I update product "product3" options with following values:
         | tags       | fr-FR:montre |
-      And product "product3" localized "tags" should be "en-US:mechanic,watch;fr-FR:montre"
+      And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
 
     Scenario: Update product tags with invalid values
-      Given product "product3" localized "tags" should be "en-US:mechanic,watch;fr-FR:montre"
+      Given product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
       When I update product "product3" options with following values:
         | tags       | en-US:#<{ |
       Then I should get error that product tag is invalid
-      And product "product3" localized "tags" should be "en-US:mechanic,watch;fr-FR:montre"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
@@ -121,3 +121,4 @@ Feature: Update product options from Back Office (BO)
       When I update product "product3" options with following values:
         | tags       | en-US:#<{ |
       Then I should get error that product tag is invalid
+      And product "product3" localized "tags" should be "en-US:mechanic,watch;fr-FR:montre"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -30,3 +30,4 @@ Feature: Update product tags from Back Office (BO)
     When I update product "product3" tags with following values:
       | tags       | en-US:#<{ |
     Then I should get error that product tag is invalid
+    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -1,0 +1,32 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-tags
+@reset-database-before-feature
+@update-tags
+Feature: Update product tags from Back Office (BO)
+  As a BO user
+  I need to be able to update product tags from BO
+
+  Scenario: I update product tags in multiple languages
+    Given language "language1" with locale "en-US" exists
+    And language with iso code "en" is the default one
+    And language "language2" with locale "fr-FR" exists
+    And I add product "product3" with following information:
+      | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
+      | is_virtual | false                                         |
+    And product "product3" should have following values:
+      | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
+    And product "product3" localized "tags" should be "en-US: ;fr-FR:"
+    When I update product "product3" tags with following values:
+      | tags       | en-US:mechanic,watch; fr-FR:montre,mécanique |
+    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre,mécanique"
+    When I update product "product3" tags with following values:
+      | tags       | en-US:mechanic,watch; fr-FR: |
+    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:"
+    When I update product "product3" tags with following values:
+      | tags       | fr-FR:montre |
+    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
+
+  Scenario: Update product tags with invalid values
+    Given product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
+    When I update product "product3" tags with following values:
+      | tags       | en-US:#<{ |
+    Then I should get error that product tag is invalid


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refacto UpdateProductOptionsCommand pr #19732 - separate command for updating tags, add missing behat assertion to assert that tags were not changed after invalid input, trim exploded strings in behat, make command input totally scalar. (previously it accepted array of objects, now - array of arrays), add constraint error code FAILED_UPDATE_TAGS
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19852)
<!-- Reviewable:end -->
