### PR TITLE
Remove duplicated info_outline icon in stock alert

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -32,7 +32,7 @@
     {% else %}
         <div class="col-md-12">
             <div class="alert alert-danger" role="alert">
-                <i class="material-icons">info_outline</i><p class="alert-text">{{ 'You can\'t manage your stock in this shop context: select a shop instead of a group of shops.'|trans({}, 'Admin.Catalog.Notification') }}</p>
+                <p class="alert-text">{{ 'You can\'t manage your stock in this shop context: select a shop instead of a group of shops.'|trans({}, 'Admin.Catalog.Notification') }}</p>
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove duplicated info_outline icon in stock alert
| Type?         |  improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19881.
| How to test?  | See #19881.

## Before
![image](https://user-images.githubusercontent.com/16455155/85200092-ce3ba080-b2f4-11ea-891f-b64eb5f344fe.png)
## After
![image](https://user-images.githubusercontent.com/16455155/85200067-a2b8b600-b2f4-11ea-97fc-d7861ee13cf1.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19882)
<!-- Reviewable:end -->
