### PR TITLE
[WIP] Fix wholesale price decimals being lost in combinations when updating them

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2119,6 +2119,7 @@ class ProductCore extends ObjectModel
 
         $price = str_replace(',', '.', $price);
         $weight = str_replace(',', '.', $weight);
+        $wholesale_price = str_replace(',', '.', $wholesale_price);
 
         $combination->price = (float) $price;
         $combination->wholesale_price = (float) $wholesale_price;


### PR DESCRIPTION
Based on the recommendation by @guirou62 here: https://github.com/PrestaShop/PrestaShop/issues/9972#issuecomment-655542548

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wholesale price was not replaced like other price values, making it lose its decimals.
| Type?         | bug fix
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Modifying a product description was removing decimals in combinations prices. Now it won't. Check it by creating a new product with combinations, store those combinations with prices. Go back to the list, edit again the product and change its description. With the fix, the combination prices' decimals won't be lost. Otherwise numbers are truncated losing their decimals.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20144)
<!-- Reviewable:end -->
