### PR TITLE
Notifications bell icon read fix

### DIFF
--- a/src/Adapter/Notification/CommandHandler/UpdateEmployeeNotificationLastElementHandler.php
+++ b/src/Adapter/Notification/CommandHandler/UpdateEmployeeNotificationLastElementHandler.php
@@ -42,6 +42,6 @@ final class UpdateEmployeeNotificationLastElementHandler implements UpdateEmploy
      */
     public function handle(UpdateEmployeeNotificationLastElementCommand $command)
     {
-        (new Notification())->updateEmployeeLastElement($command->getType());
+        (new Notification())->updateEmployeeLastElement($command->getType()->getValue());
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The notification icon showed unread notifications even when admin read them.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes #20169 .
| How to test?  | See fixed ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20188)
<!-- Reviewable:end -->
