### PR TITLE
Log when webservice key is deleted

### DIFF
--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -90,7 +90,7 @@ class WebserviceKeyCore extends ObjectModel
                 Context::getContext()->getTranslator()->trans(
                     'Webservice key %s deleted',
                     [
-                        $this->key
+                        $this->key,
                     ],
                     'Admin.Advparameters.Feature'
                 ),

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -83,7 +83,24 @@ class WebserviceKeyCore extends ObjectModel
 
     public function delete()
     {
-        return parent::delete() && ($this->deleteAssociations() !== false);
+        $result = parent::delete() && ($this->deleteAssociations() !== false);
+
+        if ($result) {
+            PrestaShopLogger::addLog(
+                Context::getContext()->getTranslator()->trans(
+                    'Webservice key deleted by employee "%d" %s %s (%s)',
+                    [
+                        Context::getContext()->employee->id,
+                        Context::getContext()->employee->firstname,
+                        Context::getContext()->employee->lastname,
+                        Context::getContext()->employee->email,
+                    ],
+                    'Admin.Advparameters.Feature'
+                )
+            );
+        }
+
+        return $result;
     }
 
     public function deleteAssociations()

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -88,15 +88,18 @@ class WebserviceKeyCore extends ObjectModel
         if ($result) {
             PrestaShopLogger::addLog(
                 Context::getContext()->getTranslator()->trans(
-                    'Webservice key deleted by employee "%d" %s %s (%s)',
+                    'Webservice key %s deleted',
                     [
-                        Context::getContext()->employee->id,
-                        Context::getContext()->employee->firstname,
-                        Context::getContext()->employee->lastname,
-                        Context::getContext()->employee->email,
+                        $this->key
                     ],
                     'Admin.Advparameters.Feature'
-                )
+                ),
+                1,
+                0,
+                'WebserviceKey',
+                (int) $this->id,
+                false,
+                (int) Context::getContext()->employee->id
             );
         }
 

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -88,7 +88,7 @@ class WebserviceKeyCore extends ObjectModel
         if ($result) {
             PrestaShopLogger::addLog(
                 Context::getContext()->getTranslator()->trans(
-                    'Webservice key %s deleted',
+                    'Webservice key %s has been deleted',
                     [
                         $this->key,
                     ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Following https://github.com/PrestaShop/PrestaShop/pull/19831 I suggest to log when webservice key is deleted because it could be important information when a shop is compromised
| Type?         | improvement
| Category?     |  BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Create a new Webservice Key then delete it. Then go in Logs page and see latest log which says "Webservice key xxxxxx has been deleted". The other columns are filled with relevant data.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20195)
<!-- Reviewable:end -->
