### PR TITLE
Fix BO Product attributes MultiShop issue

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -618,8 +618,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $doctrine = $this->getDoctrine()->getManager();
-        $language = empty($languages[0]) ? ['id_lang' => 1, 'id_shop' => 1] : $languages[0];
-        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int) $language['id_lang'], (int) $language['id_shop']);
+        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int) $this->getContext()->language->id, (int) $this->getContext()->shop->id);
 
         $drawerModules = (new HookFinder())->setHookName('displayProductPageDrawer')
             ->setParams(['product' => $product])


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Product attributes MultiShop issue. The attributes should only be displayed in the correct shop
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19999.
| How to test?  | See #19999

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20000)
<!-- Reviewable:end -->
