### PR TITLE
Deprecate constants that are no longer used

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -58,7 +58,10 @@ class TabCore extends ObjectModel
     /** @var string Icon font */
     public $icon;
 
-    const TAB_MODULE_LIST_URL = _PS_TAB_MODULE_LIST_URL_;
+    /**
+     * @deprecated Since 1.7.7
+     */
+    const TAB_MODULE_LIST_URL = '';
 
     /**
      * @see ObjectModel::$definition

--- a/config/defines_uri.inc.php
+++ b/config/defines_uri.inc.php
@@ -67,6 +67,8 @@ define('_MODULE_DIR_', __PS_BASE_URI__.'modules/');
 /* Define API URLs if not defined before */
 Tools::safeDefine('_PS_API_DOMAIN_', 'api.prestashop.com');
 Tools::safeDefine('_PS_API_URL_', 'http://'._PS_API_DOMAIN_);
-Tools::safeDefine('_PS_TAB_MODULE_LIST_URL_', _PS_API_URL_.'/xml/tab_modules_list_17.xml');
-Tools::safeDefine('_PS_API_MODULES_LIST_16_', _PS_API_DOMAIN_.'/xml/modules_list_16.xml');
+/** @deprecated Since 1.7.7 */
+Tools::safeDefine('_PS_TAB_MODULE_LIST_URL_', '');
+/** @deprecated Since 1.7.7 */
+Tools::safeDefine('_PS_API_MODULES_LIST_16_', '');
 Tools::safeDefine('_PS_CURRENCY_FEED_URL_', _PS_API_URL_.'/xml/currencies.xml');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Since #19461 some constants are no longer used. This change adds deprecation annotations and removes their values to avoid confusion.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | yes - Constants are now empty
| Deprecations? | yes - `_PS_TAB_MODULE_LIST_URL_` and `_PS_API_MODULES_LIST_16_`
| Fixed ticket? | N/A
| How to test?  | Validated by automated tests

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19944)
<!-- Reviewable:end -->
