### PR TITLE
Cannot remove attributes if token is disabled

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/product-combinations.js
+++ b/admin-dev/themes/default/js/bundle/product/product-combinations.js
@@ -182,7 +182,7 @@ var combinations = (function() {
                 onContinue: function() {
                   $.ajax({
                     type: 'GET',
-                    url: $('#accordion_combinations').attr('data-action-delete-all').replace(/\/\d+(?=\?.*)/, '/' + $('#form_id_product').val()),
+                    url: $('#accordion_combinations').attr('data-action-delete-all').replace(/\/\d+(?=\?.*)?/, '/' + $('#form_id_product').val()),
                     success: function(response) {
                       combinationsList.remove();
                       displayFieldsManager.refresh();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Unable to switch a product from multiple combinations to a simple product if the token in URL is disabled.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Disable token by adding `SetEnv _TOKEN_ disabled` in your .htaccess or virtualhost. Try to switch from a product with combinations to a simple Product.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20319)
<!-- Reviewable:end -->
