### PR TITLE
Add trace information to Command/Query debugger

### DIFF
--- a/src/Core/CommandBus/ExecutedCommandRegistry.php
+++ b/src/Core/CommandBus/ExecutedCommandRegistry.php
@@ -35,6 +35,8 @@ use PrestaShop\PrestaShop\Core\CommandBus\Parser\CommandTypeParser;
  */
 final class ExecutedCommandRegistry
 {
+    private const BACKTRACE_LIMIT = 10;
+
     /**
      * @var array
      */
@@ -110,7 +112,7 @@ final class ExecutedCommandRegistry
      */
     private function getTrace(): array
     {
-        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, self::BACKTRACE_LIMIT);
 
         foreach ($trace as $step) {
             if ($step['class'] === TacticianCommandBusAdapter::class

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/commands_and_queries.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/commands_and_queries.html.twig
@@ -72,6 +72,7 @@
         <tr>
           <th>Command</th>
           <th>Command handler</th>
+          <th>Caller</th>
         </tr>
       </thead>
       <tbody class="sf-toolbar-ajax-request-list">
@@ -80,11 +81,12 @@
             <tr>
               <td>{{ command.command }}</td>
               <td>{{ command.command_handler }}</td>
+              <td>{{ command.trace.file }}@{{ command.trace.line }}</td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td colspan="2">No Commands where executed during request.</td>
+            <td colspan="3">No Commands where executed during request.</td>
           </tr>
         {% endif %}
       </tbody>
@@ -95,6 +97,7 @@
         <tr>
           <th>Query</th>
           <th>Query Handler</th>
+          <th>Caller</th>
         </tr>
       </thead>
       <tbody class="sf-toolbar-ajax-request-list">
@@ -103,11 +106,12 @@
           <tr>
             <td>{{ query.query }}</td>
             <td>{{ query.query_handler }}</td>
+            <td>{{ query.trace.file }}@{{ query.trace.line }}</td>
           </tr>
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="2">No Queries where executed during request.</td>
+          <td colspan="3">No Queries where executed during request.</td>
         </tr>
       {% endif %}
       </tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/commands_and_queries.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/commands_and_queries.html.twig
@@ -64,54 +64,56 @@
 {% endblock %}
 
 {% block panel %}
-  <h2>Commands / Queries</h2>
+  <h2>Commands</h2>
 
   <div class="sf-toolbar-info-piece">
-    <table class="sf-toolbar-ajax-requests">
+    <table id="cqrs-commands-log">
       <thead>
         <tr>
           <th>Command</th>
-          <th>Command handler</th>
-          <th>Caller</th>
+          <th>Command Handler</th>
+          <th>Called from</th>
         </tr>
       </thead>
       <tbody class="sf-toolbar-ajax-request-list">
         {% if collector.executedCommands is not empty %}
           {% for command in collector.executedCommands %}
             <tr>
-              <td>{{ command.command }}</td>
-              <td>{{ command.command_handler }}</td>
-              <td>{{ command.trace.file }}@{{ command.trace.line }}</td>
+              <td class="text-small">{{ command.command }}</td>
+              <td class="text-small">{{ command.command_handler }}</td>
+              <td class="text-small">{{ command.trace.file }}:{{ command.trace.line }}</td>
             </tr>
           {% endfor %}
         {% else %}
           <tr>
-            <td colspan="3">No Commands where executed during request.</td>
+            <td colspan="3" class="font-normal">No Commands where executed during request.</td>
           </tr>
         {% endif %}
       </tbody>
     </table>
 
-    <table class="sf-toolbar-ajax-requests">
+    <h2>Queries</h2>
+
+    <table id="cqrs-queries-log">
       <thead>
         <tr>
           <th>Query</th>
           <th>Query Handler</th>
-          <th>Caller</th>
+          <th>Called from</th>
         </tr>
       </thead>
       <tbody class="sf-toolbar-ajax-request-list">
       {% if collector.executedQueries is not empty %}
         {% for query in collector.executedQueries %}
           <tr>
-            <td>{{ query.query }}</td>
-            <td>{{ query.query_handler }}</td>
-            <td>{{ query.trace.file }}@{{ query.trace.line }}</td>
+            <td class="text-small">{{ query.query }}</td>
+            <td class="text-small">{{ query.query_handler }}</td>
+            <td class="text-small">{{ query.trace.file }}:{{ query.trace.line }}</td>
           </tr>
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="3">No Queries where executed during request.</td>
+          <td colspan="3" class="font-normal">No Queries where executed during request.</td>
         </tr>
       {% endif %}
       </tbody>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This change tracks where Commands and Queries were fired from and shows it in the profiler.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | See below

## What it looks like

![Screenshot](https://user-images.githubusercontent.com/1009343/85033148-e8ed0880-b180-11ea-86c3-820eec08388f.png)


## How to test

1. Open any page that uses Commands or Queries in dev mode
2. Open the SF profiler
3. Go to the Commands and Queries section
4. See where the Commands and Queries were fired from.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19854)
<!-- Reviewable:end -->
