### PR TITLE
Correctly uncheck previous default combination

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -160,7 +160,7 @@ var combinations = (function() {
             }
           });
 
-          $('.attribute_default_checkbox').removeAttr('checked');
+          $('.attribute_default_checkbox').prop('checked', false);
           getCombinationForm(attributeId)
             .find('input[id^="combination"][id$="_attribute_default"]')
             .prop("checked", true);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | `removeAttr('checked')` doesn't actually uncheck the checkbox, so if you change default combination multiple times, then many inputs`$('.attribute_default_checkbox')` will remain checked, and only the last in DOM tree will be saved as default combination. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | --
| How to test?  | Open product sheet with 5-10 combinations. Most probably 1st combination is default. Set 5th combination as default and save the product. There will be **Settings updated** notification, and combination will be updated correctly.<br>After this don't reload page, and set 3rd combination as default and save product again. There will be **Settings updated** notification but default combination will not be updated correctly, you can check that after reloading page, or checking database table. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20126)
<!-- Reviewable:end -->
