### PR TITLE
Fix DNI field - trigger required instead of visibility

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -73,7 +73,7 @@
 						{else}
 							{block name="label"}
 								{if isset($input.label)}
-									<label class="control-label col-lg-3{if isset($input.required) && $input.required && $input.type != 'radio'} required{/if}">
+									<label class="control-label col-lg-3{if (isset($input.required) && $input.required && $input.type != 'radio') || ($input.name == 'dni' && $dni_required)} required{/if}">
 										{if isset($input.hint)}
 										<span class="label-tooltip" data-toggle="tooltip" data-html="true" title="{if is_array($input.hint)}
 													{foreach $input.hint as $hint}
@@ -222,7 +222,7 @@
 											{if isset($input.readonly) && $input.readonly} readonly="readonly"{/if}
 											{if isset($input.disabled) && $input.disabled} disabled="disabled"{/if}
 											{if isset($input.autocomplete) && !$input.autocomplete} autocomplete="off"{/if}
-											{if isset($input.required) && $input.required } required="required" {/if}
+											{if (isset($input.required) && $input.required) || ($input.name == 'dni' && $dni_required)} required="required" {/if}
 											{if isset($input.placeholder) && $input.placeholder } placeholder="{$input.placeholder}"{/if}
 											/>
 										{if isset($input.suffix)}

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -67,7 +67,7 @@
 					<div class="form-wrapper">
 					{foreach $field as $input}
 						{block name="input_row"}
-						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="dni_required"{if !$dni_required} style="display:none;"{/if}{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
+						<div class="form-group{if isset($input.form_group_class)} {$input.form_group_class}{/if}{if $input.type == 'hidden'} hide{/if}"{if $input.name == 'id_state'} id="contains_states"{if !$contains_states} style="display:none;"{/if}{/if}{if $input.name == 'dni'} id="dni_required"{/if}{if isset($tabs) && isset($input.tab)} data-tab-id="{$input.tab}"{/if}>
 						{if $input.type == 'hidden'}
 							<input type="hidden" name="{$input.name}" id="{$input.name}" value="{$fields_value[$input.name]|escape:'html':'UTF-8'}" />
 						{else}

--- a/js/admin.js
+++ b/js/admin.js
@@ -1409,11 +1409,11 @@ function dniRequired() {
     data: 'token=' + address_token + '&ajax=1&dni_required=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
     success: function(resp) {
       if (resp && resp.dni_required) {
-        $("#dni_required label").addClass("required");
-        $("#dni_required input").prop('required', 'required');
+        $('#dni_required label').addClass('required');
+        $('#dni_required input').prop('required', 'required');
       } else {
-        $("#dni_required label").removeClass("required");
-        $("#dni_required input").removeProp('required');
+        $('#dni_required label').removeClass('required');
+        $('#dni_required input').removeProp('required');
       }
     }
   });

--- a/js/admin.js
+++ b/js/admin.js
@@ -1409,9 +1409,11 @@ function dniRequired() {
     data: 'token=' + address_token + '&ajax=1&dni_required=1&tab=AdminAddresses&id_country=' + $('#id_country').val(),
     success: function(resp) {
       if (resp && resp.dni_required) {
-        $("#dni_required").fadeIn();
+        $("#dni_required label").addClass("required");
+        $("#dni_required input").prop('required', 'required');
       } else {
-        $("#dni_required").fadeOut();
+        $("#dni_required label").removeClass("required");
+        $("#dni_required input").removeProp('required');
       }
     }
   });


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is some ancient code in address BO form, that hides DNI field, if it's not set as required in country settings. This fix controls the required state instead. In FO, its working correctly and showing up as optional.
| Type?         | bug fix / improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #20321
| How to test?  |  see below

### How to test

1. Make two countries.
2. Set address format for both countries to this:
_firstname lastname
company
dni
vat_number
address1
postcode city
Country:name
phone_
3. Set one country to **DNI required** YES and the second one to NO.
4. Make two addresses, each with different country.
5. DNI field is required or not, as it should be, instead of hiding and showing.

### What I changed.
**form.tpl** - This is the initial state of the form. I changed it from setting display: none to the input to setting required, if needed.
**admin.js** - After loading the form or changing country, it asks adminaddresscontroller, if DNI is required for this country. If yes, it used to hide or show the input. I just changed the 2 lines to change the required class and property of the input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20325)
<!-- Reviewable:end -->
