### PR TITLE
Remove COLLATION placeholder from 1.7.6.6.sql

### DIFF
--- a/install-dev/upgrade/sql/1.7.6.6.sql
+++ b/install-dev/upgrade/sql/1.7.6.6.sql
@@ -6,11 +6,11 @@ CREATE TABLE `PREFIX_employee_session` (
   `id_employee` int(10) unsigned DEFAULT NULL,
   `token` varchar(40) DEFAULT NULL,
   PRIMARY KEY `id_employee_session` (`id_employee_session`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
 CREATE TABLE `PREFIX_customer_session` (
   `id_customer_session` int(11) unsigned NOT NULL auto_increment,
   `id_customer` int(10) unsigned DEFAULT NULL,
   `token` varchar(40) DEFAULT NULL,
   PRIMARY KEY `id_customer_session` (`id_customer_session`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.6.x
| Description?  | Remove COLLATION placeholder from 1.7.6.6.sql as it is not supported by upgrade process
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20013
| How to test?  | Please see ticket

## Insights

File `install-dev/upgrade/sql/1.7.6.6.sql` uses the placeholder COLLATION (just like we use PREFIX and ENGINE_TYPE) but the php code running it does not handle this placeholder.

One of the SQL queries that do not work:
```sql
CREATE TABLE `PREFIX_employee_session` (
  `id_employee_session` int(11) unsigned NOT NULL auto_increment,
  `id_employee` int(10) unsigned DEFAULT NULL,
  `token` varchar(40) DEFAULT NULL,
  PRIMARY KEY `id_employee_session` (`id_employee_session`)
) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8 COLLATION;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20018)
<!-- Reviewable:end -->
