### PR TITLE
Functional tests - Fix click on delete confirmation modal - Customers > Addresses

### DIFF
--- a/tests/UI/pages/BO/customers/addresses/index.js
+++ b/tests/UI/pages/BO/customers/addresses/index.js
@@ -156,7 +156,6 @@ module.exports = class Addresses extends BOBasePage {
       this.page.click(this.addressesListTableDeleteLink(row)),
       this.waitForVisibleSelector(this.deleteAddressModal),
     ]);
-    // Click on delete
     await this.page.click(this.deleteAddressModalDeleteButton);
     return this.getTextContent(this.alertSuccessBlockParagraph);
   }

--- a/tests/UI/pages/BO/customers/addresses/index.js
+++ b/tests/UI/pages/BO/customers/addresses/index.js
@@ -32,7 +32,7 @@ module.exports = class Addresses extends BOBasePage {
     this.bulkActionsDeleteButton = '#address_grid_bulk_action_delete_selection';
     // Modal Dialog
     this.deleteAddressModal = '#address-grid-confirm-modal.show';
-    this.deleteCustomerModalDeleteButton = `${this.deleteAddressModal} button.btn-confirm-submit`;
+    this.deleteAddressModalDeleteButton = `${this.deleteAddressModal} button.btn-confirm-submit`;
     // Sort Selectors
     this.tableHead = `${this.addressesListForm} thead`;
     this.sortColumnDiv = column => `${this.tableHead} div.ps-sortable-column[data-sort-col-name='${column}']`;
@@ -144,7 +144,6 @@ module.exports = class Addresses extends BOBasePage {
    * @returns {Promise<string>}
    */
   async deleteAddress(row) {
-    this.dialogListener();
     // Click on dropDown
     await Promise.all([
       this.page.click(this.addressesListTableToggleDropDown(row)),
@@ -152,8 +151,13 @@ module.exports = class Addresses extends BOBasePage {
         `${this.addressesListTableToggleDropDown(row)}[aria-expanded='true']`,
       ),
     ]);
+    // Click on delete and wait for modal
+    await Promise.all([
+      this.page.click(this.addressesListTableDeleteLink(row)),
+      this.waitForVisibleSelector(this.deleteAddressModal),
+    ]);
     // Click on delete
-    await this.page.click(this.addressesListTableDeleteLink(row));
+    await this.page.click(this.deleteAddressModalDeleteButton);
     return this.getTextContent(this.alertSuccessBlockParagraph);
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix click on delete confirmation modal - Customers > Addresses
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  |  TEST_PATH="functional/BO/04_customers/02_addresses/02_CRUDAddressInBO.js" URL_FO=yourShopURL npm run specific-test
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20262)
<!-- Reviewable:end -->
