### PR TITLE
Better form errors display for Address form

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -75,3 +75,7 @@
     }
   }
 }
+
+.invalid-feedback-container {
+  padding-top: 8px;
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -552,9 +552,13 @@
 
 {% block form_errors -%}
   {% if errors|length > 0 -%}
-    <div class="alert alert-danger">
+    <div class="invalid-feedback-container">
+      <div class="d-inline-block text-danger align-top">
+        <i class="material-icons form-error-icon">error_outline</i>
+      </div>
+      <div class="d-inline-block">
       {%- if errors|length > 1 -%}
-        <ul class="alert-text">
+        <ul class="text-danger">
           {%- for error in errors -%}
             <li> {{
               error.messagePluralization is null
@@ -565,7 +569,7 @@
           {%- endfor -%}
         </ul>
       {%- else -%}
-        <div class="alert-text">
+        <div class="text-danger">
           {%- for error in errors -%}
             <p> {{
               error.messagePluralization is null
@@ -576,6 +580,7 @@
           {%- endfor -%}
         </div>
       {%- endif -%}
+      </div>
     </div>
   {%- endif %}
 {%- endblock form_errors %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Apply [UX feedback](https://github.com/PrestaShop/PrestaShop/pull/20016#issuecomment-662915613) on how form errors should be displayed
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | See below

## How to test

### Before the PR

<img src="https://user-images.githubusercontent.com/16067358/87928969-fcdca080-ca85-11ea-9754-5d49c659f08b.png">

### After the PR

![Capture d’écran 2020-07-23 à 18 32 13](https://user-images.githubusercontent.com/3830050/88312994-31b15780-cd13-11ea-805e-5eeed4f8ad23.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20305)
<!-- Reviewable:end -->
