### PR TITLE
BO > CUSTOMERS > GENERAL SETTINGS : Wrong helper description

### DIFF
--- a/app/Resources/translations/default/AdminShopparametersHelp.xlf
+++ b/app/Resources/translations/default/AdminShopparametersHelp.xlf
@@ -524,8 +524,8 @@
         <note>Line: 38</note>
       </trans-unit>
       <trans-unit id="751e29d82b27256878d1a38f2be4e118">
-        <source>Send an email with summary of the account information (email, password) after registration.</source>
-        <target>Send an email with summary of the account information (email, password) after registration.</target>
+        <source>Send an email with summary of the account information after registration.</source>
+        <target>Send an email with summary of the account information after registration.</target>
         <note>Line: 45</note>
       </trans-unit>
       <trans-unit id="59a84d54ad58aa4bea8aeacd11e47ab2">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -42,7 +42,7 @@
                     </div>
                 </div>
                 <div class="form-group row">
-                    {{ ps.label_with_help(('Send an email after registration'|trans), ('Send an email with summary of the account information (email) after registration.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+                    {{ ps.label_with_help(('Send an email after registration'|trans), ('Send an email with summary of the account information after registration.'|trans({}, 'Admin.Shopparameters.Help'))) }}
                     <div class="col-sm">
                       {{ form_errors(generalForm.send_email_after_registration) }}
                       {{ form_widget(generalForm.send_email_after_registration) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -42,7 +42,7 @@
                     </div>
                 </div>
                 <div class="form-group row">
-                    {{ ps.label_with_help(('Send an email after registration'|trans), ('Send an email with summary of the account information (email, password) after registration.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+                    {{ ps.label_with_help(('Send an email after registration'|trans), ('Send an email with summary of the account information (email) after registration.'|trans({}, 'Admin.Shopparameters.Help'))) }}
                     <div class="col-sm">
                       {{ form_errors(generalForm.send_email_after_registration) }}
                       {{ form_widget(generalForm.send_email_after_registration) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This change fixes minor code issues I found while working on another bug. I think that since Prestashop 1.7.x passwords are no longer sent in the welcome email.
| Type?         | improvement
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20077.
| How to test?  | See #20077.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20078)
<!-- Reviewable:end -->
