### PR TITLE
Truncate category description in BO list view

### DIFF
--- a/src/Core/Grid/Data/Factory/CategoryDataFactory.php
+++ b/src/Core/Grid/Data/Factory/CategoryDataFactory.php
@@ -74,7 +74,7 @@ final class CategoryDataFactory implements GridDataFactoryInterface
     private function modifyRecords(array $records)
     {
         foreach ($records as $key => $record) {
-            $records[$key]['description'] = strip_tags(stripslashes($record['description']));
+            $records[$key]['description'] = mb_substr(strip_tags(stripslashes($record['description'])), 0, 150);
         }
 
         return $records;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Added truncation (150 characters) to back-office categories list view category description to avoid really long description make UX bad. Implemented this like wrote in issue.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19645.
| How to test?  | Make categories that have very long descriptions, then go to listing of all categories and full description will not shown up there.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19951)
<!-- Reviewable:end -->
