### PR TITLE
Mark deprecated order hooks for 1.7.7 as such

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -102,6 +102,14 @@ class HookCore extends ObjectModel
         'displayProductTabContent' => ['from' => '1.7.0.0'],
         'displayProductTab' => ['from' => '1.7.0.0'],
 
+        // Order page
+        'displayAdminOrderRight' => ['from' => '1.7.7.0'],
+        'displayAdminOrderLeft' => ['from' => '1.7.7.0'],
+        'displayAdminOrderTabOrder' => ['from' => '1.7.7.0'],
+        'displayAdminOrderTabShip' => ['from' => '1.7.7.0'],
+        'displayAdminOrderContentOrder' => ['from' => '1.7.7.0'],
+        'displayAdminOrderContentShip' => ['from' => '1.7.7.0'],
+
         // Controller
         'actionAjaxDieBefore' => ['from' => '1.6.1.1'],
     ];

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -337,10 +337,13 @@
       <alias>actionAfterDeleteProductInCart</alias>
       <name>actionDeleteProductInCartAfter</name>
     </hook_alias>
-
     <hook_alias id="displayInvoice">
       <alias>displayInvoice</alias>
       <name>displayAdminOrderTop</name>
+    </hook_alias>
+    <hook_alias id="displayBackOfficeOrderActions">
+      <alias>displayBackOfficeOrderActions</alias>
+      <name>displayAdminOrderSide</name>
     </hook_alias>
   </entities>
 </entity_hook_alias>


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | I deprecated the hooks deprecated in 1.7.7 according to [this devdocs page](https://devdocs.prestashop.com/1.7/modules/core-updates/1.7.7/) and I add the missing alias
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes, hooks
| Fixed ticket? | 
| How to test?  | I dont know 😅 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20311)
<!-- Reviewable:end -->
