### PR TITLE
Fix incorrect redirect URL parameter when editing translations

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1582,9 +1582,9 @@ class AdminTranslationsControllerCore extends AdminController
         $conf = !$conf ? 4 : $conf;
         $url_base = self::$currentIndex . '&token=' . $this->token . '&conf=' . $conf;
         if ($modify_translation) {
-            Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token . '&lang=' . Tools::getValue('langue') . '&type=' . $this->type_selected . '&module=' . Tools::getValue('module') . '&theme=' . $this->theme_selected);
+            Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token . '&lang=' . Tools::getValue('langue') . '&type=' . $this->type_selected . '&module=' . Tools::getValue('module') . '&selected-theme=' . $this->theme_selected);
         } elseif ($save_and_stay) {
-            Tools::redirectAdmin($url_base . '&lang=' . $this->lang_selected->iso_code . '&type=' . $this->type_selected . '&module=' . Tools::getValue('module') . '&theme=' . $this->theme_selected);
+            Tools::redirectAdmin($url_base . '&lang=' . $this->lang_selected->iso_code . '&type=' . $this->type_selected . '&module=' . Tools::getValue('module') . '&selected-theme=' . $this->theme_selected);
         } else {
             Tools::redirectAdmin($url_base . '&action=settings');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When using the Back Office Translations feature to edit a specific theme's module translations or email templates, the 'Save and continue' button redirects you to the page for editing the general module translations/email templates (and not those specific to the theme) because a parameter in the redirect URL is incorrectly named "theme" instead of "selected-theme". This PR fixes this issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #14182
| How to test?  | In the Back Office, go to Translations -> Email translations. Select a theme. Edit an email template and click 'Save and continue'. The URL that you are redirected to should contain &selected-theme instead of &theme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20070)
<!-- Reviewable:end -->
