### PR TITLE
Auto create symfony roles

### DIFF
--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -30,8 +30,8 @@ use Exception;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShopBundle\Entity\Repository\LangRepository;
 use PrestaShopBundle\Entity\Repository\TabRepository;
-use PrestaShopBundle\Routing\YamlModuleLoader;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -82,9 +82,9 @@ class ModuleTabRegister
     private $languages;
 
     /**
-     * @var YamlModuleLoader
+     * @var LoaderInterface
      */
-    private $moduleRoutingLoader;
+    private $routingConfigLoader;
 
     /**
      * @param TabRepository $tabRepository
@@ -93,7 +93,7 @@ class ModuleTabRegister
      * @param TranslatorInterface $translator
      * @param Filesystem $filesystem
      * @param array $languages
-     * @param YamlModuleLoader $moduleRoutingLoader
+     * @param LoaderInterface $routingConfigLoader
      */
     public function __construct(
         TabRepository $tabRepository,
@@ -102,7 +102,7 @@ class ModuleTabRegister
         TranslatorInterface $translator,
         Filesystem $filesystem,
         array $languages,
-        YamlModuleLoader $moduleRoutingLoader
+        LoaderInterface $routingConfigLoader
     ) {
         $this->langRepository = $langRepository;
         $this->tabRepository = $tabRepository;
@@ -110,7 +110,7 @@ class ModuleTabRegister
         $this->translator = $translator;
         $this->filesystem = $filesystem;
         $this->languages = $languages;
-        $this->moduleRoutingLoader = $moduleRoutingLoader;
+        $this->routingConfigLoader = $routingConfigLoader;
     }
 
     /**
@@ -270,7 +270,7 @@ class ModuleTabRegister
         }
 
         $routingControllers = [];
-        $moduleRoutes = $this->moduleRoutingLoader->import($routingFile, 'module');
+        $moduleRoutes = $this->routingConfigLoader->import($routingFile, 'yaml');
         foreach ($moduleRoutes->getIterator() as $route) {
             $legacyController = $route->getDefault('_legacy_controller');
             if (!empty($legacyController)) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -20,6 +20,7 @@ services:
             - "@translator"
             - "@filesystem"
             - "@=service('prestashop.adapter.legacy.context').getLanguages()"
+            - "@prestashop.bundle.routing.module_route_loader"
 
     prestashop.adapter.module.tab.unregister:
         class: PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabUnregister

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -20,7 +20,7 @@ services:
             - "@translator"
             - "@filesystem"
             - "@=service('prestashop.adapter.legacy.context').getLanguages()"
-            - "@prestashop.bundle.routing.module_route_loader"
+            - "@routing.loader.yml"
 
     prestashop.adapter.module.tab.unregister:
         class: PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabUnregister

--- a/src/PrestaShopBundle/Routing/YamlModuleLoader.php
+++ b/src/PrestaShopBundle/Routing/YamlModuleLoader.php
@@ -66,9 +66,7 @@ class YamlModuleLoader extends Loader
             $routingFile = $modulePath . '/config/routes.yml';
             if (file_exists($routingFile)) {
                 $loadedRoutes = $this->import($routingFile, 'yaml');
-                $modifiedRoutes = $this->modifyRoutes($loadedRoutes);
-
-                $routes->addCollection($modifiedRoutes);
+                $routes->addCollection($loadedRoutes);
             }
         }
 
@@ -83,6 +81,16 @@ class YamlModuleLoader extends Loader
     public function supports($resource, $type = null)
     {
         return 'module' === $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function import($resource, $type = null)
+    {
+        $loadedRoutes = parent::import($resource, $type);
+
+        return $this->modifyRoutes($loadedRoutes);
     }
 
     /**

--- a/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -29,6 +29,7 @@ namespace LegacyTests\Unit\Adapter\Module\Tab;
 use LegacyTests\TestCase\UnitTestCase;
 use PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabRegister;
 use PrestaShopBundle\Routing\YamlModuleLoader;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\Routing\Route;
@@ -154,7 +155,7 @@ class ModuleTabRegisterTest extends UnitTestCase
                 $this->sfKernel->getContainer()->get('translator'),
                 $this->buildFilesystemMock(),
                 $this->languages,
-                $this->buildYamlModuleLoaderMock(),
+                $this->buildRoutingConfigLoaderMock(),
             ))
             ->getMock();
         $this->tabRegister
@@ -186,15 +187,15 @@ class ModuleTabRegisterTest extends UnitTestCase
         return $filesystemMock;
     }
 
-    protected function buildYamlModuleLoaderMock()
+    protected function buildRoutingConfigLoaderMock()
     {
-        $moduleRoutingLoader = $this->getMockBuilder(YamlModuleLoader::class)
-            ->setMethods(['import'])
+        $moduleRoutingLoader = $this->getMockBuilder(LoaderInterface::class)
+            ->setMethods(['import', 'load', 'supports', 'getResolver', 'setResolver'])
             ->disableOriginalConstructor()
             ->getMock()
         ;
 
-        // We only need to mock the import method, it returns a RouteCollection, by default it returns a useless
+        // We only need to mock the import method, it returns a RouteCollection, by default the mock returns a useless
         // Route object, but ONLY for the undeclared_symfony module it returns an additional one with the _legacy_controller
         // option that will add an undeclared controller
         $moduleRoutingLoader

--- a/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Tab/ModuleTabRegisterTest.php
@@ -28,7 +28,6 @@ namespace LegacyTests\Unit\Adapter\Module\Tab;
 
 use LegacyTests\TestCase\UnitTestCase;
 use PrestaShop\PrestaShop\Adapter\Module\Tab\ModuleTabRegister;
-use PrestaShopBundle\Routing\YamlModuleLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -54,7 +53,7 @@ class ModuleTabRegisterTest extends UnitTestCase
             // Non-existing class file, must throw an exception
             array(
                 'class_name' => 'AdminMissing',
-                'exception' => 'Class "AdminMissingController" not found in controllers/admin',
+                'exception' => 'Class "AdminMissingController" not found in controllers/admin nor routing file',
             ),
         ),
         'symfony' => array(
@@ -65,7 +64,11 @@ class ModuleTabRegisterTest extends UnitTestCase
             ),
         ),
         // No tabs by default, the undeclared one comes from the routing parsing
-        'undeclared_symfony' => array(),
+        'undeclared_symfony' => array(
+            array(
+                'class_name' => 'UndeclaredLegacyController',
+            ),
+        ),
     );
 
     protected $moduleAdminControllers = array(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Symfony controllers that do not create Tab had no authorization roles created, with this update the `ModuleTabRegister` is able to scan routing file from module and automatically creates hidden Tab which creates the necessary roles (the route needs to have a `_legacy_controller` option defined)
| Type?         | improvement
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #19857
| How to test?  | To test this new feature you need to use the new demo module from this PR https://github.com/PrestaShop/example-modules/pull/21 (an archive is attached to this issue if you prefer) Once the module is installed go to the configuration of the module and try to access the "Secured controller" page Without this PR you are redirected to the Dashboard because of a permission denied error With this PR reinstall the module so that the roles are correctly created, the "Secured controller" page is now accessible

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19903)
<!-- Reviewable:end -->

Use this module to test this PR:

[democontrollertabs.zip](https://github.com/PrestaShop/PrestaShop/files/4816408/democontrollertabs.zip)


## Breaking Change

The `ModuleTabRegister` constructor needs a new parameter, however since this class is meant for internal use and in the Adapter namespace the impact should be limited.
