### PR TITLE
[CO] Mail variable are not replaced

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -316,10 +316,8 @@ class MailCore extends ObjectModel
                           self::mimeEncode($addrName);
                 $message->addTo(self::toPunycode($addr), $addrName);
             }
-            $toPlugin = $to[0];
         } else {
             /* Simple recipient, one address */
-            $toPlugin = $to;
             $toName = (($toName == null || $toName == $to) ? '' : self::mimeEncode($toName));
             $message->addTo(self::toPunycode($to), $toName);
         }
@@ -561,6 +559,12 @@ class MailCore extends ObjectModel
                 true
             );
             $templateVars = array_merge($templateVars, $extraTemplateVars);
+            
+            $toPlugin = $message->getTo();
+            if (is_array($toPlugin)) {
+                $toPlugin = array_shift(array_keys($toPlugin));
+            }
+            
             $swift->registerPlugin(new Swift_Plugins_DecoratorPlugin([self::toPunycode($toPlugin) => $templateVars]));
             if ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH ||
                 $configuration['PS_MAIL_TYPE'] == Mail::TYPE_TEXT


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is a bug when customer has uppercase character in the mail domain. Swift convert mail domain automaticaly to lower case. The replacement of variable doesn't work in this case..
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Just create (or modify) a customer account with an email containing uppercase in domain. Try to receive transactional email like order confirmation. The variable in email are not replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19922)
<!-- Reviewable:end -->
