### PR TITLE
Include customization cost in product price (Helps resolve paypal total price bug)

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3791,6 +3791,8 @@ class CartCore extends ObjectModel
 
         $products = $this->getProducts($refresh);
 
+        $specific_price_output = null;
+
         foreach ($products as $key => &$product) {
             $product['price_without_quantity_discount'] = Product::getPriceStatic(
                 $product['id_product'],
@@ -3799,7 +3801,18 @@ class CartCore extends ObjectModel
                 6,
                 null,
                 false,
-                false
+                false,
+                1,
+                false,
+                null,
+                null,
+                null,
+                $specific_price_output,
+                true,
+                true,
+                null,
+                true,
+                $product['id_customization']
             );
 
             if ($product['reduction_type'] == 'amount') {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3579,19 +3579,8 @@ class ProductCore extends ObjectModel
         $divisor = null,
         $only_reduc = false,
         $usereduc = true,
-        $quantity = 1
-    ) {
-        return Product::getPriceStatic((int) $this->id, $tax, $id_product_attribute, $decimals, $divisor, $only_reduc, $usereduc, $quantity);
-    }
-
-    public function getPublicPrice(
-        $tax = true,
-        $id_product_attribute = null,
-        $decimals = 6,
-        $divisor = null,
-        $only_reduc = false,
-        $usereduc = true,
-        $quantity = 1
+        $quantity = 1,
+        $id_customization = null
     ) {
         $specific_price_output = null;
 
@@ -3612,7 +3601,42 @@ class ProductCore extends ObjectModel
             true,
             true,
             null,
-            false
+            true,
+            $id_customization
+        );
+    }
+
+    public function getPublicPrice(
+        $tax = true,
+        $id_product_attribute = null,
+        $decimals = 6,
+        $divisor = null,
+        $only_reduc = false,
+        $usereduc = true,
+        $quantity = 1,
+        $id_customization = null
+    ) {
+        $specific_price_output = null;
+
+        return Product::getPriceStatic(
+            (int) $this->id,
+            $tax,
+            $id_product_attribute,
+            $decimals,
+            $divisor,
+            $only_reduc,
+            $usereduc,
+            $quantity,
+            false,
+            null,
+            null,
+            null,
+            $specific_price_output,
+            true,
+            true,
+            null,
+            false,
+            $id_customization
         );
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some methods, the customization cost is not taken into account, this PR helps resolve that
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Add a normal text customization to cart then change its price in the table `customized_data` (normally this is done automatically by a module). The paypal module will show the wrong total because it's not taking into account the customization cost

I also include a fix inside the paypal module
https://gist.github.com/unlocomqx/e7acd9004376dc341ef6147636d79cae

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19876)
<!-- Reviewable:end -->
