### PR TITLE
Set editorconfig to indent yml files using 4 spaces instead of two

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 4


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Updated editorconfig file to account for the current standard used for YML files 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Nothing to test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20324)
<!-- Reviewable:end -->
