### PR TITLE
Add High DPI support to ImageRetriever

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -32,6 +32,7 @@ use ImageType;
 use Language;
 use Link;
 use Product;
+use Configuration;
 
 /**
  * This class is mainly responsible of Product images.
@@ -167,6 +168,7 @@ class ImageRetriever
             $imageFolderPath,
             $id_image . '.' . $ext,
         ]);
+        $generateHighDpiImages = (bool) Configuration::get('PS_HIGHT_DPI');
 
         foreach ($image_types as $image_type) {
             $resizedImagePath = implode(DIRECTORY_SEPARATOR, [
@@ -181,6 +183,21 @@ class ImageRetriever
                     (int) $image_type['width'],
                     (int) $image_type['height']
                 );
+            }
+            
+            if ($generateHighDpiImages) {
+                $resizedImagePathHighDpi = implode(DIRECTORY_SEPARATOR, [
+                    $imageFolderPath,
+                    $id_image . '-' . $image_type['name'] . '2x.' . $ext,
+                ]);
+                if (!file_exists($resizedImagePathHighDpi)) {
+                    ImageManager::resize(
+                            $mainImagePath,
+                            $resizedImagePathHighDpi,
+                            (int) $image_type['width'] * 2,
+                            (int) $image_type['height'] * 2
+                    );
+                }
             }
 
             $url = $this->link->$getImageURL(

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -26,13 +26,13 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Image;
 
+use Configuration;
 use Image;
 use ImageManager;
 use ImageType;
 use Language;
 use Link;
 use Product;
-use Configuration;
 
 /**
  * This class is mainly responsible of Product images.
@@ -184,7 +184,7 @@ class ImageRetriever
                     (int) $image_type['height']
                 );
             }
-            
+
             if ($generateHighDpiImages) {
                 $resizedImagePathHighDpi = implode(DIRECTORY_SEPARATOR, [
                     $imageFolderPath,

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -192,10 +192,10 @@ class ImageRetriever
                 ]);
                 if (!file_exists($resizedImagePathHighDpi)) {
                     ImageManager::resize(
-                            $mainImagePath,
-                            $resizedImagePathHighDpi,
-                            (int) $image_type['width'] * 2,
-                            (int) $image_type['height'] * 2
+                        $mainImagePath,
+                        $resizedImagePathHighDpi,
+                        (int) $image_type['width'] * 2,
+                        (int) $image_type['height'] * 2
                     );
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add High DPI support to ImageRetriever
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19798
| How to test?  | 1. have a shop with no High DPI support<br>2. turn on High DPI support<br>3. go to product page<br>4. check out image folder on your server - img/p - it should have HIGH DPI images generated

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19965)
<!-- Reviewable:end -->
