### PR TITLE
Functional tests - Add edit action name to grids

### DIFF
--- a/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
@@ -138,6 +138,7 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ->add(
                                 (new LinkRowAction('edit'))
                                     ->setIcon('edit')
+                                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
                                     ->setOptions([
                                         'route' => 'admin_contacts_edit',
                                         'route_param_name' => 'contactId',

--- a/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
@@ -113,6 +113,7 @@ final class MetaGridDefinitionFactory extends AbstractGridDefinitionFactory
                             ->add(
                                 (new LinkRowAction('edit'))
                                     ->setIcon('edit')
+                                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
                                     ->setOptions([
                                         'route' => 'admin_metas_edit',
                                         'route_param_name' => 'metaId',

--- a/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
@@ -128,6 +128,7 @@ final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
                 'actions' => (new RowActionCollection())
                     ->add((new LinkRowAction('edit'))
                     ->setIcon('edit')
+                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
                     ->setOptions([
                         'route' => 'admin_profiles_edit',
                         'route_param_name' => 'profileId',

--- a/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
@@ -147,6 +147,7 @@ final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
                             ->add(
                                 (new LinkRowAction('edit'))
                                     ->setIcon('edit')
+                                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
                                     ->setOptions([
                                         'route' => 'admin_webservice_keys_edit',
                                         'route_param_name' => 'webserviceKeyId',

--- a/tests/UI/pages/BO/customers/addresses/index.js
+++ b/tests/UI/pages/BO/customers/addresses/index.js
@@ -21,7 +21,7 @@ module.exports = class Addresses extends BOBasePage {
     this.addressesListTableToggleDropDown = row => `${this.addressesListTableColumnAction(row)}`
       + ' a[data-toggle=\'dropdown\']';
     this.addressesListTableDeleteLink = row => `${this.addressesListTableColumnAction(row)} a.grid-delete-row-link`;
-    this.addressesListTableEditLink = row => `${this.addressesListTableColumnAction(row)} a.grid-view-row-link`;
+    this.addressesListTableEditLink = row => `${this.addressesListTableColumnAction(row)} a.grid-edit-row-link`;
     // Filters
     this.addressFilterColumnInput = filterBy => `${this.addressesListForm} #address_${filterBy}`;
     this.filterSearchButton = `${this.addressesListForm} .grid-search-button`;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In some grids `action.name` were empty, so a class used in tests selector was incorrect. By adding this, we can use `.grid-edit-row-link` as a selector
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | You can verify in grid changed (contacts, seo and urls, webservices and profiles), that edit link works (PS: UI tests showed that it worked, I don't think we need to retest)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19888)
<!-- Reviewable:end -->
