### PR TITLE
Return Response to provide a good error message when import directory doesnt exist

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -63,7 +63,10 @@ class ImportController extends FrameworkBundleAdminController
         $importDir = $this->get('prestashop.core.import.dir');
 
         if (!$this->checkImportDirectory($importDir)) {
-            return $this->getTemplateParams($request);
+            return $this->render(
+                '@PrestaShop/Admin/Configure/AdvancedParameters/ImportPage/import.html.twig',
+                $this->getTemplateParams($request)
+            );
         }
 
         $formHandler = $this->get('prestashop.admin.import.form_handler');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When import directory was unusable (doesnt exist or bad rights) the ImportController would return an array instead of a Response which would result in a very nasty error message (see [this issue](https://github.com/PrestaShop/PrestaShop/issues/20163)). I fix this part of the code to obtain a correct error message.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20163
| How to test?  | Fetch this PR. Delete directory `admin-dev/import`. Try to open page "Import" in BO. Before the PR you have a very nasty exception screen, with this PR you have a readable error message.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20166)
<!-- Reviewable:end -->
