### PR TITLE
Simplify Suppliers form

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -31,6 +31,8 @@ import ChoiceTable from '@js/components/choice-table.js';
 import ChoiceTree from '@js/components/form/choice-tree.js';
 import MultipleChoiceTable from '@js/components/multiple-choice-table.js';
 import GeneratableInput from '@js/components/generatable-input.js';
+import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
+import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
 import {EventEmitter} from '@components/event-emitter';
 
 const initPrestashopComponents = () => {
@@ -83,6 +85,8 @@ const initPrestashopComponents = () => {
     ChoiceTree,
     MultipleChoiceTable,
     GeneratableInput,
+    CountryStateSelectionToggler,
+    CountryDniRequiredToggler,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.js
+++ b/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.js
@@ -23,37 +23,32 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
-import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
-import TranslatableInput from '@components/translatable-input';
-import TranslatableField from '@components/translatable-field';
-import TaggableField from '@components/taggable-field';
-import ChoiceTree from '@components/form/choice-tree';
-import TinyMCEEditor from '@components/tinymce-editor';
 import SupplierMap from './supplier-map';
 
 const {$} = window;
 
 $(document).ready(() => {
-  const shopChoiceTree = new ChoiceTree('#supplier_shop_association');
-  shopChoiceTree.enableAutoCheckChildren();
-
-  new CountryStateSelectionToggler(
+  new window.prestashop.component.ChoiceTree('#supplier_shop_association').enableAutoCheckChildren();
+  new window.prestashop.component.CountryStateSelectionToggler(
     SupplierMap.supplierCountrySelect,
     SupplierMap.supplierStateSelect,
     SupplierMap.supplierStateBlock,
   );
-
-  new CountryDniRequiredToggler(
+  new window.prestashop.component.CountryDniRequiredToggler(
     SupplierMap.supplierCountrySelect,
     SupplierMap.supplierDniInput,
     SupplierMap.supplierDniInputLabel,
   );
 
-  new TinyMCEEditor();
-  new TranslatableInput();
-  new TranslatableField();
-  new TaggableField({
+  window.prestashop.component.initComponents(
+    [
+      'TinyMCEEditor',
+      'TranslatableInput',
+      'TranslatableField',
+    ],
+  );
+
+  new window.prestashop.component.TaggableField({
     tokenFieldSelector: 'input.js-taggable-field',
     options: {
       createTokensOnBlur: true,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -191,7 +191,7 @@ class SupplierType extends TranslatorAwareType
             ])
             ->add('phone', TextType::class, [
                 'label' => $this->trans('Phone', 'Admin.Global'),
-                'help' => $this->trans('Phone number for this supplier', 'Admin.Catalog.Help'),
+                'help' => $this->trans('Phone number for this supplier.', 'Admin.Catalog.Help'),
                 'required' => false,
                 'constraints' => $this->getPhoneCommonConstraints(),
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -147,11 +147,7 @@ class SupplierType extends TranslatorAwareType
             ])
             ->add('description', TranslatableType::class, [
                 'label' => $this->trans('Description', 'Admin.Global'),
-                'help' => sprintf(
-                    '%s %s',
-                    $this->trans('Will appear in the list of suppliers.', 'Admin.Catalog.Help'),
-                    $invalidCharsText
-                ),
+                'help' => $this->trans('Will appear in the list of suppliers.', 'Admin.Catalog.Help'),
                 'required' => false,
                 'type' => FormattedTextareaType::class,
                 'options' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\AddressDniRequire
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\AddressStateRequired;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\Domain\Address\AddressSettings;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\SupplierSettings;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
@@ -40,6 +41,7 @@ use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -75,16 +77,26 @@ class SupplierType extends TranslatorAwareType
     private $contextCountryId;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * @var bool
      */
     private $isMultistoreEnabled;
 
+    /** @var Router */
+    private $router;
+
     /**
      * @param array $countryChoices
+     * @param array $countryChoicesAttributes
      * @param ConfigurableFormChoiceProviderInterface $statesChoiceProvider
      * @param int $contextCountryId
      * @param TranslatorInterface $translator
      * @param bool $isMultistoreEnabled
+     * @param Router $router
      * @param array $locales
      */
     public function __construct(
@@ -94,6 +106,7 @@ class SupplierType extends TranslatorAwareType
         $contextCountryId,
         TranslatorInterface $translator,
         $isMultistoreEnabled,
+        Router $router,
         array $locales = []
     ) {
         parent::__construct($translator, $locales);
@@ -103,17 +116,36 @@ class SupplierType extends TranslatorAwareType
         $this->statesChoiceProvider = $statesChoiceProvider;
         $this->contextCountryId = $contextCountryId;
         $this->isMultistoreEnabled = $isMultistoreEnabled;
+        $this->router = $router;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $data = $builder->getData();
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;
-        $stateChoices = $this->statesChoiceProvider->getChoices(['id_country' => $countryId]);
+
+        $invalidCharsText = sprintf(
+            '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,
+            $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+        );
+
+        $invalidGenericNameHint = sprintf(
+            '%s <>={}',
+            $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+        );
+
+        $keywordHint = sprintf(
+            '%s ' . PHP_EOL . $invalidGenericNameHint,
+            $this->trans(
+                'To add tags, click in the field, write something, and then press the "Enter" key.',
+                'Admin.Shopparameters.Help'
+            ));
 
         $builder
             ->add('name', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('Name', 'Admin.Global'),
+                'required' => true,
+                'help' => $invalidCharsText,
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -134,6 +166,12 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('description', TranslateType::class, [
+                'label' => $this->trans('Description', 'Admin.Global'),
+                'help' => sprintf(
+                    '%s %s',
+                    $this->trans('Will appear in the list of suppliers.', 'Admin.Catalog.Help'),
+                    $invalidCharsText
+                ),
                 'required' => false,
                 'type' => FormattedTextareaType::class,
                 'locales' => $this->locales,
@@ -150,26 +188,28 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('phone', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('Phone', 'Admin.Global'),
+                'help' => $this->trans('Phone number for this supplier', 'Admin.Catalog.Help'),
                 'required' => false,
                 'constraints' => $this->getPhoneCommonConstraints(),
             ])
             ->add('mobile_phone', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('Mobile phone', 'Admin.Global'),
+                'help' => $this->trans('Mobile phone number for this supplier.', 'Admin.Catalog.Help'),
                 'required' => false,
                 'constraints' => $this->getPhoneCommonConstraints(),
             ])
             ->add('address', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('Address', 'Admin.Global'),
                 'constraints' => $this->getAddressCommonConstraints(),
             ])
             ->add('address2', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('Address (2)', 'Admin.Global'),
                 'required' => false,
                 'constraints' => $this->getAddressCommonConstraints(),
             ])
             ->add('post_code', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('Zip/postal code', 'Admin.Global'),
                 'required' => false,
                 'constraints' => [
                     new TypedRegex([
@@ -186,7 +226,7 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('city', TextType::class, [
-                'empty_data' => '',
+                'label' => $this->trans('City', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -207,6 +247,7 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('id_country', CountryChoiceType::class, [
+                'label' => $this->trans('Country', 'Admin.Global'),
                 'required' => true,
                 'with_dni_attr' => true,
                 'constraints' => [
@@ -216,10 +257,15 @@ class SupplierType extends TranslatorAwareType
                         ),
                     ]),
                 ],
+                'attr' => [
+                    'class' => 'js-supplier-country-select',
+                    'data-states-url' => $this->router->generate('admin_country_states'),
+                ],
             ])
             ->add('id_state', ChoiceType::class, [
+                'label' => $this->trans('State', 'Admin.Global'),
                 'required' => true,
-                'choices' => $stateChoices,
+                'choices' => $this->statesChoiceProvider->getChoices(['id_country' => $countryId]),
                 'constraints' => [
                     new AddressStateRequired([
                         'id_country' => $countryId,
@@ -227,6 +273,7 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('dni', TextType::class, [
+                'label' => $this->trans('DNI', 'Admin.Global'),
                 'required' => false,
                 'empty_data' => '',
                 'constraints' => [
@@ -248,9 +295,13 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('logo', FileType::class, [
+                'label' => $this->trans('Logo', 'Admin.Global'),
                 'required' => false,
+                'help' => $this->trans('Upload a supplier logo from your computer.', 'Admin.Catalog.Help'),
             ])
             ->add('meta_title', TranslatableType::class, [
+                'label' => $this->trans('Meta title', 'Admin.Global'),
+                'help' => $invalidGenericNameHint,
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
@@ -270,6 +321,8 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('meta_description', TranslatableType::class, [
+                'label' => $this->trans('Meta description', 'Admin.Global'),
+                'help' => $invalidGenericNameHint,
                 'type' => TextareaType::class,
                 'required' => false,
                 'options' => [
@@ -289,6 +342,8 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('meta_keyword', TranslatableType::class, [
+                'label' => $this->trans('Meta keywords', 'Admin.Global'),
+                'help' => $keywordHint,
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
@@ -312,12 +367,14 @@ class SupplierType extends TranslatorAwareType
                 ],
             ])
             ->add('is_enabled', SwitchType::class, [
+                'label' => $this->trans('Enabled', 'Admin.Global'),
                 'required' => false,
             ])
         ;
 
         if ($this->isMultistoreEnabled) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global'),
                 'required' => false,
                 'constraints' => [
                     new NotBlank([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -128,7 +128,7 @@ class SupplierType extends TranslatorAwareType
 
         $invalidCharsText = sprintf(
             '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,
-            $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+            $this->trans('Invalid characters:', 'Admin.Global')
         );
 
         $invalidGenericNameHint = sprintf(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -133,7 +133,7 @@ class SupplierType extends TranslatorAwareType
 
         $invalidGenericNameHint = sprintf(
             '%s <>={}',
-            $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+            $this->trans('Invalid characters:', 'Admin.Global')
         );
 
         $keywordHint = sprintf(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -86,7 +86,9 @@ class SupplierType extends TranslatorAwareType
      */
     private $isMultistoreEnabled;
 
-    /** @var Router */
+    /**
+     * @var Router
+     */
     private $router;
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -105,12 +105,12 @@ class SupplierType extends TranslatorAwareType
         $countryId = 0 !== $data['id_country'] ? $data['id_country'] : $this->contextCountryId;
 
         $invalidCharsText = sprintf(
-            '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,
+            '%s ' . TypedRegexValidator::CATALOG_CHARS,
             $this->trans('Invalid characters:', 'Admin.Global')
         );
 
         $invalidGenericNameHint = sprintf(
-            '%s <>={}',
+            '%s ' . TypedRegexValidator::GENERIC_NAME_CHARS,
             $this->trans('Invalid characters:', 'Admin.Global')
         );
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -211,7 +211,7 @@ class SupplierType extends TranslatorAwareType
                 'constraints' => $this->getAddressCommonConstraints(),
             ])
             ->add('post_code', TextType::class, [
-                'label' => $this->trans('Zip/postal code', 'Admin.Global'),
+                'label' => $this->trans('Zip/Postal code', 'Admin.Global'),
                 'required' => false,
                 'constraints' => [
                     new TypedRegex([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -191,13 +191,11 @@ class SupplierType extends TranslatorAwareType
             ])
             ->add('phone', TextType::class, [
                 'label' => $this->trans('Phone', 'Admin.Global'),
-                'help' => $this->trans('Phone number for this supplier.', 'Admin.Catalog.Help'),
                 'required' => false,
                 'constraints' => $this->getPhoneCommonConstraints(),
             ])
             ->add('mobile_phone', TextType::class, [
                 'label' => $this->trans('Mobile phone', 'Admin.Global'),
-                'help' => $this->trans('Mobile phone number for this supplier.', 'Admin.Catalog.Help'),
                 'required' => false,
                 'constraints' => $this->getPhoneCommonConstraints(),
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -39,7 +39,6 @@ use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -57,16 +56,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class SupplierType extends TranslatorAwareType
 {
     /**
-     * @var array
-     */
-    private $countryChoices;
-
-    /**
-     * @var array
-     */
-    private $countryChoicesAttributes;
-
-    /**
      * @var ConfigurableFormChoiceProviderInterface
      */
     private $statesChoiceProvider;
@@ -75,11 +64,6 @@ class SupplierType extends TranslatorAwareType
      * @var int
      */
     private $contextCountryId;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
 
     /**
      * @var bool
@@ -92,8 +76,6 @@ class SupplierType extends TranslatorAwareType
     private $router;
 
     /**
-     * @param array $countryChoices
-     * @param array $countryChoicesAttributes
      * @param ConfigurableFormChoiceProviderInterface $statesChoiceProvider
      * @param int $contextCountryId
      * @param TranslatorInterface $translator
@@ -102,8 +84,6 @@ class SupplierType extends TranslatorAwareType
      * @param array $locales
      */
     public function __construct(
-        array $countryChoices,
-        array $countryChoicesAttributes,
         ConfigurableFormChoiceProviderInterface $statesChoiceProvider,
         $contextCountryId,
         TranslatorInterface $translator,
@@ -113,8 +93,6 @@ class SupplierType extends TranslatorAwareType
     ) {
         parent::__construct($translator, $locales);
 
-        $this->countryChoices = $countryChoices;
-        $this->countryChoicesAttributes = $countryChoicesAttributes;
         $this->statesChoiceProvider = $statesChoiceProvider;
         $this->contextCountryId = $contextCountryId;
         $this->isMultistoreEnabled = $isMultistoreEnabled;
@@ -167,7 +145,7 @@ class SupplierType extends TranslatorAwareType
                     ]),
                 ],
             ])
-            ->add('description', TranslateType::class, [
+            ->add('description', TranslatableType::class, [
                 'label' => $this->trans('Description', 'Admin.Global'),
                 'help' => sprintf(
                     '%s %s',
@@ -176,8 +154,6 @@ class SupplierType extends TranslatorAwareType
                 ),
                 'required' => false,
                 'type' => FormattedTextareaType::class,
-                'locales' => $this->locales,
-                'hideTabs' => false,
                 'options' => [
                     'constraints' => [
                         new CleanHtml([

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -999,6 +999,7 @@ services:
             - '@=service("prestashop.adapter.legacy.context").getContext().country.id'
             - '@translator'
             - '@=service("prestashop.adapter.multistore_feature").isActive()'
+            - '@router'
             - "@=service('prestashop.adapter.legacy.context').getLanguages()"
         tags:
           - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -993,8 +993,6 @@ services:
     form.type.sell.supplier:
         class: 'PrestaShopBundle\Form\Admin\Sell\Supplier\SupplierType'
         arguments:
-            - '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
-            - '@=service("prestashop.core.form.choice_provider.country_by_id").getChoicesAttributes()'
             - '@prestashop.adapter.form.choice_provider.country_state_by_id'
             - '@=service("prestashop.adapter.legacy.context").getContext().country.id'
             - '@translator'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
@@ -34,14 +34,6 @@
   <div class="card-block row">
     <div class="card-text">
 
-      {% if logoImage is defined and logoImage is not null %}
-        <div class="form-group row">
-          <label class="form-control-label"></label>
-          <div class="col-sm">
-            {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/logo_image.html.twig' %}
-          </div>
-        </div>
-      {% endif %}
       {{ form_row(supplierForm.name) }}
       {{ form_row(supplierForm.description) }}
       {{ form_row(supplierForm.phone) }}
@@ -54,8 +46,18 @@
         <div class="js-supplier-state{% if supplierForm.id_state.vars.choices is empty %} d-none{% endif %}">
           {{ form_row(supplierForm.id_state) }}
         </div>
+      {{ form_row(supplierForm.dni) }}
+      {{ form_row(supplierForm.logo) }}
 
-        {{ form_widget(supplierForm) }}
+      {% if logoImage is defined and logoImage is not null %}
+        <div class="form-group row">
+          <label class="form-control-label"></label>
+          <div class="col-sm">
+            {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/logo_image.html.twig' %}
+          </div>
+        </div>
+      {% endif %}
+      {{ form_widget(supplierForm) }}
 
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme supplierForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(supplierForm) }}
 <div class="card">
@@ -34,77 +34,6 @@
   <div class="card-block row">
     <div class="card-text">
 
-      {% set invalidCatalogNameHint %}
-        {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}' }}
-      {% endset %}
-
-      {{ ps.form_group_row(supplierForm.name, {}, {
-        'label': 'Name'|trans({}, 'Admin.Global'),
-        'help': invalidCatalogNameHint
-      }) }}
-
-      {% set invalidGenericNameHint %}
-        {{ 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>={}' }}
-      {% endset %}
-
-      {% set descriptionHint %}
-        {% autoescape false %}
-          {{ 'Will appear in the list of suppliers.'|trans({}, 'Admin.Catalog.Help')~ invalidCatalogNameHint }}
-        {% endautoescape %}
-      {% endset %}
-
-      {{ ps.form_group_row(supplierForm.description, {}, {
-        'label': 'Description'|trans({}, 'Admin.Global'),
-        'help': descriptionHint
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.phone, {}, {
-        'label': 'Home phone'|trans({}, 'Admin.Global'),
-        'hint': 'Phone number for this supplier'|trans({}, 'Admin.Catalog.Help')
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.mobile_phone, {}, {
-        'label': 'Mobile phone'|trans({}, 'Admin.Global'),
-        'hint': 'Mobile phone number for this supplier.'|trans({}, 'Admin.Catalog.Help')
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.address, {}, {
-        'label': 'Address'|trans({}, 'Admin.Global'),
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.address2, {}, {
-        'label': 'Address (2)'|trans({}, 'Admin.Global'),
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.post_code, {}, {
-        'label': 'Zip/postal code'|trans({}, 'Admin.Global'),
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.city, {}, {
-        'label': 'City'|trans({}, 'Admin.Global'),
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.id_country, {'attr': {
-        'class': 'js-supplier-country-select',
-        'data-states-url': path('admin_country_states') }}, {
-        'label': 'Country'|trans({}, 'Admin.Global'),
-      }) }}
-
-      <div class="js-supplier-state{% if supplierForm.id_state.vars.choices is empty %} d-none{% endif %}">
-        {{ ps.form_group_row(supplierForm.id_state, {}, {
-          'label': 'State'|trans({}, 'Admin.Global'),
-        }) }}
-      </div>
-
-      {{ ps.form_group_row(supplierForm.dni, {}, {
-        'label': 'DNI'|trans({}, 'Admin.Global'),
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.logo, {}, {
-        'label': 'Logo'|trans({}, 'Admin.Global'),
-        'help': 'Upload a supplier logo from your computer.'|trans({}, 'Admin.Catalog.Help')
-      }) }}
-
       {% if logoImage is defined and logoImage is not null %}
         <div class="form-group row">
           <label class="form-control-label"></label>
@@ -114,38 +43,8 @@
         </div>
       {% endif %}
 
-      {{ ps.form_group_row(supplierForm.meta_title, {}, {
-        'label': 'Meta title'|trans({}, 'Admin.Catalog.Feature'),
-        'help': invalidGenericNameHint
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.meta_description, {}, {
-        'label': 'Meta description'|trans({}, 'Admin.Global'),
-        'help': invalidGenericNameHint
-      }) }}
-
-      {% set keywordHint %}
-        {{ 'To add tags, click in the field, write something, and then press the "Enter" key.'|trans({}, 'Admin.Shopparameters.Help') }}
-        {{ invalidGenericNameHint }}
-      {% endset %}
-
-      {{ ps.form_group_row(supplierForm.meta_keyword, {}, {
-        'label': 'Meta keywords'|trans({}, 'Admin.Global'),
-        'help': keywordHint
-      }) }}
-
-      {{ ps.form_group_row(supplierForm.is_enabled, {}, {
-        'label': 'Enabled'|trans({}, 'Admin.Global')
-      }) }}
-
-      {% if supplierForm.shop_association is defined %}
-        {{ ps.form_group_row(supplierForm.shop_association, {}, {
-          'label': 'Shop association'|trans({}, 'Admin.Global')
-        }) }}
-      {% endif %}
-
-      {% block supplier_form_rest %}
-        {{ form_rest(supplierForm) }}
+      {% block supplier_form_widget %}
+        {{ form_widget(supplierForm) }}
       {% endblock %}
 
     </div>
@@ -159,4 +58,4 @@
     </button>
   </div>
 </div>
- {{ form_end(supplierForm) }}
+{{ form_end(supplierForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
@@ -42,10 +42,20 @@
           </div>
         </div>
       {% endif %}
+      {{ form_row(supplierForm.name) }}
+      {{ form_row(supplierForm.description) }}
+      {{ form_row(supplierForm.phone) }}
+      {{ form_row(supplierForm.mobile_phone) }}
+      {{ form_row(supplierForm.address) }}
+      {{ form_row(supplierForm.address2) }}
+      {{ form_row(supplierForm.post_code) }}
+      {{ form_row(supplierForm.city) }}
+      {{ form_row(supplierForm.id_country) }}
+        <div class="js-supplier-state{% if supplierForm.id_state.vars.choices is empty %} d-none{% endif %}">
+          {{ form_row(supplierForm.id_state) }}
+        </div>
 
-      {% block supplier_form_widget %}
         {{ form_widget(supplierForm) }}
-      {% endblock %}
 
     </div>
   </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifying  supplier form rendering
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Supplier form must look and work exactly as before. There is one exception is that description no longer has a hint about invalid characters as that hint was simply not true.

:notebook: **BC Break**
Backwards compatibility because of changed construct parameters for suppliers type. If any module extends that type they will get an exception upon updating to version containing this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/19996)
<!-- Reviewable:end -->
