### PR TITLE
Use ChoiceType in Log severity column filter

### DIFF
--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -29,6 +29,14 @@
  */
 class PrestaShopLoggerCore extends ObjectModel
 {
+    /**
+     * List of log level types.
+     */
+    const LOG_SEVERITY_LEVEL_INFORMATIVE = 1;
+    const LOG_SEVERITY_LEVEL_WARNING = 2;
+    const LOG_SEVERITY_LEVEL_ERROR = 3;
+    const LOG_SEVERITY_LEVEL_MAJOR = 4;
+    
     /** @var int Log id */
     public $id_log;
 

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -36,7 +36,7 @@ class PrestaShopLoggerCore extends ObjectModel
     const LOG_SEVERITY_LEVEL_WARNING = 2;
     const LOG_SEVERITY_LEVEL_ERROR = 3;
     const LOG_SEVERITY_LEVEL_MAJOR = 4;
-    
+
     /** @var int Log id */
     public $id_log;
 

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -42,6 +42,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use PrestaShopLoggerCore;
 
 /**
  * Class LogGridDefinitionFactory is responsible for creating new instance of Log grid definition.
@@ -185,6 +186,8 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
                 (new Filter('severity', ChoiceType::class))
                     ->setTypeOptions([
                         'required' => false,
+                        'choices' => $this->getSeveritysChoices(),
+                        'translation_domain' => false,
                     ])
                     ->setAssociatedColumn('severity')
             )
@@ -192,8 +195,6 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
                 (new Filter('message', TextType::class))
                     ->setTypeOptions([
                         'required' => false,
-                        'choices' => $this->getSeveritysChoices(),
-                        'translation_domain' => false,
                     ])
                     ->setAssociatedColumn('message')
             )
@@ -272,10 +273,10 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
     private function getSeveritysChoices()
     {
         return [
-            $this->trans('Informative only', [], 'Admin.Advparameters.Help') => 1,
-            $this->trans('Warning', [], 'Admin.Advparameters.Help') => 2,
-            $this->trans('Error', [], 'Admin.Advparameters.Help') => 3,
-            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') => 4,
+            $this->trans('Informative only', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_INFORMATIVE,
+            $this->trans('Warning', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_WARNING,
+            $this->trans('Error', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_ERROR,
+            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_MAJOR,
         ];
     }
 }

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -42,7 +42,7 @@ use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use PrestaShopLoggerCore;
+use PrestaShopLogger;
 
 /**
  * Class LogGridDefinitionFactory is responsible for creating new instance of Log grid definition.
@@ -273,10 +273,10 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
     private function getSeveritysChoices()
     {
         return [
-            $this->trans('Informative only', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_INFORMATIVE,
-            $this->trans('Warning', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_WARNING,
-            $this->trans('Error', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_ERROR,
-            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') => PrestaShopLoggerCore::LOG_SEVERITY_LEVEL_MAJOR,
+            $this->trans('Informative only', [], 'Admin.Advparameters.Help') => PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE,
+            $this->trans('Warning', [], 'Admin.Advparameters.Help') => PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING,
+            $this->trans('Error', [], 'Admin.Advparameters.Help') => PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR,
+            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') => PrestaShopLogger::LOG_SEVERITY_LEVEL_MAJOR,
         ];
     }
 }

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -269,12 +269,13 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
             );
     }
 
-    private function getSeveritysChoices(){
+    private function getSeveritysChoices()
+    {
         return [
             $this->trans('Informative only', [], 'Admin.Advparameters.Help') => 1,
-            $this->trans('Warning', [], 'Admin.Advparameters.Help') =>  2,
-            $this->trans('Error', [], 'Admin.Advparameters.Help') =>  3,
-            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') =>  4,
+            $this->trans('Warning', [], 'Admin.Advparameters.Help') => 2,
+            $this->trans('Error', [], 'Admin.Advparameters.Help') => 3,
+            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') => 4,
         ];
-	}
+    }
 }

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -40,9 +40,9 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use PrestaShopLogger;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use PrestaShopLogger;
 
 /**
  * Class LogGridDefinitionFactory is responsible for creating new instance of Log grid definition.

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
@@ -181,7 +182,7 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setAssociatedColumn('employee')
             )
             ->add(
-                (new Filter('severity', TextType::class))
+                (new Filter('severity', ChoiceType::class))
                     ->setTypeOptions([
                         'required' => false,
                     ])
@@ -191,6 +192,8 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
                 (new Filter('message', TextType::class))
                     ->setTypeOptions([
                         'required' => false,
+                        'choices' => $this->getSeveritysChoices(),
+                        'translation_domain' => false,
                     ])
                     ->setAssociatedColumn('message')
             )
@@ -265,4 +268,13 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setIcon('storage')
             );
     }
+
+    private function getSeveritysChoices(){
+        return [
+            $this->trans('Informative only', [], 'Admin.Advparameters.Help') => 1,
+            $this->trans('Warning', [], 'Admin.Advparameters.Help') =>  2,
+            $this->trans('Error', [], 'Admin.Advparameters.Help') =>  3,
+            $this->trans('Major issue (crash)!', [], 'Admin.Advparameters.Help') =>  4,
+        ];
+	}
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Use `ChoiceType` in Log severity column filter instaed of  `TextType`. 
| Type?         | improvement 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A.
| How to test?  | Make sure you can filter by severity using the choice input.![Capture du 2020-07-16 20-52-27 (1)](https://user-images.githubusercontent.com/16455155/87710825-9cf4aa00-c7a6-11ea-8b96-0ac68b97467f.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20200)
<!-- Reviewable:end -->

