### PR TITLE
Simplify Attachment form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -54,6 +54,7 @@ class AttachmentType extends AbstractType
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,
                 'required' => true,
+                'label' => $this->trans('File name', [], 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new TypedRegex(
@@ -80,6 +81,7 @@ class AttachmentType extends AbstractType
             ->add('file_description', TranslatableType::class, [
                 'type' => TextType::class,
                 'required' => false,
+                'label' => $this->trans('Description', [], 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new CleanHtml(),
@@ -87,7 +89,8 @@ class AttachmentType extends AbstractType
                 ],
             ])
             ->add('file', FileType::class, [
-                'required' => false,
+                'required' => true,
+                'label' => $this->trans('File', [], 'Admin.Global'),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -31,8 +31,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\Configuration\AttachmentConstraint;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -41,10 +40,8 @@ use Symfony\Component\Validator\Constraints\Length;
 /**
  * Attachment form type definition
  */
-class AttachmentType extends AbstractType
+class AttachmentType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * {@inheritdoc}
      */
@@ -54,7 +51,7 @@ class AttachmentType extends AbstractType
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,
                 'required' => true,
-                'label' => $this->trans('File name', [], 'Admin.Global'),
+                'label' => $this->trans('File name', 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new TypedRegex(
@@ -67,8 +64,8 @@ class AttachmentType extends AbstractType
                                 'max' => AttachmentConstraint::MAX_NAME_LENGTH,
                                 'maxMessage' => $this->trans(
                                     'This field cannot be longer than %limit% characters',
-                                    ['%limit%' => AttachmentConstraint::MAX_NAME_LENGTH],
-                                    'Admin.Notifications.Error'
+                                    'Admin.Notifications.Error',
+                                    ['%limit%' => AttachmentConstraint::MAX_NAME_LENGTH]
                                 ),
                             ]
                         ),
@@ -81,7 +78,7 @@ class AttachmentType extends AbstractType
             ->add('file_description', TranslatableType::class, [
                 'type' => TextType::class,
                 'required' => false,
-                'label' => $this->trans('Description', [], 'Admin.Global'),
+                'label' => $this->trans('Description', 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new CleanHtml(),
@@ -90,7 +87,7 @@ class AttachmentType extends AbstractType
             ])
             ->add('file', FileType::class, [
                 'required' => true,
-                'label' => $this->trans('File', [], 'Admin.Global'),
+                'label' => $this->trans('File', 'Admin.Global'),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -39,7 +39,7 @@ use Symfony\Component\Validator\Constraints\Length;
 
 /**
  *
- * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using translator as dependency.
+ * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using trait
  *
  * Attachment form type definition
  */

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -49,6 +49,10 @@ class AttachmentType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $required = true;
+        if (isset($options['data']['file_name']) && $options['data']['file_name']) {
+            $required = false;
+        }
         $builder
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,
@@ -88,7 +92,7 @@ class AttachmentType extends TranslatorAwareType
                 ],
             ])
             ->add('file', FileType::class, [
-                'required' => false,
+                'required' => $required,
                 'label' => $this->trans('File', 'Admin.Global'),
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -38,7 +38,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**
- *
  * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using trait
  *
  * Attachment form type definition

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -88,7 +88,7 @@ class AttachmentType extends TranslatorAwareType
                 ],
             ])
             ->add('file', FileType::class, [
-                'required' => true,
+                'required' => false,
                 'label' => $this->trans('File', 'Admin.Global'),
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -38,6 +38,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**
+ *
+ * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using translator as dependency.
+ *
  * Attachment form type definition
  */
 class AttachmentType extends TranslatorAwareType

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1171,8 +1171,8 @@ services:
 
     prestashop.bundle.form.admin.sell.attachment.attachment:
         class: 'PrestaShopBundle\Form\Admin\Sell\Attachment\AttachmentType'
-        calls:
-            - { method: setTranslator, arguments: ['@translator'] }
+        parent: 'form.type.translatable.aware'
+        public: true
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme attachmentForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block attachment_form %}
   {{ form_start(attachmentForm) }}
@@ -36,25 +36,9 @@
         <div class="card-text">
           {{ form_errors(attachmentForm) }}
 
-          {{ ps.form_group_row(attachmentForm.name, {}, {
-            'label': 'File name'|trans({}, 'Admin.Global')
-          }) }}
-
-          {{ ps.form_group_row(attachmentForm.file_description, {}, {
-            'label': 'Description'|trans({}, 'Admin.Global')
-          }) }}
-
-          <div class="form-group row">
-            <label class="form-control-label">
-              <span class="text-danger">*</span>
-              {{ 'File'|trans({}, 'Admin.Global') }}
-            </label>
-            <div class="col-sm">
-              {{ form_widget(attachmentForm.file) }}
-              {{ form_errors(attachmentForm.file) }}
-            </div>
-            {% block attachment_download %}{% endblock %}
-          </div>
+          {% block attachment_form_widget %}
+            {{ form_widget(attachmentForm) }}
+          {% endblock %}
 
           {% if attachmentId is defined %}
             <div class="form-group row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
@@ -35,10 +35,7 @@
       <div class="card-block row">
         <div class="card-text">
           {{ form_errors(attachmentForm) }}
-
-          {% block attachment_form_widget %}
-            {{ form_widget(attachmentForm) }}
-          {% endblock %}
+          {{ form_widget(attachmentForm) }}
 
           {% if attachmentId is defined %}
             <div class="form-group row">
@@ -50,10 +47,6 @@
               </div>
             </div>
           {% endif %}
-
-          {% block attachment_form_rest %}
-            {{ form_rest(attachmentForm) }}
-          {% endblock %}
         </div>
       </div>
       <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifying attachment form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Attachment form must behave and look exactly as before.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType instead of using TranslatorAwareTrait. This means if any module extends AttachmentType file they will get an exception.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19995)
<!-- Reviewable:end -->
