### PR TITLE
Enable the use of constant COLLATION placeholder into upgrade/install scripts

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -489,10 +489,13 @@ class Install extends AbstractInstall
 
             // Install custom SQL data (db_data.sql file)
             if (file_exists(_PS_INSTALL_DATA_PATH_ . 'db_data.sql')) {
+                $allowed_collation = array('utf8_general_ci', 'utf8_unicode_ci');
+                $collation_database = Db::getInstance()->getValue('SELECT @@collation_database');
                 $sql_loader = new SqlLoader();
                 $sql_loader->setMetaData(array(
                     'PREFIX_' => _DB_PREFIX_,
                     'ENGINE_TYPE' => _MYSQL_ENGINE_,
+                    'COLLATION' => (empty($collation_database) || !in_array($collation_database, $allowed_collation)) ? '' : 'COLLATE ' . $collation_database,
                 ));
 
                 $sql_loader->parse_file(_PS_INSTALL_DATA_PATH_ . 'db_data.sql', false);

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -110,6 +110,7 @@ namespace PrestaShopBundle\Install {
 
         const FILE_PREFIX = 'PREFIX_';
         const ENGINE_TYPE = 'ENGINE_TYPE';
+        const COLLATION = 'COLLATION';
 
         private static $classes14 = ['Cache', 'CacheFS', 'CarrierModule', 'Db', 'FrontController', 'Helper', 'ImportModule',
             'MCached', 'Module', 'ModuleGraph', 'ModuleGraphEngine', 'ModuleGrid', 'ModuleGridEngine',
@@ -410,6 +411,11 @@ namespace PrestaShopBundle\Install {
 
             $sqlContentVersion = array();
             $mysqlEngine = (defined('_MYSQL_ENGINE_') ? _MYSQL_ENGINE_ : 'MyISAM');
+
+            $allowed_collation = array('utf8_general_ci', 'utf8_unicode_ci');
+            $collation_database = $this->db->getValue('SELECT @@collation_database');
+            $collation = (empty($collation_database) || !in_array($collation_database, $allowed_collation)) ? '' : 'COLLATE ' . $collation_database;
+
             if (!$this->hasFailure()) {
                 foreach ($neededUpgradeFiles as $version) {
                     $file = _PS_INSTALLER_SQL_UPGRADE_DIR_ . $version . '.sql';
@@ -420,7 +426,11 @@ namespace PrestaShopBundle\Install {
                         $this->logError('Error while loading SQL upgrade file "%file%.sql".', 33, array('%file%' => $version));
                     }
                     $sqlContent .= "\n";
-                    $sqlContent = str_replace(array(self::FILE_PREFIX, self::ENGINE_TYPE), array(_DB_PREFIX_, $mysqlEngine), $sqlContent);
+                    $sqlContent = str_replace(
+                        array(self::FILE_PREFIX, self::ENGINE_TYPE, self::COLLATION),
+                        array(_DB_PREFIX_, $mysqlEngine, $collation),
+                        $sqlContent
+                    );
                     $sqlContent = preg_split("/;\s*[\r\n]+/", $sqlContent);
 
                     $sqlContentVersion[$version] = $sqlContent;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Enable the use of constant COLLATION into upgrade/install scripts. See below for details
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20013
| How to test?  | Please see ticket

## Insights

File `install-dev/upgrade/sql/1.7.6.6.sql` uses the placeholder COLLATION (just like we use PREFIX and ENGINE_TYPE) but the php code running it does not handle this placeholder.

One of the SQL queries that do not work:
```sql
CREATE TABLE `PREFIX_employee_session` (
  `id_employee_session` int(11) unsigned NOT NULL auto_increment,
  `id_employee` int(10) unsigned DEFAULT NULL,
  `token` varchar(40) DEFAULT NULL,
  PRIMARY KEY `id_employee_session` (`id_employee_session`)
) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
```

I consequently went into php files Install.php and Upgrade.php and I saw that in 3 places in the code, we use SQL placeholder ENGINE_TYPE. But only in [1 of those 3 locations](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/src/PrestaShopBundle/Install/Install.php#L285), the COLLATION placeholder was handled too.

So I added the COLLATION placeholder in the 2 areas ([in Install.php](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/src/PrestaShopBundle/Install/Install.php#L493) and [in Upgrade.php](https://github.com/PrestaShop/PrestaShop/blob/1.7.6.x/src/PrestaShopBundle/Install/Upgrade.php#L423)) where it seemed missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20014)
<!-- Reviewable:end -->
