### PR TITLE
Show last visible order state in customer order history page

### DIFF
--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -298,6 +298,8 @@ class OrderLazyArray extends AbstractLazyArray
         $historyList = $order->getHistory($context->language->id, false, true);
 
         foreach ($historyList as $historyId => $history) {
+            // HistoryList only contains order states that are not hidden to customers, the last visible order state,
+            // that is to say the one we get in the first iteration
             if ($historyId === array_key_first($historyList)) {
                 $historyId = 'current';
             }

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -298,7 +298,7 @@ class OrderLazyArray extends AbstractLazyArray
         $historyList = $order->getHistory($context->language->id, false, true);
 
         foreach ($historyList as $historyId => $history) {
-            if ($history['id_order_state'] == $order->current_state) {
+            if ($historyId === array_key_first($historyList)) {
                 $historyId = 'current';
             }
             $orderHistory[$historyId] = $history;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When an order has a state that is invisible to customer, in the customer order history page, we should display the last visible order state instead of displaying an empty field.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18892
| How to test?  | **1/** In BO > Shop Parameters > Orders > Order States, create a new state, and check "hide this state for customers"<br>**2/** In FO, do a complete order.<br>**3/** In BO, go to the created order and change its state, use the one you just created<br>**4/** Go in FO > Order History, check the current state of the order: it should not be empty, it should not display the state you just set (because it's invisible to customers), instead it should display the last visible order state.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20096)
<!-- Reviewable:end -->
