### PR TITLE
[ WIP ] Do not display any shipping method in the summary of virtual cart

### DIFF
--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -58,36 +58,36 @@
 
   {if !$cart.is_virtual}
     <div class="row">
-    <div class="col-md-12">
-      <h4 class="h4">
-      {l s='Shipping Method' d='Shop.Theme.Checkout'}
-        <span class="step-edit step-to-delivery js-edit-delivery"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
-      </h4>
+      <div class="col-md-12">
+        <h4 class="h4">
+        {l s='Shipping Method' d='Shop.Theme.Checkout'}
+          <span class="step-edit step-to-delivery js-edit-delivery"><i class="material-icons edit">mode_edit</i> {l s='edit' d='Shop.Theme.Actions'}</span>
+        </h4>
 
-      <div class="col-md-12 summary-selected-carrier">
-        <div class="row">
-          <div class="col-md-2">
-            <div class="logo-container">
-              {if $selected_delivery_option.logo}
-                <img src="{$selected_delivery_option.logo}" alt="{$selected_delivery_option.name}">
-              {else}
-                &nbsp;
-              {/if}
+        <div class="col-md-12 summary-selected-carrier">
+          <div class="row">
+            <div class="col-md-2">
+              <div class="logo-container">
+                {if $selected_delivery_option.logo}
+                  <img src="{$selected_delivery_option.logo}" alt="{$selected_delivery_option.name}">
+                {else}
+                  &nbsp;
+                {/if}
+              </div>
             </div>
-          </div>
-          <div class="col-md-4">
-            <span class="carrier-name">{$selected_delivery_option.name}</span>
-          </div>
-          <div class="col-md-4">
-            <span class="carrier-delay">{$selected_delivery_option.delay}</span>
-          </div>
-          <div class="col-md-2">
-            <span class="carrier-price">{$selected_delivery_option.price}</span>
+            <div class="col-md-4">
+              <span class="carrier-name">{$selected_delivery_option.name}</span>
+            </div>
+            <div class="col-md-4">
+              <span class="carrier-delay">{$selected_delivery_option.delay}</span>
+            </div>
+            <div class="col-md-2">
+              <span class="carrier-price">{$selected_delivery_option.price}</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
   {/if}
 
   <div class="row">

--- a/themes/classic/templates/checkout/_partials/order-final-summary.tpl
+++ b/themes/classic/templates/checkout/_partials/order-final-summary.tpl
@@ -56,7 +56,8 @@
     </div>
   </div>
 
-  <div class="row">
+  {if !$cart.is_virtual}
+    <div class="row">
     <div class="col-md-12">
       <h4 class="h4">
       {l s='Shipping Method' d='Shop.Theme.Checkout'}
@@ -87,6 +88,7 @@
       </div>
     </div>
   </div>
+  {/if}
 
   <div class="row">
     {block name='order_confirmation_table'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In FO, order summary for virutal cart shoudn't contain shipping method. This PR adds only an if statement (2 lines ) and all the other modifications are caused by trying to indent. 
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #19963 
| How to test?  | Steps to reproduce the behavior:<br><br>- Go to BO > Shop Preferences > Order Preference<br>- Activate order summary<br>- Save<br>- In BO : Create a virtual product<br>- As a customer add the virtual product to your cart<br>- Checkout , create account, put address and view summary without shipping method

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20190)
<!-- Reviewable:end -->
