### PR TITLE
Use /usr/sbin/sendmail instead of mail() in config wording

### DIFF
--- a/src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/MailMethodChoiceProvider.php
@@ -67,7 +67,7 @@ final class MailMethodChoiceProvider implements FormChoiceProviderInterface
 
         if (null === $this->configuration->get('_PS_HOST_MODE_')) {
             $choices[
-                $this->trans('Use PHP\'s mail() function (recommended; works in most cases)', [], 'Admin.Advparameters.Feature')
+                $this->trans('Use /usr/sbin/sendmail (recommended; works in most cases)', [], 'Admin.Advparameters.Feature')
             ] = MailOption::METHOD_NATIVE;
         }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -137,7 +137,7 @@
                         <strong>{{ 'Mail method:'|trans }}</strong>
 
                         {% if system.isNativePHPmail %}
-                        {{ 'You are using the PHP mail() function.'|trans }}
+                        {{ 'You are using /usr/sbin/sendmail'|trans }}
                         {% else %}
                         {{ 'You are using your own SMTP parameters.'|trans }}</p>
                     <p>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Since [we updated Swiftmailer](https://github.com/PrestaShop/PrestaShop/pull/13761/commits/fd62d7d1ee76b5f18d98832d5bad730e8125995a#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R111), the class [`Swift_Transport_MailTransport`](https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/Transport/MailTransport.php) which was using the `mail()` function is not available anymore because it has been removed [for security reasons](https://github.com/swiftmailer/swiftmailer/issues/866#issuecomment-289291228). Instead we are relying on the class [`Swift_Transport_SendmailTransport`](https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Transport/SendmailTransport.php) which use `/usr/sbin/sendmail`. Even if that change has been made a few months ago, the Back Office options didn't reflect that change. This PR aims to change the wording according to that change.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Wordings should be validated first but in :<br>*Configure > Advanced Parameters > E-mail*  and  <br>*Configure > Advanced Parameters > Information*<br>you should have something similar the to following screenshots : 
<img width="591" alt="Capture d’écran 2020-07-09 à 17 44 38" src="https://user-images.githubusercontent.com/2168836/87061998-c5136480-c20c-11ea-9609-49732e06c477.png">
<img width="1197" alt="Capture d’écran 2020-07-09 à 17 46 45" src="https://user-images.githubusercontent.com/2168836/87062000-c6449180-c20c-11ea-8d30-4b4bdb8652c9.png">



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20124)
<!-- Reviewable:end -->
