### PR TITLE
CO : Add the theme name to the compile_id

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -35,6 +35,7 @@ if (Configuration::get('PS_SMARTY_LOCAL')) {
 }
 
 $smarty->setCompileDir(_PS_CACHE_DIR_.'smarty/compile');
+$smarty->setCompileId(_THEME_NAME_);
 $smarty->setCacheDir(_PS_CACHE_DIR_.'smarty/cache');
 $smarty->use_sub_dirs = true;
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -35,7 +35,7 @@ if (Configuration::get('PS_SMARTY_LOCAL')) {
 }
 
 $smarty->setCompileDir(_PS_CACHE_DIR_.'smarty/compile');
-$smarty->setCompileId(_THEME_NAME_);
+$smarty->setCompileId(Context::getContext()->shop->id . '-' . _THEME_NAME_);
 $smarty->setCacheDir(_PS_CACHE_DIR_.'smarty/cache');
 $smarty->use_sub_dirs = true;
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');


### PR DESCRIPTION
In order to avoid collisions between different themes (in multishop mode), we have to specify the theme name in the compile id.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In order to avoid collisions between different themes (in multishop mode), we have to specify the theme name in the compile id. Otherwise we were loading compiled templates from other themes in the current theme randomly
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a multi shop with different themes but sames modules activated. The compiled templates will be loaded from different themes if we do not set the compile ID.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20033)
<!-- Reviewable:end -->
