### PR TITLE
Improve sitemap-nested-list.tpl

### DIFF
--- a/themes/classic/templates/cms/_partials/sitemap-nested-list.tpl
+++ b/themes/classic/templates/cms/_partials/sitemap-nested-list.tpl
@@ -29,7 +29,7 @@
         <a id="{$link.id}" href="{$link.url}" title="{$link.label}">
           {$link.label}
         </a>
-        {if isset($link.children) && $link.children|@count > 0}
+        {if !empty($link.children)}
           {include file='cms/_partials/sitemap-nested-list.tpl' links=$link.children is_nested=true}
         {/if}
       </li>

--- a/themes/classic/templates/cms/_partials/sitemap-nested-list.tpl
+++ b/themes/classic/templates/cms/_partials/sitemap-nested-list.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 {block name='sitemap_item'}
-  <ul{if isset($is_nested)} class="nested"{/if}>
+  <ul{if !empty($is_nested)} class="nested"{/if}>
     {foreach $links as $link}
       <li>
         <a id="{$link.id}" href="{$link.url}" title="{$link.label}">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Don't add "nested" class when $is_nested is falsy and Simplify link.children checking in cms tpl because Empty already checks count
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | the sitemap should display as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20309)
<!-- Reviewable:end -->
