### PR TITLE
Multistore: assign a color to a shop

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -42,6 +42,9 @@ class ShopCore extends ObjectModel
     /** @var string Shop name */
     public $name;
 
+    /** @var string Shop color */
+    public $color;
+
     public $active = true;
     public $deleted;
 
@@ -70,6 +73,7 @@ class ShopCore extends ObjectModel
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'deleted' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 64],
+            'color' => ['type' => self::TYPE_STRING, 'validate' => 'isColor'],
             'id_category' => ['type' => self::TYPE_INT, 'required' => true],
             'theme_name' => ['type' => self::TYPE_STRING, 'validate' => 'isThemeName'],
             'id_shop_group' => ['type' => self::TYPE_INT, 'required' => true],

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -410,6 +410,16 @@ class AdminShopControllerCore extends AdminController
             }
 
             $this->fields_form['input'][] = [
+                'type' => 'color',
+                'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
+                'name' => 'color',
+                'desc' => [
+                    $this->trans('It will apply to the multistore header to underline your shop context.', [], 'Admin.Shopparameters.Feature')
+                ],
+                'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
+            ];
+
+            $this->fields_form['input'][] = [
                 'type' => 'select',
                 'label' => $this->trans('Shop group', [], 'Admin.Shopparameters.Feature'),
                 'desc' => $group_desc,

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -414,7 +414,7 @@ class AdminShopControllerCore extends AdminController
                 'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
                 'name' => 'color',
                 'desc' => [
-                    $this->trans('It will apply to the multistore header to underline your shop context.', [], 'Admin.Shopparameters.Feature'),
+                    $this->trans('It will only be applied to the multistore header to highlight your shop context.', [], 'Admin.Shopparameters.Feature'),
                 ],
                 'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
             ];

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -414,7 +414,7 @@ class AdminShopControllerCore extends AdminController
                 'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
                 'name' => 'color',
                 'desc' => [
-                    $this->trans('It will apply to the multistore header to underline your shop context.', [], 'Admin.Shopparameters.Feature')
+                    $this->trans('It will apply to the multistore header to underline your shop context.', [], 'Admin.Shopparameters.Feature'),
                 ],
                 'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
             ];

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -389,6 +389,16 @@ class AdminShopControllerCore extends AdminController
             }
         }
 
+        $this->fields_form['input'][] = [
+            'type' => 'color',
+            'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
+            'name' => 'color',
+            'desc' => [
+                $this->trans('It will only be applied to the multistore header to highlight your shop context.', [], 'Admin.Shopparameters.Feature'),
+            ],
+            'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
+        ];
+
         if ($display_group_list) {
             $options = [];
             foreach (ShopGroup::getShopGroups() as $group) {
@@ -408,16 +418,6 @@ class AdminShopControllerCore extends AdminController
             } else {
                 $group_desc = $this->trans('You can only move your shop to a shop group with all "share" options disabled -- or to a shop group with no customers/orders.', [], 'Admin.Shopparameters.Notification');
             }
-
-            $this->fields_form['input'][] = [
-                'type' => 'color',
-                'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
-                'name' => 'color',
-                'desc' => [
-                    $this->trans('It will only be applied to the multistore header to highlight your shop context.', [], 'Admin.Shopparameters.Feature'),
-                ],
-                'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
-            ];
 
             $this->fields_form['input'][] = [
                 'type' => 'select',

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -16,4 +16,3 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
 ;
 
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;
-ALTER TABLE `PREFIX_shop` ADD `color` VARCHAR(50) NULL DEFAULT NULL AFTER `name`;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -14,4 +14,6 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionGetProductPropertiesAfterUnitPrice', 'Product Properties', 'This hook is called after defining the properties of a product', '1'),
   (NULL, 'actionOverrideEmployeeImage', 'Override Employee Image', 'This hook is used to override the employee image', '1')
 ;
+
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;
+ALTER TABLE `PREFIX_shop` ADD `color` VARCHAR(50) NULL DEFAULT NULL AFTER `name`;

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -141,7 +141,7 @@ class Shop
     /**
      * @return string
      */
-    public function getColor(): string
+    public function getColor(): ?string
     {
         return $this->color;
     }

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -59,6 +59,13 @@ class Shop
     private $name;
 
     /**
+     * @var string
+     *
+     *  @ORM\Column(name="color", type="string", length=50)
+     */
+    private $color;
+
+    /**
      * @var int
      *
      * @ORM\Column(name="id_category", type="integer")
@@ -118,6 +125,25 @@ class Shop
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @param string $color
+     * @return Shop
+     */
+    public function setColor(string $color): Shop
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getColor(): string
+    {
+        return $this->color;
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -129,6 +129,7 @@ class Shop
 
     /**
      * @param string $color
+     *
      * @return Shop
      */
     public function setColor(string $color): Shop


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR adds a colorpicker in the shop creation/edition page (multistore context), it saves the color in DB (the ps_shop table) on save.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19302
| How to test?  | 1/ Activate multistore (BO > Shop Parameters > General Parameters)<br>2/ Add a shop (BO > Advanced Parameters > Multistore > Add Shop)<br>3/ Check that the colorpicker is here, and that the color is saved on creation and edition.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20106)
<!-- Reviewable:end -->
