### PR TITLE
Grid row delete confirmation modal - Customers > Addresses

### DIFF
--- a/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AddressGridDefinitionFactory.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
@@ -46,6 +45,7 @@ use PrestaShopBundle\Form\Admin\Type\CountryChoiceType;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class is responsible for defining 'Sell > Customer > Addresses' grid.
@@ -53,6 +53,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     public const GRID_ID = 'address';
 
@@ -147,19 +148,12 @@ final class AddressGridDefinitionFactory extends AbstractFilterableGridDefinitio
                             ])
                     )
                     ->add(
-                        (new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                                'route' => 'admin_addresses_delete',
-                                'route_param_name' => 'addressId',
-                                'route_param_field' => 'id_address',
-                            ])
+                        $this->buildDeleteAction(
+                            'admin_addresses_delete',
+                            'addressId',
+                            'id_address',
+                            Request::METHOD_DELETE
+                        )
                     ),
             ])
             )

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/addresses.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer/addresses.yml
@@ -62,7 +62,7 @@ admin_addresses_delete_bulk:
 
 admin_addresses_delete:
   path: /{addressId}/delete
-  methods: [POST]
+  methods: [POST, DELETE]
   defaults:
     _controller: PrestaShopBundle:Admin\Sell\Address\Address:delete
     _legacy_controller: AdminAddresses


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br>Customers > Addresses.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847 
| How to test?  | Go to Customers > Addresses in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20253)
<!-- Reviewable:end -->
