### PR TITLE
Fix order history font-size and contrast

### DIFF
--- a/themes/classic/_dev/css/components/customer.scss
+++ b/themes/classic/_dev/css/components/customer.scss
@@ -188,9 +188,9 @@
 
 /*** Order details page ***/
 .page-order-detail {
-  font-size: 0.875rem;
-  color: $gray;
-
+  #content {
+    font-size: 0.875rem;
+  }
   .box {
     @include customer-area-base-box();
     margin-bottom: 1rem;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Order history page has different global font-size and color
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19144
| How to test?  | Go to Order details and check that header font size is the same as other pages.


Before:
![Anotación 2020-07-19 182343](https://user-images.githubusercontent.com/194784/87880682-ee45a900-c9f3-11ea-8c2e-33eaf9d00b4e.png)

After:
![Anotación 2020-07-19 190419](https://user-images.githubusercontent.com/194784/87880684-f1409980-c9f3-11ea-8879-8d5ee333cfe9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20233)
<!-- Reviewable:end -->
