### PR TITLE
Product/Category: allow specifying minimal quantity for products search

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -959,7 +959,8 @@ class CategoryCore extends ObjectModel
         $random = false,
         $randomNumberProducts = 1,
         $checkAccess = true,
-        Context $context = null
+        Context $context = null,
+        $minQuantity = null
     ) {
         if (!$context) {
             $context = Context::getContext();
@@ -978,10 +979,12 @@ class CategoryCore extends ObjectModel
 					FROM `' . _DB_PREFIX_ . 'product` p
 					' . Shop::addSqlAssociation('product', 'p') . '
 					LEFT JOIN `' . _DB_PREFIX_ . 'category_product` cp ON p.`id_product` = cp.`id_product`
+					' . Product::sqlStock('p', 0) . '
 					WHERE cp.`id_category` = ' . (int) $this->id .
                 ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '') .
                 ($active ? ' AND product_shop.`active` = 1' : '') .
-                ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
+                ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '') .
+                ($minQuantity ? ' AND IFNULL(stock.quantity, 0) >= ' . (int) $minQuantity : '');
 
             return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
         }
@@ -1045,7 +1048,8 @@ class CategoryCore extends ObjectModel
 					AND cp.`id_category` = ' . (int) $this->id
                     . ($active ? ' AND product_shop.`active` = 1' : '')
                     . ($front ? ' AND product_shop.`visibility` IN ("both", "catalog")' : '')
-                    . ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '');
+                    . ($idSupplier ? ' AND p.id_supplier = ' . (int) $idSupplier : '')
+                    . ($minQuantity ? ' AND IFNULL(stock.quantity, 0) >= ' . (int) $minQuantity : '');
 
         if ($random === true) {
             $sql .= ' ORDER BY RAND() LIMIT ' . (int) $randomNumberProducts;

--- a/src/Adapter/Category/CategoryProductSearchProvider.php
+++ b/src/Adapter/Category/CategoryProductSearchProvider.php
@@ -76,7 +76,10 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
                 $type !== 'products',
                 true,
                 true,
-                $query->getResultsPerPage()
+                $query->getResultsPerPage(),
+                true,
+                null,
+                $query->getMinQuantity()
             );
         } else {
             return $this->category->getProducts(
@@ -85,7 +88,13 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
                 $query->getResultsPerPage(),
                 $query->getSortOrder()->toLegacyOrderBy(),
                 $query->getSortOrder()->toLegacyOrderWay(),
-                $type !== 'products'
+                $type !== 'products',
+                true,
+                false,
+                1,
+                true,
+                null,
+                $query->getMinQuantity()
             );
         }
     }

--- a/src/Core/Product/Search/ProductSearchQuery.php
+++ b/src/Core/Product/Search/ProductSearchQuery.php
@@ -85,6 +85,11 @@ class ProductSearchQuery
     private $sortOrder;
 
     /**
+     * @var int
+     */
+    private $minQuantity;
+
+    /**
      * ProductSearchQuery constructor.
      */
     public function __construct()
@@ -290,5 +295,25 @@ class ProductSearchQuery
     public function getEncodedFacets()
     {
         return $this->encodedFacets;
+    }
+
+    /**
+     * @param $minQuantity
+     *
+     * @return $this
+     */
+    public function setMinQuantity($minQuantity)
+    {
+        $this->minQuantity = (int) $minQuantity;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMinQuantity()
+    {
+        return $this->minQuantity;
     }
 }


### PR DESCRIPTION
```
Category: allow getting products with specified minimal quantity

Some controllers/modules may want to display available products only.
E.g. for ps_featuredproducts it makes quite some sense to feature
products that can be ordered actually.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```
```
Product: allow specifying min quantity in search query

Some controllers/modules may want to display available products only.
E.g. for ps_featuredproducts it makes quite some sense to feature
products that can be ordered actually.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I'd like to enhance `ps_featuredproducts` by adding option to search for available products only (quantity > 0 or more). I don't like PrestaShop featuring (recommending) products that are not available.<br>To implement that cleanly (without custom SQL queries in `ps_featuredproducts`) I need to extend `Product` and `Category` as suggested in this Pull Request.
| Type?         | new feature
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #20507
| How to test?  | Edit `ps_featuredproducts.php` and add `$query->setMinQuantity(1);` in `getProducts()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19976)
<!-- Reviewable:end -->
