### PR TITLE
Add hooks to cart modal - crosseling and promotion

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -19,12 +19,12 @@
     <hook id="displayCartModalContent">
       <name>displayCartModalContent</name>
       <title>Content of Add-to-cart modal</title>
-      <description>This hook displays content in the middle of the window that appears after adding product to cart.</description>
+      <description>This hook displays content in the middle of the window that appears after adding product to cart</description>
     </hook>
     <hook id="displayCartModalFooter">
       <name>displayCartModalFooter</name>
       <title>Bottom of Add-to-cart modal</title>
-      <description>This hook displays content in the bottom of window that appears after adding product to cart.</description>
+      <description>This hook displays content in the bottom of window that appears after adding product to cart</description>
     </hook>     
     <hook id="displayProductPageDrawer">
       <name>displayProductPageDrawer</name>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -16,6 +16,16 @@
       <title>Maintenance Page</title>
       <description>This hook displays new elements on the maintenance page</description>
     </hook>
+    <hook id="displayCartModalContent">
+      <name>displayCartModalContent</name>
+      <title>Content of Add-to-cart modal</title>
+      <description>This hook displays content in the middle of the window that appears after adding product to cart.</description>
+    </hook>
+    <hook id="displayCartModalFooter">
+      <name>displayCartModalFooter</name>
+      <title>Bottom of Add-to-cart modal</title>
+      <description>This hook displays content in the bottom of window that appears after adding product to cart.</description>
+    </hook>     
     <hook id="displayProductPageDrawer">
       <name>displayProductPageDrawer</name>
       <title>Product Page Drawer</title>

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -9,6 +9,9 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayBanner', 'Display Banner', 'Use this hook for banners on top of every pages', '1'),
   (NULL, 'actionModuleUninstallBefore', 'Module uninstall before', 'This hook is called before module uninstall process', '1'),
   (NULL, 'actionModuleUninstallAfter', 'Module uninstall after', 'This hook is called at the end of module uninstall process', '1'),
+  (NULL, 'actionPresentProductListing', 'Product Listing Presenter', 'This hook is called before a product listing is presented', '1'),
+  (NULL, 'displayCartModalContent', 'Cart Presenter', 'This hook displays content in the middle of the window that appears after adding product to cart', '1'),
+  (NULL, 'displayCartModalFooter', 'Cart Presenter', 'This hook displays content in the bottom of window that appears after adding product to cart', '1')
   (NULL, 'actionCheckoutRender', 'Checkout process render', 'This hook is called when checkout process is constructed', '1'),
   (NULL, 'actionPresentProductListing', 'Product Listing Presenter', 'This hook is called before a product listing is presented', '1'),
   (NULL, 'actionGetProductPropertiesAfterUnitPrice', 'Product Properties', 'This hook is called after defining the properties of a product', '1'),

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -9,7 +9,6 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayBanner', 'Display Banner', 'Use this hook for banners on top of every pages', '1'),
   (NULL, 'actionModuleUninstallBefore', 'Module uninstall before', 'This hook is called before module uninstall process', '1'),
   (NULL, 'actionModuleUninstallAfter', 'Module uninstall after', 'This hook is called at the end of module uninstall process', '1'),
-  (NULL, 'actionPresentProductListing', 'Product Listing Presenter', 'This hook is called before a product listing is presented', '1'),
   (NULL, 'displayCartModalContent', 'Cart Presenter', 'This hook displays content in the middle of the window that appears after adding product to cart', '1'),
   (NULL, 'displayCartModalFooter', 'Cart Presenter', 'This hook displays content in the bottom of window that appears after adding product to cart', '1')
   (NULL, 'actionCheckoutRender', 'Checkout process render', 'This hook is called when checkout process is constructed', '1'),

--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -75,7 +75,7 @@
               {if $cart.subtotals.tax}
                 <p class="product-tax">{l s='%label%:' sprintf=['%label%' => $cart.subtotals.tax.label] d='Shop.Theme.Global'}&nbsp;<span class="value">{$cart.subtotals.tax.value}</span></p>
               {/if}
-
+              {hook h='displayCartModalContent' product=$product}
               <div class="cart-content-btn">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Continue shopping' d='Shop.Theme.Actions'}</button>
                 <a href="{$cart_url}" class="btn btn-primary"><i class="material-icons rtl-no-flip">&#xE876;</i>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</a>
@@ -84,6 +84,7 @@
           </div>
         </div>
       </div>
+      {hook h='displayCartModalFooter' product=$product}
     </div>
   </div>
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR adds two hooks to the modal that appears after adding product to cart. The bottom one can be used to display crosseling, the middle one to display special promotions or additional information.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17709
| How to test?  | Use ps_qualityassurance to see the new hooks in shopping cart modal. The 2 new hooks are `displayCartModalFooter` and `displayCartModalContent`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20140)
<!-- Reviewable:end -->
