### PR TITLE
Allow the + sign in the url path

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -73,6 +73,7 @@ class CookieCore
         $this->_path = rawurlencode($this->_path);
         $this->_path = str_replace('%2F', '/', $this->_path);
         $this->_path = str_replace('%7E', '~', $this->_path);
+        $this->_path = str_replace('%2B', '+', $this->_path);
         $this->_domain = $this->getDomain($shared_urls);
         $this->_name = 'PrestaShop-' . md5(($this->_standalone ? '' : _PS_VERSION_) . $name . $this->_domain);
         $this->_allow_writing = true;

--- a/src/Adapter/Assets/AssetUrlGeneratorTrait.php
+++ b/src/Adapter/Assets/AssetUrlGeneratorTrait.php
@@ -54,7 +54,7 @@ trait AssetUrlGeneratorTrait
     protected function getPathFromUri($fullUri)
     {
         if ('' !== ($trimmedUri = rtrim($this->configuration->get('__PS_BASE_URI__'), '/'))) {
-            return $this->configuration->get('_PS_ROOT_DIR_') . preg_replace('#\\' . $trimmedUri . '#', '', $fullUri, 1);
+            return $this->configuration->get('_PS_ROOT_DIR_') . preg_replace('#\\' . preg_quote($trimmedUri) . '#', '', $fullUri, 1);
         }
 
         return $this->configuration->get('_PS_ROOT_DIR_') . $fullUri;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Even if PrestaShop could be installed from a directory named with a "+" character, it was not working once installed. This PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12565
| How to test?  | 1) Try to install PrestaShop from a subfolder containing the character "+" (e.g. /prestashop+dev)<br>2) Both the FO and the BO should work without any problem. (see #12565 for more details)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20006)
<!-- Reviewable:end -->
