### PR TITLE
Product duplication in table ps_product_supplier

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4745,6 +4745,7 @@ class ProductCore extends ObjectModel
             WHERE pa.`id_product` = ' . (int) $id_product_old
         );
         $combinations = [];
+        $product_supplier_keys = [];
 
         foreach ($result as $row) {
             $id_product_attribute_old = (int) $row['id_product_attribute'];
@@ -4799,6 +4800,14 @@ class ProductCore extends ObjectModel
             AND `id_product` = ' . (int) $id_product_old);
 
             foreach ($result3 as $row3) {
+                $current_supplier_key = $id_product_new . '_' . $id_product_attribute_new . '_' . $row3['id_supplier'];
+
+                if (in_array($current_supplier_key, $product_supplier_keys)) {
+                    continue;
+                } else {
+                    $product_supplier_keys[] = $current_supplier_key;
+                }
+
                 unset($row3['id_product_supplier']);
                 $row3['id_product'] = $id_product_new;
                 $row3['id_product_attribute'] = $id_product_attribute_new;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4801,13 +4801,13 @@ class ProductCore extends ObjectModel
 
             foreach ($result3 as $row3) {
                 $current_supplier_key = $id_product_new . '_' . $id_product_attribute_new . '_' . $row3['id_supplier'];
-                
+
                 if (in_array($current_supplier_key, $product_supplier_keys)) {
                     continue;
                 } else {
                     $product_supplier_keys[] = $current_supplier_key;
                 }
-                
+
                 unset($row3['id_product_supplier']);
                 $row3['id_product'] = $id_product_new;
                 $row3['id_product_attribute'] = $id_product_attribute_new;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4804,9 +4804,9 @@ class ProductCore extends ObjectModel
 
                 if (in_array($current_supplier_key, $product_supplier_keys)) {
                     continue;
-                } else {
-                    $product_supplier_keys[] = $current_supplier_key;
                 }
+
+                $product_supplier_keys[] = $current_supplier_key;
 
                 unset($row3['id_product_supplier']);
                 $row3['id_product'] = $id_product_new;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4745,6 +4745,7 @@ class ProductCore extends ObjectModel
             WHERE pa.`id_product` = ' . (int) $id_product_old
         );
         $combinations = [];
+        $product_supplier_keys = [];
 
         foreach ($result as $row) {
             $id_product_attribute_old = (int) $row['id_product_attribute'];
@@ -4799,6 +4800,13 @@ class ProductCore extends ObjectModel
             AND `id_product` = ' . (int) $id_product_old);
 
             foreach ($result3 as $row3) {
+                $current_supplier_key = $id_product_new . '_' . $id_product_attribute_new . '_' . $row3['id_supplier'];
+                if (in_array($current_supplier_key, $product_supplier_keys)) {
+                    continue;
+                } else {
+                    $product_supplier_keys[] = $current_supplier_key;
+                }
+                
                 unset($row3['id_product_supplier']);
                 $row3['id_product'] = $id_product_new;
                 $row3['id_product_attribute'] = $id_product_attribute_new;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4801,6 +4801,7 @@ class ProductCore extends ObjectModel
 
             foreach ($result3 as $row3) {
                 $current_supplier_key = $id_product_new . '_' . $id_product_attribute_new . '_' . $row3['id_supplier'];
+                
                 if (in_array($current_supplier_key, $product_supplier_keys)) {
                     continue;
                 } else {


### PR DESCRIPTION
Excessive product duplication in table ps_product_supplier

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When duplicating a product in a multistore installation and only with products that have features and/or combinations a 500 error page is shown.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | yes / no
| Deprecations? | no
| Fixed ticket? | Fixes #19574 
| How to test?  | Activate multistore<br>All Shops environment in BO<br>Have Suppliers ready<br>Go to Products list<br>Edit that product > in tab Option, choose a Supplier > Save<br>Go back to your product list<br>Duplicate the newly edited product -> NOK 500 error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20153)
<!-- Reviewable:end -->
