### PR TITLE
Add actionGetProductPropertiesAfterUnitPrice hook

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -104,6 +104,7 @@ class HookCore extends ObjectModel
 
         // Controller
         'actionAjaxDieBefore' => ['from' => '1.6.1.1'],
+        'actionGetProductPropertiesAfter' => ['from' => '1.7.8.0'],
     ];
 
     const MODULE_LIST_BY_HOOK_KEY = 'hook_module_exec_list_';

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5539,6 +5539,12 @@ class ProductCore extends ObjectModel
             }
         }
 
+        Hook::exec('actionGetProductPropertiesAfter', [
+            'id_lang' => $id_lang,
+            'product' => &$row,
+            'context' => $context,
+        ]);
+
         $combination = new Combination($id_product_attribute);
 
         if (0 != $combination->unit_price_impact && 0 != $row['unit_price_ratio']) {
@@ -5552,7 +5558,7 @@ class ProductCore extends ObjectModel
             $row['unit_price'] = 0.0;
         }
 
-         Hook::exec('actionGetProductPropertiesAfter', [
+        Hook::exec('actionGetProductPropertiesAfterUnitPrice', [
             'id_lang' => $id_lang,
             'product' => &$row,
             'context' => $context,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5539,12 +5539,6 @@ class ProductCore extends ObjectModel
             }
         }
 
-        Hook::exec('actionGetProductPropertiesAfter', [
-            'id_lang' => $id_lang,
-            'product' => &$row,
-            'context' => $context,
-        ]);
-
         $combination = new Combination($id_product_attribute);
 
         if (0 != $combination->unit_price_impact && 0 != $row['unit_price_ratio']) {
@@ -5557,6 +5551,12 @@ class ProductCore extends ObjectModel
         } else {
             $row['unit_price'] = 0.0;
         }
+
+         Hook::exec('actionGetProductPropertiesAfter', [
+            'id_lang' => $id_lang,
+            'product' => &$row,
+            'context' => $context,
+        ]);
 
         self::$productPropertiesCache[$cache_key] = $row;
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2754,5 +2754,10 @@
       <title>Product Listing Presenter</title>
       <description>This hook is called before a product listing is presented</description>
     </hook>
+    <hook id="actionGetProductPropertiesAfterUnitPrice">
+      <name>actionGetProductPropertiesAfterUnitPrice</name>
+      <title>Product Properties</title>
+      <description>This hook is called after defining the properties of a product</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -10,4 +10,5 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionModuleUninstallBefore', 'Module uninstall before', 'This hook is called before module uninstall process', '1'),
   (NULL, 'actionModuleUninstallAfter', 'Module uninstall after', 'This hook is called at the end of module uninstall process', '1'),
   (NULL, 'actionPresentProductListing', 'Product Listing Presenter', 'This hook is called before a product listing is presented', '1')
+  (NULL, 'actionGetProductPropertiesAfterUnitPrice', 'Product Properties', 'This hook is called after defining the properties of a product', '1')
 ;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Move the hook actionGetProductPropertiesAfter to allow the unit price to be changed if necessary. Basically, the hook is called before the calculation
| Type?         | new feature 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| How to test? | Use module https://github.com/PrestaShop/ps_qualityassurance. This PR adds a new hook `actionGetProductPropertiesAfterUnitPrice` that is called in the same situation as `actionGetProductPropertiesAfter` but a little bit later so more data are accessible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20143)
<!-- Reviewable:end -->
