### PR TITLE
Multistore: assign a color to a shop group

### DIFF
--- a/classes/shop/ShopGroup.php
+++ b/classes/shop/ShopGroup.php
@@ -30,6 +30,7 @@
 class ShopGroupCore extends ObjectModel
 {
     public $name;
+    public $color;
     public $active = true;
     public $share_customer;
     public $share_stock;
@@ -44,6 +45,7 @@ class ShopGroupCore extends ObjectModel
         'primary' => 'id_shop_group',
         'fields' => [
             'name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 64],
+            'color' => ['type' => self::TYPE_STRING, 'validate' => 'isColor'],
             'share_customer' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'share_order' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'share_stock' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],

--- a/controllers/admin/AdminShopGroupController.php
+++ b/controllers/admin/AdminShopGroupController.php
@@ -188,6 +188,15 @@ class AdminShopGroupControllerCore extends AdminController
                     'required' => true,
                 ],
                 [
+                    'type' => 'color',
+                    'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
+                    'name' => 'color',
+                    'desc' => [
+                        $this->trans('It will only apply to this group of shops, each store keeps its individual color.', [], 'Admin.Shopparameters.Feature'),
+                    ],
+                    'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
+                ],
+                [
                     'type' => 'switch',
                     'label' => $this->trans('Share customers', [], 'Admin.Advparameters.Feature'),
                     'name' => 'share_customer',

--- a/controllers/admin/AdminShopGroupController.php
+++ b/controllers/admin/AdminShopGroupController.php
@@ -192,7 +192,7 @@ class AdminShopGroupControllerCore extends AdminController
                     'label' => $this->trans('Color', [], 'Admin.Catalog.Feature'),
                     'name' => 'color',
                     'desc' => [
-                        $this->trans('It will only apply to this group of shops, each store keeps its individual color.', [], 'Admin.Shopparameters.Feature'),
+                        $this->trans('It will only be applied to this group of shops, each store will keep its individual color.', [], 'Admin.Shopparameters.Feature'),
                     ],
                     'hint' => $this->trans('Choose a color with the color picker, or enter an HTML color (e.g. "lightblue", "#CC6600").', [], 'Admin.Catalog.Help'),
                 ],

--- a/src/PrestaShopBundle/Entity/ShopGroup.php
+++ b/src/PrestaShopBundle/Entity/ShopGroup.php
@@ -55,7 +55,7 @@ class ShopGroup
     /**
      * @var string
      *
-     * @ORM\Column(name="name", type="string", length=50)
+     * @ORM\Column(name="color", type="string", length=50)
      */
     private $color;
 

--- a/src/PrestaShopBundle/Entity/ShopGroup.php
+++ b/src/PrestaShopBundle/Entity/ShopGroup.php
@@ -53,6 +53,13 @@ class ShopGroup
     private $name;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", length=50)
+     */
+    private $color;
+
+    /**
      * @var bool
      *
      * @ORM\Column(name="share_customer", type="boolean")
@@ -119,6 +126,29 @@ class ShopGroup
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Set color
+     *
+     * @param string $color
+     * @return ShopGroup
+     */
+    public function setColor(string $color): ShopGroup
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * Get color
+     *
+     * @return string|null
+     */
+    public function getColor(): ?string
+    {
+        return $this->color;
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/ShopGroup.php
+++ b/src/PrestaShopBundle/Entity/ShopGroup.php
@@ -132,6 +132,7 @@ class ShopGroup
      * Set color
      *
      * @param string $color
+     *
      * @return ShopGroup
      */
     public function setColor(string $color): ShopGroup


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR adds a colorpicker in the shop group creation/edition page (multistore context), it saves the color in DB (the ps_shop table) on save.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19303
| How to test?  | 1/ Activate multistore (BO > Shop Parameters > General Parameters)<br>2/ Add a shop group (BO > Advanced Parameters > Multistore > Add Shop group)<br>3/ Check that the colorpicker is here, and that the color is saved on creation and edition.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20125)
<!-- Reviewable:end -->
