### PR TITLE
Computing precision: set minimum computing precision value to zero

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -948,6 +948,8 @@ abstract class PaymentModuleCore extends Module
         $order = new Order();
         $order->product_list = $productList;
 
+        $computingPrecision = Context::getContext()->getComputingPrecision();
+
         if (Configuration::get('PS_TAX_ADDRESS_TYPE') == 'id_address_delivery') {
             $address = new Address((int) $addressId);
             $context->country = new Country((int) $address->id_country, (int) $cart->id_lang);
@@ -986,29 +988,59 @@ abstract class PaymentModuleCore extends Module
         $order->gift_message = $cart->gift_message;
         $order->mobile_theme = $cart->mobile_theme;
         $order->conversion_rate = $currency->conversion_rate;
-        $amount_paid = !$dont_touch_amount ? Tools::ps_round((float) $amount_paid, Context::getContext()->getComputingPrecision()) : $amount_paid;
+        $amount_paid = !$dont_touch_amount ? Tools::ps_round((float) $amount_paid, $computingPrecision) : $amount_paid;
         $order->total_paid_real = 0;
 
-        $order->total_products = (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId);
-        $order->total_products_wt = (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId);
-        $order->total_discounts_tax_excl = (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId));
-        $order->total_discounts_tax_incl = (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId));
+        $order->total_products = (float) Tools::ps_round(
+            (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId),
+            $computingPrecision
+        );
+        $order->total_products_wt = (float) Tools::ps_round(
+            (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId),
+            $computingPrecision
+        );
+        $order->total_discounts_tax_excl = (float) Tools::ps_round(
+            (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId)),
+            $computingPrecision
+        );
+        $order->total_discounts_tax_incl = (float) Tools::ps_round(
+            (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId)),
+            $computingPrecision
+        );
         $order->total_discounts = $order->total_discounts_tax_incl;
 
-        $order->total_shipping_tax_excl = (float) $cart->getPackageShippingCost($carrierId, false, null, $order->product_list);
-        $order->total_shipping_tax_incl = (float) $cart->getPackageShippingCost($carrierId, true, null, $order->product_list);
+        $order->total_shipping_tax_excl = (float) Tools::ps_round(
+            (float) $cart->getPackageShippingCost($carrierId, false, null, $order->product_list),
+            $computingPrecision
+        );
+        $order->total_shipping_tax_incl = (float) Tools::ps_round(
+            (float) $cart->getPackageShippingCost($carrierId, true, null, $order->product_list),
+            $computingPrecision
+        );
         $order->total_shipping = $order->total_shipping_tax_incl;
 
         if (null !== $carrier && Validate::isLoadedObject($carrier)) {
             $order->carrier_tax_rate = $carrier->getTaxesRate(new Address((int) $cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
         }
 
-        $order->total_wrapping_tax_excl = (float) abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING, $order->product_list, $carrierId));
-        $order->total_wrapping_tax_incl = (float) abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING, $order->product_list, $carrierId));
+        $order->total_wrapping_tax_excl = (float) Tools::ps_round(
+            (float) abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING, $order->product_list, $carrierId)),
+            $computingPrecision
+        );
+        $order->total_wrapping_tax_incl = (float) Tools::ps_round(
+            (float) abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING, $order->product_list, $carrierId)),
+            $computingPrecision
+        );
         $order->total_wrapping = $order->total_wrapping_tax_incl;
 
-        $order->total_paid_tax_excl = (float) Tools::ps_round((float) $cart->getOrderTotal(false, Cart::BOTH, $order->product_list, $carrierId), Context::getContext()->getComputingPrecision());
-        $order->total_paid_tax_incl = (float) Tools::ps_round((float) $cart->getOrderTotal(true, Cart::BOTH, $order->product_list, $carrierId), Context::getContext()->getComputingPrecision());
+        $order->total_paid_tax_excl = (float) Tools::ps_round(
+            (float) $cart->getOrderTotal(false, Cart::BOTH, $order->product_list, $carrierId),
+            $computingPrecision
+        );
+        $order->total_paid_tax_incl = (float) Tools::ps_round(
+            (float) $cart->getOrderTotal(true, Cart::BOTH, $order->product_list, $carrierId),
+            $computingPrecision
+        );
         $order->total_paid = $order->total_paid_tax_incl;
         $order->round_mode = Configuration::get('PS_PRICE_ROUND_MODE');
         $order->round_type = Configuration::get('PS_ROUND_TYPE');
@@ -1035,10 +1067,10 @@ abstract class PaymentModuleCore extends Module
         if ($order_status->logable
             && number_format(
                 $cart_total_paid,
-                Context::getContext()->getComputingPrecision()
+                $computingPrecision
             ) != number_format(
                 $amount_paid,
-                Context::getContext()->getComputingPrecision()
+                $computingPrecision
             )
         ) {
             $id_order_state = Configuration::get('PS_OS_ERROR');

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -991,29 +991,29 @@ abstract class PaymentModuleCore extends Module
         $amount_paid = !$dont_touch_amount ? Tools::ps_round((float) $amount_paid, $computingPrecision) : $amount_paid;
         $order->total_paid_real = 0;
 
-        $order->total_products = (float) Tools::ps_round(
+        $order->total_products = Tools::ps_round(
             (float) $cart->getOrderTotal(false, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId),
             $computingPrecision
         );
-        $order->total_products_wt = (float) Tools::ps_round(
+        $order->total_products_wt = Tools::ps_round(
             (float) $cart->getOrderTotal(true, Cart::ONLY_PRODUCTS, $order->product_list, $carrierId),
             $computingPrecision
         );
-        $order->total_discounts_tax_excl = (float) Tools::ps_round(
+        $order->total_discounts_tax_excl = Tools::ps_round(
             (float) abs($cart->getOrderTotal(false, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId)),
             $computingPrecision
         );
-        $order->total_discounts_tax_incl = (float) Tools::ps_round(
+        $order->total_discounts_tax_incl = Tools::ps_round(
             (float) abs($cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS, $order->product_list, $carrierId)),
             $computingPrecision
         );
         $order->total_discounts = $order->total_discounts_tax_incl;
 
-        $order->total_shipping_tax_excl = (float) Tools::ps_round(
+        $order->total_shipping_tax_excl = Tools::ps_round(
             (float) $cart->getPackageShippingCost($carrierId, false, null, $order->product_list),
             $computingPrecision
         );
-        $order->total_shipping_tax_incl = (float) Tools::ps_round(
+        $order->total_shipping_tax_incl = Tools::ps_round(
             (float) $cart->getPackageShippingCost($carrierId, true, null, $order->product_list),
             $computingPrecision
         );
@@ -1023,21 +1023,21 @@ abstract class PaymentModuleCore extends Module
             $order->carrier_tax_rate = $carrier->getTaxesRate(new Address((int) $cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}));
         }
 
-        $order->total_wrapping_tax_excl = (float) Tools::ps_round(
+        $order->total_wrapping_tax_excl = Tools::ps_round(
             (float) abs($cart->getOrderTotal(false, Cart::ONLY_WRAPPING, $order->product_list, $carrierId)),
             $computingPrecision
         );
-        $order->total_wrapping_tax_incl = (float) Tools::ps_round(
+        $order->total_wrapping_tax_incl = Tools::ps_round(
             (float) abs($cart->getOrderTotal(true, Cart::ONLY_WRAPPING, $order->product_list, $carrierId)),
             $computingPrecision
         );
         $order->total_wrapping = $order->total_wrapping_tax_incl;
 
-        $order->total_paid_tax_excl = (float) Tools::ps_round(
+        $order->total_paid_tax_excl = Tools::ps_round(
             (float) $cart->getOrderTotal(false, Cart::BOTH, $order->product_list, $carrierId),
             $computingPrecision
         );
-        $order->total_paid_tax_incl = (float) Tools::ps_round(
+        $order->total_paid_tax_incl = Tools::ps_round(
             (float) $cart->getOrderTotal(true, Cart::BOTH, $order->product_list, $carrierId),
             $computingPrecision
         );

--- a/src/Core/Localization/CLDR/ComputingPrecision.php
+++ b/src/Core/Localization/CLDR/ComputingPrecision.php
@@ -33,7 +33,7 @@ namespace PrestaShop\PrestaShop\Core\Localization\CLDR;
 final class ComputingPrecision implements ComputingPrecisionInterface
 {
     const MULTIPLIER = 1;
-    const MINIMAL_VALUE = 2;
+    const MINIMAL_VALUE = 0;
 
     /**
      * {@inheritdoc}

--- a/tests/Unit/Core/Localization/CLDR/ComputingPrecisionTest.php
+++ b/tests/Unit/Core/Localization/CLDR/ComputingPrecisionTest.php
@@ -56,9 +56,9 @@ class ComputingPrecisionTest extends TestCase
     public function provider()
     {
         return [
-            [1, 2],
+            [1, 1],
             [3, 3],
-            [0, 2],
+            [0, 0],
         ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | On prestashop 1.7.7, the computing precision and the display precision (that is to say the precision of the currency) always have the same value, except that there is a minimum computing precision of 2. So if a currency has a precision of ZERO then the computing precision and display precision don't match anymore. This PR fixes this by setting the minimum precision to ZERO, so that it matches all the time. <br><br>In 1.7.8, we would like to make the computing precision always higher than the display precision, this would fix some minor but nonetheless important bugs we have on subtotal calculations. This won't be done in 1.7.7.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17729
| How to test?  | See issue #17729, I'm not sure there is much to test. Maybe setting the currency's precision to 0 in database, and then test that prices are well rounded, even after percent reductions?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20137)
<!-- Reviewable:end -->

