### PR TITLE
Fixed preview in Order Page

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/preview-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/preview-extension.js
@@ -30,7 +30,7 @@ const {$} = window;
  */
 export default class PreviewExtension {
   constructor(previewCustomization) {
-    this.lock = [];
+    this.locks = [];
     this.expandSelector = '.js-expand';
     this.collapseSelector = '.js-collapse';
     this.previewOpenClass = 'preview-open';
@@ -180,7 +180,7 @@ export default class PreviewExtension {
   }
 
   isLocked(key) {
-    return this.lock.indexOf(key) !== -1;
+    return this.locks.indexOf(key) !== -1;
   }
 
   lock(key) {
@@ -188,17 +188,17 @@ export default class PreviewExtension {
       return;
     }
 
-    this.lock.push(key);
+    this.locks.push(key);
   }
 
   unlock(key) {
-    const index = this.lock.indexOf(key);
+    const index = this.locks.indexOf(key);
 
     if (index === -1) {
       return;
     }
 
-    this.lock.splice(index, 1);
+    this.locks.splice(index, 1);
   }
 
   /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed preview in Order Page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18957
| How to test?  | 0. Build assets<br>1. Go to Orders listing<br>2. **BEFORE :**Click, next to the ID, on the small arrow it should open an order preview, it does not<br>2. **AFTER :**Click, next to the ID, on the small arrow it open an order preview


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19947)
<!-- Reviewable:end -->
