### PR TITLE
Fixed combination with an hyphen in Stock Manager

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
@@ -41,7 +41,7 @@ export default {
       const separator = ' - ';
       let attr = '';
       combinations.forEach((attribute, index) => {
-        const value = attribute.slice(attributes[index].length + separator.length);
+        const value = attribute.trim().slice(attributes[index].trim().length + separator.length);
         attr += attr.length ? ` - ${value}` : value;
       });
       return attr;

--- a/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
@@ -39,7 +39,7 @@ export default {
       const arr = this.product.combination_name.split(',');
       let attr = '';
       arr.forEach((attribute) => {
-        const value = attribute.split('-');
+        const value = attribute.split(' - ');
         attr += attr.length ? ` - ${value[1]}` : value[1];
       });
       return attr;

--- a/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
@@ -36,11 +36,13 @@ export default {
       return null;
     },
     combinationName() {
-      const arr = this.product.combination_name.split(',');
+      const combinations = this.product.combination_name.split(',');
+      const attributes = this.product.attribute_name.split(',');
+      const separator = ' - ';
       let attr = '';
-      arr.forEach((attribute) => {
-        const value = attribute.split(' - ');
-        attr += attr.length ? ` - ${value[1]}` : value[1];
+      combinations.forEach((attribute, index) => {
+        const value = attribute.slice(attributes[index].length + separator.length);
+        attr += attr.length ? ` - ${value}` : value;
       });
       return attr;
     },

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -415,6 +415,35 @@ abstract class StockManagementRepository
     }
 
     /**
+     * Get the attribute name subquery to be used in the select field of the main query.
+     *
+     * @return string
+     */
+    protected function getAttributeNameSubquery()
+    {
+        return '(SELECT GROUP_CONCAT(
+                        DISTINCT CONCAT(agl.name)
+                        SEPARATOR ", "
+                    )
+                    FROM ' . $this->tablePrefix . 'product_attribute pa2
+                    JOIN ' . $this->tablePrefix . 'product_attribute_combination pac ON (
+                        pac.id_product_attribute = pa2.id_product_attribute
+                    )
+                    JOIN ' . $this->tablePrefix . 'attribute a ON (
+                        a.id_attribute = pac.id_attribute
+                    )
+                    JOIN ' . $this->tablePrefix . 'attribute_group ag ON (
+                        ag.id_attribute_group = a.id_attribute_group
+                    )
+                    JOIN ' . $this->tablePrefix . 'attribute_group_lang agl ON (
+                        ag.id_attribute_group = agl.id_attribute_group
+                        AND agl.id_lang = :language_id
+                    )
+                    WHERE pa2.id_product=p.id_product AND pa2.id_product_attribute=pa.id_product_attribute)
+                    AS attribute_name';
+    }
+
+    /**
      * Get the combination name subquery to be used in the select field of the main query.
      *
      * @return string

--- a/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
@@ -81,6 +81,7 @@ class StockMovementRepository extends StockManagementRepository
         }
 
         $combinationNameQuery = $this->getCombinationNameSubquery();
+        $attributeNameQuery = $this->getAttributeNameSubquery();
 
         return str_replace(
             [
@@ -89,6 +90,7 @@ class StockMovementRepository extends StockManagementRepository
                 '{order_by}',
                 '{table_prefix}',
                 '{combination_name}',
+                '{attribute_name}',
             ],
             [
                 $andWhereClause,
@@ -96,6 +98,7 @@ class StockMovementRepository extends StockManagementRepository
                 $orderByClause,
                 $this->tablePrefix,
                 $combinationNameQuery,
+                $attributeNameQuery,
             ],
             'SELECT SQL_CALC_FOUND_ROWS
               sm.id_stock_mvt,
@@ -120,7 +123,8 @@ class StockMovementRepository extends StockManagementRepository
               p.id_supplier                               AS supplier_id,
               COALESCE(s.name, "N/A")                     AS supplier_name,
               COALESCE(ic.id_image, 0)                    AS product_cover_id,
-              {combination_name}
+              {combination_name},
+              {attribute_name}
            FROM {table_prefix}stock_mvt sm
             INNER JOIN {table_prefix}stock_mvt_reason_lang smrl ON (
               smrl.id_stock_mvt_reason = sm.id_stock_mvt_reason

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -235,6 +235,7 @@ class StockRepository extends StockManagementRepository
         }
 
         $combinationNameQuery = $this->getCombinationNameSubquery();
+        $attributeNameQuery = $this->getAttributeNameSubquery();
 
         return str_replace(
             [
@@ -243,6 +244,7 @@ class StockRepository extends StockManagementRepository
                 '{order_by}',
                 '{table_prefix}',
                 '{combination_name}',
+                '{attribute_name}',
             ],
             [
                 $andWhereClause,
@@ -250,6 +252,7 @@ class StockRepository extends StockManagementRepository
                 $orderByClause,
                 $this->tablePrefix,
                 $combinationNameQuery,
+                $attributeNameQuery,
             ],
             'SELECT SQL_CALC_FOUND_ROWS
           p.id_product                                                                      AS product_id,
@@ -269,7 +272,8 @@ class StockRepository extends StockManagementRepository
                       "N/A"))                                                               AS product_low_stock_threshold,
           IF(COALESCE(pa.id_product_attribute, 0) > 0, IF(sa.quantity <= pas.low_stock_threshold, 1, 0),
              IF(sa.quantity <= ps.low_stock_threshold, 1, 0))                               AS product_low_stock_alert,
-          {combination_name}
+          {combination_name},
+          {attribute_name}
         FROM {table_prefix}product p
           LEFT JOIN {table_prefix}product_attribute pa ON (p.id_product = pa.id_product)
           LEFT JOIN {table_prefix}product_lang pl ON (p.id_product = pl.id_product AND pl.id_lang = :language_id)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixed combination with an hyphen in Stock Manager
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #16706
| How to test?  | * Build assets<br>* Create an attribute group named like this: "Example-name"<br>* Create values for this attribute group<br>* Create a product with combination with this attribute<br>* Go to Stock Manager<br>* **BEFORE**<br>![image](https://user-images.githubusercontent.com/1533248/88402350-4bae7100-cdcb-11ea-9f70-1e6b916c591f.png)<br>* **AFTER**<br>![image](https://user-images.githubusercontent.com/1533248/88402382-5537d900-cdcb-11ea-8d45-e517c4d161ba.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20330)
<!-- Reviewable:end -->
