### PR TITLE
Cast changelogs to array for twig - Backport of #19778

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_notification_update.html.twig
@@ -35,7 +35,7 @@
 {% block addon_description %}
   {% if module.attributes.changeLog is defined %}
     <ul>
-      {% for version, lines in module.attributes.changeLog %}
+      {% for version, lines in module.attributes.changeLog|arrayCast %}
         <li><b>{{ version }}:</b>
           {% for line in lines %}
             {{ line }}<br/>


### PR DESCRIPTION
(cherry picked from commit a29e14ee7d9609ba5fea15fc189848127ab01afa)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Even if the changeLog key of the api-addons was send, the actual implementation would be unable to show it. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18450
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19942)
<!-- Reviewable:end -->
