### PR TITLE
Simplify Order messages form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\OrderMessageConstraint;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Length;
@@ -38,7 +38,7 @@ use Symfony\Component\Validator\Constraints\Length;
 /**
  * Builds add/edit form for order message
  */
-class OrderMessageType extends AbstractType
+class OrderMessageType extends TranslatorAwareType
 {
     /**
      * @param FormBuilderInterface $builder
@@ -48,6 +48,7 @@ class OrderMessageType extends AbstractType
     {
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->trans('Name', 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new TypedRegex([
@@ -63,6 +64,7 @@ class OrderMessageType extends AbstractType
                 ],
             ])
             ->add('message', TranslatableType::class, [
+                'label' => $this->trans('Message', 'Admin.Global'),
                 'type' => TextareaType::class,
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -68,9 +68,9 @@ class OrderMessageType extends TranslatorAwareType
             ])
             ->add('message', TranslatableType::class, [
                 'label' => $this->trans('Message', 'Admin.Global'),
-                'error_bubbling' => true,
                 'type' => TextareaType::class,
                 'options' => [
+                    'error_bubbling' => true,
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'message',

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -52,6 +52,7 @@ class OrderMessageType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
                 'options' => [
+                    'error_bubbling' => true,
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'generic_name',
@@ -67,6 +68,7 @@ class OrderMessageType extends TranslatorAwareType
             ])
             ->add('message', TranslatableType::class, [
                 'label' => $this->trans('Message', 'Admin.Global'),
+                'error_bubbling' => true,
                 'type' => TextareaType::class,
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -30,16 +30,21 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\OrderMessageConstraint;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Translation\TranslatorAwareTrait;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**
+ * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
+ *
  * Builds add/edit form for order message
  */
-class OrderMessageType extends TranslatorAwareType
+class OrderMessageType extends AbstractType
 {
+    use TranslatorAwareTrait;
+
     /**
      * @param FormBuilderInterface $builder
      * @param array $options
@@ -48,7 +53,7 @@ class OrderMessageType extends TranslatorAwareType
     {
         $builder
             ->add('name', TranslatableType::class, [
-                'label' => $this->trans('Name', 'Admin.Global'),
+                'label' => $this->trans('Name', [], 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new TypedRegex([
@@ -64,7 +69,7 @@ class OrderMessageType extends TranslatorAwareType
                 ],
             ])
             ->add('message', TranslatableType::class, [
-                'label' => $this->trans('Message', 'Admin.Global'),
+                'label' => $this->trans('Message', [], 'Admin.Global'),
                 'type' => TextareaType::class,
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -30,8 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\OrderMessageConstraint;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Length;
@@ -41,10 +40,8 @@ use Symfony\Component\Validator\Constraints\Length;
  *
  * Builds add/edit form for order message
  */
-class OrderMessageType extends AbstractType
+class OrderMessageType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @param FormBuilderInterface $builder
      * @param array $options
@@ -53,7 +50,7 @@ class OrderMessageType extends AbstractType
     {
         $builder
             ->add('name', TranslatableType::class, [
-                'label' => $this->trans('Name', [], 'Admin.Global'),
+                'label' => $this->trans('Name', 'Admin.Global'),
                 'options' => [
                     'constraints' => [
                         new TypedRegex([
@@ -69,7 +66,7 @@ class OrderMessageType extends AbstractType
                 ],
             ])
             ->add('message', TranslatableType::class, [
-                'label' => $this->trans('Message', [], 'Admin.Global'),
+                'label' => $this->trans('Message', 'Admin.Global'),
                 'type' => TextareaType::class,
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -36,7 +36,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**
- * Backwards compatibility break due to addition of translator via TranslatorAwareTrait
+ * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using trait
  *
  * Builds add/edit form for order message
  */

--- a/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CustomerService/OrderMessageType.php
@@ -52,7 +52,6 @@ class OrderMessageType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
                 'options' => [
-                    'error_bubbling' => true,
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'generic_name',
@@ -70,7 +69,6 @@ class OrderMessageType extends TranslatorAwareType
                 'label' => $this->trans('Message', 'Admin.Global'),
                 'type' => TextareaType::class,
                 'options' => [
-                    'error_bubbling' => true,
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'message',

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -107,6 +107,13 @@ class TranslatableType extends TranslatorAwareType
     {
         foreach ($options['locales'] as $locale) {
             $typeOptions = $options['options'];
+
+            /**
+             * Makes sure that error_bubbling is true unless specified otherwise. Solves problems with errors.
+             */
+            if (!isset($typeOptions['error_bubbling'])) {
+                $typeOptions['error_bubbling'] = true;
+            }
             $typeOptions['label'] = $locale['iso_code'];
 
             if (!isset($typeOptions['required'])) {
@@ -161,7 +168,8 @@ class TranslatableType extends TranslatorAwareType
     {
         $resolver->setDefaults([
             'type' => TextType::class,
-            'options' => [],
+            'options' => [
+            ],
             'error_bubbling' => false,
             'only_enabled_locales' => false,
             'locales' => function (Options $options) {

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -107,7 +107,6 @@ class TranslatableType extends TranslatorAwareType
     {
         foreach ($options['locales'] as $locale) {
             $typeOptions = $options['options'];
-
             $typeOptions['label'] = $locale['iso_code'];
 
             if (!isset($typeOptions['required'])) {

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -168,8 +168,7 @@ class TranslatableType extends TranslatorAwareType
     {
         $resolver->setDefaults([
             'type' => TextType::class,
-            'options' => [
-            ],
+            'options' => [],
             'error_bubbling' => false,
             'only_enabled_locales' => false,
             'locales' => function (Options $options) {

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -108,12 +108,6 @@ class TranslatableType extends TranslatorAwareType
         foreach ($options['locales'] as $locale) {
             $typeOptions = $options['options'];
 
-            /**
-             * Makes sure that error_bubbling is true unless specified otherwise. Solves problems with errors.
-             */
-            if (!isset($typeOptions['error_bubbling'])) {
-                $typeOptions['error_bubbling'] = true;
-            }
             $typeOptions['label'] = $locale['iso_code'];
 
             if (!isset($typeOptions['required'])) {

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1138,8 +1138,8 @@ services:
 
     form.type.order.message:
         class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\OrderMessageType'
-        parent: 'form.type.translatable.aware'
-        public: true
+        calls:
+          - { method: setTranslator, arguments: ['@translator'] }
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1138,8 +1138,8 @@ services:
 
     form.type.order.message:
         class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\OrderMessageType'
-        calls:
-          - { method: setTranslator, arguments: ['@translator'] }
+        parent: 'form.type.translatable.aware'
+        public: true
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1138,6 +1138,8 @@ services:
 
     form.type.order.message:
         class: 'PrestaShopBundle\Form\Admin\Sell\CustomerService\OrderMessageType'
+        parent: 'form.type.translatable.aware'
+        public: true
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig
@@ -23,6 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme orderMessageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+
 {{ form_start(orderMessageForm) }}
   <div class="card">
   <h3 class="card-header">
@@ -32,17 +34,8 @@
   <div class="card-block row">
     <div class="card-text">
       {{ form_errors(orderMessageForm) }}
-
-      {{ ps.form_group_row(orderMessageForm.name, {}, {
-        'label': 'Name'|trans({}, 'Admin.Global')
-      }) }}
-
-      {{ ps.form_group_row(orderMessageForm.message, {}, {
-        'label': 'Message'|trans({}, 'Admin.Global')
-      }) }}
-
-      {% block order_message_form_rest %}
-        {{ form_rest(orderMessageForm) }}
+      {% block order_message_form_widget %}
+        {{ form_widget(orderMessageForm) }}
       {% endblock %}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -318,7 +318,7 @@
           {{ form.vars.default_locale.iso_code }}
         </button>
 
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item"
                   data-locale="{{ locale.iso_code }}"

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -358,7 +358,7 @@
           {{ form.vars.default_locale.iso_code }}
         </button>
 
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
           {% endfor %}
@@ -396,7 +396,7 @@
           {{ form.vars.default_locale.iso_code }}
         </button>
 
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item"
                   data-locale="{{ locale.iso_code }}"
@@ -729,7 +729,7 @@
         >
           {{ form.vars.default_locale.iso_code }}
         </button>
-        <div class="dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
           {% endfor %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifying order messages form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Order messages form must work and look exactly the same

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType instead of using TranslatorAwareTrait. This means if any module extends OrderMessage file they will get an exception.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20103)
<!-- Reviewable:end -->
