### PR TITLE
[WIP] Simplified credit slip options

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
@@ -84,7 +84,6 @@ class CreditSlipController extends FrameworkBundleAdminController
         $pdfByDateForm = $this->createForm(GeneratePdfByDateType::class, [], [
             'method' => Request::METHOD_GET,
         ]);
-        $pdfByDateForm->handleRequest($request);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/CreditSlip/index.html.twig', [
             'enableSidebar' => true,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
@@ -84,6 +84,7 @@ class CreditSlipController extends FrameworkBundleAdminController
         $pdfByDateForm = $this->createForm(GeneratePdfByDateType::class, [], [
             'method' => Request::METHOD_GET,
         ]);
+        $pdfByDateForm->handleRequest($request);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/CreditSlip/index.html.twig', [
             'enableSidebar' => true,
@@ -166,9 +167,7 @@ class CreditSlipController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_credit_slips_index', [
-            $pdfByDateForm->getName() => $pdfByDateForm->getData(),
-        ]);
+        return $this->redirectToRoute('admin_credit_slips_index');
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -53,6 +53,8 @@ final class CreditSlipOptionsType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('slip_prefix', TranslatableType::class, [
+            'label' => $this->translator->trans('Credit slip prefix', [], 'Admin.Orderscustomers.Feature'),
+            'help' => $this->translator->trans('Prefix used for credit slips.', [], 'Admin.Orderscustomers.Help'),
             'required' => false,
             'error_bubbling' => true,
             'options' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -60,9 +60,12 @@ final class GeneratePdfByDateType extends CommonAbstractType
 
         $blankMessage = $this->translator->trans('This field is required', [], 'Admin.Notifications.Error');
         $invalidDateMessage = $this->translator->trans('Invalid date format.', [], 'Admin.Notifications.Error');
+        $dateHintTrans = $this->translator->trans('Format: 2011-12-31 (inclusive).', [], 'Admin.Global');
 
         $builder
             ->add('from', DatePickerType::class, [
+                'label' => $this->translator->trans('From', [], 'Admin.Global'),
+                'help' => $dateHintTrans,
                 'data' => $nowDate,
                 'constraints' => [
                     new NotBlank([
@@ -75,6 +78,8 @@ final class GeneratePdfByDateType extends CommonAbstractType
                 ],
             ])
             ->add('to', DatePickerType::class, [
+                'label' => $this->translator->trans('To', [], 'Admin.Global'),
+                'help' => $dateHintTrans,
                 'data' => $nowDate,
                 'constraints' => [
                     new NotBlank([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -48,16 +49,32 @@ class SlipOptionsType extends TranslatorAwareType
                 'prefix',
                 TranslatableType::class,
                 [
+                    'label' => $this->trans('Delivery prefix', 'Admin.Orderscustomers.Help'),
+                    'help' => $this->trans('Prefix used for delivery slips.', 'Admin.Orderscustomers.Help'),
                     'type' => TextType::class,
                 ]
             )
             ->add(
                 'number',
-                FormType\NumberType::class
+                FormType\NumberType::class,
+                [
+                    'label' => $this->trans('Delivery number', 'Admin.Orderscustomers.Help'),
+                    'tooltip' => $this->trans(
+                        'The next delivery slip will begin with this number and then increase with each additional slip.',
+                        'Admin.Orderscustomers.Help'
+                    ),
+                ]
             )
             ->add(
                 'enable_product_image',
-                SwitchType::class
+                SwitchType::class,
+                [
+                    'label' => $this->trans('Enable product image', 'Admin.Orderscustomers.Help'),
+                    'help' => $this->trans(
+                        'Add an image before product name on delivery slip.',
+                        'Admin.Orderscustomers.Help'
+                    ),
+                ]
             );
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig
@@ -23,8 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme creditSlipOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {{ form_start(creditSlipOptionsForm, {
   'method': 'POST',
@@ -39,14 +39,10 @@
 
   <div class="card-block row">
     <div class="card-text">
-      {{ ps.form_group_row(creditSlipOptionsForm.slip_prefix, {}, {
-        'label': 'Credit slip prefix'|trans({}, 'Admin.Orderscustomers.Feature'),
-        'help': 'Prefix used for credit slips.'|trans({}, 'Admin.Orderscustomers.Help')
-      }) }}
+      {% block credit_slip_options_form %}
+        {{ form_widget(creditSlipOptionsForm) }}
+      {% endblock %}
     </div>
-    {% block credit_slip_options_form_rest %}
-      {{ form_rest(creditSlipOptionsForm) }}
-    {% endblock %}
   </div>
 
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
@@ -23,8 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme pdfByDateForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {{ form_start(pdfByDateForm, {
   'method': 'GET',
@@ -38,6 +38,9 @@
 
   <div class="card-block row">
     <div class="card-text">
+{#      {% block credit_slip_pdf_by_date_form %}#}
+{#        {{ form_widget(pdfByDateForm) }}#}
+{#      {% endblock %}#}
       {% set dateHint = 'Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help') %}
       {{ ps.form_group_row(pdfByDateForm.from, {}, {
         'label': 'From'|trans({}, 'Admin.Global'),
@@ -49,9 +52,6 @@
         'help': dateHint
       }) }}
     </div>
-    {% block credit_slip_pdf_by_date_form_rest %}
-      {{ form_rest(pdfByDateForm) }}
-    {% endblock %}
   </div>
 
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
@@ -38,19 +38,9 @@
 
   <div class="card-block row">
     <div class="card-text">
-{#      {% block credit_slip_pdf_by_date_form %}#}
-{#        {{ form_widget(pdfByDateForm) }}#}
-{#      {% endblock %}#}
-      {% set dateHint = 'Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help') %}
-      {{ ps.form_group_row(pdfByDateForm.from, {}, {
-        'label': 'From'|trans({}, 'Admin.Global'),
-        'help': dateHint
-      }) }}
-
-      {{ ps.form_group_row(pdfByDateForm.to, {}, {
-        'label': 'To'|trans({}, 'Admin.Global'),
-        'help': dateHint
-      }) }}
+      {% block credit_slip_pdf_by_date_form %}
+        {{ form_widget(pdfByDateForm) }}
+      {% endblock %}
     </div>
   </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
@@ -24,7 +24,7 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme optionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block content %}
   {{ form_start(pdfForm, {
@@ -78,28 +78,10 @@
             </h3>
             <div class="card-block row">
               <div class="card-text">
-                <div class="form-group row">
-                  {{ ps.label_with_help(('Delivery prefix'|trans), ('Prefix used for delivery slips.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(optionsForm.prefix) }}
-                    {{ form_widget(optionsForm.prefix) }}
-                  </div>
-                </div>
-                <div class="form-group row">
-                  {{ ps.label_with_help(('Delivery number'|trans), ('The next delivery slip will begin with this number and then increase with each additional slip.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(optionsForm.number) }}
-                    {{ form_widget(optionsForm.number) }}
-                  </div>
-                </div>
-                <div class="form-group row">
-                  {{ ps.label_with_help(('Enable product image'|trans), ('Add an image before product name on delivery slip'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(optionsForm.enable_product_image) }}
-                    {{ form_widget(optionsForm.enable_product_image) }}
-                  </div>
-                </div>
-                {{ form_rest(optionsForm) }}
+                {{ form_errors(optionsForm) }}
+                {% block slip_options_form_widget %}
+                  {{ form_widget(optionsForm) }}
+                {% endblock %}
               </div>
             </div>
             <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify credit slip options
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Form must work and look exactly the same as before

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType instead of using translator as dependency. This means if any module extends CreditSlipsOptionsType or GeneratePdfByDateType files they will get an exception.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20104)
<!-- Reviewable:end -->
