### PR TITLE
Product supplier_reference is not updated when saving a product in the BO

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7168,6 +7168,7 @@ class ProductCore extends ObjectModel
      * Update default supplier data
      *
      * @param int $idProduct
+     * @param int $idSupplier
      * @param float $wholesalePrice
      * @param string $supplierReference
      *

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7167,15 +7167,18 @@ class ProductCore extends ObjectModel
     /**
      * Update default supplier data
      *
-     * @param int $idProduct
      * @param int $idSupplier
      * @param float $wholesalePrice
      * @param string $supplierReference
      *
      * @return bool
      */
-    public function updateDefaultSupplierData(int $idProduct, int $idSupplier, string $supplierReference, float $wholesalePrice): bool
+    public function updateDefaultSupplierData(int $idSupplier, string $supplierReference, float $wholesalePrice): bool
     {
+        if (!$this->id) {
+            return false;
+        }
+
         $sql = 'UPDATE `' . _DB_PREFIX_ . 'product` ' .
              'SET ' .
              'id_supplier = %d, ' .
@@ -7189,7 +7192,7 @@ class ProductCore extends ObjectModel
                 $idSupplier,
                 pSQL($supplierReference),
                 $wholesalePrice,
-                $idProduct
+                $this->id
             )
         );
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -121,7 +121,11 @@ class ProductCore extends ObjectModel
     /** @var string Reference */
     public $reference;
 
-    /** @var string Supplier Reference */
+    /**
+     * @var string Supplier Reference
+     *
+     * @deprecated since 1.7.7.0
+     */
     public $supplier_reference;
 
     /** @var string Location */
@@ -7158,5 +7162,34 @@ class ProductCore extends ObjectModel
         }
 
         return $return;
+    }
+
+    /**
+     * Update default supplier data
+     *
+     * @param int $idProduct
+     * @param float $wholesalePrice
+     * @param string $supplierReference
+     *
+     * @return bool
+     */
+    public function updateDefaultSupplierData(int $idProduct, int $idSupplier, string $supplierReference, float $wholesalePrice): bool
+    {
+        $sql = 'UPDATE `' . _DB_PREFIX_ . 'product` ' .
+             'SET ' .
+             'id_supplier = %d, ' .
+             'supplier_reference = "%s", ' .
+             'wholesale_price = "%s" ' .
+             'WHERE id_product = %d';
+
+        return Db::getInstance()->execute(
+            sprintf(
+                $sql,
+                $idSupplier,
+                pSQL($supplierReference),
+                $wholesalePrice,
+                $idProduct
+            )
+        );
     }
 }

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2442,6 +2442,8 @@ class AdminProductsControllerCore extends AdminController
 
             $suppliers_to_associate = [];
             $new_default_supplier = 0;
+            $defaultWholeslePrice = (float) 0;
+            $defaultReference = '';
 
             if (Tools::isSubmit('default_supplier')) {
                 $new_default_supplier = (int) Tools::getValue('default_supplier');
@@ -2545,15 +2547,21 @@ class AdminProductsControllerCore extends AdminController
                             $product_supplier->update();
                         }
 
-                        if ($product->id_supplier == $supplier->id_supplier && (int) $attribute['id_product_attribute'] > 0) {
-                            $data = [
-                                'supplier_reference' => pSQL($reference),
-                                'wholesale_price' => (float) Tools::convertPrice($price, $id_currency),
-                            ];
-                            $where = '
+                        if ($new_default_supplier == $supplier->id_supplier) {
+                            if ((int) $attribute['id_product_attribute'] > 0) {
+                                $data = [
+                                    'supplier_reference' => pSQL($reference),
+                                    'wholesale_price' => (float) Tools::convertPrice($price, $id_currency),
+                                ];
+                                $where = '
                                     a.id_product = ' . (int) $product->id . '
                                     AND a.id_product_attribute = ' . (int) $attribute['id_product_attribute'];
-                            ObjectModel::updateMultishopTable('Combination', $data, $where);
+                                ObjectModel::updateMultishopTable('Combination', $data, $where);
+                            } else {
+                                // @deprecated 1.7.7.0 This condition block will be remove in the next major, use ProductSupplier instead
+                                $defaultWholeslePrice = (float) Tools::convertPrice($price, $id_currency);
+                                $defaultReference = $reference;
+                            }
                         }
                     } elseif (Tools::isSubmit('supplier_reference_' . $product->id . '_' . $attribute['id_product_attribute'] . '_' . $supplier->id_supplier)) {
                         //int attribute with default values if possible
@@ -2567,11 +2575,13 @@ class AdminProductsControllerCore extends AdminController
                     }
                 }
             }
-            // Manage defaut supplier for product
-            if ($this->object && $new_default_supplier != $product->id_supplier) {
-                $this->object->id_supplier = $new_default_supplier;
-                $this->object->update();
-            }
+
+            $product->updateDefaultSupplierData(
+                $product->id,
+                $new_default_supplier,
+                $defaultReference,
+                $defaultWholeslePrice
+            );
         }
     }
 

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2578,7 +2578,6 @@ class AdminProductsControllerCore extends AdminController
 
             if ($this->object) {
                 $product->updateDefaultSupplierData(
-                    $product->id,
                     $new_default_supplier,
                     $defaultReference,
                     $defaultWholeslePrice

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2576,12 +2576,14 @@ class AdminProductsControllerCore extends AdminController
                 }
             }
 
-            $product->updateDefaultSupplierData(
-                $product->id,
-                $new_default_supplier,
-                $defaultReference,
-                $defaultWholeslePrice
-            );
+            if ($this->object) {
+                $product->updateDefaultSupplierData(
+                    $product->id,
+                    $new_default_supplier,
+                    $defaultReference,
+                    $defaultWholeslePrice
+                );
+            }
         }
     }
 

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -193,12 +193,14 @@ class AdminProductWrapper
 
             // We need to reload the product because some other calls have modified the database
             // It's done just for the setAvailableDate to avoid side effects
+            Product::disableCache();
             $consistentProduct = new Product($product->id);
             if ($available_date = $combinationValues['available_date_attribute']) {
                 $consistentProduct->setAvailableDate($available_date);
             } else {
                 $consistentProduct->setAvailableDate();
             }
+            Product::enableCache();
         }
 
         if (isset($combinationValues['attribute_quantity'])) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Mark `wholesale_price` and `supplier_reference` as deprecated. These values are already register with `ProductSupplier` ObjectModel, it's useless to duplicate values. I also restore the registration of these fields when there is no combination even if values can be fetched by a request into `ProductSupplier` table.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | Fixes #20094
| How to test?  | Follow ticket instruction. Make sure the issue #16353 is still resolved.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20198)
<!-- Reviewable:end -->
