### PR TITLE
Simplify Taxes and Tax options forms

### DIFF
--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -41,6 +41,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class TypedRegexValidator extends ConstraintValidator
 {
+    const CATALOG_CHARS = '<>;=#{}';
+
     /**
      * @var CharacterCleaner
      */

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -89,7 +89,7 @@ class TaxController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function saveOptionsAction(Request $request)
     {

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -113,6 +113,8 @@ class TaxOptionsType extends TranslatorAwareType
             ])
             ->add('tax_address_type', ChoiceType::class, [
                 'label' => $this->trans('Based on', 'Admin.International.Feature'),
+                'required' => false,
+                'placeholder' => false,
                 'choices' => $this->taxAddressTypeChoiceProvider->getChoices(),
             ])
             ->add('use_eco_tax', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -56,7 +56,7 @@ class TaxOptionsType extends TranslatorAwareType
     /**
      * TaxOptionsType constructor.
      *
-     * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
+     * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslatorAwareType
      *
      * @param TranslatorInterface $translator
      * @param array $locales

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -28,16 +28,19 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use RuntimeException;
 
 /**
  * Defines "Improve > International > Taxes" options form
  */
 class TaxOptionsType extends AbstractType
 {
+    use TranslatorAwareTrait;
+
     /**
      * @var bool
      */
@@ -54,28 +57,22 @@ class TaxOptionsType extends AbstractType
     private $taxRuleGroupChoiceProvider;
 
     /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
      * TaxOptionsType constructor.
+     *
+     * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
      *
      * @param bool $ecoTaxEnabled
      * @param FormChoiceProviderInterface $taxAddressTypeChoiceProvider
      * @param FormChoiceProviderInterface $taxRuleGroupChoiceProvider
-     * @param TranslatorInterface $translator
      */
     public function __construct(
         $ecoTaxEnabled,
         FormChoiceProviderInterface $taxAddressTypeChoiceProvider,
-        FormChoiceProviderInterface $taxRuleGroupChoiceProvider,
-        TranslatorInterface $translator
+        FormChoiceProviderInterface $taxRuleGroupChoiceProvider
     ) {
         $this->ecoTaxEnabled = $ecoTaxEnabled;
         $this->taxAddressTypeChoiceProvider = $taxAddressTypeChoiceProvider;
         $this->taxRuleGroupChoiceProvider = $taxRuleGroupChoiceProvider;
-        $this->translator = $translator;
     }
 
     /**
@@ -83,12 +80,16 @@ class TaxOptionsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        if ($this->translator ===null) {
+            throw new RuntimeException('Translator variable must not be null');
+        }
+
         $builder->add(
             'enable_tax',
             SwitchType::class,
             [
-                'label' => $this->translator->trans('Enable tax', [], 'Admin.International.Feature'),
-                'help' => $this->translator->trans(
+                'label' => $this->trans('Enable tax', [], 'Admin.International.Feature'),
+                'help' => $this->trans(
                     'Select whether or not to include tax on purchases.',
                     [],
                     'Admin.International.Help'
@@ -100,12 +101,12 @@ class TaxOptionsType extends AbstractType
             ]
         )
             ->add('display_tax_in_cart', SwitchType::class, [
-                'label' => $this->translator->trans(
+                'label' => $this->trans(
                     'Display tax in the shopping cart',
                     [],
                     'Admin.International.Feature'
                 ),
-                'help' => $this->translator->trans(
+                'help' => $this->trans(
                     'Select whether or not to display tax on a distinct line in the cart.',
                     [],
                     'Admin.International.Help'
@@ -116,14 +117,14 @@ class TaxOptionsType extends AbstractType
                 ],
             ])
             ->add('tax_address_type', ChoiceType::class, [
-                'label' => $this->translator->trans('Based on', [], 'Admin.International.Feature'),
+                'label' => $this->trans('Based on', [], 'Admin.International.Feature'),
                 'required' => false,
                 'choices' => $this->taxAddressTypeChoiceProvider->getChoices(),
             ])
             ->add('use_eco_tax', SwitchType::class, [
-                'label' => $this->translator->trans('Use ecotax', [], 'Admin.International.Feature'),
+                'label' => $this->trans('Use ecotax', [], 'Admin.International.Feature'),
                 'required' => false,
-                'help' => $this->translator->trans(
+                'help' => $this->trans(
                     'If you disable the ecotax, the ecotax for all your products will be set to 0.',
                     [],
                     'Admin.International.Help'),
@@ -132,11 +133,11 @@ class TaxOptionsType extends AbstractType
 
         if ($this->ecoTaxEnabled) {
             $builder->add('eco_tax_rule_group', ChoiceType::class, [
-                'label' => $this->translator->trans(
+                'label' => $this->trans(
                     'Ecotax',
                     [],
                     'Admin.International.Feature'),
-                'help' => $this->translator->trans(
+                'help' => $this->trans(
                     'Define the ecotax (e.g. French ecotax: 19.6%).',
                     [],
                     'Admin.International.Help'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2020 PrestaShop SA and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -31,6 +31,7 @@ use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Defines "Improve > International > Taxes" options form
@@ -53,20 +54,28 @@ class TaxOptionsType extends AbstractType
     private $taxRuleGroupChoiceProvider;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * TaxOptionsType constructor.
      *
      * @param bool $ecoTaxEnabled
      * @param FormChoiceProviderInterface $taxAddressTypeChoiceProvider
      * @param FormChoiceProviderInterface $taxRuleGroupChoiceProvider
+     * @param TranslatorInterface $translator
      */
     public function __construct(
         $ecoTaxEnabled,
         FormChoiceProviderInterface $taxAddressTypeChoiceProvider,
-        FormChoiceProviderInterface $taxRuleGroupChoiceProvider
+        FormChoiceProviderInterface $taxRuleGroupChoiceProvider,
+        TranslatorInterface $translator
     ) {
         $this->ecoTaxEnabled = $ecoTaxEnabled;
         $this->taxAddressTypeChoiceProvider = $taxAddressTypeChoiceProvider;
         $this->taxRuleGroupChoiceProvider = $taxRuleGroupChoiceProvider;
+        $this->translator = $translator;
     }
 
     /**
@@ -74,16 +83,59 @@ class TaxOptionsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('enable_tax', SwitchType::class)
-            ->add('display_tax_in_cart', SwitchType::class)
+        $builder->add('enable_tax', SwitchType::class, [
+            'label' => $this->translator->trans('Enable tax', [], 'Admin.International.Feature'),
+            'help' => $this->translator->trans(
+                'Select whether or not to include tax on purchases.',
+                [],
+                'Admin.International.Help'
+            ),
+            'required' => false,
+            'attr' => [
+                'class' => 'js-enable-tax',
+            ],
+        ])
+            ->add('display_tax_in_cart', SwitchType::class, [
+                'label' => $this->translator->trans(
+                    'Display tax in the shopping cart',
+                    [],
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->translator->trans(
+                    'Select whether or not to display tax on a distinct line in the cart.',
+                    [],
+                    'Admin.International.Help'
+                ),
+                'required' => false,
+                'attr' => [
+                    'class' => 'js-display-in-cart',
+                ],
+            ])
             ->add('tax_address_type', ChoiceType::class, [
+                'label' => $this->translator->trans('Based on', [], 'Admin.International.Feature'),
+                'required' => false,
                 'choices' => $this->taxAddressTypeChoiceProvider->getChoices(),
             ])
-            ->add('use_eco_tax', SwitchType::class)
+            ->add('use_eco_tax', SwitchType::class, [
+                'label' => $this->translator->trans('Use ecotax', [], 'Admin.International.Feature'),
+                'required' => false,
+                'help' => $this->translator->trans(
+                    'If you disable the ecotax, the ecotax for all your products will be set to 0.',
+                    [],
+                    'Admin.International.Help'),
+            ])
         ;
 
         if ($this->ecoTaxEnabled) {
             $builder->add('eco_tax_rule_group', ChoiceType::class, [
+                'label' => $this->translator->trans(
+                    'Ecotax',
+                    [],
+                    'Admin.International.Feature'),
+                'help' => $this->translator->trans(
+                    'Define the ecotax (e.g. French ecotax: 19.6%).',
+                    [],
+                    'Admin.International.Help'),
                 'choices' => $this->taxRuleGroupChoiceProvider->getChoices(),
             ]);
         }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -118,7 +118,6 @@ class TaxOptionsType extends AbstractType
             ])
             ->add('tax_address_type', ChoiceType::class, [
                 'label' => $this->trans('Based on', [], 'Admin.International.Feature'),
-                'required' => false,
                 'choices' => $this->taxAddressTypeChoiceProvider->getChoices(),
             ])
             ->add('use_eco_tax', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -81,7 +81,7 @@ class TaxOptionsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($this->translator === null) {
-            throw new RuntimeException('Translator variable must not be null');
+            throw new RuntimeException('Translator variable must not be null.');
         }
 
         $builder->add(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use RuntimeException;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -87,7 +86,7 @@ class TaxOptionsType extends TranslatorAwareType
             'enable_tax',
             SwitchType::class,
             [
-                'label' => $this->trans('Enable tax','Admin.International.Feature'),
+                'label' => $this->trans('Enable tax', 'Admin.International.Feature'),
                 'help' => $this->trans(
                     'Select whether or not to include tax on purchases.',
                     'Admin.International.Help'
@@ -117,7 +116,7 @@ class TaxOptionsType extends TranslatorAwareType
                 'choices' => $this->taxAddressTypeChoiceProvider->getChoices(),
             ])
             ->add('use_eco_tax', SwitchType::class, [
-                'label' => $this->trans('Use ecotax','Admin.International.Feature'),
+                'label' => $this->trans('Use ecotax', 'Admin.International.Feature'),
                 'required' => false,
                 'help' => $this->trans(
                     'If you disable the ecotax, the ecotax for all your products will be set to 0.',

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -28,19 +28,17 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use RuntimeException;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Defines "Improve > International > Taxes" options form
  */
-class TaxOptionsType extends AbstractType
+class TaxOptionsType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var bool
      */
@@ -61,15 +59,20 @@ class TaxOptionsType extends AbstractType
      *
      * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
      *
+     * @param TranslatorInterface $translator
+     * @param array $locales
      * @param bool $ecoTaxEnabled
      * @param FormChoiceProviderInterface $taxAddressTypeChoiceProvider
      * @param FormChoiceProviderInterface $taxRuleGroupChoiceProvider
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         $ecoTaxEnabled,
         FormChoiceProviderInterface $taxAddressTypeChoiceProvider,
         FormChoiceProviderInterface $taxRuleGroupChoiceProvider
     ) {
+        parent::__construct($translator, $locales);
         $this->ecoTaxEnabled = $ecoTaxEnabled;
         $this->taxAddressTypeChoiceProvider = $taxAddressTypeChoiceProvider;
         $this->taxRuleGroupChoiceProvider = $taxRuleGroupChoiceProvider;
@@ -80,18 +83,13 @@ class TaxOptionsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($this->translator === null) {
-            throw new RuntimeException('Translator variable must not be null.');
-        }
-
         $builder->add(
             'enable_tax',
             SwitchType::class,
             [
-                'label' => $this->trans('Enable tax', [], 'Admin.International.Feature'),
+                'label' => $this->trans('Enable tax','Admin.International.Feature'),
                 'help' => $this->trans(
                     'Select whether or not to include tax on purchases.',
-                    [],
                     'Admin.International.Help'
                 ),
                 'required' => false,
@@ -103,12 +101,10 @@ class TaxOptionsType extends AbstractType
             ->add('display_tax_in_cart', SwitchType::class, [
                 'label' => $this->trans(
                     'Display tax in the shopping cart',
-                    [],
                     'Admin.International.Feature'
                 ),
                 'help' => $this->trans(
                     'Select whether or not to display tax on a distinct line in the cart.',
-                    [],
                     'Admin.International.Help'
                 ),
                 'required' => false,
@@ -117,15 +113,14 @@ class TaxOptionsType extends AbstractType
                 ],
             ])
             ->add('tax_address_type', ChoiceType::class, [
-                'label' => $this->trans('Based on', [], 'Admin.International.Feature'),
+                'label' => $this->trans('Based on', 'Admin.International.Feature'),
                 'choices' => $this->taxAddressTypeChoiceProvider->getChoices(),
             ])
             ->add('use_eco_tax', SwitchType::class, [
-                'label' => $this->trans('Use ecotax', [], 'Admin.International.Feature'),
+                'label' => $this->trans('Use ecotax','Admin.International.Feature'),
                 'required' => false,
                 'help' => $this->trans(
                     'If you disable the ecotax, the ecotax for all your products will be set to 0.',
-                    [],
                     'Admin.International.Help'),
             ])
         ;
@@ -134,11 +129,9 @@ class TaxOptionsType extends AbstractType
             $builder->add('eco_tax_rule_group', ChoiceType::class, [
                 'label' => $this->trans(
                     'Ecotax',
-                    [],
                     'Admin.International.Feature'),
                 'help' => $this->trans(
                     'Define the ecotax (e.g. French ecotax: 19.6%).',
-                    [],
                     'Admin.International.Help'),
                 'choices' => $this->taxRuleGroupChoiceProvider->getChoices(),
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -29,10 +29,10 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
+use RuntimeException;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use RuntimeException;
 
 /**
  * Defines "Improve > International > Taxes" options form
@@ -80,7 +80,7 @@ class TaxOptionsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($this->translator ===null) {
+        if ($this->translator === null) {
             throw new RuntimeException('Translator variable must not be null');
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -83,18 +83,22 @@ class TaxOptionsType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('enable_tax', SwitchType::class, [
-            'label' => $this->translator->trans('Enable tax', [], 'Admin.International.Feature'),
-            'help' => $this->translator->trans(
-                'Select whether or not to include tax on purchases.',
-                [],
-                'Admin.International.Help'
-            ),
-            'required' => false,
-            'attr' => [
-                'class' => 'js-enable-tax',
-            ],
-        ])
+        $builder->add(
+            'enable_tax',
+            SwitchType::class,
+            [
+                'label' => $this->translator->trans('Enable tax', [], 'Admin.International.Feature'),
+                'help' => $this->translator->trans(
+                    'Select whether or not to include tax on purchases.',
+                    [],
+                    'Admin.International.Help'
+                ),
+                'required' => false,
+                'attr' => [
+                    'class' => 'js-enable-tax',
+                ],
+            ]
+        )
             ->add('display_tax_in_cart', SwitchType::class, [
                 'label' => $this->translator->trans(
                     'Display tax in the shopping cart',

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -85,7 +85,7 @@ class TaxType extends TranslatorAwareType
                 ],
             ])
             ->add('rate', TextType::class, [
-                'label' => $this->trans('Rate', [], 'Admin.International.Feature'),
+                'label' => $this->trans('Rate', 'Admin.International.Feature'),
                 'help' => $this->trans(
                     'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)',
                     'Admin.International.Help'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ * 2007-2020 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,8 +18,8 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to https://www.prestashop.com for more information.
  *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2020 PrestaShop SA and Contributors
+ * 2007-2019 PrestaShop SA and Contributors
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to https://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\AbstractType;
@@ -61,8 +62,24 @@ class TaxType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $invalidCharsText = sprintf(
+            '%s ' . TypedRegexValidator::CATALOG_CHARS,
+            $this->translator->trans('Invalid characters:', [], 'Admin.Notifications.Info')
+        );
+
+        $nameHintText =
+            $this->translator->trans(
+                'Tax name to display in carts and on invoices (e.g. "VAT").',
+                [],
+                'Admin.International.Help'
+            )
+            . PHP_EOL
+            . $invalidCharsText;
+
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->translator->trans('Name', [], 'Admin.Global'),
+                'help' => $nameHintText,
                 'options' => [
                     'constraints' => [
                         new Length([
@@ -83,6 +100,12 @@ class TaxType extends AbstractType
                 ],
             ])
             ->add('rate', TextType::class, [
+                'label' => $this->translator->trans('Rate', [], 'Admin.International.Feature'),
+                'help' => $this->translator->trans(
+                    'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)',
+                    [],
+                    'Admin.International.Help'
+                ),
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->translator->trans(
@@ -114,6 +137,7 @@ class TaxType extends AbstractType
                 ],
             ])
             ->add('is_enabled', SwitchType::class, [
+                'label' => $this->translator->trans('Enable', [], 'Admin.Actions'),
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -39,6 +39,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
 /**
+ * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
  * Form type for tax add/edit
  */
 class TaxType extends TranslatorAwareType

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -31,10 +31,9 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
@@ -42,21 +41,8 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * Form type for tax add/edit
  */
-class TaxType extends AbstractType
+class TaxType extends TranslatorAwareType
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @param TranslatorInterface $translator
-     */
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -64,13 +50,12 @@ class TaxType extends AbstractType
     {
         $invalidCharsText = sprintf(
             '%s ' . TypedRegexValidator::CATALOG_CHARS,
-            $this->translator->trans('Invalid characters:', [], 'Admin.Notifications.Info')
+            $this->trans('Invalid characters:', 'Admin.Notifications.Info')
         );
 
         $nameHintText =
-            $this->translator->trans(
+            $this->trans(
                 'Tax name to display in carts and on invoices (e.g. "VAT").',
-                [],
                 'Admin.International.Help'
             )
             . PHP_EOL
@@ -78,16 +63,16 @@ class TaxType extends AbstractType
 
         $builder
             ->add('name', TranslatableType::class, [
-                'label' => $this->translator->trans('Name', [], 'Admin.Global'),
+                'label' => $this->trans('Name', 'Admin.Global'),
                 'help' => $nameHintText,
                 'options' => [
                     'constraints' => [
                         new Length([
                             'max' => 32,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 32],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 32]
                             ),
                         ]),
                         new TypedRegex([
@@ -100,44 +85,42 @@ class TaxType extends AbstractType
                 ],
             ])
             ->add('rate', TextType::class, [
-                'label' => $this->translator->trans('Rate', [], 'Admin.International.Feature'),
-                'help' => $this->translator->trans(
+                'label' => $this->trans('Rate', [], 'Admin.International.Feature'),
+                'help' => $this->trans(
                     'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)',
-                    [],
                     'Admin.International.Help'
                 ),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->translator->trans(
+                        'message' => $this->trans(
                             'The %s field is required.',
+                            'Admin.Notifications.Error',
                             [
-                                sprintf('"%s"', $this->translator->trans(
-                                    'Rate', [], 'Admin.International.Feature'
+                                sprintf('"%s"', $this->trans(
+                                    'Rate','Admin.International.Feature'
                                 )),
-                            ],
-                            'Admin.Notifications.Error'
+                            ]
                         ),
                     ]),
                     new Length([
                         'max' => 6,
-                        'maxMessage' => $this->translator->trans(
+                        'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => 6],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => 6]
                         ),
                     ]),
                     new Type([
                         'type' => 'numeric',
-                        'message' => $this->translator->trans(
+                        'message' => $this->trans(
                             'This field is invalid, it must contain numeric values',
-                            [],
                             'Admin.Notifications.Error'
                         ),
                     ]),
                 ],
             ])
             ->add('is_enabled', SwitchType::class, [
-                'label' => $this->translator->trans('Enable', [], 'Admin.Actions'),
+                'label' => $this->trans('Enable', 'Admin.Actions'),
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -39,7 +39,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
 /**
- * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
+ * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslatorAwareType
  * Form type for tax add/edit
  */
 class TaxType extends TranslatorAwareType

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -97,7 +97,7 @@ class TaxType extends TranslatorAwareType
                             'Admin.Notifications.Error',
                             [
                                 sprintf('"%s"', $this->trans(
-                                    'Rate','Admin.International.Feature'
+                                    'Rate', 'Admin.International.Feature'
                                 )),
                             ]
                         ),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxType.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * 2007-2019 PrestaShop SA and Contributors
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
  * NOTICE OF LICENSE
  *
@@ -18,8 +19,8 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to https://www.prestashop.com for more information.
  *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -780,7 +780,8 @@ services:
         - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_USE_ECOTAX")'
         - '@=service("prestashop.core.form.choice_provider.tax_address_type_choice_provider")'
         - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider")'
-        - '@translator'
+      calls:
+        - { method: setTranslator, arguments: ['@translator'] }
       tags:
         - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -776,12 +776,12 @@ services:
 
     form.type.international.tax_options:
       class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxOptionsType'
+      parent: 'form.type.translatable.aware'
+      public: true
       arguments:
         - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_USE_ECOTAX")'
         - '@=service("prestashop.core.form.choice_provider.tax_address_type_choice_provider")'
         - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider")'
-      calls:
-        - { method: setTranslator, arguments: ['@translator'] }
       tags:
         - { name: form.type }
 
@@ -807,8 +807,8 @@ services:
 
     form.type.international.tax:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxType'
-        arguments:
-            - '@translator'
+        parent: 'form.type.translatable.aware'
+        public: true
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -780,6 +780,7 @@ services:
         - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_USE_ECOTAX")'
         - '@=service("prestashop.core.form.choice_provider.tax_address_type_choice_provider")'
         - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider")'
+        - '@translator'
       tags:
         - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme taxForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(taxForm) }}
 <div class="card">
@@ -34,32 +34,8 @@
   <div class="card-block row">
     <div class="card-text">
       {{ form_errors(taxForm) }}
-
-      {% set nameHint %}
-        {{ 'Tax name to display in carts and on invoices (e.g. "VAT").'|trans({}, 'Admin.International.Help') }}
-        {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
-      {% endset %}
-
-      {{ ps.form_group_row(taxForm.name, {}, {
-        'label': 'Name'|trans({}, 'Admin.Global'),
-        'help': nameHint,
-      }) }}
-
-      {% set rateHint %}
-        {{ 'Format: XX.XX or XX.XXX (e.g. 19.60 or 13.925)'|trans({}, 'Admin.International.Help') }}
-      {% endset %}
-
-      {{ ps.form_group_row(taxForm.rate, {}, {
-        'label': 'Rate'|trans({}, 'Admin.International.Feature'),
-        'help': rateHint,
-      }) }}
-
-      {{ ps.form_group_row(taxForm.is_enabled, {}, {
-        'label': 'Enable'|trans({}, 'Admin.Actions')
-      }) }}
-
-      {% block tax_form_rest %}
-        {{ form_rest(taxForm) }}
+      {% block tax_form_widget %}
+        {{ form_widget(taxForm) }}
       {% endblock %}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/tax_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/tax_options.html.twig
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme taxOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(taxOptionsForm, {'action': path('admin_taxes_save_options')}) }}
 <div class="card">
@@ -32,58 +32,8 @@
   </h3>
   <div class="card-block row">
     <div class="card-text">
-      <div class="form-group row">
-        <label class="form-control-label" for="{{ taxOptionsForm.enable_tax.vars.id }}">
-          {{ 'Enable tax'|trans({}, 'Admin.International.Feature') }}
-        </label>
-        <div class="col-sm">
-          {{ form_widget(taxOptionsForm.enable_tax, {'attr': {'class': 'js-enable-tax'}}) }}
-            <small class="form-text">
-              {{ 'Select whether or not to include tax on purchases.'|trans({}, 'Admin.International.Help') }}
-            </small>
-        </div>
-      </div>
-      <div class="form-group row">
-        <label class="form-control-label" for="{{ taxOptionsForm.display_tax_in_cart.vars.id }}">
-          {{ 'Display tax in the shopping cart'|trans({}, 'Admin.International.Feature') }}
-        </label>
-        <div class="col-sm">
-          {{ form_widget(taxOptionsForm.display_tax_in_cart, {'attr': {'class': 'js-display-in-cart'}}) }}
-          <small class="form-text">
-            {{ 'Select whether or not to display tax on a distinct line in the cart.'|trans({}, 'Admin.International.Help') }}
-          </small>
-        </div>
-      </div>
-      <div class="form-group row">
-        <label for="{{ taxOptionsForm.tax_address_type.vars.id }}" class="form-control-label">
-          {{ 'Based on'|trans({}, 'Admin.International.Feature') }}
-        </label>
-        <div class="col-sm">
-          {{ form_widget(taxOptionsForm.tax_address_type) }}
-        </div>
-      </div>
-      <div class="form-group row">
-        <label class="form-control-label" for="{{ taxOptionsForm.use_eco_tax.vars.id }}">
-          {{ 'Use ecotax'|trans({}, 'Admin.International.Feature') }}
-        </label>
-        <div class="col-sm">
-          {{ form_widget(taxOptionsForm.use_eco_tax) }}
-          {% if (taxOptionsForm.use_eco_tax.vars.value != 0) %}
-            <small class="form-text">
-              {{ 'If you disable the ecotax, the ecotax for all your products will be set to 0.'|trans({}, 'Admin.International.Help') }}
-            </small>
-          {% endif %}
-        </div>
-      </div>
-      {% if taxOptionsForm.eco_tax_rule_group is defined %}
-        {{ ps.form_group_row(taxOptionsForm.eco_tax_rule_group, {}, {
-          label: 'Ecotax'|trans({}, 'Admin.International.Feature'),
-          help: 'Define the ecotax (e.g. French ecotax: 19.6%).'|trans({}, 'Admin.International.Help')
-        }) }}
-      {% endif %}
-
-      {% block tax_options_rest %}
-        {{ form_rest(taxOptionsForm) }}
+      {% block tax_options_form_widget %}
+        {{ form_widget(taxOptionsForm) }}
       {% endblock %}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -800,7 +800,7 @@
 
 {% block form_help %}
   {% if help %}
-    <small class="form-text">{{ help|nl2br }}</small>
+    <small class="form-text">{{ help }}</small>
   {% endif %}
 {% endblock form_help %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -800,7 +800,7 @@
 
 {% block form_help %}
   {% if help %}
-    <small class="form-text">{{ help }}</small>
+    <small class="form-text">{{ help|nl2br }}</small>
   {% endif %}
 {% endblock form_help %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -695,6 +695,7 @@
       </div>
     {% endif %}
   </div>
+  {{ block('form_help') }}
 {%- endblock translatable_widget %}
 
 {% block birthday_widget %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -81,11 +81,13 @@
       <i class="icon-question" data-toggle="pstooltip" data-placement="{{ placement }}"
          title="{{ label_attr['tooltip'] }}"></i>
     {% endif %}
+
     {% if label_attr['popover'] is defined %}
       {% set placement = label_attr['popover_placement'] is defined ? label_attr['popover_placement'] : 'top' %}
       {% include '@Common/HelpBox/helpbox.html.twig' with { "placement" : placement, "content": label_attr['popover'] } %}
     {% endif %}
     </label>
+
   {%- endif -%}
 {%- endblock form_label -%}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -86,7 +86,6 @@
       {% include '@Common/HelpBox/helpbox.html.twig' with { "placement" : placement, "content": label_attr['popover'] } %}
     {% endif %}
     </label>
-
   {%- endif -%}
 {%- endblock form_label -%}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -82,6 +82,9 @@
       {% set placement = label_attr['popover_placement'] is defined ? label_attr['popover_placement'] : 'top' %}
       {% include '@Common/HelpBox/helpbox.html.twig' with { "placement" : placement, "content": label_attr['popover'] } %}
     {% endif %}
+    {% if required %}
+      <span class="text-danger">*</span>
+    {% endif %}
     </label>
 
   {%- endif -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -71,19 +71,19 @@
         {% set label = name|humanize %}
       {%- endif -%}
     {%- endif -%}
-    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ translation_domain is same as(false) ? label|raw : label|raw }}
+    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+    {% if required %}
+      <span class="text-danger">*</span>
+    {% endif %}
+    {{ translation_domain is same as(false) ? label|raw : label|raw }}
     {% if label_attr['tooltip'] is defined %}
       {% set placement = label_attr['tooltip_placement'] is defined ? label_attr['tooltip_placement'] : 'top' %}
       <i class="icon-question" data-toggle="pstooltip" data-placement="{{ placement }}"
          title="{{ label_attr['tooltip'] }}"></i>
     {% endif %}
-
     {% if label_attr['popover'] is defined %}
       {% set placement = label_attr['popover_placement'] is defined ? label_attr['popover_placement'] : 'top' %}
       {% include '@Common/HelpBox/helpbox.html.twig' with { "placement" : placement, "content": label_attr['popover'] } %}
-    {% endif %}
-    {% if required %}
-      <span class="text-danger">*</span>
     {% endif %}
     </label>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify forms for Taxes and Tax options, introduces BC breaks for both forms by extending TranslatorAwareType. Now any forms that have extended TaxType or TaxOptionType will crash.
| Type?         | refacto
| Category?     | BO
| BC breaks?    |  yes
| Deprecations? | no
| Fixed ticket? | Fixes #16482
| How to test?  | Tax page and tax options pages must work exactly like before. Also they must look mostly the same.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19866)
<!-- Reviewable:end -->
