### PR TITLE
Create specific price when product price is updated in order

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1241,7 +1241,7 @@ class CartRuleCore extends ObjectModel
                 $reduction_amount = (float) $this->reduction_amount;
                 // If the cart rule is restricted to one product it can't exceed this product price
                 if ($this->reduction_product > 0) {
-                    foreach ($context->cart->getProducts() as $product) {
+                    foreach ($all_products as $product) {
                         if ($product['id_product'] == $this->reduction_product) {
                             if ($this->reduction_tax) {
                                 $max_reduction_amount = (int) $product['cart_quantity'] * (float) $product['price_wt'];
@@ -1280,7 +1280,7 @@ class CartRuleCore extends ObjectModel
                     $reduction_value += $prorata * $reduction_amount;
                 } else {
                     if ($this->reduction_product > 0) {
-                        foreach ($context->cart->getProducts() as $product) {
+                        foreach ($all_products as $product) {
                             if ($product['id_product'] == $this->reduction_product) {
                                 $product_price_ti = $product['price_wt'];
                                 $product_price_te = $product['price'];

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -27,15 +27,24 @@
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use Cart;
+use Combination;
+use Configuration;
+use Context;
 use Currency;
 use Customer;
 use Group;
 use Order;
+use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use PrestaShopException;
+use Product;
+use SpecificPrice;
+use Validate;
 
 /**
  * Reusable methods for Order subdomain command/query handlers.
@@ -102,5 +111,168 @@ abstract class AbstractOrderHandler
         $currency = new Currency((int) $cart->id_currency);
 
         return $computingPrecision->getPrecision($currency->precision);
+    }
+
+    /**
+     * @param Number $priceTaxIncluded
+     * @param Number $priceTaxExcluded
+     * @param Order $order
+     * @param Cart $cart
+     * @param Product $product
+     * @param Combination|null $combination
+     *
+     * @return SpecificPrice|void
+     */
+    protected function createSpecificPriceIfNeeded(
+        Number $priceTaxIncluded,
+        Number $priceTaxExcluded,
+        Order $order,
+        Cart $cart,
+        Product $product,
+        $combination
+    ): ?SpecificPrice {
+        // Check it the SpecificPrice has already been added by restoreOrderProductsSpecificPrices, if yes ignore new
+        // price because the first one is kept
+        if (SpecificPrice::exists(
+            $product->id,
+            $combination ? $combination->id : 0,
+            0,
+            0,
+            0,
+            $order->id_currency,
+            $order->id_customer,
+            1,
+            DateTime::NULL_VALUE,
+            DateTime::NULL_VALUE
+        )) {
+            return null;
+        }
+
+        $initialProductPriceTaxExcl = Product::getPriceStatic(
+            $product->id,
+            false,
+            $combination ? $combination->id : null,
+            $this->getPrecisionFromCart($cart),
+            null,
+            false,
+            true,
+            1,
+            false,
+            $order->id_customer,
+            $cart->id,
+            $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
+        );
+
+        // Better check with price tax excluded since it's the one saved in database, if the price matches
+        // the product's one no need for specific price
+        if ($priceTaxExcluded->equals(new Number((string) $initialProductPriceTaxExcl))) {
+            return null;
+        }
+
+        $specificPrice = new SpecificPrice();
+        $specificPrice->id_shop = 0;
+        $specificPrice->id_cart = 0;
+        $specificPrice->id_shop_group = 0;
+        $specificPrice->id_currency = $order->id_currency;
+        $specificPrice->id_country = 0;
+        $specificPrice->id_group = 0;
+        $specificPrice->id_customer = $order->id_customer;
+        $specificPrice->id_product = $product->id;
+        $specificPrice->id_product_attribute = $combination ? $combination->id : 0;
+        $specificPrice->price = (float) (string) $priceTaxExcluded;
+        $specificPrice->from_quantity = 1;
+        $specificPrice->reduction = 0;
+        $specificPrice->reduction_type = 'amount';
+        $specificPrice->reduction_tax = !$priceTaxIncluded->equals($priceTaxExcluded);
+        $specificPrice->from = '0000-00-00 00:00:00';
+        $specificPrice->to = '0000-00-00 00:00:00';
+        $specificPrice->add();
+
+        return $specificPrice;
+    }
+
+    /**
+     * @param Order $order
+     *
+     * @return Cart
+     */
+    protected function createNewOrEditExistingCart(Order $order)
+    {
+        $cartId = Cart::getCartIdByOrderId($order->id);
+        if ($cartId) {
+            $cart = new Cart($cartId);
+        } else {
+            $cart = new Cart();
+            $cart->id_shop_group = $order->id_shop_group;
+            $cart->id_shop = $order->id_shop;
+            $cart->id_customer = $order->id_customer;
+            $cart->id_carrier = $order->id_carrier;
+            $cart->id_address_delivery = $order->id_address_delivery;
+            $cart->id_address_invoice = $order->id_address_invoice;
+            $cart->id_currency = $order->id_currency;
+            $cart->id_lang = $order->id_lang;
+            $cart->secure_key = $order->secure_key;
+
+            $cart->add();
+        }
+
+        Context::getContext()->cart = $cart;
+
+        return $cart;
+    }
+
+    /**
+     * @param int $combinationId
+     *
+     * @return Combination|null
+     */
+    protected function getCombination($combinationId)
+    {
+        $combination = null;
+
+        if (0 !== $combinationId) {
+            $combination = new Combination($combinationId);
+
+            if (!Validate::isLoadedObject($combination)) {
+                throw new OrderException('Product combination not found.');
+            }
+        }
+
+        return $combination;
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param int $langId
+     *
+     * @return Product
+     */
+    protected function getProductObject(ProductId $productId, $langId)
+    {
+        $product = new Product($productId->getValue(), false, $langId);
+
+        if ($product->id !== $productId->getValue()) {
+            throw new OrderException(sprintf('Product with id "%d" is invalid.', $productId->getValue()));
+        }
+
+        return $product;
+    }
+
+    /**
+     * Clean all the specific prices that were created but this handler
+     *
+     * @param SpecificPrice[] $temporarySpecificPrices
+     *
+     * @throws \PrestaShopException
+     */
+    protected function clearTemporarySpecificPrices(array $temporarySpecificPrices): void
+    {
+        if (empty($temporarySpecificPrices)) {
+            return;
+        }
+
+        foreach ($temporarySpecificPrices as $specificPrice) {
+            $specificPrice->delete();
+        }
     }
 }

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -56,7 +56,7 @@ abstract class AbstractOrderHandler
      *
      * @return Order
      */
-    protected function getOrderObject(OrderId $orderId)
+    protected function getOrder(OrderId $orderId)
     {
         try {
             $order = new Order($orderId->getValue());
@@ -247,7 +247,7 @@ abstract class AbstractOrderHandler
      *
      * @return Product
      */
-    protected function getProductObject(ProductId $productId, $langId)
+    protected function getProduct(ProductId $productId, $langId)
     {
         $product = new Product($productId->getValue(), false, $langId);
 

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -51,7 +51,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
      */
     public function handle(AddCartRuleToOrderCommand $command): void
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
 
         $computingPrecision = new ComputingPrecision();
         $currency = new Currency((int) $order->id_currency);

--- a/src/Adapter/Order/CommandHandler/AddPaymentHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddPaymentHandler.php
@@ -44,7 +44,7 @@ final class AddPaymentHandler extends AbstractOrderHandler implements AddPayment
      */
     public function handle(AddPaymentCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
 
         $currency = new Currency($command->getPaymentCurrencyId()->getValue());
         $orderHasInvoice = $order->hasInvoice();

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -138,6 +138,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             if (!($cart instanceof Cart)) {
                 throw new OrderException('Cart linked to the order cannot be found.');
             }
+            $this->contextStateManager->setCart($cart);
             // Cart precision is more adapted
             $this->computingPrecision = $this->getPrecisionFromCart($cart);
 

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -88,11 +88,6 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
     private $translator;
 
     /**
-     * @var array
-     */
-    private $temporarySpecificPrices;
-
-    /**
      * @var int
      */
     private $computingPrecision;
@@ -100,6 +95,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
     /**
      * @param TranslatorInterface $translator
      * @param ContextStateManager $contextStateManager
+     * @param OrderAmountUpdater $orderAmountUpdater
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -117,7 +113,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
      */
     public function handle(AddProductToOrderCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
 
         $this->contextStateManager
             ->setCurrency(new Currency($order->id_currency))
@@ -129,7 +125,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
         try {
             $this->assertOrderWasNotShipped($order);
 
-            $product = $this->getProductObject($command->getProductId(), (int) $order->id_lang);
+            $product = $this->getProduct($command->getProductId(), (int) $order->id_lang);
             $combination = $this->getCombination($command->getCombinationId());
 
             $this->checkProductInStock($product, $command);

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -52,8 +52,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\AddProductToOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
-use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use Product;
 use Shop;
 use SpecificPrice;
@@ -127,7 +125,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
 
         // Get context precision just in case
         $this->computingPrecision = $this->context->getComputingPrecision();
-        $this->temporarySpecificPrices = [];
+        $temporarySpecificPrices = [];
         try {
             $this->assertOrderWasNotShipped($order);
 
@@ -136,18 +134,21 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
 
             $this->checkProductInStock($product, $command);
 
-            $cart = $this->createNewOrEditExistingCart($order);
+            $cart = Cart::getCartByOrderId($order->id);
+            if (!($cart instanceof Cart)) {
+                throw new OrderException('Cart linked to the order cannot be found.');
+            }
             // Cart precision is more adapted
             $this->computingPrecision = $this->getPrecisionFromCart($cart);
 
             // Restore any specific prices for the products in the order
-            $this->restoreOrderProductsSpecificPrices(
+            $temporarySpecificPrices = $this->restoreOrderProductsSpecificPrices(
                 $order,
                 $cart
             );
 
             // Add specific price for the product being added
-            $this->createSpecificPriceIfNeeded(
+            $specificPrice = $this->createSpecificPriceIfNeeded(
                 $command->getProductPriceTaxIncluded(),
                 $command->getProductPriceTaxExcluded(),
                 $order,
@@ -155,6 +156,10 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
                 $product,
                 $combination
             );
+
+            if (null !== $specificPrice) {
+                $temporarySpecificPrices[] = $specificPrice;
+            }
 
             $this->addProductToCart($cart, $product, $combination, $command->getProductQuantity());
 
@@ -200,11 +205,11 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $order = $this->orderAmountUpdater->update($order, $cart, $orderDetail->id_order_invoice != 0);
 
             // Delete temporary specific prices
-            $this->clearTemporarySpecificPrices();
+            $this->clearTemporarySpecificPrices($temporarySpecificPrices);
 
             $order->update();
         } catch (Exception $e) {
-            $this->clearTemporarySpecificPrices();
+            $this->clearTemporarySpecificPrices($temporarySpecificPrices);
             $this->contextStateManager->restoreContext();
             throw $e;
         }
@@ -264,73 +269,6 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
     }
 
     /**
-     * @param int $combinationId
-     *
-     * @return Combination|null
-     */
-    private function getCombination($combinationId)
-    {
-        $combination = null;
-
-        if (0 !== $combinationId) {
-            $combination = new Combination($combinationId);
-
-            if (!Validate::isLoadedObject($combination)) {
-                throw new OrderException('Product combination not found.');
-            }
-        }
-
-        return $combination;
-    }
-
-    /**
-     * @param ProductId $productId
-     * @param int $langId
-     *
-     * @return Product
-     */
-    private function getProductObject(ProductId $productId, $langId)
-    {
-        $product = new Product($productId->getValue(), false, $langId);
-
-        if ($product->id !== $productId->getValue()) {
-            throw new OrderException(sprintf('Product with id "%d" is invalid.', $productId->getValue()));
-        }
-
-        return $product;
-    }
-
-    /**
-     * @param Order $order
-     *
-     * @return Cart
-     */
-    private function createNewOrEditExistingCart(Order $order)
-    {
-        $cartId = Cart::getCartIdByOrderId($order->id);
-        if ($cartId) {
-            $cart = new Cart($cartId);
-        } else {
-            $cart = new Cart();
-            $cart->id_shop_group = $order->id_shop_group;
-            $cart->id_shop = $order->id_shop;
-            $cart->id_customer = $order->id_customer;
-            $cart->id_carrier = $order->id_carrier;
-            $cart->id_address_delivery = $order->id_address_delivery;
-            $cart->id_address_invoice = $order->id_address_invoice;
-            $cart->id_currency = $order->id_currency;
-            $cart->id_lang = $order->id_lang;
-            $cart->secure_key = $order->secure_key;
-
-            $cart->add();
-        }
-
-        $this->context->cart = $cart;
-
-        return $cart;
-    }
-
-    /**
      * @param Order $order
      * @param OrderInvoice|null $invoice
      * @param Cart $cart
@@ -359,16 +297,19 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
      * @param Order $order
      * @param Cart $cart
      *
+     * @return SpecificPrice[]
+     *
      * @throws \PrestaShopDatabaseException
      * @throws \PrestaShopException
      */
-    private function restoreOrderProductsSpecificPrices(Order $order, Cart $cart): void
+    private function restoreOrderProductsSpecificPrices(Order $order, Cart $cart): array
     {
+        $specificPrices = [];
         foreach ($order->getOrderDetailList() as $row) {
             $orderDetail = new OrderDetail($row['id_order_detail']);
             $product = new Product((int) $orderDetail->product_id);
 
-            $this->createSpecificPriceIfNeeded(
+            $specificPrice = $this->createSpecificPriceIfNeeded(
                 new Number((string) $orderDetail->unit_price_tax_incl),
                 new Number((string) $orderDetail->unit_price_tax_excl),
                 $order,
@@ -376,100 +317,13 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
                 $product,
                 new Combination($orderDetail->product_attribute_id)
             );
-        }
-    }
 
-    /**
-     * Clean all the specific prices that were created but this handler
-     *
-     * @throws \PrestaShopException
-     */
-    private function clearTemporarySpecificPrices(): void
-    {
-        if (empty($this->temporarySpecificPrices)) {
-            return;
+            if (null !== $specificPrice) {
+                $specificPrices[] = $specificPrice;
+            }
         }
 
-        /** @var SpecificPrice $specificPrice */
-        foreach ($this->temporarySpecificPrices as $specificPrice) {
-            $specificPrice->delete();
-        }
-        $this->temporarySpecificPrices = [];
-    }
-
-    /**
-     * @param Number $priceTaxIncluded
-     * @param Number $priceTaxExcluded
-     * @param Order $order
-     * @param Cart $cart
-     * @param Product $product
-     * @param Combination|null $combination
-     */
-    private function createSpecificPriceIfNeeded(
-        Number $priceTaxIncluded,
-        Number $priceTaxExcluded,
-        Order $order,
-        Cart $cart,
-        Product $product,
-        $combination
-    ): void {
-        // Check it the SpecificPrice has already been added by restoreOrderProductsSpecificPrices, if yes ignore new
-        // price because the first one is kept
-        if (SpecificPrice::exists(
-            $product->id,
-            $combination ? $combination->id : 0,
-            0,
-            0,
-            0,
-            $order->id_currency,
-            $order->id_customer,
-            1,
-            DateTime::NULL_VALUE,
-            DateTime::NULL_VALUE
-        )) {
-            return;
-        }
-
-        $initialProductPriceTaxExcl = Product::getPriceStatic(
-            $product->id,
-            false,
-            $combination ? $combination->id : null,
-            $this->computingPrecision,
-            null,
-            false,
-            true,
-            1,
-            false,
-            $order->id_customer,
-            $cart->id,
-            $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
-        );
-
-        // Better check with price tax excluded since it's the one saved in database, if the price matches
-        // the product's one no need for specific price
-        if ($priceTaxExcluded->equals(new Number((string) $initialProductPriceTaxExcl))) {
-            return;
-        }
-
-        $specificPrice = new SpecificPrice();
-        $specificPrice->id_shop = 0;
-        $specificPrice->id_cart = 0;
-        $specificPrice->id_shop_group = 0;
-        $specificPrice->id_currency = $order->id_currency;
-        $specificPrice->id_country = 0;
-        $specificPrice->id_group = 0;
-        $specificPrice->id_customer = $order->id_customer;
-        $specificPrice->id_product = $product->id;
-        $specificPrice->id_product_attribute = $combination ? $combination->id : 0;
-        $specificPrice->price = (float) (string) $priceTaxExcluded;
-        $specificPrice->from_quantity = 1;
-        $specificPrice->reduction = 0;
-        $specificPrice->reduction_type = 'amount';
-        $specificPrice->reduction_tax = !$priceTaxIncluded->equals($priceTaxExcluded);
-        $specificPrice->from = '0000-00-00 00:00:00';
-        $specificPrice->to = '0000-00-00 00:00:00';
-        $specificPrice->add();
-        $this->temporarySpecificPrices[] = $specificPrice;
+        return $specificPrices;
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/ChangeOrderCurrencyHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderCurrencyHandler.php
@@ -52,7 +52,7 @@ final class ChangeOrderCurrencyHandler extends AbstractOrderHandler implements C
      */
     public function handle(ChangeOrderCurrencyCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
 
         if ($command->getNewCurrencyId()->getValue() === (int) $order->id_currency || $order->valid) {
             throw new OrderException('You cannot change the currency.');

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -44,7 +44,7 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
      */
     public function handle(ChangeOrderDeliveryAddressCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         $address = new Address($command->getNewDeliveryAddressId()->getValue());
 
         $cart = Cart::getCartByOrderId($order->id);

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -44,7 +44,7 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
      */
     public function handle(ChangeOrderInvoiceAddressCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         $address = new Address($command->getNewInvoiceAddressId()->getValue());
 
         $cart = Cart::getCartByOrderId($order->id);

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -44,7 +44,7 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
      */
     public function handle(DeleteCartRuleFromOrderCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         $orderCartRule = new OrderCartRule($command->getOrderCartRuleId());
 
         if (!Validate::isLoadedObject($orderCartRule) || $orderCartRule->id_order != $order->id) {

--- a/src/Adapter/Order/CommandHandler/GenerateInvoiceHandler.php
+++ b/src/Adapter/Order/CommandHandler/GenerateInvoiceHandler.php
@@ -42,7 +42,7 @@ final class GenerateInvoiceHandler extends AbstractOrderHandler implements Gener
      */
     public function handle(GenerateInvoiceCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
 
         if (!Configuration::get('PS_INVOICE', null, null, $order->id_shop)) {
             throw new OrderException('Invoice management has been disabled.');

--- a/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
@@ -97,7 +97,7 @@ final class IssuePartialRefundHandler extends AbstractOrderCommandHandler implem
     public function handle(IssuePartialRefundCommand $command): void
     {
         /** @var Order $order */
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         if (!$order->hasBeenPaid() && !$order->hasPayments()) {
             throw new InvalidOrderStateException(
                 InvalidOrderStateException::NOT_PAID,

--- a/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
@@ -103,7 +103,7 @@ class IssueReturnProductHandler extends AbstractOrderCommandHandler implements I
         }
 
         /** @var Order $order */
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         if (!$order->hasBeenDelivered()) {
             throw new InvalidOrderStateException(
                 InvalidOrderStateException::DELIVERY_NOT_FOUND,

--- a/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
@@ -103,7 +103,7 @@ class IssueStandardRefundHandler extends AbstractOrderCommandHandler implements 
         }
 
         /** @var Order $order */
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         if (!$order->hasBeenPaid() && !$order->hasPayments()) {
             throw new InvalidOrderStateException(
                 InvalidOrderStateException::NOT_PAID,

--- a/src/Adapter/Order/CommandHandler/ResendOrderEmailHandler.php
+++ b/src/Adapter/Order/CommandHandler/ResendOrderEmailHandler.php
@@ -46,7 +46,7 @@ final class ResendOrderEmailHandler extends AbstractOrderCommandHandler implemen
      */
     public function handle(ResendOrderEmailCommand $command): void
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         $orderState = new OrderState($command->getOrderStatusId());
 
         if (!Validate::isLoadedObject($orderState)) {

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -47,7 +47,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
      */
     public function handle(UpdateOrderShippingDetailsCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
 
         $trackingNumber = $command->getShippingTrackingNumber();
         $carrierId = $command->getNewCarrierId();

--- a/src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php
@@ -48,7 +48,7 @@ final class UpdateOrderStatusHandler extends AbstractOrderHandler implements Upd
      */
     public function handle(UpdateOrderStatusCommand $command)
     {
-        $order = $this->getOrderObject($command->getOrderId());
+        $order = $this->getOrder($command->getOrderId());
         $orderState = $this->getOrderStateObject($command->getNewOrderStatusId());
 
         $currentOrderState = $order->getCurrentOrderState();

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -69,7 +69,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         $temporarySpecificPrices = [];
 
         try {
-            $order = $this->getOrderObject($command->getOrderId());
+            $order = $this->getOrder($command->getOrderId());
             $orderDetail = new OrderDetail($command->getOrderDetailId());
             $orderInvoice = null;
             if (!empty($command->getOrderInvoiceId())) {
@@ -106,7 +106,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
                 if (!($cart instanceof Cart)) {
                     throw new OrderException('Cart linked to the order cannot be found.');
                 }
-                $product = $this->getProductObject(new ProductId((int) $orderDetail->product_id), (int) $order->id_lang);
+                $product = $this->getProduct(new ProductId((int) $orderDetail->product_id), (int) $order->id_lang);
                 $combination = $this->getCombination((int) $orderDetail->product_attribute_id);
 
                 // Add specific price for the product being added

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -27,15 +27,12 @@
 namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Cart;
-use Combination;
-use Configuration;
-use Context;
 use Customization;
+use Exception;
 use Hook;
 use Order;
 use OrderDetail;
 use OrderInvoice;
-use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
@@ -44,9 +41,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrder
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\UpdateProductInOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
-use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
-use Product;
-use SpecificPrice;
 use StockAvailable;
 use Validate;
 
@@ -60,11 +54,6 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
      */
     private $orderProductQuantityUpdater;
 
-    /**
-     * @var array
-     */
-    private $temporarySpecificPrices;
-
     public function __construct(OrderProductQuantityUpdater $orderProductQuantityUpdater)
     {
         $this->orderProductQuantityUpdater = $orderProductQuantityUpdater;
@@ -77,77 +66,90 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
     {
         // Return value
         $res = true;
+        $temporarySpecificPrices = [];
 
-        $order = $this->getOrderObject($command->getOrderId());
-        $orderDetail = new OrderDetail($command->getOrderDetailId());
-        $orderInvoice = null;
-        if (!empty($command->getOrderInvoiceId())) {
-            $orderInvoice = new OrderInvoice($command->getOrderInvoiceId());
+        try {
+            $order = $this->getOrderObject($command->getOrderId());
+            $orderDetail = new OrderDetail($command->getOrderDetailId());
+            $orderInvoice = null;
+            if (!empty($command->getOrderInvoiceId())) {
+                $orderInvoice = new OrderInvoice($command->getOrderInvoiceId());
+            }
+
+            // Check fields validity
+            $this->assertProductCanBeUpdated($command, $orderDetail, $order, $orderInvoice);
+
+            if (0 < $orderDetail->id_customization) {
+                $customization = new Customization($orderDetail->id_customization);
+                $customization->quantity = $command->getQuantity();
+                $customization->save();
+            }
+            $product_quantity = $command->getQuantity();
+
+            // @todo: use https://github.com/PrestaShop/decimal for price computations
+            $product_price_tax_incl = (float) $command->getPriceTaxIncluded()->round(2);
+            $product_price_tax_excl = (float) $command->getPriceTaxExcluded()->round(2);
+            $total_products_tax_incl = $product_price_tax_incl * $product_quantity;
+            $total_products_tax_excl = $product_price_tax_excl * $product_quantity;
+
+            // Calculate differences of price (Before / After)
+            $diff_price_tax_incl = $total_products_tax_incl - $orderDetail->total_price_tax_incl;
+            $diff_price_tax_excl = $total_products_tax_excl - $orderDetail->total_price_tax_excl;
+            if ($diff_price_tax_incl != 0 && $diff_price_tax_excl != 0) {
+                $orderDetail->unit_price_tax_excl = $product_price_tax_excl;
+                $orderDetail->unit_price_tax_incl = $product_price_tax_incl;
+
+                $orderDetail->total_price_tax_incl += $diff_price_tax_incl;
+                $orderDetail->total_price_tax_excl += $diff_price_tax_excl;
+
+                $cart = Cart::getCartByOrderId($order->id);
+                if (!($cart instanceof Cart)) {
+                    throw new OrderException('Cart linked to the order cannot be found.');
+                }
+                $product = $this->getProductObject(new ProductId((int) $orderDetail->product_id), (int) $order->id_lang);
+                $combination = $this->getCombination((int) $orderDetail->product_attribute_id);
+
+                // Add specific price for the product being added
+                $specificPrice = $this->createSpecificPriceIfNeeded(
+                    $command->getPriceTaxIncluded(),
+                    $command->getPriceTaxExcluded(),
+                    $order,
+                    $cart,
+                    $product,
+                    $combination
+                );
+
+                if (null !== $specificPrice) {
+                    $temporarySpecificPrices[] = $specificPrice;
+                }
+
+                // Apply changes on Order
+                $order = new Order($orderDetail->id_order);
+                $order->total_products += $diff_price_tax_excl;
+                $order->total_products_wt += $diff_price_tax_incl;
+
+                $order->total_paid += $diff_price_tax_incl;
+                $order->total_paid_tax_excl += $diff_price_tax_excl;
+                $order->total_paid_tax_incl += $diff_price_tax_incl;
+
+                $res &= $order->update();
+            }
+
+            // Update quantity and amounts
+            $order = $this->orderProductQuantityUpdater->update($order, $orderDetail, $product_quantity, $orderInvoice);
+
+            if (!$res) {
+                throw new OrderException('An error occurred while editing the product line.');
+            }
+
+            Hook::exec('actionOrderEdited', ['order' => $order]);
+
+            // Delete temporary specific prices
+            $this->clearTemporarySpecificPrices($temporarySpecificPrices);
+        } catch (Exception $e) {
+            $this->clearTemporarySpecificPrices($temporarySpecificPrices);
+            throw $e;
         }
-
-        // Check fields validity
-        $this->assertProductCanBeUpdated($command, $orderDetail, $order, $orderInvoice);
-
-        if (0 < $orderDetail->id_customization) {
-            $customization = new Customization($orderDetail->id_customization);
-            $customization->quantity = $command->getQuantity();
-            $customization->save();
-        }
-        $product_quantity = $command->getQuantity();
-
-        // @todo: use https://github.com/PrestaShop/decimal for price computations
-        $product_price_tax_incl = (float) $command->getPriceTaxIncluded()->round(2);
-        $product_price_tax_excl = (float) $command->getPriceTaxExcluded()->round(2);
-        $total_products_tax_incl = $product_price_tax_incl * $product_quantity;
-        $total_products_tax_excl = $product_price_tax_excl * $product_quantity;
-
-        // Calculate differences of price (Before / After)
-        $diff_price_tax_incl = $total_products_tax_incl - $orderDetail->total_price_tax_incl;
-        $diff_price_tax_excl = $total_products_tax_excl - $orderDetail->total_price_tax_excl;
-        if ($diff_price_tax_incl != 0 && $diff_price_tax_excl != 0) {
-            $orderDetail->unit_price_tax_excl = $product_price_tax_excl;
-            $orderDetail->unit_price_tax_incl = $product_price_tax_incl;
-
-            $orderDetail->total_price_tax_incl += $diff_price_tax_incl;
-            $orderDetail->total_price_tax_excl += $diff_price_tax_excl;
-
-            $cart = $this->createNewOrEditExistingCart($order);
-            $product = $this->getProductObject(new ProductId((int) $orderDetail->product_id), (int) $order->id_lang);
-            $combination = $this->getCombination((int) $orderDetail->product_attribute_id);
-
-            // Add specific price for the product being added
-            $this->createSpecificPriceIfNeeded(
-                $command->getPriceTaxIncluded(),
-                $command->getPriceTaxExcluded(),
-                $order,
-                $cart,
-                $product,
-                $combination
-            );
-
-            // Apply changes on Order
-            $order = new Order($orderDetail->id_order);
-            $order->total_products += $diff_price_tax_excl;
-            $order->total_products_wt += $diff_price_tax_incl;
-
-            $order->total_paid += $diff_price_tax_incl;
-            $order->total_paid_tax_excl += $diff_price_tax_excl;
-            $order->total_paid_tax_incl += $diff_price_tax_incl;
-
-            $res &= $order->update();
-        }
-
-        // Update quantity and amounts
-        $order = $this->orderProductQuantityUpdater->update($order, $orderDetail, $product_quantity, $orderInvoice);
-
-        // Delete temporary specific prices
-        $this->clearTemporarySpecificPrices();
-
-        if (!$res) {
-            throw new OrderException('An error occurred while editing the product line.');
-        }
-
-        Hook::exec('actionOrderEdited', ['order' => $order]);
     }
 
     /**
@@ -216,165 +218,5 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
                 throw new ProductOutOfStockException('Not enough products in stock');
             }
         }
-    }
-
-    /**
-     * @param Number $priceTaxIncluded
-     * @param Number $priceTaxExcluded
-     * @param Order $order
-     * @param Cart $cart
-     * @param Product $product
-     * @param Combination|null $combination
-     */
-    private function createSpecificPriceIfNeeded(
-        Number $priceTaxIncluded,
-        Number $priceTaxExcluded,
-        Order $order,
-        Cart $cart,
-        Product $product,
-        $combination
-    ): void {
-        // Check it the SpecificPrice has already been added by restoreOrderProductsSpecificPrices, if yes ignore new
-        // price because the first one is kept
-        if (SpecificPrice::exists(
-            $product->id,
-            $combination ? $combination->id : 0,
-            0,
-            0,
-            0,
-            $order->id_currency,
-            $order->id_customer,
-            1,
-            DateTime::NULL_VALUE,
-            DateTime::NULL_VALUE
-        )) {
-            return;
-        }
-
-        $initialProductPriceTaxExcl = Product::getPriceStatic(
-            $product->id,
-            false,
-            $combination ? $combination->id : null,
-            $this->getPrecisionFromCart($cart),
-            null,
-            false,
-            true,
-            1,
-            false,
-            $order->id_customer,
-            $cart->id,
-            $order->{Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop)}
-        );
-
-        // Better check with price tax excluded since it's the one saved in database, if the price matches
-        // the product's one no need for specific price
-        if ($priceTaxExcluded->equals(new Number((string) $initialProductPriceTaxExcl))) {
-            return;
-        }
-
-        $specificPrice = new SpecificPrice();
-        $specificPrice->id_shop = 0;
-        $specificPrice->id_cart = 0;
-        $specificPrice->id_shop_group = 0;
-        $specificPrice->id_currency = $order->id_currency;
-        $specificPrice->id_country = 0;
-        $specificPrice->id_group = 0;
-        $specificPrice->id_customer = $order->id_customer;
-        $specificPrice->id_product = $product->id;
-        $specificPrice->id_product_attribute = $combination ? $combination->id : 0;
-        $specificPrice->price = (float) (string) $priceTaxExcluded;
-        $specificPrice->from_quantity = 1;
-        $specificPrice->reduction = 0;
-        $specificPrice->reduction_type = 'amount';
-        $specificPrice->reduction_tax = !$priceTaxIncluded->equals($priceTaxExcluded);
-        $specificPrice->from = '0000-00-00 00:00:00';
-        $specificPrice->to = '0000-00-00 00:00:00';
-        $specificPrice->add();
-        $this->temporarySpecificPrices[] = $specificPrice;
-    }
-
-    /**
-     * @param Order $order
-     *
-     * @return Cart
-     */
-    private function createNewOrEditExistingCart(Order $order)
-    {
-        $cartId = Cart::getCartIdByOrderId($order->id);
-        if ($cartId) {
-            $cart = new Cart($cartId);
-        } else {
-            $cart = new Cart();
-            $cart->id_shop_group = $order->id_shop_group;
-            $cart->id_shop = $order->id_shop;
-            $cart->id_customer = $order->id_customer;
-            $cart->id_carrier = $order->id_carrier;
-            $cart->id_address_delivery = $order->id_address_delivery;
-            $cart->id_address_invoice = $order->id_address_invoice;
-            $cart->id_currency = $order->id_currency;
-            $cart->id_lang = $order->id_lang;
-            $cart->secure_key = $order->secure_key;
-
-            $cart->add();
-        }
-
-        Context::getContext()->cart = $cart;
-
-        return $cart;
-    }
-
-    /**
-     * @param int $combinationId
-     *
-     * @return Combination|null
-     */
-    private function getCombination($combinationId)
-    {
-        $combination = null;
-
-        if (0 !== $combinationId) {
-            $combination = new Combination($combinationId);
-
-            if (!Validate::isLoadedObject($combination)) {
-                throw new OrderException('Product combination not found.');
-            }
-        }
-
-        return $combination;
-    }
-
-    /**
-     * @param ProductId $productId
-     * @param int $langId
-     *
-     * @return Product
-     */
-    private function getProductObject(ProductId $productId, $langId)
-    {
-        $product = new Product($productId->getValue(), false, $langId);
-
-        if ($product->id !== $productId->getValue()) {
-            throw new OrderException(sprintf('Product with id "%d" is invalid.', $productId->getValue()));
-        }
-
-        return $product;
-    }
-
-    /**
-     * Clean all the specific prices that were created but this handler
-     *
-     * @throws \PrestaShopException
-     */
-    private function clearTemporarySpecificPrices(): void
-    {
-        if (empty($this->temporarySpecificPrices)) {
-            return;
-        }
-
-        /** @var SpecificPrice $specificPrice */
-        foreach ($this->temporarySpecificPrices as $specificPrice) {
-            $specificPrice->delete();
-        }
-        $this->temporarySpecificPrices = [];
     }
 }

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -46,7 +46,6 @@ use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerDataProvider;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderDocumentType;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderProductsForViewing;
@@ -195,24 +194,6 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->getOrderDiscounts($order),
             $this->getOrderSources($order)
         );
-    }
-
-    /**
-     * @param OrderId $orderId
-     *
-     * @return Order
-     *
-     * @throws OrderNotFoundException
-     */
-    private function getOrder(OrderId $orderId): Order
-    {
-        $order = new Order($orderId->getValue());
-
-        if ($order->id !== $orderId->getValue()) {
-            throw new OrderNotFoundException($orderId, sprintf('Order with id "%s" was not found.', $orderId->getValue()));
-        }
-
-        return $order;
     }
 
     /**

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -83,7 +83,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
 
     public function handle(GetOrderProductsForViewing $query): OrderProductsForViewing
     {
-        $order = $this->getOrderObject($query->getOrderId());
+        $order = $this->getOrder($query->getOrderId());
         $taxCalculationMethod = $this->getOrderTaxCalculationMethod($order);
 
         $products = $order->getProducts();

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -80,7 +80,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
-  Scenario: Add product linked to a cart rule to an existing Order without invoice with free shipping and new invoice And update the product quantity
+  Scenario: Add product linked to a cart rule to an existing Order without invoice with free shipping and new invoice And update the product quantity and price
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total
     Then order "bo_order1" should have 0 invoices
@@ -133,6 +133,24 @@ Feature: Order from Back Office (BO)
       | total_products_wt        | 72.930 |
       | total_discounts_tax_excl | 45.000 |
       | total_discounts_tax_incl | 47.7 |
+      | total_paid_tax_excl      | 30.8   |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I edit product "Test Product Cart Rule On Select Product" to order "bo_order1" with following products details:
+      | amount        | 3                       |
+      | price         | 10                      |
+    Then order "bo_order1" should have 5 products in total
+    Then order "bo_order1" should contain 3 products "Test Product Cart Rule On Select Product"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRuleAmountOnSelectedProduct" with amount "$30.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 53.800 |
+      | total_products_wt        | 57.03  |
+      | total_discounts_tax_excl | 30.000 |
+      | total_discounts_tax_incl | 31.8   |
       | total_paid_tax_excl      | 30.8   |
       | total_paid_tax_incl      | 32.650 |
       | total_paid               | 32.650 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix discount calculation when product price in order is updated. We create a specific price like in AddProductToOrder to fix products total
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19890
| How to test?  | Create a cart rule of 50% on selected product<br>Add the discounted product to any order and see the discount <br>edit the product price<br>The discount must be correct

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19970)
<!-- Reviewable:end -->
