### PR TITLE
Fixes the import configuration save

### DIFF
--- a/js/admin/import.js
+++ b/js/admin/import.js
@@ -30,14 +30,14 @@ $(document).ready(function(){
 
 	$('#saveImportMatchs').unbind('click').click(function(){
 
-	var newImportMatchs = $('#newImportMatchs').attr('value');
+	var newImportMatchs = $('#newImportMatchs').val();
 	if (newImportMatchs == '')
 		jAlert(errorEmpty);
 	else
 	{
 		var matchFields = '';
 		$('.type_value').each( function () {
-			matchFields += '&'+$(this).attr('id')+'='+$(this).attr('value');
+			matchFields += '&'+$(this).attr('id')+'='+$(this).val();
 		});
 		$.ajax({
 	       type: 'POST',
@@ -45,7 +45,7 @@ $(document).ready(function(){
 	       async: false,
 	       cache: false,
 	       dataType : "json",
-	       data: 'ajax=1&action=saveImportMatchs&tab=AdminImport&token=' + token + '&skip=' + $('input[name=skip]').attr('value') + '&newImportMatchs=' + newImportMatchs + matchFields,
+	       data: 'ajax=1&action=saveImportMatchs&tab=AdminImport&token=' + token + '&skip=' + $('input[name=skip]').val() + '&newImportMatchs=' + newImportMatchs + matchFields,
 	       success: function(jsonData)
 	       {
 				$('#valueImportMatchs').append('<option id="'+jsonData.id+'" value="'+matchFields+'" selected="selected">'+newImportMatchs+'</option>');


### PR DESCRIPTION
`$(this).attr('value')` was returning `undefined`
Replacing it by `$(this).val()` is doing the job

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | I'm using PrestaShop 1.7.7 with Firefox 77 but the problem seems to exist on any 1.7.x version. See below for more details.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? |  Fixes #19746 (backport #19738) 
| How to test?  | Please, have a look at "How to test?" below.

## Problem description
While using the "save import configuration" on Firefox 77, I couldn't load the configuration again.
Once the network tab inspected, I realized that values were undefined.
In the `js/admin/import.js` values were called with `.attr('value')` function. I'm not sure but I think it's more `.val()` function we need to use to get a value of an input with jQuery.
Once all `.attr('value')` replaced by `.val()` everything is working smoothly. 
Just a quick fix but we can now save our import configuration and use it again :)


## How to test?
Pretty simple to test, try to save a import configuration and check the payload sent, you should see something like this:

```
ajax	"1"
action	"saveImportMatchs"
tab	"AdminImport"
token	"ee20d0f98a45013400a34a36bd0e4ea6"
skip	"1"
newImportMatchs	"undefined"
type_value[0]	"undefined"
type_value[1]	"undefined"
type_value[2]	"undefined"
type_value[3]	"undefined"
// ...
```

Once you apply the fix it should become:
```
ajax	"1"
action	"saveImportMatchs"
tab	"AdminImport"
token	"ee20d0f98a45013400a34a36bd0e4ea6"
skip	"1"
newImportMatchs	"default-product-import-configuration"
type_value[0]	"id"
type_value[1]	"active"
type_value[2]	"name"
type_value[3]	"category"
// ...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19738)
<!-- Reviewable:end -->
