### PR TITLE
Adjust UpdatePack command to be able to remove items

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductPackHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductPackHandler.php
@@ -57,8 +57,8 @@ final class UpdateProductPackHandler extends AbstractProductHandler implements U
 
         if (false === Pack::deleteItems($packId)) {
             throw new ProductPackException(
-                sprintf('Failed deleting previous products from pack #%s before adding new ones', $packId),
-                ProductPackException::FAILED_DELETING_PREVIOUS_PACKS
+                sprintf('Failed deleting products from pack #%s', $packId),
+                ProductPackException::FAILED_DELETING_PRODUCTS_FROM_PACK
             );
         }
 
@@ -93,6 +93,8 @@ final class UpdateProductPackHandler extends AbstractProductHandler implements U
                 Pack::resetStaticCache();
             }
         }
+        // reset cache also if products array is empty and in-loop cache resetting isn't reached
+        Pack::resetStaticCache();
     }
 
     /**

--- a/src/Core/Domain/Product/Command/UpdateProductPackCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductPackCommand.php
@@ -52,7 +52,7 @@ class UpdateProductPackCommand
      *
      * @param int $packId the id of product which becomes the pack after it contains packed items
      *
-     * @return static
+     * @return UpdateProductPackCommand
      */
     public static function cleanPack(int $packId): self
     {
@@ -61,13 +61,13 @@ class UpdateProductPackCommand
 
     /**
      * Builds command to upsert pack with new products list.
-     * Provided products should replace all previous products in the pack
+     * Provided products will replace all previous products in the pack
      *
      * @param int $packId the id of product which becomes the pack after it contains packed items
      * @param array $products array of elements where each element contains product information
      *                        which allows building @var QuantifiedProduct
      *
-     * @return static
+     * @return UpdateProductPackCommand
      */
     public static function upsertPack(int $packId, array $products): self
     {

--- a/src/Core/Domain/Product/Command/UpdateProductPackCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductPackCommand.php
@@ -45,7 +45,7 @@ class UpdateProductPackCommand
     /**
      * @var QuantifiedProduct[]
      */
-    private $products;
+    private $products = [];
 
     /**
      * @param int $packId the id of product which becomes the pack after it contains packed items
@@ -79,13 +79,6 @@ class UpdateProductPackCommand
      */
     private function setProducts(array $products): void
     {
-        if (empty($products)) {
-            throw new ProductPackException(
-                'Empty products list provided for packing',
-                ProductPackException::EMPTY_PRODUCT_LIST_FOR_PACKING
-            );
-        }
-
         foreach ($products as $product) {
             $this->assertQuantity($product['quantity']);
 

--- a/src/Core/Domain/Product/Command/UpdateProductPackCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductPackCommand.php
@@ -48,14 +48,36 @@ class UpdateProductPackCommand
     private $products = [];
 
     /**
+     * Builds command to remove all items from the pack
+     *
+     * @param int $packId the id of product which becomes the pack after it contains packed items
+     *
+     * @return static
+     */
+    public static function cleanPack(int $packId): self
+    {
+        return new self($packId, []);
+    }
+
+    /**
+     * Builds command to upsert pack with new products list.
+     * Provided products should replace all previous products in the pack
+     *
      * @param int $packId the id of product which becomes the pack after it contains packed items
      * @param array $products array of elements where each element contains product information
      *                        which allows building @var QuantifiedProduct
+     *
+     * @return static
      */
-    public function __construct(int $packId, array $products)
+    public static function upsertPack(int $packId, array $products): self
     {
-        $this->packId = new ProductId($packId);
-        $this->setProducts($products);
+        if (empty($products)) {
+            throw new ProductPackException(
+                'Empty array of products provided. Use UpdateProductPackCommand::cleanPack to empty the pack.'
+            );
+        }
+
+        return new self($packId, $products);
     }
 
     /**
@@ -72,6 +94,18 @@ class UpdateProductPackCommand
     public function getProducts(): array
     {
         return $this->products;
+    }
+
+    /**
+     * Use static factories to build this command
+     *
+     * @param int $packId
+     * @param array $products
+     */
+    private function __construct(int $packId, array $products)
+    {
+        $this->packId = new ProductId($packId);
+        $this->setProducts($products);
     }
 
     /**

--- a/src/Core/Domain/Product/Exception/ProductPackException.php
+++ b/src/Core/Domain/Product/Exception/ProductPackException.php
@@ -39,9 +39,9 @@ class ProductPackException extends ProductException
     const FAILED_ADDING_TO_PACK = 10;
 
     /**
-     * When fails to delete previous packs of product
+     * When fails to delete products from a pack
      */
-    const FAILED_DELETING_PREVIOUS_PACKS = 20;
+    const FAILED_DELETING_PRODUCTS_FROM_PACK = 20;
 
     /**
      * When trying to pack a product which is already a pack itself
@@ -52,9 +52,4 @@ class ProductPackException extends ProductException
      * When product for packing quantity is invalid
      */
     const INVALID_QUANTITY = 40;
-
-    /**
-     * When provided list of products for packing is empty
-     */
-    const EMPTY_PRODUCT_LIST_FOR_PACKING = 50;
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -118,16 +118,21 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
 
         $packId = $this->getSharedStorage()->get($packReference);
 
-        $this->updatePack($packId, $products);
+        $this->upsertPack($packId, $products);
     }
 
     /**
-     * @When I update pack :packReference not providing any products for packing
+     * @When I clean pack :packReference
      */
-    public function updateProductPackProvidingNoProducts(string $packReference)
+    public function cleanPack(string $packReference)
     {
         $packId = $this->getSharedStorage()->get($packReference);
-        $this->updatePack($packId, []);
+
+        try {
+            $this->getCommandBus()->handle(UpdateProductPackCommand::cleanPack($packId));
+        } catch (ProductException $e) {
+            $this->lastException = $e;
+        }
     }
 
     /**
@@ -540,10 +545,10 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
      * @param int $packId
      * @param array $products
      */
-    private function updatePack(int $packId, array $products): void
+    private function upsertPack(int $packId, array $products): void
     {
         try {
-            $this->getCommandBus()->handle(new UpdateProductPackCommand(
+            $this->getCommandBus()->handle(UpdateProductPackCommand::upsertPack(
                 $packId,
                 $products
             ));

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -453,17 +453,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then I should get error that provided products list for packing is empty
-     */
-    public function assertEmptyProductsForPackingError()
-    {
-        $this->assertLastErrorIs(
-            ProductPackException::class,
-            ProductPackException::EMPTY_PRODUCT_LIST_FOR_PACKING
-        );
-    }
-
-    /**
      * @Then I should get error that product for packing quantity is invalid
      */
     public function assertPackProductQuantityError()

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -79,10 +79,12 @@ Feature: Add product to pack from Back Office (BO)
         | product3 | 3                          |
       Then I should get error that product for packing quantity is invalid
 
-    Scenario: I don't provide any products for packing
-      Given product "product2" type should be standard
-      When I update pack product2 not providing any products for packing
-      Then I should get error that provided products list for packing is empty
-      And product "product2" type should be standard
+    Scenario: I remove all products from existing pack
+      Given product "productPack4" type should be pack
+      And pack productPack4 should contain products with following quantities:
+        | product2   | 2                          |
+        | product3   | 3                          |
+      When I update pack productPack4 not providing any products for packing
+      Then product "productPack4" type should be standard
 
 #@todo: add combination product to a pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -84,7 +84,7 @@ Feature: Add product to pack from Back Office (BO)
       And pack productPack4 should contain products with following quantities:
         | product2   | 2                          |
         | product3   | 3                          |
-      When I update pack productPack4 not providing any products for packing
+      When I clean pack productPack4
       Then product "productPack4" type should be standard
 
 #@todo: add combination product to a pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -41,6 +41,15 @@ Feature: Add product to pack from Back Office (BO)
       | product3   | 3                           |
       | product4   | 20                          |
 
+  Scenario: I update pack by removing one of the products
+    Given pack productPack2 should contain products with following quantities:
+      | product3   | 3                           |
+      | product4   | 20                          |
+    When I update pack "productPack2" with following product quantities:
+      | product3   | 3                           |
+    And pack productPack2 should contain products with following quantities:
+      | product3   | 3                           |
+
   Scenario: I add pack product to a pack
     Given product "productPack1" type should be pack
     And product "productPack2" type should be pack


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | implement static factories in UpdatePackCommand. cleanPack() and upsertPack(). Adjust behat tests and add some missing cases. All in all the UpdatePackCommand will handle all cases - it will add/update products list in pack or delete them. Basically it always replace old association with new one. We can separate commands if we really need it later, but for now its not worth the excessive work until we are sure.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | not testable

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19938)
<!-- Reviewable:end -->
