### PR TITLE
Set product image if combination image is null in displayAjaxProductsList 

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -3377,7 +3377,7 @@ class AdminProductsControllerCore extends AdminController
                                 $results[$combination['id_product_attribute']]['ref'] = !empty($item['reference']) ? $item['reference'] : '';
                             }
                             if (empty($results[$combination['id_product_attribute']]['image'])) {
-                                $image_id = $combination['id_image'] ? $combination['id_image'] : $item['id_image'];
+                                $image_id = $combination['id_image'] ?? $item['id_image'];
                                 $results[$combination['id_product_attribute']]['image'] = str_replace('http://', Tools::getShopProtocol(), $context->link->getImageLink($item['link_rewrite'], $image_id, 'home_default'));
 
                             }

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -3379,7 +3379,6 @@ class AdminProductsControllerCore extends AdminController
                             if (empty($results[$combination['id_product_attribute']]['image'])) {
                                 $image_id = $combination['id_image'] ?? $item['id_image'];
                                 $results[$combination['id_product_attribute']]['image'] = str_replace('http://', Tools::getShopProtocol(), $context->link->getImageLink($item['link_rewrite'], $image_id, 'home_default'));
-
                             }
                         }
                     } else {

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -3377,7 +3377,9 @@ class AdminProductsControllerCore extends AdminController
                                 $results[$combination['id_product_attribute']]['ref'] = !empty($item['reference']) ? $item['reference'] : '';
                             }
                             if (empty($results[$combination['id_product_attribute']]['image'])) {
-                                $results[$combination['id_product_attribute']]['image'] = str_replace('http://', Tools::getShopProtocol(), $context->link->getImageLink($item['link_rewrite'], $combination['id_image'], 'home_default'));
+                                $image_id = $combination['id_image'] ? $combination['id_image'] : $item['id_image'];
+                                $results[$combination['id_product_attribute']]['image'] = str_replace('http://', Tools::getShopProtocol(), $context->link->getImageLink($item['link_rewrite'], $image_id, 'home_default'));
+
                             }
                         }
                     } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>



| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When create a product pack, If any image is selected for a combination product (ex. if the product image it's the same for all combinations) the default image of the product will be shown by default.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20001 .
| How to test?  | Create a Product Pack -> Add a product -> You can see now the default image is loaded

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20225)
<!-- Reviewable:end -->
