### PR TITLE
Fix missing pagination for alternative lang url

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1986,7 +1986,7 @@ class FrontControllerCore extends Controller
         foreach ($languages as $lang) {
             $langUrl = $this->context->link->getLanguageLink($lang['id_lang']);
 
-            $params = array();
+            $params = [];
             $url_details = parse_url($langUrl);
 
             if (!empty($url_details['query'])) {
@@ -1996,7 +1996,7 @@ class FrontControllerCore extends Controller
                 }
             }
 
-            $excluded_key = array('isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms');
+            $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
             $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
             foreach ($_GET as $key => $value) {
                 if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -797,29 +797,8 @@ class FrontControllerCore extends Controller
 
         $match_url = rawurldecode(Tools::getCurrentUrlProtocolPrefix() . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
         if (!preg_match('/^' . Tools::pRegexp(rawurldecode($canonical_url), '/') . '([&?].*)?$/', $match_url)) {
-            $params = [];
-            $url_details = parse_url($canonical_url);
-
-            if (!empty($url_details['query'])) {
-                parse_str($url_details['query'], $query);
-                foreach ($query as $key => $value) {
-                    $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
-                }
-            }
-            $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
-            $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
-            foreach ($_GET as $key => $value) {
-                if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
-                    $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
-                }
-            }
-
-            $str_params = http_build_query($params, '', '&');
-            if (!empty($str_params)) {
-                $final_url = preg_replace('/^([^?]*)?.*$/', '$1', $canonical_url) . '?' . $str_params;
-            } else {
-                $final_url = preg_replace('/^([^?]*)?.*$/', '$1', $canonical_url);
-            }
+            
+            $final_url = $this->sanitizeUrl($canonical_url);
 
             // Don't send any cookie
             Context::getContext()->cookie->disallowWriting();
@@ -1985,35 +1964,46 @@ class FrontControllerCore extends Controller
 
         foreach ($languages as $lang) {
             $langUrl = $this->context->link->getLanguageLink($lang['id_lang']);
-
-            $params = [];
-            $url_details = parse_url($langUrl);
-
-            if (!empty($url_details['query'])) {
-                parse_str($url_details['query'], $query);
-                foreach ($query as $key => $value) {
-                    $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
-                }
-            }
-
-            $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
-            $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
-            foreach ($_GET as $key => $value) {
-                if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
-                    $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
-                }
-            }
-
-            $str_params = http_build_query($params, '', '&');
-            if (!empty($str_params)) {
-                $langUrl = preg_replace('/^([^?]*)?.*$/', '$1', $langUrl) . '?' . $str_params;
-            } else {
-                $langUrl = preg_replace('/^([^?]*)?.*$/', '$1', $langUrl);
-            }
-
-            $alternativeLangs[$lang['language_code']] = $langUrl;
+            $alternativeLangs[$lang['language_code']] = $this->sanitizeUrl($langUrl);
         }
 
         return $alternativeLangs;
+    }
+
+    /**
+     * Sanitize / Clean params of an URL
+     *
+     * @param string $url URL to clean
+     * @return string cleaned URL
+     */
+    private function sanitizeUrl($url) 
+    {
+        $params = [];
+        $url_details = parse_url($url);
+        $sanitizedUrl = null;
+
+        if (!empty($url_details['query'])) {
+            parse_str($url_details['query'], $query);
+            foreach ($query as $key => $value) {
+                $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
+            }
+        }
+
+        $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
+        $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
+        foreach ($_GET as $key => $value) {
+            if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
+                $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
+            }
+        }
+
+        $str_params = http_build_query($params, '', '&');
+        if (!empty($str_params)) {
+            $sanitizedUrl = preg_replace('/^([^?]*)?.*$/', '$1', $url) . '?' . $str_params;
+        } else {
+            $sanitizedUrl = preg_replace('/^([^?]*)?.*$/', '$1', $url);
+        }
+
+        return $sanitizedUrl;
     }
 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -797,7 +797,6 @@ class FrontControllerCore extends Controller
 
         $match_url = rawurldecode(Tools::getCurrentUrlProtocolPrefix() . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
         if (!preg_match('/^' . Tools::pRegexp(rawurldecode($canonical_url), '/') . '([&?].*)?$/', $match_url)) {
-            
             $final_url = $this->sanitizeUrl($canonical_url);
 
             // Don't send any cookie
@@ -1974,13 +1973,13 @@ class FrontControllerCore extends Controller
      * Sanitize / Clean params of an URL
      *
      * @param string $url URL to clean
+     *
      * @return string cleaned URL
      */
-    private function sanitizeUrl($url) 
+    private function sanitizeUrl(string $url): string
     {
         $params = [];
         $url_details = parse_url($url);
-        $sanitizedUrl = null;
 
         if (!empty($url_details['query'])) {
             parse_str($url_details['query'], $query);

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1984,7 +1984,34 @@ class FrontControllerCore extends Controller
         }
 
         foreach ($languages as $lang) {
-            $alternativeLangs[$lang['language_code']] = $this->context->link->getLanguageLink($lang['id_lang']);
+            $langUrl = $this->context->link->getLanguageLink($lang['id_lang']);
+
+            $params = array();
+            $url_details = parse_url($langUrl);
+
+            if (!empty($url_details['query'])) {
+                parse_str($url_details['query'], $query);
+                foreach ($query as $key => $value) {
+                    $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
+                }
+            }
+
+            $excluded_key = array('isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms');
+            $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
+            foreach ($_GET as $key => $value) {
+                if (!in_array($key, $excluded_key) && Validate::isUrl($key) && Validate::isUrl($value)) {
+                    $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
+                }
+            }
+
+            $str_params = http_build_query($params, '', '&');
+            if (!empty($str_params)) {
+                $langUrl = preg_replace('/^([^?]*)?.*$/', '$1', $langUrl) . '?' . $str_params;
+            } else {
+                $langUrl = preg_replace('/^([^?]*)?.*$/', '$1', $langUrl);
+            }
+
+            $alternativeLangs[$lang['language_code']] = $langUrl;
         }
 
         return $alternativeLangs;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | This PR makes it possible to correct the absence of the "page" parameter on the `<link rel=" alternate ">` tags.  This modification can also work for other parameters and pages other than the category page.
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #17122
| How to test?  | Have a Prestashop with active multilingual. Go to a category page, on page 2 and check if the different meta files related to the alternative versions in other languages contain the "page" parameter. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20211)
<!-- Reviewable:end -->
