### PR TITLE
Remove useless ini_set for Windows

### DIFF
--- a/classes/Windows.php
+++ b/classes/Windows.php
@@ -32,7 +32,5 @@ class WindowsCore
 {
     public static function improveFilesytemPerformances()
     {
-        ini_set('realpath_cache_size', '1M');
-        ini_set('realpath_cache_ttl', '300');
     }
 }

--- a/classes/Windows.php
+++ b/classes/Windows.php
@@ -27,6 +27,8 @@
 /**
  * Class Windows, used to improve the experience
  * when using PrestaShop on Windows operating system.
+ *
+ * @deprecated since 1.7.8.0
  */
 class WindowsCore
 {

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -55,7 +55,11 @@ if (!file_exists(_PS_ROOT_DIR_ . '/app/config/parameters.yml') && !file_exists(_
 
 require_once $currentDir . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
-/* Improve PHP configuration on Windows */
+/*
+ * Improve PHP configuration on Windows
+ *
+ * @deprecated since 1.7.8.0
+ */
 if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
     Windows::improveFilesytemPerformances();
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | These configuration variables can only be set by php.ini or httpd.conf and have no effect here. I keep the class in case of someone override the Windows class.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20206
| How to test?  | No need QA.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20235)
<!-- Reviewable:end -->
