### PR TITLE
Fix color of cursor using arrow keyboard on product page

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_product_page.scss
@@ -457,7 +457,9 @@
       padding: 0.3125rem 0.625rem;
       color: $gray-medium;
       cursor: pointer;
-      &:hover {
+
+      &:hover,
+      &.tt-cursor {
         color: #fff;
         background-color: $primary-hover;
       }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On product page combinations, the input to select some combination has a blue hover effect that was not effective while using keyboard's arrows
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14052.
| How to test?  | Go on product combination page, and then type something like : "Size", and try to select one using keyboard's arrow, selected item should be blue ( check issue if needed, there is a video and more)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20260)
<!-- Reviewable:end -->
