### PR TITLE
Color picker doesn't recognize html color name on page load, in BO

### DIFF
--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -67,7 +67,7 @@
         'color': $.fn.mColorPicker.textColor(element.css('background-color'))
       }).trigger('change');
     } catch (r) {}
-    };
+  };
 
   $.fn.mColorPicker.currentColor = false;
   $.fn.mColorPicker.currentValue = false;

--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -59,7 +59,7 @@
     return this;
   };
 
- $.fn.mColorPicker.setTextColor = function(element) {
+  $.fn.mColorPicker.setTextColor = function(element) {
     try {
       element.css({
         'background-color': element.val()

--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -39,15 +39,11 @@
     if ($('#css_disabled_color_picker').length < 1) $('head').prepend('<style id="css_disabled_color_picker" type="text/css">.mColorPicker[disabled] + span, .mColorPicker[disabled="disabled"] + span, .mColorPicker[disabled="true"] + span {filter:alpha(opacity=50);-moz-opacity:0.5;-webkit-opacity:0.5;-khtml-opacity: 0.5;opacity: 0.5;}</style>');
 
     $(document).on('keyup', '.mColorPicker', function () {
-
-      try {
-
-        $(this).css({
-          'background-color': $(this).val()
-        }).css({
-          'color': $.fn.mColorPicker.textColor($(this).css('background-color'))
-        }).trigger('change');
-      } catch (r) {}
+     $.fn.mColorPicker.setTextColor($(this));
+    });
+    
+    $(document).ready(function() {
+      $.fn.mColorPicker.setTextColor($('.mColorPicker'));
     });
 
     $(document).on('click', '.mColorPickerTrigger', function () {
@@ -61,6 +57,16 @@
     });
 
     return this;
+  };
+
+ $.fn.mColorPicker.setTextColor = function(element) {
+    try {
+      element.css({
+      'background-color': element.val()
+    }).css({
+      'color': $.fn.mColorPicker.textColor(element.css('background-color'))
+      }).trigger('change');
+    } catch (r) {}
   };
 
   $.fn.mColorPicker.currentColor = false;

--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -62,12 +62,12 @@
  $.fn.mColorPicker.setTextColor = function(element) {
     try {
       element.css({
-      'background-color': element.val()
-    }).css({
-      'color': $.fn.mColorPicker.textColor(element.css('background-color'))
+        'background-color': element.val()
+      }).css({
+        'color': $.fn.mColorPicker.textColor(element.css('background-color'))
       }).trigger('change');
     } catch (r) {}
-  };
+    };
 
   $.fn.mColorPicker.currentColor = false;
   $.fn.mColorPicker.currentValue = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | In BO, the color picker allows to pick a color, but also to write an HTML color name, like "blue" or "red" for example. When we type "red", the color automatically switches to red, this is working, and the value"red" is properly saved when we push the form. But if you go back, in edit mode, the field will have the value "red", which is correct, but the color will remain black, it seems like the colorpicker doesn't update the color on page load when it is an HTML color name, it works fine with hexa codes. by @matthieu-rolland 
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20108
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/20108 by @matthieu-rolland .

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20148)
<!-- Reviewable:end -->
