### PR TITLE
BO - Customers / Wrong redirection after creating a new address from the customer detail page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -292,12 +292,16 @@ class AddressController extends FrameworkBundleAdminController
                     );
                 }
 
-                return $this->redirectToRoute('admin_addresses_index');
+                return $this->redirectToRoute('admin_customers_view', [
+                    'customerId' => $customerId,
+                ]);
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
-            return $this->redirectToRoute('admin_addresses_index');
+            return $this->redirectToRoute('admin_customers_view', [
+                'customerId' => $customerId,
+            ]);
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Address/add.html.twig', [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Changed the redirect route to redirect back to the appropriate customers_view. Added a parameter to the route to set the customer it returns back to.
| Type?         | bug fix 
| Category?     |  BO 
| BC breaks?    |  Not sure how i can test this ( Willing to take advice )
| Deprecations? |no
| Fixed ticket? | Fixes #19912
| How to test?  | <ul><li>Go to Customers => Customers </li><li>Select any customer and go to the customer detail page</li><li> Scroll down to the bottom of the page and in the address block click on the + icon to add a new address</li><li> Fill all the required fields and click on save</li><li> See Fix => redirected to the Customers Page and not the Addresses list page </li></ul>


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20028)
<!-- Reviewable:end -->
