### PR TITLE
Simplified credit slip options

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
@@ -167,9 +167,7 @@ class CreditSlipController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_credit_slips_index', [
-            $pdfByDateForm->getName() => $pdfByDateForm->getData(),
-        ]);
+        return $this->redirectToRoute('admin_credit_slips_index');
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -53,6 +53,8 @@ final class CreditSlipOptionsType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('slip_prefix', TranslatableType::class, [
+            'label' => $this->translator->trans('Credit slip prefix', [], 'Admin.Orderscustomers.Feature'),
+            'help' => $this->translator->trans('Prefix used for credit slips.', [], 'Admin.Orderscustomers.Help'),
             'required' => false,
             'error_bubbling' => true,
             'options' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -32,7 +32,6 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- *
  * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using translator as dependency.
  *
  * Defines credit slips options form

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -27,25 +27,15 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Defines credit slips options form
  */
-final class CreditSlipOptionsType extends CommonAbstractType
+final class CreditSlipOptionsType extends TranslatorAwareType
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
 
     /**
      * {@inheritdoc}
@@ -53,17 +43,16 @@ final class CreditSlipOptionsType extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('slip_prefix', TranslatableType::class, [
-            'label' => $this->translator->trans('Credit slip prefix', [], 'Admin.Orderscustomers.Feature'),
-            'help' => $this->translator->trans('Prefix used for credit slips.', [], 'Admin.Orderscustomers.Help'),
+            'label' => $this->trans('Credit slip prefix','Admin.Orderscustomers.Feature'),
+            'help' => $this->trans('Prefix used for credit slips.', 'Admin.Orderscustomers.Help'),
             'required' => false,
             'error_bubbling' => true,
             'options' => [
                 'constraints' => [
                     new TypedRegex([
                         'type' => 'file_name',
-                        'message' => $this->translator->trans(
+                        'message' => $this->trans(
                             '%s is invalid.',
-                            [],
                             'Admin.Notifications.Error'
                         ),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -32,6 +32,9 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
+ *
+ * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using translator as dependency.
+ *
  * Defines credit slips options form
  */
 final class CreditSlipOptionsType extends TranslatorAwareType

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -36,14 +36,13 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 final class CreditSlipOptionsType extends TranslatorAwareType
 {
-
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('slip_prefix', TranslatableType::class, [
-            'label' => $this->trans('Credit slip prefix','Admin.Orderscustomers.Feature'),
+            'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),
             'help' => $this->trans('Prefix used for credit slips.', 'Admin.Orderscustomers.Help'),
             'required' => false,
             'error_bubbling' => true,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -26,11 +26,10 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Valid;
@@ -38,18 +37,8 @@ use Symfony\Component\Validator\Constraints\Valid;
 /**
  * Defines form for generating Credit slip PDF
  */
-final class GeneratePdfByDateType extends CommonAbstractType
+final class GeneratePdfByDateType extends TranslatorAwareType
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -58,13 +47,13 @@ final class GeneratePdfByDateType extends CommonAbstractType
         $dateFormat = 'Y-m-d';
         $nowDate = (new \DateTime())->format($dateFormat);
 
-        $blankMessage = $this->translator->trans('This field is required', [], 'Admin.Notifications.Error');
-        $invalidDateMessage = $this->translator->trans('Invalid date format.', [], 'Admin.Notifications.Error');
-        $dateHintTrans = $this->translator->trans('Format: 2011-12-31 (inclusive).', [], 'Admin.Global');
+        $blankMessage = $this->trans('This field is required', 'Admin.Notifications.Error');
+        $invalidDateMessage = $this->trans('Invalid date format.', 'Admin.Notifications.Error');
+        $dateHintTrans = $this->trans('Format: 2011-12-31 (inclusive).', 'Admin.Global');
 
         $builder
             ->add('from', DatePickerType::class, [
-                'label' => $this->translator->trans('From', [], 'Admin.Global'),
+                'label' => $this->trans('From', 'Admin.Global'),
                 'help' => $dateHintTrans,
                 'data' => $nowDate,
                 'constraints' => [
@@ -78,7 +67,7 @@ final class GeneratePdfByDateType extends CommonAbstractType
                 ]
             ])
             ->add('to', DatePickerType::class, [
-                'label' => $this->translator->trans('To', [], 'Admin.Global'),
+                'label' => $this->trans('To', 'Admin.Global'),
                 'help' => $dateHintTrans,
                 'data' => $nowDate,
                 'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -60,9 +60,12 @@ final class GeneratePdfByDateType extends CommonAbstractType
 
         $blankMessage = $this->translator->trans('This field is required', [], 'Admin.Notifications.Error');
         $invalidDateMessage = $this->translator->trans('Invalid date format.', [], 'Admin.Notifications.Error');
+        $dateHintTrans = $this->translator->trans('Format: 2011-12-31 (inclusive).', [], 'Admin.Global');
 
         $builder
             ->add('from', DatePickerType::class, [
+                'label' => $this->translator->trans('From', [], 'Admin.Global'),
+                'help' => $dateHintTrans,
                 'data' => $nowDate,
                 'constraints' => [
                     new NotBlank([
@@ -71,10 +74,12 @@ final class GeneratePdfByDateType extends CommonAbstractType
                     new DateTime([
                         'format' => $dateFormat,
                         'message' => $invalidDateMessage,
-                    ]),
-                ],
+                    ])
+                ]
             ])
             ->add('to', DatePickerType::class, [
+                'label' => $this->translator->trans('To', [], 'Admin.Global'),
+                'help' => $dateHintTrans,
                 'data' => $nowDate,
                 'constraints' => [
                     new NotBlank([

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -63,8 +63,8 @@ final class GeneratePdfByDateType extends TranslatorAwareType
                     new DateTime([
                         'format' => $dateFormat,
                         'message' => $invalidDateMessage,
-                    ])
-                ]
+                    ]),
+                ],
             ])
             ->add('to', DatePickerType::class, [
                 'label' => $this->trans('To', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/GeneratePdfByDateType.php
@@ -35,6 +35,8 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Valid;
 
 /**
+ * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using translator as dependency.
+ *
  * Defines form for generating Credit slip PDF
  */
 final class GeneratePdfByDateType extends TranslatorAwareType

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1071,18 +1071,14 @@ services:
 
     form.type.order.credit_slip.generate_pdf_by_date:
         class: 'PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip\GeneratePdfByDateType'
-        parent: 'form.type.common_type'
-        arguments:
-            - '@translator'
+        parent: 'form.type.translatable.aware'
         public: true
         tags:
             - { name: form.type }
 
     form.type.order.credit_slip.credit_slip_options:
         class: 'PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip\CreditSlipOptionsType'
-        parent: 'form.type.common_type'
-        arguments:
-            - '@translator'
+        parent: 'form.type.translatable.aware'
         public: true
         tags:
             - { name: form.type }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig
@@ -23,8 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme creditSlipOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {{ form_start(creditSlipOptionsForm, {
   'method': 'POST',
@@ -39,14 +39,10 @@
 
   <div class="card-block row">
     <div class="card-text">
-      {{ ps.form_group_row(creditSlipOptionsForm.slip_prefix, {}, {
-        'label': 'Credit slip prefix'|trans({}, 'Admin.Orderscustomers.Feature'),
-        'help': 'Prefix used for credit slips.'|trans({}, 'Admin.Orderscustomers.Help')
-      }) }}
+      {% block credit_slip_options_form %}
+        {{ form_widget(creditSlipOptionsForm) }}
+      {% endblock %}
     </div>
-    {% block credit_slip_options_form_rest %}
-      {{ form_rest(creditSlipOptionsForm) }}
-    {% endblock %}
   </div>
 
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
@@ -23,8 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme pdfByDateForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {{ form_start(pdfByDateForm, {
   'method': 'GET',
@@ -38,20 +38,10 @@
 
   <div class="card-block row">
     <div class="card-text">
-      {% set dateHint = 'Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help') %}
-      {{ ps.form_group_row(pdfByDateForm.from, {}, {
-        'label': 'From'|trans({}, 'Admin.Global'),
-        'help': dateHint
-      }) }}
-
-      {{ ps.form_group_row(pdfByDateForm.to, {}, {
-        'label': 'To'|trans({}, 'Admin.Global'),
-        'help': dateHint
-      }) }}
+      {% block credit_slip_pdf_by_date_form %}
+        {{ form_widget(pdfByDateForm) }}
+      {% endblock %}
     </div>
-    {% block credit_slip_pdf_by_date_form_rest %}
-      {{ form_rest(pdfByDateForm) }}
-    {% endblock %}
   </div>
 
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -421,6 +421,7 @@
         </div>
       </div>
     </div>
+    {{ block('form_help') }}
   {% endspaceless %}
 {% endblock date_picker_widget %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify credit slip options
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Form must work and look exactly the same as before

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType instead of using translator as dependency. This means if any module extends CreditSlipsOptionsType or GeneratePdfByDateType files they will get an exception.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20104)
<!-- Reviewable:end -->
