### PR TITLE
Delete a product from the cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1719,7 +1719,7 @@ class CartCore extends ObjectModel
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product . '
                 AND `id_customization` = ' . (int) $id_customization .
-                ($id_product_attribute != null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                ((int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 
@@ -1730,7 +1730,7 @@ class CartCore extends ObjectModel
                 SET `quantity` = ' . (int) $preservedGifts[(int) $id_product . '-' . (int) $id_product_attribute] . '
                 WHERE `id_cart` = ' . (int) $this->id . '
                 AND `id_product` = ' . (int) $id_product .
-                ($id_product_attribute != null ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
+                ((int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '')
             );
         }
 
@@ -1739,7 +1739,7 @@ class CartCore extends ObjectModel
         DELETE FROM `' . _DB_PREFIX_ . 'cart_product`
         WHERE `id_product` = ' . (int) $id_product . '
         AND `id_customization` = ' . (int) $id_customization .
-            (null !== $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '') . '
+            ((int) $id_product_attribute ? ' AND `id_product_attribute` = ' . (int) $id_product_attribute : '') . '
         AND `id_cart` = ' . (int) $this->id . '
         ' . ((int) $id_address_delivery ? 'AND `id_address_delivery` = ' . (int) $id_address_delivery : ''));
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Previously, the "$id_product_attribute" argument was NULL by default. You can't delete a product now without explicit instructions $id_product_attribute argument = null. $cart->deleteProduct($id, null);
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | $cart->deleteProduct($id); does not delete the product if $id_product_attribute is not equal to 0

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20117)
<!-- Reviewable:end -->
