### PR TITLE
Functional tests - Add checking order status in FO after update status in BO

### DIFF
--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/04_checkInvoiceDownloadedFromList.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/04_checkInvoiceDownloadedFromList.js
@@ -11,6 +11,8 @@ const dashboardPage = require('@pages/BO/dashboard');
 const ordersPage = require('@pages/BO/orders/index');
 const homePage = require('@pages/FO/home');
 const foLoginPage = require('@pages/FO/login');
+const foMyAccountPage = require('@pages/FO/myAccount');
+const foOrderHistoryPage = require('@pages/FO/myAccount/orderHistory');
 const productPage = require('@pages/FO/product');
 const cartPage = require('@pages/FO/cart');
 const checkoutPage = require('@pages/FO/checkout');
@@ -34,6 +36,7 @@ Create order in FO with bank wire payment
 Go to BO orders page and change order status to 'payment accepted'
 Check invoice creation
 Download invoice from list and check pdf text
+Go to FO and check the new order status
  */
 describe('Check invoice downloaded from list', async () => {
   // before and after functions
@@ -170,6 +173,49 @@ describe('Check invoice downloaded from list', async () => {
       // Check total paid in pdf
       const totalPaidExist = await files.isTextInPDF(filePath, orderInformation.totalPaid);
       await expect(totalPaidExist, `Total paid '${orderInformation.totalPaid}' does not exist in invoice`).to.be.true;
+    });
+  });
+
+  describe('Check order status in FO ', async () => {
+    it('should go to FO page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToFO', baseContext);
+
+      await homePage.goToFo(page);
+      await homePage.changeLanguage(page, 'en');
+
+      const isHomePage = await homePage.isHomePage(page);
+      await expect(isHomePage, 'Fail to open FO home page').to.be.true;
+    });
+
+    it('should go to login page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToLoginPageFO', baseContext);
+
+      await homePage.goToLoginPage(page);
+      const pageTitle = await foLoginPage.getPageTitle(page);
+      await expect(pageTitle, 'Fail to open FO login page').to.contains(foLoginPage.pageTitle);
+    });
+
+    it('should sign in with default customer', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'sighInFO', baseContext);
+
+      await foLoginPage.customerLogin(page, DefaultAccount);
+      const isCustomerConnected = await foLoginPage.isCustomerConnected(page);
+      await expect(isCustomerConnected, 'Customer is not connected').to.be.true;
+    });
+
+    it('should go to orders history page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToOrderHistoryPage', baseContext);
+
+      await foMyAccountPage.goToHistoryAndDetailsPage(page);
+      const pageTitle = await foOrderHistoryPage.getPageTitle(page);
+      await expect(pageTitle, 'Fail to open order history page').to.contains(foOrderHistoryPage.pageTitle);
+    });
+
+    it('should check last order status in FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'sighInFO', baseContext);
+
+      const orderStatusFO = await foOrderHistoryPage.getOrderStatus(page, 1);
+      await expect(orderStatusFO, 'Order status is not correct').to.equal(Statuses.paymentAccepted.status);
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/05_checkDeliverySlipDownloadedFromList.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/05_checkDeliverySlipDownloadedFromList.js
@@ -11,6 +11,8 @@ const dashboardPage = require('@pages/BO/dashboard');
 const ordersPage = require('@pages/BO/orders/index');
 const homePage = require('@pages/FO/home');
 const foLoginPage = require('@pages/FO/login');
+const foMyAccountPage = require('@pages/FO/myAccount');
+const foOrderHistoryPage = require('@pages/FO/myAccount/orderHistory');
 const productPage = require('@pages/FO/product');
 const cartPage = require('@pages/FO/cart');
 const checkoutPage = require('@pages/FO/checkout');
@@ -34,6 +36,7 @@ Create order in FO with bank wire payment
 Go to BO orders page and change order status to 'shipped'
 Check delivery slip creation
 Download delivery slip from list and check pdf text
+Go to FO and check the new order status
  */
 describe('Check delivery slip downloaded from list', async () => {
   // before and after functions
@@ -185,6 +188,49 @@ describe('Check delivery slip downloaded from list', async () => {
         totalPaidExist,
         `Total paid '${orderInformation.totalPaid}' does not exist in delivery slip`,
       ).to.be.true;
+    });
+  });
+
+  describe('Check order status in FO ', async () => {
+    it('should go to FO page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToFO', baseContext);
+
+      await homePage.goToFo(page);
+      await homePage.changeLanguage(page, 'en');
+
+      const isHomePage = await homePage.isHomePage(page);
+      await expect(isHomePage, 'Fail to open FO home page').to.be.true;
+    });
+
+    it('should go to login page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToLoginPageFO', baseContext);
+
+      await homePage.goToLoginPage(page);
+      const pageTitle = await foLoginPage.getPageTitle(page);
+      await expect(pageTitle, 'Fail to open FO login page').to.contains(foLoginPage.pageTitle);
+    });
+
+    it('should sign in with default customer', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'sighInFO', baseContext);
+
+      await foLoginPage.customerLogin(page, DefaultAccount);
+      const isCustomerConnected = await foLoginPage.isCustomerConnected(page);
+      await expect(isCustomerConnected, 'Customer is not connected').to.be.true;
+    });
+
+    it('should go to orders history page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToOrderHistoryPage', baseContext);
+
+      await foMyAccountPage.goToHistoryAndDetailsPage(page);
+      const pageTitle = await foOrderHistoryPage.getPageTitle(page);
+      await expect(pageTitle, 'Fail to open order history page').to.contains(foOrderHistoryPage.pageTitle);
+    });
+
+    it('should check last order status in FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'sighInFO', baseContext);
+
+      const orderStatusFO = await foOrderHistoryPage.getOrderStatus(page, 1);
+      await expect(orderStatusFO, 'Order status is not correct').to.equal(Statuses.shipped.status);
     });
   });
 });

--- a/tests/UI/pages/FO/myAccount/orderHistory.js
+++ b/tests/UI/pages/FO/myAccount/orderHistory.js
@@ -8,7 +8,10 @@ class OrderHistory extends FOBasePage {
     this.pageTitle = 'Order history';
 
     // Selectors
-    this.reorderLink = id => `#content td.order-actions a[href*='Reorder=&id_order=${id}']`;
+    this.ordersTable = '#content table';
+    this.ordersTableRow = row => `${this.ordersTable} tbody tr:nth-child(${row})`;
+    this.orderTableColumn = (row, column) => `${this.ordersTableRow(row)} td:nth-child(${column})`;
+    this.reorderLink = id => `${this.ordersTable} td.order-actions a[href*='Reorder=&id_order=${id}']`;
   }
 
   /*
@@ -18,11 +21,21 @@ class OrderHistory extends FOBasePage {
   /**
    * Is reorder link visible
    * @param page
-   * @param idOrder
+   * @param idOrder, database id of the order
    * @returns {boolean}
    */
   isReorderLinkVisible(page, idOrder = 1) {
     return this.elementVisible(page, this.reorderLink(idOrder), 1000);
+  }
+
+  /**
+   * Get order status from orders history page
+   * @param page
+   * @param orderRow, row in orders table
+   * @return {Promise<string>}
+   */
+  getOrderStatus(page, orderRow = 1) {
+    return this.getTextContent(page, `${this.orderTableColumn(orderRow, 5)} span`);
   }
 }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add checking order status in FO after update status in BO
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/02_orders/01_orders/*" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20215)
<!-- Reviewable:end -->
