### PR TITLE
BackOffice - Addresses page - Fix error after saving new address 

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -301,7 +301,7 @@ class AddressController extends FrameworkBundleAdminController
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
-            if($customerId){
+            if ($customerId){
                 return $this->redirectToRoute('admin_customers_view', ['customerId' => $customerId]);
             }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -292,7 +292,7 @@ class AddressController extends FrameworkBundleAdminController
                     );
                 }
 
-                if ($customerId){
+                if ($customerId) {
                     return $this->redirectToRoute('admin_customers_view', ['customerId' => $customerId]);
                 }
 
@@ -301,7 +301,7 @@ class AddressController extends FrameworkBundleAdminController
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
-            if ($customerId){
+            if ($customerId) {
                 return $this->redirectToRoute('admin_customers_view', ['customerId' => $customerId]);
             }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -292,16 +292,24 @@ class AddressController extends FrameworkBundleAdminController
                     );
                 }
 
-                return $this->redirectToRoute('admin_customers_view', [
-                    'customerId' => $customerId,
-                ]);
+                if($customerId){
+                    return $this->redirectToRoute('admin_customers_view', [
+                        'customerId' => $customerId,
+                    ]);
+                }
+
+                return $this->redirectToRoute('admin_addresses_index');
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
-            return $this->redirectToRoute('admin_customers_view', [
-                'customerId' => $customerId,
-            ]);
+            if($customerId){
+                return $this->redirectToRoute('admin_customers_view', [
+                    'customerId' => $customerId,
+                ]);
+            }
+
+           return $this->redirectToRoute('admin_addresses_index');
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Address/add.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -292,10 +292,8 @@ class AddressController extends FrameworkBundleAdminController
                     );
                 }
 
-                if($customerId){
-                    return $this->redirectToRoute('admin_customers_view', [
-                        'customerId' => $customerId,
-                    ]);
+                if ($customerId){
+                    return $this->redirectToRoute('admin_customers_view', ['customerId' => $customerId]);
                 }
 
                 return $this->redirectToRoute('admin_addresses_index');
@@ -304,12 +302,10 @@ class AddressController extends FrameworkBundleAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
 
             if($customerId){
-                return $this->redirectToRoute('admin_customers_view', [
-                    'customerId' => $customerId,
-                ]);
+                return $this->redirectToRoute('admin_customers_view', ['customerId' => $customerId]);
             }
 
-           return $this->redirectToRoute('admin_addresses_index');
+            return $this->redirectToRoute('admin_addresses_index');
         }
 
         return $this->render('@PrestaShop/Admin/Sell/Address/add.html.twig', [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | An error occurs when trying to add a new address in BO. This bug was introduced here https://github.com/PrestaShop/PrestaShop/pull/20028
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20095.
| How to test?  | See #20095 by @boubkerbribri .

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20149)
<!-- Reviewable:end -->
