### PR TITLE
Rename AddCustomizationFieldsCommand to AddCustomizationCommand

### DIFF
--- a/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
@@ -27,10 +27,10 @@
 namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
-use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationFieldsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddProductToCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
-use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\AddCustomizationFieldsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\AddCustomizationHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\AddProductToCartHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateProductQuantityInCartHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
@@ -41,9 +41,9 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 final class AddProductToCartHandler extends AbstractCartHandler implements AddProductToCartHandlerInterface
 {
     /**
-     * @var AddCustomizationFieldsHandlerInterface
+     * @var AddCustomizationHandlerInterface
      */
-    private $addCustomizationFieldsHandler;
+    private $addCustomizationHandler;
 
     /**
      * @var UpdateProductQuantityInCartHandlerInterface
@@ -51,14 +51,14 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
     private $updateProductQuantityInCartHandler;
 
     /**
-     * @param AddCustomizationFieldsHandlerInterface $addCustomizationFieldsHandler
+     * @param AddCustomizationHandlerInterface $addCustomizationHandler
      * @param UpdateProductQuantityInCartHandlerInterface $updateProductQuantityInCartHandler
      */
     public function __construct(
-        AddCustomizationFieldsHandlerInterface $addCustomizationFieldsHandler,
+        AddCustomizationHandlerInterface $addCustomizationHandler,
         UpdateProductQuantityInCartHandlerInterface $updateProductQuantityInCartHandler
     ) {
-        $this->addCustomizationFieldsHandler = $addCustomizationFieldsHandler;
+        $this->addCustomizationHandler = $addCustomizationHandler;
         $this->updateProductQuantityInCartHandler = $updateProductQuantityInCartHandler;
     }
 
@@ -73,7 +73,7 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
         $customizationId = null;
 
         if (!empty($command->getCustomizationsByFieldIds())) {
-            $customizationId = $this->addCustomizationFieldsHandler->handle(new AddCustomizationFieldsCommand(
+            $customizationId = $this->addCustomizationHandler->handle(new AddCustomizationCommand(
                 $cartIdValue,
                 $command->getProductId()->getValue(),
                 $command->getCustomizationsByFieldIds()
@@ -103,7 +103,10 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
     private function assertQuantityIsPositiveInt(int $quantity): void
     {
         if (0 > $quantity) {
-            throw new CartConstraintException(sprintf('Quantity must be positive integer, but %s given.', $quantity), CartConstraintException::INVALID_QUANTITY);
+            throw new CartConstraintException(
+                sprintf('Quantity must be positive integer, but %s given.', $quantity),
+                CartConstraintException::INVALID_QUANTITY
+            );
         }
     }
 }

--- a/src/Core/Domain/Cart/Command/AddCustomizationCommand.php
+++ b/src/Core/Domain/Cart/Command/AddCustomizationCommand.php
@@ -30,7 +30,10 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
-class AddCustomizationFieldsCommand
+/**
+ * Adds product customization
+ */
+class AddCustomizationCommand
 {
     /**
      * @var CartId
@@ -45,20 +48,20 @@ class AddCustomizationFieldsCommand
     /**
      * @var array key - value pairs where key is the id of customization field and the value is the customization value
      */
-    private $customizationsByFieldIds;
+    private $customizationValuesByFieldIds;
 
     /**
      * @param int $cartId
      * @param int $productId
-     * @param array $customizationsByFieldIds
+     * @param array $customizationValuesByFieldIds
      *
      * @throws CartConstraintException
      */
-    public function __construct(int $cartId, int $productId, array $customizationsByFieldIds)
+    public function __construct(int $cartId, int $productId, array $customizationValuesByFieldIds)
     {
         $this->cartId = new CartId($cartId);
         $this->productId = new ProductId($productId);
-        $this->customizationsByFieldIds = $customizationsByFieldIds;
+        $this->customizationValuesByFieldIds = $customizationValuesByFieldIds;
     }
 
     /**
@@ -80,8 +83,8 @@ class AddCustomizationFieldsCommand
     /**
      * @return array
      */
-    public function getCustomizationsByFieldIds(): array
+    public function getCustomizationValuesByFieldIds(): array
     {
-        return $this->customizationsByFieldIds;
+        return $this->customizationValuesByFieldIds;
     }
 }

--- a/src/Core/Domain/Cart/CommandHandler/AddCustomizationHandlerInterface.php
+++ b/src/Core/Domain/Cart/CommandHandler/AddCustomizationHandlerInterface.php
@@ -26,18 +26,18 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationFieldsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationId;
 
 /**
- * Interface for handling AddCustomizationFields command
+ * Defines contract to handle @var AddCustomizationCommand
  */
-interface AddCustomizationFieldsHandlerInterface
+interface AddCustomizationHandlerInterface
 {
     /**
-     * @param AddCustomizationFieldsCommand $command
+     * @param AddCustomizationCommand $command
      *
      * @return CustomizationId|null customizationId
      */
-    public function handle(AddCustomizationFieldsCommand $command): ?CustomizationId;
+    public function handle(AddCustomizationCommand $command): ?CustomizationId;
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -109,16 +109,16 @@ services:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartInformation'
 
-  prestashop.adapter.command_handler.add_customization_fields_handler:
-    class: 'PrestaShop\PrestaShop\Adapter\Cart\CommandHandler\AddCustomizationFieldsHandler'
+  prestashop.adapter.command_handler.add_customization_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\Cart\CommandHandler\AddCustomizationHandler'
     tags:
       - name: tactician.handler
-        command: 'PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationFieldsCommand'
+        command: 'PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationCommand'
 
   prestashop.adapter.command_handler.add_product_to_cart_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Cart\CommandHandler\AddProductToCartHandler'
     arguments:
-      - '@prestashop.adapter.command_handler.add_customization_fields_handler'
+      - '@prestashop.adapter.command_handler.add_customization_handler'
       - '@prestashop.adapter.command_handler.update_product_quantity_in_cart_handler'
     tags:
       - name: tactician.handler

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -38,7 +38,7 @@ use DateTime;
 use Exception;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCartRuleToCartCommand;
-use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationFieldsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCustomizationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\CreateEmptyCustomerCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\RemoveCartRuleFromCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\RemoveProductFromCartCommand;
@@ -175,7 +175,7 @@ class CartFeatureContext extends AbstractDomainFeatureContext
         $cartId = (int) SharedStorage::getStorage()->get($reference);
 
         /** @var CustomizationId $customizationId */
-        $customizationId = $this->getCommandBus()->handle(new AddCustomizationFieldsCommand(
+        $customizationId = $this->getCommandBus()->handle(new AddCustomizationCommand(
             $cartId,
             $productId,
             $customizations


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Command and handler name was misleading (`AddCustomizationFields`). Renamed to `AddCustomization` and some variables that were used inside (to make it clearer what it does). This command saves the customized_data and creates the actual customization. (whereas the customization_fields are created during product creation/update). `Didn't change any behavior, just renamed couple classes and local variables`. :warning: It didn't cause any troubles in UI, it is purely to avoid confusing developers in future and its important to fix it until 1.7.7 release, because then to change it would mean BC break.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | If Travis CI passes it means I did not forget to rename any occurrences that would cause errors.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19955)
<!-- Reviewable:end -->
