### PR TITLE
Refactoring of the Order Updater and multiple related bugfixes

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -664,7 +664,7 @@ class CartRuleCore extends ObjectModel
             // When checking the cart rules present in that cart the request result is accurate
             // When we check if using the cart rule one more time is valid then we increment this value
             if (!$alreadyInCart) {
-                $quantityUsed += 1;
+                ++$quantityUsed;
             }
             if ($quantityUsed > $this->quantity_per_user) {
                 return (!$display_error) ? false : $this->trans('You cannot use this voucher anymore (usage limit reached)', [], 'Shop.Notifications.Error');

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -631,17 +631,25 @@ class CartRuleCore extends ObjectModel
             return false;
         }
 
-        if (!$this->active) {
-            return (!$display_error) ? false : $this->trans('This voucher is disabled', [], 'Shop.Notifications.Error');
-        }
-        if (!$this->quantity) {
-            return (!$display_error) ? false : $this->trans('This voucher has already been used', [], 'Shop.Notifications.Error');
-        }
-        if (strtotime($this->date_from) > time()) {
-            return (!$display_error) ? false : $this->trans('This voucher is not valid yet', [], 'Shop.Notifications.Error');
-        }
-        if (strtotime($this->date_to) < time()) {
-            return (!$display_error) ? false : $this->trans('This voucher has expired', [], 'Shop.Notifications.Error');
+        // All these checks are necessary when you add the cart rule the first, so when it's not in cart yet
+        // However when it's in the cart and you are checking if the cart rule is still valid (when performing auto remove)
+        // these rules are outdated For example:
+        //  - the cart rule can now be disabled but it was at the time it was applied, so it doesn't need to be removed
+        //  - the current date is not in the range any more but it was at the time
+        //  - the quantity is now zero but it was not when it was added
+        if (!$alreadyInCart) {
+            if (!$this->active) {
+                return (!$display_error) ? false : $this->trans('This voucher is disabled', [], 'Shop.Notifications.Error');
+            }
+            if (!$this->quantity) {
+                return (!$display_error) ? false : $this->trans('This voucher has already been used', [], 'Shop.Notifications.Error');
+            }
+            if (strtotime($this->date_from) > time()) {
+                return (!$display_error) ? false : $this->trans('This voucher is not valid yet', [], 'Shop.Notifications.Error');
+            }
+            if (strtotime($this->date_to) < time()) {
+                return (!$display_error) ? false : $this->trans('This voucher has expired', [], 'Shop.Notifications.Error');
+            }
         }
 
         if ($context->cart->id_customer) {
@@ -653,7 +661,12 @@ class CartRuleCore extends ObjectModel
 			AND od.id_cart_rule = ' . (int) $this->id . '
 			AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.current_state
 			');
-            if ($quantityUsed + 1 > $this->quantity_per_user) {
+            // When checking the cart rules present in that cart the request result is accurate
+            // When we check if using the cart rule one more time is valid then we increment this value
+            if (!$alreadyInCart) {
+                $quantityUsed += 1;
+            }
+            if ($quantityUsed > $this->quantity_per_user) {
                 return (!$display_error) ? false : $this->trans('You cannot use this voucher anymore (usage limit reached)', [], 'Shop.Notifications.Error');
             }
         }

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -67,7 +67,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
      */
     public function handle(AddCartRuleToOrderCommand $command): void
     {
-        $this->validatePercentCartRule($command);
+        $this->assertPercentCartRule($command);
         $order = $this->getOrder($command->getOrderId());
 
         $computingPrecision = new ComputingPrecision();
@@ -82,8 +82,8 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
                 throw new OrderException('Can\'t load Order Invoice object');
             }
         }
-        $this->validateAmountCartRule($command, $order, $orderInvoice);
-        $this->validateFreeShippingCartRule($command, $order, $orderInvoice);
+        $this->assertAmountCartRule($command, $order, $orderInvoice);
+        $this->assertFreeShippingCartRule($command, $order, $orderInvoice);
 
         $cart = Cart::getCartByOrderId($order->id);
         $cartRuleObj = new CartRule();
@@ -135,7 +135,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
      *
      * @throws InvalidCartRuleDiscountValueException
      */
-    private function validatePercentCartRule(AddCartRuleToOrderCommand $command): void
+    private function assertPercentCartRule(AddCartRuleToOrderCommand $command): void
     {
         if (OrderDiscountType::DISCOUNT_PERCENT !== $command->getCartRuleType()) {
             return;
@@ -162,7 +162,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
      *
      * @throws InvalidCartRuleDiscountValueException
      */
-    private function validateAmountCartRule(AddCartRuleToOrderCommand $command, Order $order, ?OrderInvoice $orderInvoice): void
+    private function assertAmountCartRule(AddCartRuleToOrderCommand $command, Order $order, ?OrderInvoice $orderInvoice): void
     {
         if (OrderDiscountType::DISCOUNT_AMOUNT !== $command->getCartRuleType()) {
             return;
@@ -207,7 +207,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
      *
      * @throws InvalidCartRuleDiscountValueException
      */
-    private function validateFreeShippingCartRule(AddCartRuleToOrderCommand $command, Order $order, ?OrderInvoice $orderInvoice): void
+    private function assertFreeShippingCartRule(AddCartRuleToOrderCommand $command, Order $order, ?OrderInvoice $orderInvoice): void
     {
         if (OrderDiscountType::FREE_SHIPPING !== $command->getCartRuleType()) {
             return;

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -30,11 +30,9 @@ use Cart;
 use CartRule;
 use Configuration;
 use Currency;
-use OrderCartRule;
 use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
-use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\InvalidCartRuleDiscountValueException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\AddCartRuleToOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -124,6 +122,6 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
             throw new OrderException('An error occurred while adding CartRule to cart', 0, $e);
         }
 
-        $this->orderAmountUpdater->update($order, $cart, null !== $orderInvoice);
+        $this->orderAmountUpdater->update($order, $cart, null !== $orderInvoice ? (int) $orderInvoice->id : null);
     }
 }

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -33,12 +33,14 @@ use Currency;
 use OrderCartRule;
 use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
+use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\InvalidCartRuleDiscountValueException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\AddCartRuleToOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderDiscountType;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
+use PrestaShopException;
 use Tools;
 use Validate;
 
@@ -47,6 +49,19 @@ use Validate;
  */
 final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements AddCartRuleToOrderHandlerInterface
 {
+    /**
+     * @var OrderAmountUpdater
+     */
+    private $orderAmountUpdater;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     */
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
+        $this->orderAmountUpdater = $orderAmountUpdater;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -59,6 +74,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
         $precision = $computingPrecision->getPrecision($currency->precision);
 
         // If the discount is for only one invoice
+        $orderInvoice = null;
         if ($order->hasInvoice() && null !== $command->getOrderInvoiceId()) {
             $orderInvoice = new OrderInvoice($command->getOrderInvoiceId()->getValue());
             if (!Validate::isLoadedObject($orderInvoice)) {
@@ -66,255 +82,48 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
             }
         }
 
-        $cartRules = [];
-        $discountValue = (float) (string) $command->getDiscountValue();
-        switch ($command->getCartRuleType()) {
-            // Percent type
-            case OrderDiscountType::DISCOUNT_PERCENT:
-                if ($discountValue <= 0 || $discountValue > 100) {
-                    throw new InvalidCartRuleDiscountValueException();
-                }
-                if (isset($orderInvoice)) {
-                    $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::ps_round(
-                        $orderInvoice->total_paid_tax_incl * $discountValue / 100,
-                        $precision
-                    );
-                    $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::ps_round(
-                        $orderInvoice->total_paid_tax_excl * $discountValue / 100,
-                        $precision
-                    );
-
-                    // Update OrderInvoice
-                    $this->applyDiscountOnInvoice(
-                        $orderInvoice,
-                        $cartRules[$orderInvoice->id]['value_tax_incl'],
-                        $cartRules[$orderInvoice->id]['value_tax_excl']
-                    );
-                } elseif ($order->hasInvoice()) {
-                    $orderInvoices = $order->getInvoicesCollection();
-                    foreach ($orderInvoices as $orderInvoice) {
-                        /* @var OrderInvoice $orderInvoice */
-                        $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::ps_round(
-                            $orderInvoice->total_paid_tax_incl * $discountValue / 100,
-                            $precision
-                        );
-                        $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::ps_round(
-                            $orderInvoice->total_paid_tax_excl * $discountValue / 100,
-                            $precision
-                        );
-
-                        // Update OrderInvoice
-                        $this->applyDiscountOnInvoice(
-                            $orderInvoice,
-                            $cartRules[$orderInvoice->id]['value_tax_incl'],
-                            $cartRules[$orderInvoice->id]['value_tax_excl']
-                        );
-                    }
-                } else {
-                    $cartRules[0]['value_tax_incl'] = Tools::ps_round(
-                        $order->total_paid_tax_incl * $discountValue / 100,
-                        $precision
-                    );
-                    $cartRules[0]['value_tax_excl'] = Tools::ps_round(
-                        $order->total_paid_tax_excl * $discountValue / 100,
-                        $precision
-                    );
-                }
-
-                break;
-            // Amount type
-            case OrderDiscountType::DISCOUNT_AMOUNT:
-                if ($discountValue <= 0) {
-                    throw new InvalidCartRuleDiscountValueException();
-                }
-                if (isset($orderInvoice)) {
-                    if ($discountValue > $orderInvoice->total_paid_tax_incl) {
-                        throw new InvalidCartRuleDiscountValueException();
-                    }
-
-                    $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::ps_round($discountValue, $precision);
-                    $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::ps_round(
-                        $discountValue / (1 + ($order->getTaxesAverageUsed() / 100)),
-                        $precision
-                    );
-
-                    // Update OrderInvoice
-                    $this->applyDiscountOnInvoice(
-                        $orderInvoice,
-                        $cartRules[$orderInvoice->id]['value_tax_incl'],
-                        $cartRules[$orderInvoice->id]['value_tax_excl']
-                    );
-                } elseif ($order->hasInvoice()) {
-                    $orderInvoices = $order->getInvoicesCollection();
-                    foreach ($orderInvoices as $orderInvoice) {
-                        /** @var OrderInvoice $orderInvoice */
-                        if ($discountValue > $orderInvoice->total_paid_tax_incl) {
-                            throw new InvalidCartRuleDiscountValueException();
-                        }
-
-                        $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::ps_round($discountValue, 2);
-                        $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::ps_round(
-                            $discountValue / (1 + ($order->getTaxesAverageUsed() / 100)),
-                            $precision
-                        );
-
-                        // Update OrderInvoice
-                        $this->applyDiscountOnInvoice(
-                            $orderInvoice,
-                            $cartRules[$orderInvoice->id]['value_tax_incl'],
-                            $cartRules[$orderInvoice->id]['value_tax_excl']
-                        );
-                    }
-                } else {
-                    if ($discountValue > $order->total_paid_tax_incl) {
-                        throw new InvalidCartRuleDiscountValueException();
-                    }
-
-                    $cartRules[0]['value_tax_incl'] = Tools::ps_round($discountValue, $precision);
-                    $cartRules[0]['value_tax_excl'] = Tools::ps_round(
-                        $discountValue / (1 + ($order->getTaxesAverageUsed() / 100)),
-                        $precision
-                    );
-                }
-
-                break;
-            // Free shipping type
-            case OrderDiscountType::FREE_SHIPPING:
-                if (isset($orderInvoice)) {
-                    if ($orderInvoice->total_paid_tax_incl - $orderInvoice->total_shipping_tax_incl <= 0) {
-                        throw new InvalidCartRuleDiscountValueException();
-                    }
-                    $cartRules[$orderInvoice->id]['value_tax_incl'] = $orderInvoice->total_shipping_tax_incl;
-                    $cartRules[$orderInvoice->id]['value_tax_excl'] = $orderInvoice->total_shipping_tax_excl;
-
-                    // Update OrderInvoice
-                    $this->applyDiscountOnInvoice(
-                        $orderInvoice,
-                        $cartRules[$orderInvoice->id]['value_tax_incl'],
-                        $cartRules[$orderInvoice->id]['value_tax_excl']
-                    );
-                } elseif ($order->hasInvoice()) {
-                    $orderInvoices = $order->getInvoicesCollection();
-                    foreach ($orderInvoices as $orderInvoice) {
-                        /** @var OrderInvoice $orderInvoice */
-                        if ($orderInvoice->total_paid_tax_incl - $orderInvoice->total_shipping_tax_incl <= 0) {
-                            throw new InvalidCartRuleDiscountValueException();
-                        }
-                        $cartRules[$orderInvoice->id]['value_tax_incl'] = $orderInvoice->total_shipping_tax_incl;
-                        $cartRules[$orderInvoice->id]['value_tax_excl'] = $orderInvoice->total_shipping_tax_excl;
-
-                        // Update OrderInvoice
-                        $this->applyDiscountOnInvoice(
-                            $orderInvoice,
-                            $cartRules[$orderInvoice->id]['value_tax_incl'],
-                            $cartRules[$orderInvoice->id]['value_tax_excl']
-                        );
-                    }
-                } else {
-                    if ($order->total_paid_tax_incl - $order->total_shipping_tax_incl <= 0) {
-                        throw new InvalidCartRuleDiscountValueException();
-                    }
-                    $cartRules[0]['value_tax_incl'] = $order->total_shipping_tax_incl;
-                    $cartRules[0]['value_tax_excl'] = $order->total_shipping_tax_excl;
-                }
-
-                break;
-            default:
-               throw new OrderException('The discount type is invalid.');
-        }
-
         $cart = Cart::getCartByOrderId($order->id);
-        $result = true;
-        foreach ($cartRules as &$cartRule) {
-            // @todo: move to separate private method
-            $cartRuleObj = new CartRule();
-            $cartRuleObj->date_from = date('Y-m-d H:i:s', strtotime('-1 hour', strtotime($order->date_add)));
-            $cartRuleObj->date_to = date('Y-m-d H:i:s', strtotime('+1 hour'));
-            $cartRuleObj->name[Configuration::get('PS_LANG_DEFAULT')] = $command->getCartRuleName();
-            // This a one time cart rule, for a specific user that can only be used once
-            $cartRuleObj->id_customer = $cart->id_customer;
-            $cartRuleObj->quantity = 1;
-            $cartRuleObj->quantity_per_user = 1;
-            $cartRuleObj->active = 0;
-            $cartRuleObj->highlight = 0;
+        $cartRuleObj = new CartRule();
+        $cartRuleObj->date_from = date('Y-m-d H:i:s', strtotime('-1 hour', strtotime($order->date_add)));
+        $cartRuleObj->date_to = date('Y-m-d H:i:s', strtotime('+1 hour'));
+        $cartRuleObj->name[Configuration::get('PS_LANG_DEFAULT')] = $command->getCartRuleName();
+        // This a one time cart rule, for a specific user that can only be used once
+        $cartRuleObj->id_customer = $cart->id_customer;
+        $cartRuleObj->quantity = 1;
+        $cartRuleObj->quantity_per_user = 1;
+        $cartRuleObj->active = 0;
+        $cartRuleObj->highlight = 0;
 
-            if ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_PERCENT) {
-                $cartRuleObj->reduction_percent = $discountValue;
-            } elseif ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_AMOUNT) {
-                $cartRuleObj->reduction_amount = $cartRule['value_tax_excl'];
-            } elseif ($command->getCartRuleType() === OrderDiscountType::FREE_SHIPPING) {
-                $cartRuleObj->free_shipping = 1;
-            }
+        if ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_PERCENT) {
+            $cartRuleObj->reduction_percent = (float) (string) $command->getDiscountValue();
+        } elseif ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_AMOUNT) {
+            $discountValueTaxIncluded = (float) (string) $command->getDiscountValue();
+            $discountValueTaxExcluded = Tools::ps_round(
+                $discountValueTaxIncluded / (1 + ($order->getTaxesAverageUsed() / 100)),
+                $precision
+            );
+            $cartRuleObj->reduction_amount = $discountValueTaxExcluded;
+        } elseif ($command->getCartRuleType() === OrderDiscountType::FREE_SHIPPING) {
+            $cartRuleObj->free_shipping = 1;
+        }
 
-            if ($result = $cartRuleObj->add()) {
-                $cartRule['id'] = $cartRuleObj->id;
-            } else {
-                break;
+        try {
+            if (!$cartRuleObj->add()) {
+                throw new OrderException('An error occurred during the CartRule creation');
             }
+        } catch (PrestaShopException $e) {
+            throw new OrderException('An error occurred during the CartRule creation', 0, $e);
+        }
+
+        try {
             // It's important to add the cart rule to the cart Or it will be ignored when cart performs AutoRemove AddAdd
-            $cart->addCartRule($cartRuleObj->id);
-        }
-
-        if ($result) {
-            foreach ($cartRules as $orderInvoiceId => $cartRule) {
-                // Create OrderCartRule
-                // @todo: move to separate private method
-                $orderCartRule = new OrderCartRule();
-                $orderCartRule->id_order = $order->id;
-                $orderCartRule->id_cart_rule = $cartRule['id'];
-                $orderCartRule->id_order_invoice = $orderInvoiceId;
-                $orderCartRule->name = $command->getCartRuleName();
-                $orderCartRule->value = $cartRule['value_tax_incl'];
-                $orderCartRule->value_tax_excl = $cartRule['value_tax_excl'];
-                $result &= $orderCartRule->add();
-
-                $order->total_discounts = Tools::ps_round(
-                    $order->total_discounts + $orderCartRule->value,
-                    $precision
-                );
-                $order->total_discounts_tax_incl = Tools::ps_round(
-                    $order->total_discounts_tax_incl + $orderCartRule->value,
-                    $precision
-                );
-                $order->total_discounts_tax_excl = Tools::ps_round(
-                    $order->total_discounts_tax_excl + $orderCartRule->value_tax_excl,
-                    $precision
-                );
-                $order->total_paid = Tools::ps_round(
-                    $order->total_paid - $orderCartRule->value,
-                    $precision
-                );
-                $order->total_paid_tax_incl = Tools::ps_round(
-                    $order->total_paid_tax_incl - $orderCartRule->value,
-                    $precision
-                );
-                $order->total_paid_tax_excl = Tools::ps_round(
-                    $order->total_paid_tax_excl - $orderCartRule->value_tax_excl,
-                    $precision
-                );
+            if (!$cart->addCartRule($cartRuleObj->id)) {
+                throw new OrderException('An error occurred while adding CartRule to cart');
             }
-
-            // Update Order
-            $result &= $order->update();
+        } catch (PrestaShopException $e) {
+            throw new OrderException('An error occurred while adding CartRule to cart', 0, $e);
         }
 
-        if (!$result) {
-            throw new OrderException('An error occurred during the OrderCartRule creation');
-        }
-    }
-
-    /**
-     * @param OrderInvoice $orderInvoice
-     * @param float $valueTaxIncl
-     * @param float $valueTaxExcl
-     */
-    protected function applyDiscountOnInvoice(OrderInvoice $orderInvoice, $valueTaxIncl, $valueTaxExcl)
-    {
-        // Update OrderInvoice
-        $orderInvoice->total_discount_tax_incl += $valueTaxIncl;
-        $orderInvoice->total_discount_tax_excl += $valueTaxExcl;
-        $orderInvoice->total_paid_tax_incl -= $valueTaxIncl;
-        $orderInvoice->total_paid_tax_excl -= $valueTaxExcl;
-        $orderInvoice->update();
+        $this->orderAmountUpdater->update($order, $cart, null !== $orderInvoice);
     }
 }

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Address;
 use Attribute;
-use Cache;
 use Carrier;
 use Cart;
 use CartRule;
@@ -41,7 +40,6 @@ use Exception;
 use Hook;
 use Order;
 use OrderCarrier;
-use OrderCartRule;
 use OrderDetail;
 use OrderInvoice;
 use PrestaShop\Decimal\Number;
@@ -197,7 +195,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             Hook::exec('actionOrderEdited', ['order' => $order]);
 
             // Update totals amount of order
-            $this->orderAmountUpdater->update($order, $cart, $orderDetail->id_order_invoice != 0);
+            $this->orderAmountUpdater->update($order, $cart, (int) $orderDetail->id_order_invoice);
 
             // Delete temporary specific prices
             $this->clearTemporarySpecificPrices($temporarySpecificPrices);

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -79,8 +79,6 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
         $orderCartRule->delete();
         $cart->removeCartRule($orderCartRule->id_cart_rule);
 
-        // We udpate the order nad its cart rules, but we disble automatic add cart rule
-        // to avoid adding the on that was just added
-        $this->orderAmountUpdater->update($order, $cart, false, false);
+        $this->orderAmountUpdater->update($order, $cart, $orderCartRule->id_order_invoice);
     }
 }

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -26,9 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
+use Cart;
+use CartRule;
 use OrderCartRule;
-use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
+use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteCartRuleFromOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\DeleteCartRuleFromOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -40,45 +42,45 @@ use Validate;
 final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implements DeleteCartRuleFromOrderHandlerInterface
 {
     /**
+     * @var OrderAmountUpdater
+     */
+    private $orderAmountUpdater;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     */
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
+        $this->orderAmountUpdater = $orderAmountUpdater;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(DeleteCartRuleFromOrderCommand $command)
     {
         $order = $this->getOrder($command->getOrderId());
         $orderCartRule = new OrderCartRule($command->getOrderCartRuleId());
-
         if (!Validate::isLoadedObject($orderCartRule) || $orderCartRule->id_order != $order->id) {
             throw new OrderException('Invalid order cart rule provided.');
         }
 
-        if ($orderCartRule->id_order_invoice) {
-            $orderInvoice = new OrderInvoice($orderCartRule->id_order_invoice);
-            if (!Validate::isLoadedObject($orderInvoice)) {
-                throw new OrderException('Can\'t load Order Invoice object');
-            }
-
-            // Update amounts of Order Invoice
-            $orderInvoice->total_discount_tax_excl -= $orderCartRule->value_tax_excl;
-            $orderInvoice->total_discount_tax_incl -= $orderCartRule->value;
-
-            $orderInvoice->total_paid_tax_excl += $orderCartRule->value_tax_excl;
-            $orderInvoice->total_paid_tax_incl += $orderCartRule->value;
-
-            // Update Order Invoice
-            $orderInvoice->update();
+        $cart = Cart::getCartByOrderId($order->id);
+        if (!Validate::isLoadedObject($cart) || $order->id_cart != $cart->id) {
+            throw new OrderException('Invalid cart provided.');
         }
 
-        // Update amounts of order
-        $order->total_discounts -= $orderCartRule->value;
-        $order->total_discounts_tax_incl -= $orderCartRule->value;
-        $order->total_discounts_tax_excl -= $orderCartRule->value_tax_excl;
-
-        $order->total_paid += $orderCartRule->value;
-        $order->total_paid_tax_incl += $orderCartRule->value;
-        $order->total_paid_tax_excl += $orderCartRule->value_tax_excl;
+        $cartRule = new CartRule($orderCartRule->id_cart_rule);
+        if (!Validate::isLoadedObject($cartRule)) {
+            throw new OrderException('Invalid cart rule provided.');
+        }
 
         // Delete Order Cart Rule and update Order
         $orderCartRule->delete();
-        $order->update();
+        $cart->removeCartRule($orderCartRule->id_cart_rule);
+
+        // We udpate the order nad its cart rules, but we disble automatic add cart rule
+        // to avoid adding the on that was just added
+        $this->orderAmountUpdater->update($order, $cart, false, false);
     }
 }

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -247,7 +247,7 @@ class OrderAmountUpdater
 
         // Shipping are computed on first invoice only
         $carrierId = $order->id_carrier;
-        $totalMethod = $firstInvoice === null || $firstInvoice->id == $invoice->id ? Cart::BOTH : Cart::BOTH_WITHOUT_SHIPPING;
+        $totalMethod = ($firstInvoice === null || $firstInvoice->id == $invoice->id) ? Cart::BOTH : Cart::BOTH_WITHOUT_SHIPPING;
         $invoice->total_paid_tax_excl = Tools::ps_round(
             (float) $cart->getOrderTotal(false, $totalMethod, $invoiceProducts, $carrierId),
             $computingPrecision

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -177,26 +177,19 @@ class OrderProductQuantityUpdater
             return $cart;
         }
 
-        if (0 === $newQuantity) {
-            // Product deletion
-            $this->orderProductRemover->deleteProductFromOrder($order, $orderDetail, $oldQuantity);
+        // Update product and customization in the cart
+        $updateQuantityResult = $cart->updateQty(
+            abs($deltaQuantity),
+            $orderDetail->product_id,
+            $orderDetail->product_attribute_id,
+            false,
+            $deltaQuantity > 0 ? 'down' : 'up'
+        );
 
-            $this->updateCustomizationOnProductDelete($order, $orderDetail, $oldQuantity);
-        } else {
-            // Update product and customization in the cart
-            $updateQuantityResult = $cart->updateQty(
-                abs($deltaQuantity),
-                $orderDetail->product_id,
-                $orderDetail->product_attribute_id,
-                false,
-                $deltaQuantity > 0 ? 'down' : 'up'
-            );
-
-            if (-1 === $updateQuantityResult) {
-                throw new \LogicException('Minimum quantity is not respected');
-            } elseif (true !== $updateQuantityResult) {
-                throw new \LogicException('Something went wrong');
-            }
+        if (-1 === $updateQuantityResult) {
+            throw new \LogicException('Minimum quantity is not respected');
+        } elseif (true !== $updateQuantityResult) {
+            throw new \LogicException('Something went wrong');
         }
 
         return $cart;

--- a/src/Core/Domain/CartRule/Exception/InvalidCartRuleDiscountValueException.php
+++ b/src/Core/Domain/CartRule/Exception/InvalidCartRuleDiscountValueException.php
@@ -33,4 +33,28 @@ namespace PrestaShop\PrestaShop\Core\Domain\CartRule\Exception;
  */
 class InvalidCartRuleDiscountValueException extends InvalidCartRuleValueException
 {
+    /**
+     * Code used when an invalid percent value is under min value
+     */
+    const INVALID_MIN_PERCENT = 10;
+
+    /**
+     * Code used when an invalid percent value is above max value
+     */
+    const INVALID_MAX_PERCENT = 20;
+
+    /**
+     * Code used when the specified amount is under min value
+     */
+    const INVALID_MIN_AMOUNT = 30;
+
+    /**
+     * Code used when the specified amount is above max value
+     */
+    const INVALID_MAX_AMOUNT = 40;
+
+    /**
+     * Code used when free shipping cannot be applied
+     */
+    const INVALID_FREE_SHIPPING = 50;
 }

--- a/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
+++ b/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
@@ -82,7 +82,7 @@ class AddCartRuleToOrderCommand
         $this->orderId = new OrderId($orderId);
         $this->cartRuleName = $cartRuleName;
         $this->cartRuleType = $cartRuleType;
-        $this->value = $value ? new Number($value) : null;
+        $this->value = null !== $value ? new Number($value) : null;
         $this->orderInvoiceId = $orderInvoiceId ? new OrderInvoiceId($orderInvoiceId) : null;
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1515,13 +1515,28 @@ class OrderController extends FrameworkBundleAdminController
                 'Only numbers and decimal points (".") are allowed in the amount fields, e.g. 10.50 or 1050.',
                 'Admin.Orderscustomers.Notification'
             ),
-            InvalidCartRuleDiscountValueException::class => sprintf(
-                '%s<ol><li>%s</li><li>%s</li><li>%s</li></ol>',
-                $this->trans('It looks like the value is invalid:', 'Admin.Orderscustomers.Notification'),
-                $this->trans('Percent or amount value must be greater than 0.', 'Admin.Orderscustomers.Notification'),
-                $this->trans('Percent value cannot exceed 100.', 'Admin.Orderscustomers.Notification'),
-                $this->trans('Discount value cannot exceed the total price of this order.', 'Admin.Orderscustomers.Notification')
-            ),
+            InvalidCartRuleDiscountValueException::class => [
+                InvalidCartRuleDiscountValueException::INVALID_MIN_PERCENT => $this->trans(
+                    'Percent value must be greater than 0.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+                InvalidCartRuleDiscountValueException::INVALID_MAX_PERCENT => $this->trans(
+                    'Percent value cannot exceed 100.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+                InvalidCartRuleDiscountValueException::INVALID_MIN_AMOUNT => $this->trans(
+                    'Amount value must be greater than 0.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+                InvalidCartRuleDiscountValueException::INVALID_MAX_AMOUNT => $this->trans(
+                    'Discount value cannot exceed the total price of this order.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+                InvalidCartRuleDiscountValueException::INVALID_FREE_SHIPPING => $this->trans(
+                    'Shipping discount value cannot exceed the total price of this order.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+            ],
             InvalidCancelProductException::class => [
                 InvalidCancelProductException::INVALID_QUANTITY => $this->trans(
                     'Positive product quantity is required.',

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -80,12 +80,16 @@ services:
 
   prestashop.adapter.order.command_handler.delete_cart_rule_from_order_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\DeleteCartRuleFromOrderHandler
+    arguments:
+      - '@prestashop.adapter.order.amount.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteCartRuleFromOrderCommand
 
   prestashop.adapter.order.command_handler.add_cart_rule_to_order_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\AddCartRuleToOrderHandler
+    arguments:
+      - '@prestashop.adapter.order.amount.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -244,6 +244,8 @@ services:
 
   prestashop.adapter.order.amount.updater:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
 
   prestashop.adapter.order.product_quantity.updater:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -232,9 +232,9 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Given /^cart rule "(.+)" is applied on order$/
+     * @Given /^cart rule "(.+)" is applied on every order$/
      */
-    public function cartRuleIsRestrictedToOrder($cartRuleName)
+    public function cartRuleIsRestrictedToEveryOrder($cartRuleName)
     {
         $this->checkCartRuleWithNameExists($cartRuleName);
         $this->cartRules[$cartRuleName]->product_restriction = 0;

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -35,6 +35,7 @@ use Order;
 use OrderState;
 use PHPUnit\Framework\Assert as Assert;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
+use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\InvalidCartRuleDiscountValueException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddOrderFromBackOfficeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\BulkChangeOrderStatusCommand;
@@ -800,12 +801,16 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         $orderId = SharedStorage::getStorage()->get($orderReference);
         $data = $table->getRowsHash();
 
-        $this->getQueryBus()->handle(new AddCartRuleToOrderCommand(
-            $orderId,
-            $data['name'],
-            $data['type'],
-            $data['value']
-        ));
+        try {
+            $this->getQueryBus()->handle(new AddCartRuleToOrderCommand(
+                $orderId,
+                $data['name'],
+                $data['type'],
+                $data['value']
+            ));
+        } catch (InvalidCartRuleDiscountValueException $e) {
+            $this->lastException = $e;
+        }
     }
 
     /**
@@ -832,6 +837,50 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             $data['value'],
             (int) $invoices->getLast()->id
         ));
+    }
+
+    /**
+     * @Then I should get error that cart rule has invalid min percent
+     */
+    public function assertInvalidMinPercentCartRule(): void
+    {
+        $this->assertLastErrorIs(
+            InvalidCartRuleDiscountValueException::class,
+            InvalidCartRuleDiscountValueException::INVALID_MIN_PERCENT
+        );
+    }
+
+    /**
+     * @Then I should get error that cart rule has invalid max percent
+     */
+    public function assertInvalidMaxPercentCartRule(): void
+    {
+        $this->assertLastErrorIs(
+            InvalidCartRuleDiscountValueException::class,
+            InvalidCartRuleDiscountValueException::INVALID_MAX_PERCENT
+        );
+    }
+
+    /**
+     * @Then I should get error that cart rule has invalid max amount
+     */
+    public function assertInvalidMaxAmountCartRule(): void
+    {
+        $this->assertLastErrorIs(
+            InvalidCartRuleDiscountValueException::class,
+            InvalidCartRuleDiscountValueException::INVALID_MAX_AMOUNT
+        );
+    }
+
+    /**
+     * @Then I should get error that cart rule has invalid min amount
+     */
+    public function assertInvalidMinAmountCartRule(): void
+    {
+        $this->assertLastErrorIs(
+            InvalidCartRuleDiscountValueException::class,
+            InvalidCartRuleDiscountValueException::INVALID_MIN_AMOUNT
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -212,3 +212,39 @@ Feature: Add discounts to order from Back Office (BO)
       | shipping tax included     | 7.42  |
       | total paid tax excluded   | 18.90 |
       | total paid tax included   | 20.03 |
+
+  Scenario: Add invalid percent value
+    Given order "bo_order1" does not have any invoices
+    When I add discount to order "bo_order1" with following details:
+      | name      | invalid percent |
+      | type      | percent         |
+      | value     | -1              |
+    Then I should get error that cart rule has invalid min percent
+    When I add discount to order "bo_order1" with following details:
+      | name      | invalid percent |
+      | type      | percent         |
+      | value     | 0               |
+    Then I should get error that cart rule has invalid min percent
+    When I add discount to order "bo_order1" with following details:
+      | name      | invalid percent |
+      | type      | percent         |
+      | value     | 101             |
+    Then I should get error that cart rule has invalid max percent
+
+  Scenario: Add invalid amount value
+    Given order "bo_order1" does not have any invoices
+    When I add discount to order "bo_order1" with following details:
+      | name      | invalid amount |
+      | type      | amount         |
+      | value     | 0              |
+    Then I should get error that cart rule has invalid min amount
+    When I add discount to order "bo_order1" with following details:
+      | name      | invalid amount |
+      | type      | amount         |
+      | value     | -1             |
+    Then I should get error that cart rule has invalid min amount
+    When I add discount to order "bo_order1" with following details:
+      | name      | invalid amount |
+      | type      | amount         |
+      | value     | 10000          |
+    Then I should get error that cart rule has invalid max amount

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags add-discounts-to-order
 @reset-database-before-feature
 @reboot-kernel-before-feature
+@add-discounts-to-order
 Feature: Add discounts to order from Back Office (BO)
   As a BO user
   I need to be able to add discounts to existing orders from the BO
@@ -42,7 +43,6 @@ Feature: Add discounts to order from Back Office (BO)
       | taxes         | $1.85    |
       | total         | $30.80   |
 
-  @add-discounts-to-order
   Scenario: Add amount type discount to order which has no invoices
     Given order "bo_order1" does not have any invoices
     When I add discount to order "bo_order1" with following details:
@@ -68,13 +68,39 @@ Feature: Add discounts to order from Back Office (BO)
       | taxes         | $1.54  |
       | total         | $25.61 |
 
-  @add-discounts-to-order
   Scenario: Add percent type discount to order which has no invoices
     Given order "bo_order1" does not have any invoices
     When I add discount to order "bo_order1" with following details:
       | name      | discount fifty-fifty |
       | type      | percent              |
       | value     | 50                   |
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.8  |
+      | total_products_wt        | 25.23 |
+      | total_shipping           | 7.42  |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
+      | total_discounts_tax_excl | 11.90 |
+      | total_discounts_tax_incl | 12.62 |
+      | total_paid_tax_excl      | 18.9  |
+      | total_paid_tax_incl      | 20.03 |
+      | total_paid               | 20.03 |
+      | total_paid_real          | 0     |
+    Then Order "bo_order1" should have following prices:
+      | products      | $23.80 |
+      | discounts     | $11.90 |
+      | shipping      | $7.00  |
+      | taxes         | $1.13  |
+      | total         | $18.90 |
+
+  # The discount amount was voluntarily computed on whole total (shipping included 32.648) excluded tax and then applied the tax rate
+  # This emphasizes the difference compared to performing rounding on each steps which makes a 0.01 difference
+  Scenario: Add amount discount matching fifty percent on whole total
+    Given order "bo_order1" does not have any invoices
+    When I add discount to order "bo_order1" with following details:
+      | name      | discount fifty-fifty |
+      | type      | amount               |
+      | value     | 16.324               |
     Then order "bo_order1" should have following details:
       | total_products           | 23.8  |
       | total_products_wt        | 25.23 |
@@ -94,35 +120,6 @@ Feature: Add discounts to order from Back Office (BO)
       | taxes         | $0.92  |
       | total         | $15.40 |
 
-  @add-discounts-to-order
-  # The discount amount was voluntarily computed on total excluded tax and then applied the tax rate
-  # This emphasizes the difference compared to performing rounding on each steps which makes a 0.01 difference
-  Scenario: Add amount discount matching fifty percent on whole total
-    Given order "bo_order1" does not have any invoices
-    When I add discount to order "bo_order1" with following details:
-      | name      | discount fifty-fifty |
-      | type      | amount               |
-      | value     | 16.324               |
-    Then order "bo_order1" should have following details:
-      | total_products           | 23.8  |
-      | total_products_wt        | 25.23 |
-      | total_shipping           | 7.42  |
-      | total_shipping_tax_excl  | 7.0   |
-      | total_shipping_tax_incl  | 7.42  |
-      | total_discounts_tax_excl | 15.4  |
-      | total_discounts_tax_incl | 16.32 |
-      | total_paid_tax_excl      | 15.4  |
-      | total_paid_tax_incl      | 16.33 |
-      | total_paid               | 16.33 |
-      | total_paid_real          | 0     |
-    Then Order "bo_order1" should have following prices:
-      | products      | $23.80 |
-      | discounts     | $15.40 |
-      | shipping      | $7.00  |
-      | taxes         | $0.93  |
-      | total         | $15.40 |
-
-  @add-discounts-to-order
   Scenario: Add amount discount matching fifty percent on products only
     Given order "bo_order1" does not have any invoices
     When I add discount to order "bo_order1" with following details:
@@ -136,19 +133,18 @@ Feature: Add discounts to order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0   |
       | total_shipping_tax_incl  | 7.42  |
       | total_discounts_tax_excl | 11.9  |
-      | total_discounts_tax_incl | 12.61 |
+      | total_discounts_tax_incl | 12.62 |
       | total_paid_tax_excl      | 18.9  |
-      | total_paid_tax_incl      | 20.04 |
-      | total_paid               | 20.04 |
+      | total_paid_tax_incl      | 20.03 |
+      | total_paid               | 20.03 |
       | total_paid_real          | 0     |
     Then Order "bo_order1" should have following prices:
       | products      | $23.80 |
       | discounts     | $11.90 |
       | shipping      | $7.00  |
-      | taxes         | $1.14  |
+      | taxes         | $1.13  |
       | total         | $18.90 |
 
-  @add-discounts-to-order
   Scenario: Add amount type discount to order and update single invoice
     When I generate invoice for "bo_order1" order
     Then order "bo_order1" should have invoice
@@ -183,7 +179,6 @@ Feature: Add discounts to order from Back Office (BO)
       | total paid tax excluded   | 25.61 |
       | total paid tax included   | 27.15 |
 
-  @add-discounts-to-order
   Scenario: Add percent type discount to order and update single invoice
     When I generate invoice for "bo_order1" order
     Then order "bo_order1" should have invoice
@@ -197,23 +192,23 @@ Feature: Add discounts to order from Back Office (BO)
       | total_shipping           | 7.42  |
       | total_shipping_tax_excl  | 7.0   |
       | total_shipping_tax_incl  | 7.42  |
-      | total_discounts_tax_excl | 15.4  |
-      | total_discounts_tax_incl | 16.33 |
-      | total_paid_tax_excl      | 15.4  |
-      | total_paid_tax_incl      | 16.32 |
-      | total_paid               | 16.32 |
+      | total_discounts_tax_excl | 11.9  |
+      | total_discounts_tax_incl | 12.62 |
+      | total_paid_tax_excl      | 18.9  |
+      | total_paid_tax_incl      | 20.03 |
+      | total_paid               | 20.03 |
       | total_paid_real          | 0     |
     Then Order "bo_order1" should have following prices:
       | products      | $23.80 |
-      | discounts     | $15.40 |
+      | discounts     | $11.90 |
       | shipping      | $7.00  |
-      | taxes         | $0.92  |
-      | total         | $15.40 |
+      | taxes         | $1.13  |
+      | total         | $18.90 |
     And last invoice for order "bo_order1" should have following prices:
       | products                  | 23.80 |
-      | discounts tax excluded    | 15.40 |
-      | discounts tax included    | 16.33 |
+      | discounts tax excluded    | 11.90 |
+      | discounts tax included    | 12.62 |
       | shipping tax excluded     | 7.00  |
       | shipping tax included     | 7.42  |
-      | total paid tax excluded   | 15.40 |
-      | total paid tax included   | 16.32 |
+      | total paid tax excluded   | 18.90 |
+      | total paid tax included   | 20.03 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -259,7 +259,7 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
-  Scenario: Add discount to whole order, when a product is cancelled the discount should still be present
+  Scenario: Add discount to all orders, when a product is cancelled the discount should still be present
     Given I add order "bo_order_cancel_product" with the following details:
       | cart                | dummy_cart                 |
       | message             | test                       |
@@ -284,7 +284,7 @@ Feature: Cancel Order Product from Back Office (BO)
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
     Given there is a cart rule named "CartRuleAmountOnWholeOrder" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
-    And cart rule "CartRuleAmountOnWholeOrder" is applied on order
+    And cart rule "CartRuleAmountOnWholeOrder" is applied on every order
     When I add products to order "bo_order_cancel_product" with new invoice and the following products details:
       | name          | Test Product Cart Rule On Order |
       | amount        | 1                               |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -99,12 +99,12 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_products_wt        | 0.0000 |
       | total_discounts_tax_excl | 0.0    |
       | total_discounts_tax_incl | 0.0    |
+      | total_shipping_tax_excl  | 0.0000 |
+      | total_shipping_tax_incl  | 0.0000 |
       | total_paid_tax_excl      | 0.0000 |
       | total_paid_tax_incl      | 0.0000 |
       | total_paid               | 0.0000 |
       | total_paid_real          | 0.0    |
-      | total_shipping_tax_excl  | 0.0000   |
-      | total_shipping_tax_incl  | 0.0000   |
 
   Scenario: Quantity is required
     Given I add order "bo_order_cancel_product" with the following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -349,6 +349,8 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
+  @test-order-discount
+  @test-order-discount-1
   Scenario: Add product with associated discount to order, Add discount to the specific order, when I remove a product the order specific discount is still present
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total
@@ -424,7 +426,8 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
-  @test-discount-removal
+  @test-order-discount
+  @test-order-discount-2
   Scenario: Add discount to the specific order, then remove it When I perform add/remove product actions the discount is not reapplied
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total
@@ -447,15 +450,21 @@ Feature: Order from Back Office (BO)
       | type      | percent               |
       | value     | 5                     |
     Then order "bo_order1" should have 1 cart rule
-    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$1.19"
+#    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$1.19"
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$1.54"
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 1.190  |
-      | total_discounts_tax_incl | 1.260  |
-      | total_paid_tax_excl      | 29.610 |
-      | total_paid_tax_incl      | 31.390 |
-      | total_paid               | 31.390 |
+#      | total_discounts_tax_excl | 1.190  |
+#      | total_discounts_tax_incl | 1.260  |
+#      | total_paid_tax_excl      | 29.610 |
+#      | total_paid_tax_incl      | 31.390 |
+#      | total_paid               | 31.390 |
+      | total_discounts_tax_excl | 1.540  |
+      | total_discounts_tax_incl | 1.630  |
+      | total_paid_tax_excl      | 29.260 |
+      | total_paid_tax_incl      | 31.020 |
+      | total_paid               | 31.020 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -220,7 +220,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
-  Scenario: Add discount to whole order, when a product is added the discount is applied, when a product is removed the discount should still be present
+  Scenario: Add discount to all orders, when a product is added the discount is applied, when a product is removed the discount should still be present
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total
     Then order "bo_order1" should have 0 invoices
@@ -239,7 +239,7 @@ Feature: Order from Back Office (BO)
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
     Given there is a cart rule named "CartRuleAmountOnWholeOrder" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
-    And cart rule "CartRuleAmountOnWholeOrder" is applied on order
+    And cart rule "CartRuleAmountOnWholeOrder" is applied on every order
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product Cart Rule On Order |
       | amount        | 1                               |
@@ -277,8 +277,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
-  @remove-cart-rule
-  Scenario: Add discount to whole order, I remove the discount from order, when I remove a product the generic discount is reapplied
+  Scenario: Add discount to all orders, I remove the discount from order, when I remove a product the generic discount is reapplied
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total
     Then order "bo_order1" should have 0 invoices
@@ -297,7 +296,7 @@ Feature: Order from Back Office (BO)
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
     And there is a product in the catalog named "Test Product Cart Rule On Order" with a price of 15.0 and 100 items in stock
     Given there is a cart rule named "CartRuleAmountOnWholeOrder" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
-    And cart rule "CartRuleAmountOnWholeOrder" is applied on order
+    And cart rule "CartRuleAmountOnWholeOrder" is applied on every order
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product Cart Rule On Order |
       | amount        | 1                               |
@@ -349,3 +348,155 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: Add product with associated discount to order, Add discount to the specific order, when I remove a product the order specific discount is still present
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should have 0 invoices
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
+    And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product With Percent Discount |
+      | amount        | 1                                  |
+      | price         | 350.00                             |
+      | free_shipping | true                               |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 175.00 |
+      | total_discounts_tax_incl | 185.50 |
+      | total_paid_tax_excl      | 205.80 |
+      | total_paid_tax_incl      | 218.15 |
+      | total_paid               | 218.15 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I add discount to order "bo_order1" with following details:
+      | name      | discount five-percent |
+      | type      | percent               |
+      | value     | 5                     |
+    Then order "bo_order1" should have 2 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$10.29"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 185.29 |
+      | total_discounts_tax_incl | 196.41 |
+      | total_paid_tax_excl      | 195.51 |
+      | total_paid_tax_incl      | 207.24 |
+      | total_paid               | 207.24 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I remove product "Test Product With Percent Discount" from order "bo_order1"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should contain 0 product "Test Product Cart Rule On Order"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$1.19"
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 1.190  |
+      | total_discounts_tax_incl | 1.260  |
+      | total_paid_tax_excl      | 29.610 |
+      | total_paid_tax_incl      | 31.390 |
+      | total_paid               | 31.390 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+
+  @test-discount-removal
+  Scenario: Add discount to the specific order, then remove it When I perform add/remove product actions the discount is not reapplied
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should have 0 invoices
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    When I add discount to order "bo_order1" with following details:
+      | name      | discount five-percent |
+      | type      | percent               |
+      | value     | 5                     |
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$1.19"
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 1.190  |
+      | total_discounts_tax_incl | 1.260  |
+      | total_paid_tax_excl      | 29.610 |
+      | total_paid_tax_incl      | 31.390 |
+      | total_paid               | 31.390 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
+    And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product With Percent Discount |
+      | amount        | 1                                  |
+      | price         | 350.00                             |
+      | free_shipping | true                               |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    Then order "bo_order1" should have 2 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$10.29"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 185.29 |
+      | total_discounts_tax_incl | 196.41 |
+      | total_paid_tax_excl      | 195.51 |
+      | total_paid_tax_incl      | 207.24 |
+      | total_paid               | 207.24 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I remove cart rule "discount five-percent" from order "bo_order1"
+    Then order "bo_order1" should have 1 cart rule
+    And order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    And order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 175.00 |
+      | total_discounts_tax_incl | 185.50 |
+      | total_paid_tax_excl      | 205.80 |
+      | total_paid_tax_incl      | 218.15 |
+      | total_paid               | 218.15 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I remove product "Test Product With Percent Discount" from order "bo_order1"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should contain 0 product "Test Product Cart Rule On Order"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This PR originally intended to fix a few bugs, but I realized a few things needed some refacto so it includes quite a lot of modifications:<br>- **CartRule:checkValidity**: some rules were considered invalid when auto removed because `$alreadyInCart` was ignored in most cases<br>- CartRule addition/removal on order was performed **manually**, so any future computations led to invalid amounts, now it insert/delete a CartRule instance in DB and then the amounts are re-computed (which fixes a lot of issues when performing multiple edition in the BO)<br>- the Order discount feature was false, it computed the total amount (so shipping fees were included in the computations)<br>- same problem happened with Invoices udpates that were updated manually<br>- the OrderAmountUpdater didn't use the carrier in its computation, it now handles weight and shipping cost updates correctly<br>- all the modifs are now performed thanks to OrderAmountUpdater which is used in all the handlers, it prevents from having different behaviour and allows to fix the potential problems in ONE place
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19949 #19960 #19890 (EPIC - Wrong discount on the order page #20162)
| How to test?  | You can look into the issues for more details (and sample videos), but basically try and perform multiple edition in an Order, by adding various discounts and products with associated discounts, try and remove discounts separately, try and remove products separately IMPORTANT NOTE: when a global discount is applied on all order you can not remove it any more until it's activated (it is actually removed and added again) Which makes sense because it respects the Shop cart rules, however from a merchant point of view this needs to be validated by the @PrestaShop/prestashop-product-team 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20083)
<!-- Reviewable:end -->
