### PR TITLE
Functional tests - Wait for neworkidle in wait for navigation function

### DIFF
--- a/tests/UI/pages/BO/catalog/categories/index.js
+++ b/tests/UI/pages/BO/catalog/categories/index.js
@@ -332,7 +332,7 @@ module.exports = class Categories extends BOBasePage {
     let i = 0;
     while (await this.elementNotVisible(sortColumnDiv, 500) && i < 2) {
       await this.page.hover(this.sortColumnDiv(sortBy));
-      await this.clickAndWaitForNavigation(sortColumnSpanButton, 'networkidle');
+      await this.clickAndWaitForNavigation(sortColumnSpanButton);
       i += 1;
     }
     await this.waitForVisibleSelector(sortColumnDiv);

--- a/tests/UI/pages/BO/customers/index.js
+++ b/tests/UI/pages/BO/customers/index.js
@@ -325,7 +325,7 @@ module.exports = class Customers extends BOBasePage {
     const sortColumnSpanButton = this.sortColumnSpanButton(sortBy);
     let i = 0;
     while (await this.elementNotVisible(sortColumnDiv, 1000) && i < 2) {
-      await this.clickAndWaitForNavigation(sortColumnSpanButton, 'networkidle');
+      await this.clickAndWaitForNavigation(sortColumnSpanButton);
       i += 1;
     }
     await this.waitForVisibleSelector(sortColumnDiv);

--- a/tests/UI/pages/commonPage.js
+++ b/tests/UI/pages/commonPage.js
@@ -246,7 +246,7 @@ module.exports = class CommonPage {
    * @param waitUntil, the event to wait after click (load/networkidle/domcontentloaded)
    * @return {Promise<void>}
    */
-  async clickAndWaitForNavigation(selector, waitUntil = 'load') {
+  async clickAndWaitForNavigation(selector, waitUntil = 'networkidle') {
     await Promise.all([
       this.page.waitForNavigation({waitUntil}),
       this.page.click(selector),


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Wait for neworkidle in wait for navigation function
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | All campaign has been tested

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19920)
<!-- Reviewable:end -->
