### PR TITLE
Fixed alert system failing when the $error variable is malformed

### DIFF
--- a/admin-dev/themes/default/template/layout.tpl
+++ b/admin-dev/themes/default/template/layout.tpl
@@ -31,7 +31,7 @@
 		</div>
 	</div>
 {/if}
-{if isset($error)}
+{if count($error)}
   <div class="bootstrap">
     <div class="alert alert-danger">
       <button type="button" class="close" data-dismiss="alert">&times;</button>

--- a/admin-dev/themes/default/template/layout.tpl
+++ b/admin-dev/themes/default/template/layout.tpl
@@ -31,7 +31,7 @@
 		</div>
 	</div>
 {/if}
-{if count($error)}
+{if !empty($error)}
   <div class="bootstrap">
     <div class="alert alert-danger">
       <button type="button" class="close" data-dismiss="alert">&times;</button>


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | this notification is visible on back even is empty with array(null).
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | this notification is visible before modification. I just change one line. <br>I test this bug with any simaltion {$error = array('test')} before line 34.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20320)
<!-- Reviewable:end -->
