### PR TITLE
Improve combination tests, use IDs instead of names to check quantities

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -207,6 +207,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $packItems[] = new OrderProductForViewing(
                     null,
                     $pack_item['id_product'],
+                    0,
                     $pack_item['name'],
                     $pack_item['reference'],
                     $pack_item['supplier_reference'],
@@ -233,6 +234,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
             $productsForViewing[] = new OrderProductForViewing(
                 $product['id_order_detail'],
                 $product['product_id'],
+                $product['product_attribute_id'],
                 $product['product_name'],
                 $product['product_reference'],
                 $product['product_supplier_reference'],

--- a/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderProductForViewing.php
@@ -40,6 +40,11 @@ class OrderProductForViewing implements JsonSerializable
     private $id;
 
     /**
+     * @var int
+     */
+    private $combinationId;
+
+    /**
      * @var string
      */
     private $location;
@@ -157,6 +162,7 @@ class OrderProductForViewing implements JsonSerializable
     /**
      * @param int $orderDetailId
      * @param int $id
+     * @param int $combinationId
      * @param string $name
      * @param string $reference
      * @param string $supplierReference
@@ -183,6 +189,7 @@ class OrderProductForViewing implements JsonSerializable
     public function __construct(
         ?int $orderDetailId,
         int $id,
+        int $combinationId,
         string $name,
         string $reference,
         string $supplierReference,
@@ -207,6 +214,7 @@ class OrderProductForViewing implements JsonSerializable
         ?OrderProductCustomizationsForViewing $customizations = null
     ) {
         $this->id = $id;
+        $this->combinationId = $combinationId;
         $this->name = $name;
         $this->reference = $reference;
         $this->supplierReference = $supplierReference;
@@ -250,6 +258,14 @@ class OrderProductForViewing implements JsonSerializable
     public function getId(): int
     {
         return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCombinationId(): int
+    {
+        return $this->combinationId;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -427,7 +427,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_incl  | 7.42   |
     When I remove product "Test Product With Percent Discount" from order "bo_order1"
     Then order "bo_order1" should have 2 products in total
-    Then order "bo_order1" should contain 0 product "Test Product Cart Rule On Order"
+    Then order "bo_order1" should contain 0 product "Test Product With Percent Discount"
     Then order "bo_order1" should have 1 cart rule
     Then order "bo_order1" should have cart rule "discount five-percent" with amount "$1.19"
     Then order "bo_order1" should have following details:
@@ -516,4 +516,4 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_incl  | 7.42   |
     When I remove product "Test Product With Percent Discount" from order "bo_order1"
     Then order "bo_order1" should have 2 products in total
-    Then order "bo_order1" should contain 0 product "Test Product Cart Rule On Order"
+    Then order "bo_order1" should contain 0 product "Test Product With Percent Discount"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -367,8 +367,8 @@ Feature: Order from Back Office (BO)
       | combination   | combination2  |
       | amount        | 1             |
       | price         | 10            |
-    Then order "bo_order1" should contain 1 product "My Product - Size : L"
-    And order "bo_order1" should contain 1 product "My Product - Size : M"
+    Then order "bo_order1" should contain 1 combination "combination1" of product "My Product"
+    And order "bo_order1" should contain 1 combination "combination2" of product "My Product"
 
   Scenario: Generating invoice for Order
     When I generate invoice for "bo_order1" order

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_out_of_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_out_of_stock.feature
@@ -79,7 +79,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 200
     And order "bo_order1" should have 102 products in total
-    And order "bo_order1" should contain 100 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 100 combinations "whiteM" of product "Test Product Max Stock"
     When I edit combination "whiteM" of product "Test Product Max Stock" to order "bo_order1" with following products details:
       | amount        | 160                     |
       | price         | 15                      |
@@ -88,7 +88,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 200
     And order "bo_order1" should have 102 products in total
-    And order "bo_order1" should contain 100 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 100 combinations "whiteM" of product "Test Product Max Stock"
     # I can decrease the number in stock (note: 100 + 60 > 150 to check the available quantity considers the amount in the order)
     When I edit combination "whiteM" of product "Test Product Max Stock" to order "bo_order1" with following products details:
       | amount        | 60                     |
@@ -97,7 +97,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 240
     And order "bo_order1" should have 62 products in total
-    And order "bo_order1" should contain 60 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 60 combinations "whiteM" of product "Test Product Max Stock"
     When I edit combination "whiteM" of product "Test Product Max Stock" to order "bo_order1" with following products details:
       | amount        | 150                     |
       | price         | 15                      |
@@ -105,7 +105,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 150
     And order "bo_order1" should have 152 products in total
-    And order "bo_order1" should contain 150 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 150 combinations "whiteM" of product "Test Product Max Stock"
     When I edit combination "whiteM" of product "Test Product Max Stock" to order "bo_order1" with following products details:
       | amount        | 149                     |
       | price         | 15                      |
@@ -113,7 +113,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 151
     And order "bo_order1" should have 151 products in total
-    And order "bo_order1" should contain 149 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 149 combinations "whiteM" of product "Test Product Max Stock"
 
   Scenario: Add product in order with the exact amount of stock (first add)
     Given there is a product in the catalog named "Test Product Max Stock" with a price of 15.0 and 100 items in stock
@@ -179,7 +179,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 300
     And order "bo_order1" should have 2 products in total
-    And order "bo_order1" should contain 0 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 0 combinations "whiteM" of product "Test Product Max Stock"
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product Max Stock  |
       | combination   | whiteM                  |
@@ -189,7 +189,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 150
     And order "bo_order1" should have 152 products in total
-    And order "bo_order1" should contain 150 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 150 combinations "whiteM" of product "Test Product Max Stock"
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product Max Stock  |
       | combination   | whiteM                  |
@@ -200,7 +200,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 150
     And order "bo_order1" should have 152 products in total
-    And order "bo_order1" should contain 150 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 150 combinations "whiteM" of product "Test Product Max Stock"
 
   Scenario: Add combination in order with the exact amount of stock (second addition in new invoice)
     Given there is a product in the catalog named "Test Product Max Stock" with a price of 15.0 and 100 items in stock
@@ -220,7 +220,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 100
     And the available stock for product "Test Product Max Stock" should be 120
     And order "bo_order1" should have 82 products in total
-    And order "bo_order1" should contain 80 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 80 combinations "whiteM" of product "Test Product Max Stock"
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product Max Stock  |
       | combination   | whiteM                  |
@@ -230,7 +230,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 100
     And the available stock for product "Test Product Max Stock" should be 100
     And order "bo_order1" should have 102 products in total
-    And order "bo_order1" should contain 100 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 100 combinations "whiteM" of product "Test Product Max Stock"
 
   Scenario: Add product two times and empty stock but edit the first one after
     Given there is a product in the catalog named "Test Product Max Stock" with a price of 15.0 and 100 items in stock
@@ -276,7 +276,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 299
     And order "bo_order1" should have 3 products in total
-    And order "bo_order1" should contain 1 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 1 combinations "whiteM" of product "Test Product Max Stock"
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product Max Stock  |
       | combination   | whiteM                  |
@@ -286,7 +286,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 150
     And order "bo_order1" should have 152 products in total
-    And order "bo_order1" should contain 150 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 150 combinations "whiteM" of product "Test Product Max Stock"
     When I edit combination "whiteM" of product "Test Product Max Stock" to order "bo_order1" with following products details:
       | amount        | 150                     |
       | price         | 15                      |
@@ -295,7 +295,7 @@ Feature: Order from Back Office (BO)
     And the available stock for combination "whiteL" of product "Test Product Max Stock" should be 150
     And the available stock for product "Test Product Max Stock" should be 150
     And order "bo_order1" should have 152 products in total
-    And order "bo_order1" should contain 150 products "Test Product Max Stock - Size : M- Color : White"
+    And order "bo_order1" should contain 150 combinations "whiteM" of product "Test Product Max Stock"
 
   Scenario: Update product that is allowed out of stock in order
     Given there is a product in the catalog named "Test Product Max Stock" with a price of 15.0 and 100 items in stock


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Improve behat tests about combination, they now use the IDs to perform quantity checks instead of the name (if the name format was changed then the tests would fail)
| Type?         | improvement
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Required to finish the merge PR towards develop
| How to test?  | No QA needed only travis tests green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20312)
<!-- Reviewable:end -->
