### PR TITLE
Fix bad redirection after error in address controller - edit usecase

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -451,8 +451,6 @@ class AddressController extends FrameworkBundleAdminController
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
-
-            return $this->redirectToRoute('admin_orders_view', ['orderId' => $orderId]);
         }
 
         $customerInfo = $editableAddress->getLastName() . ' ' .

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -359,8 +359,6 @@ class AddressController extends FrameworkBundleAdminController
             }
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
-
-            return $this->redirectToRoute('admin_addresses_index');
         }
 
         $customerInfo = $editableAddress->getLastName() . ' ' .


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | PR https://github.com/PrestaShop/PrestaShop/pull/20263 fixed the "create an address" usecase described in https://github.com/PrestaShop/PrestaShop/issues/20170 but not the "edit an address"
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20170
| How to test?  | See ticket, for "edit an address" usecase. The PR https://github.com/PrestaShop/PrestaShop/pull/20263 fixed the "create an address" usecase. <br> Before the PR, you are redirected into "adresses listing" page. You should stay on the form with error message. This is what this PR fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20303)
<!-- Reviewable:end -->
