### PR TITLE
Install classic theme when possible

### DIFF
--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -116,12 +116,20 @@ if (!defined('_THEME_NAME_')) {
          * @deprecated since 1.7.5.x to be removed in 1.8.x
          * Rely on "PS_THEME_NAME" environment variable value
          */
-        $themes = glob(dirname(__DIR__).'/themes/*/config/theme.yml', GLOB_NOSORT);
-        usort($themes, function ($a, $b) {
-            return strcmp($b, $a);
-        });
-
-        define('_THEME_NAME_', basename(substr($themes[0], 0, -strlen('/config/theme.yml'))));
+        $dirThemes = dirname(__DIR__).'/themes/';
+        $fileConfig = '/config/theme.yml';
+        $defaultTheme = 'classic';
+        // Choose classic theme as default
+        if (file_exists($dirThemes . $defaultTheme . $fileConfig)) {
+            define('_THEME_NAME_', $defaultTheme);
+        } else {
+            // Choose the first theme alphabetically
+            $themes = glob($dirThemes . '*' . $fileConfig, GLOB_NOSORT);
+            usort($themes, function ($a, $b) {
+                return strcmp($a, $b);
+            });
+            define('_THEME_NAME_', basename(substr($themes[0], 0, -strlen('/config/theme.yml'))));
+        }
     }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Install classic theme when possible
| Type?         | improvement
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9708
| How to test?  | 1. Have multiple themes (3 if possible) : classic and two other(`Aaaa` & `Zzzz`)<br>2. Install PrestaShop : the default theme is `classic`<br>3. Remove `themes/classic`<br>4. Install PrestaShop : the default theme is the first directory in alphabetical sort (`Aaaa` in example)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19961)
<!-- Reviewable:end -->
