### PR TITLE
Remove discount from order (persist state)

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4325,7 +4325,7 @@ class CartCore extends ObjectModel
         $orderId = Order::getIdByCartId((int) $this->id);
         $product_gift = [];
         if ($orderId) {
-            $product_gift = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT cr.`gift_product`, cr.`gift_product_attribute` FROM `' . _DB_PREFIX_ . 'cart_rule` cr LEFT JOIN `' . _DB_PREFIX_ . 'order_cart_rule` ocr ON (ocr.`id_order` = ' . (int) $orderId . ') WHERE ocr.`id_cart_rule` = cr.`id_cart_rule`');
+            $product_gift = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT cr.`gift_product`, cr.`gift_product_attribute` FROM `' . _DB_PREFIX_ . 'cart_rule` cr LEFT JOIN `' . _DB_PREFIX_ . 'order_cart_rule` ocr ON (ocr.`id_order` = ' . (int) $orderId . ') WHERE ocr.`deleted` = 0 AND ocr.`id_cart_rule` = cr.`id_cart_rule`');
         }
 
         $id_address_delivery = Configuration::get('PS_ALLOW_MULTISHIPPING') ? $cart->id_address_delivery : 0;

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -526,7 +526,7 @@ class CartRuleCore extends ObjectModel
 		SELECT id_cart_rule
 		FROM `' . _DB_PREFIX_ . 'order_cart_rule` ocr
 		LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON ocr.`id_order` = o.`id_order`
-		WHERE ocr.`id_cart_rule` = ' . (int) $this->id . '
+		WHERE ocr.`deleted` = 0 AND ocr.`id_cart_rule` = ' . (int) $this->id . '
 		AND o.`id_customer` = ' . (int) $id_customer);
     }
 
@@ -631,7 +631,7 @@ class CartRuleCore extends ObjectModel
             return false;
         }
 
-        // All these checks are necessary when you add the cart rule the first, so when it's not in cart yet
+        // All these checks are necessary when you add the cart rule the first time, so when it's not in cart yet
         // However when it's in the cart and you are checking if the cart rule is still valid (when performing auto remove)
         // these rules are outdated For example:
         //  - the cart rule can now be disabled but it was at the time it was applied, so it doesn't need to be removed
@@ -655,11 +655,12 @@ class CartRuleCore extends ObjectModel
         if ($context->cart->id_customer) {
             $quantityUsed = Db::getInstance()->getValue('
 			SELECT count(*)
-			FROM ' . _DB_PREFIX_ . 'orders o
-			LEFT JOIN ' . _DB_PREFIX_ . 'order_cart_rule od ON o.id_order = od.id_order
-			WHERE o.id_customer = ' . $context->cart->id_customer . '
-			AND od.id_cart_rule = ' . (int) $this->id . '
-			AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.current_state
+			FROM `' . _DB_PREFIX_ . 'orders` o
+			LEFT JOIN `' . _DB_PREFIX_ . 'order_cart_rule` ocr ON o.`id_order` = ocr.`id_order`
+			WHERE o.`id_customer` = ' . $context->cart->id_customer . '
+			AND ocr.`deleted` = 0
+			AND ocr.`id_cart_rule` = ' . (int) $this->id . '
+			AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.`current_state`
 			');
             // When checking the cart rules present in that cart the request result is accurate
             // When we check if using the cart rule one more time is valid then we increment this value
@@ -833,6 +834,18 @@ class CartRuleCore extends ObjectModel
 
         if (!$nb_products) {
             return (!$display_error) ? false : $this->trans('Cart is empty', [], 'Shop.Notifications.Error');
+        }
+
+        // Check if order cart rule was removed from back office
+        $removed_order_cartRule_id = (int) Db::getInstance()->getValue('
+			SELECT ocr.`id_order_cart_rule`
+			FROM `' . _DB_PREFIX_ . 'order_cart_rule` ocr
+			LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON ocr.`id_order` = o.`id_order`
+			WHERE ocr.`id_cart_rule` = ' . (int) $this->id . '
+			AND ocr.`deleted` = 1
+			AND o.`id_cart` = ' . $context->cart->id);
+        if ($removed_order_cartRule_id) {
+            return (!$display_error) ? false : $this->trans('You cannot use this voucher because it was manually removed.', [], 'Shop.Notifications.Error');
         }
 
         if (!$display_error) {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -845,7 +845,7 @@ class CartRuleCore extends ObjectModel
 			AND ocr.`deleted` = 1
 			AND o.`id_cart` = ' . $context->cart->id);
         if ($removed_order_cartRule_id) {
-            return (!$display_error) ? false : $this->trans('You cannot use this voucher because it was manually removed.', [], 'Shop.Notifications.Error');
+            return (!$display_error) ? false : $this->trans('You cannot use this voucher because it has manually been removed.', [], 'Shop.Notifications.Error');
         }
 
         if (!$display_error) {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -818,7 +818,7 @@ class OrderCore extends ObjectModel
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
         SELECT *
         FROM `' . _DB_PREFIX_ . 'order_cart_rule` ocr
-        WHERE ocr.`id_order` = ' . (int) $this->id);
+        WHERE ocr.`deleted` = 0 AND ocr.`id_order` = ' . (int) $this->id);
     }
 
     public static function getDiscountsCustomer($id_customer, $id_cart_rule)
@@ -827,9 +827,9 @@ class OrderCore extends ObjectModel
         if (!Cache::isStored($cache_id)) {
             $result = (int) Db::getInstance()->getValue('
             SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'orders` o
-            LEFT JOIN ' . _DB_PREFIX_ . 'order_cart_rule ocr ON (ocr.id_order = o.id_order)
-            WHERE o.id_customer = ' . (int) $id_customer . '
-            AND ocr.id_cart_rule = ' . (int) $id_cart_rule);
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_cart_rule` ocr ON (ocr.`id_order` = o.`id_order`)
+            WHERE o.`id_customer` = ' . (int) $id_customer . '
+            AND ocr.`deleted` = 0 AND ocr.`id_cart_rule` = ' . (int) $id_cart_rule);
             Cache::store($cache_id, $result);
 
             return $result;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -821,6 +821,21 @@ class OrderCore extends ObjectModel
         WHERE ocr.`deleted` = 0 AND ocr.`id_order` = ' . (int) $this->id);
     }
 
+    /**
+     *  Return the list of all order cart rules, even the softy deleted ones
+     *
+     * @return array|false
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public function getDeletedCartRules()
+    {
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+        SELECT *
+        FROM `' . _DB_PREFIX_ . 'order_cart_rule` ocr
+        WHERE ocr.`deleted` = 1 AND ocr.`id_order` = ' . (int) $this->id);
+    }
+
     public static function getDiscountsCustomer($id_customer, $id_cart_rule)
     {
         $cache_id = 'Order::getDiscountsCustomer_' . (int) $id_customer . '-' . (int) $id_cart_rule;

--- a/classes/order/OrderCartRule.php
+++ b/classes/order/OrderCartRule.php
@@ -49,6 +49,9 @@ class OrderCartRuleCore extends ObjectModel
     /** @var bool value : voucher gives free shipping or not */
     public $free_shipping;
 
+    /** @var bool value : deleted from order */
+    public $deleted = 0;
+
     /**
      * @see ObjectModel::$definition
      */
@@ -63,6 +66,7 @@ class OrderCartRuleCore extends ObjectModel
             'value' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'required' => true],
             'value_tax_excl' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'required' => true],
             'free_shipping' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
+            'deleted' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
         ],
     ];
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1397,6 +1397,7 @@ CREATE TABLE `PREFIX_order_cart_rule` (
   `value` decimal(20, 6) NOT NULL DEFAULT '0.000000',
   `value_tax_excl` decimal(20, 6) NOT NULL DEFAULT '0.000000',
   `free_shipping` tinyint(1) NOT NULL DEFAULT '0',
+  `deleted` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_order_cart_rule`),
   KEY `id_order` (`id_order`),
   KEY `id_cart_rule` (`id_cart_rule`)

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -595,6 +595,9 @@ UPDATE `PREFIX_order_cart_rule` SET `value_tax_excl` = RIGHT(`value_tax_excl`, 1
 ALTER TABLE `PREFIX_order_cart_rule` CHANGE `value` `value` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000';
 ALTER TABLE `PREFIX_order_cart_rule` CHANGE `value_tax_excl` `value_tax_excl` DECIMAL(20, 6) NOT NULL DEFAULT '0.000000';
 
+/* add deleted field */
+ALTER TABLE `PREFIX_order_cart_rule` ADD `deleted` TINYINT(1) UNSIGNED NOT NULL;
+
 UPDATE
     `PREFIX_order_detail` `od`
 SET

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -76,7 +76,7 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
         }
 
         // Delete Order Cart Rule and update Order
-        $orderCartRule->delete();
+        $orderCartRule->softDelete();
         $cart->removeCartRule($orderCartRule->id_cart_rule);
 
         $this->orderAmountUpdater->update($order, $cart, $orderCartRule->id_order_invoice);

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -193,6 +193,8 @@ class OrderAmountUpdater
 
             // This one is no longer in the new cart rules so we delete it
             $orderCartRule = new OrderCartRule($orderCartRuleData['id_order_cart_rule']);
+            // This one really needs to be deleted because it doesn't match the applied cart rules any more
+            // we don't use soft deleted here (unlike in the handler) but hard delete
             if (!$orderCartRule->delete()) {
                 throw new OrderException('Could not delete order cart rule from database.');
             }

--- a/src/Adapter/Order/Refund/OrderProductRemover.php
+++ b/src/Adapter/Order/Refund/OrderProductRemover.php
@@ -27,10 +27,11 @@
 namespace PrestaShop\PrestaShop\Adapter\Order\Refund;
 
 use Cart;
+use CartRule;
 use Configuration;
-use Context;
 use Db;
 use Order;
+use OrderCartRule;
 use OrderDetail;
 use OrderHistory;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DeleteCustomizedProductFromOrderException;
@@ -68,62 +69,31 @@ class OrderProductRemover
      */
     public function deleteProductFromOrder(Order $order, OrderDetail $orderDetail, int $quantity)
     {
-        if ((int) $orderDetail->id_customization > 0) {
-            $this->deleteCustomization($order, $orderDetail, $quantity);
-        }
-        $productPriceTaxExcl = $orderDetail->unit_price_tax_excl * $quantity;
-        $productPriceTaxIncl = $orderDetail->unit_price_tax_incl * $quantity;
-
         $cart = new Cart($order->id_cart);
-        $this->updateCart($cart, $orderDetail, $quantity);
 
-        $packageShippingCostTaxIncl = $cart->getPackageShippingCost(
-            $order->id_carrier,
-            true,
-            null,
-            $order->getCartProducts()
-        );
-        $packageShippingCostTaxExcl = $cart->getPackageShippingCost(
-            $order->id_carrier,
-            false,
-            null,
-            $order->getCartProducts()
-        );
+        // Important to remove order cart rule before the product is removed, so that cart rule can detect if it's applied on it
+        $this->deleteOrderCartRule($order, $orderDetail, $cart);
 
-        $shippingDiffTaxIncl = $order->total_shipping_tax_incl - $packageShippingCostTaxIncl;
-        $shippingDiffTaxExcl = $order->total_shipping_tax_excl - $packageShippingCostTaxExcl;
+        if ((int) $orderDetail->id_customization > 0) {
+            $this->deleteCustomization($order, $orderDetail);
+        }
 
-        $this->updateOrder(
+        $this->updateCart($cart, $orderDetail);
+
+        $this->deleteOrderDetail(
             $order,
-            $productPriceTaxIncl,
-            $productPriceTaxExcl,
-            $shippingDiffTaxIncl,
-            $shippingDiffTaxExcl
+            $orderDetail
         );
-
-        $this->updateOrderDetail(
-            $order,
-            $orderDetail,
-            $quantity,
-            $productPriceTaxIncl,
-            $productPriceTaxExcl,
-            $shippingDiffTaxIncl,
-            $shippingDiffTaxExcl
-        );
-
-        $orderDetail->update();
-        $order->update();
     }
 
     /**
      * @param Cart $cart
      * @param OrderDetail $orderDetail
-     * @param int $quantity
      */
-    private function updateCart(Cart $cart, OrderDetail $orderDetail, int $quantity)
+    private function updateCart(Cart $cart, OrderDetail $orderDetail)
     {
         $cart->updateQty(
-            $quantity,
+            $orderDetail->product_quantity,
             $orderDetail->product_id,
             $orderDetail->product_attribute_id,
             false,
@@ -134,131 +104,88 @@ class OrderProductRemover
 
     /**
      * @param Order $order
-     * @param float $productPriceTaxIncl
-     * @param float $productPriceTaxExcl
-     * @param float $shippingDiffTaxIncl
-     * @param float $shippingDiffTaxExcl
-     */
-    private function updateOrder(
-        Order $order,
-        float $productPriceTaxIncl,
-        float $productPriceTaxExcl,
-        float $shippingDiffTaxIncl,
-        float $shippingDiffTaxExcl
-    ) {
-        $order->total_shipping -= $shippingDiffTaxIncl;
-        $order->total_shipping_tax_excl -= $shippingDiffTaxExcl;
-        $order->total_shipping_tax_incl -= $shippingDiffTaxIncl;
-        $order->total_products -= $productPriceTaxExcl;
-        $order->total_products_wt -= $productPriceTaxIncl;
-        $order->total_paid -= $productPriceTaxIncl + $shippingDiffTaxIncl;
-        $order->total_paid_tax_incl -= $productPriceTaxIncl + $shippingDiffTaxIncl;
-        $order->total_paid_tax_excl -= $productPriceTaxExcl + $shippingDiffTaxExcl;
-        $order->total_paid_real -= $productPriceTaxIncl + $shippingDiffTaxIncl;
-
-        $fields = [
-            'total_shipping',
-            'total_shipping_tax_excl',
-            'total_shipping_tax_incl',
-            'total_products',
-            'total_products_wt',
-            'total_paid',
-            'total_paid_tax_incl',
-            'total_paid_tax_excl',
-            'total_paid_real',
-        ];
-
-        /* Prevent from floating precision issues */
-        foreach ($fields as $field) {
-            if ($order->{$field} < 0) {
-                $order->{$field} = 0;
-            }
-        }
-
-        /* Prevent from floating precision issues */
-        foreach ($fields as $field) {
-            $order->{$field} = number_format(
-                $order->{$field},
-                Context::getContext()->getComputingPrecision(),
-                '.',
-                ''
-            );
-        }
-    }
-
-    /**
-     * @param Order $order
      * @param OrderDetail $orderDetail
-     * @param int $quantity
-     * @param float $productPriceTaxIncl
-     * @param float $productPriceTaxExcl
-     * @param float $shippingDiffTaxIncl
-     * @param float $shippingDiffTaxExcl
      *
      * @throws DeleteProductFromOrderException
      * @throws \PrestaShopDatabaseException
      * @throws \PrestaShopException
      */
-    private function updateOrderDetail(
+    private function deleteOrderDetail(
         Order $order,
-        OrderDetail $orderDetail,
-        int $quantity,
-        float $productPriceTaxIncl,
-        float $productPriceTaxExcl,
-        float $shippingDiffTaxIncl,
-        float $shippingDiffTaxExcl
+        OrderDetail $orderDetail
     ) {
-        $orderDetail->product_quantity = max($orderDetail->product_quantity - $quantity, 0);
-        if ($orderDetail->product_quantity == 0) {
-            if (!$orderDetail->delete()) {
-                throw new DeleteProductFromOrderException('Could not delete order detail');
-            }
-            if (count($order->getProductsDetail()) == 0) {
-                $history = new OrderHistory();
-                $history->id_order = (int) $order->id;
-                $history->changeIdOrderState(Configuration::get('PS_OS_CANCELED'), $order);
-                if (!$history->addWithemail()) {
-                    // email failure must not block order update process
-                    $this->logger->warning(
-                        $this->translator->trans(
-                            'Order history email could not be sent, test your email configuration in the Advanced Parameters > E-mail section of your back office.',
-                            [],
-                            'Admin.Orderscustomers.Notification'
-                        )
-                    );
-                }
-            }
-
-            $order->update();
-        } else {
-            $orderDetail->total_price_tax_incl -= $productPriceTaxIncl;
-            $orderDetail->total_price_tax_excl -= $productPriceTaxExcl;
-            $orderDetail->total_shipping_price_tax_incl -= $shippingDiffTaxIncl;
-            $orderDetail->total_shipping_price_tax_excl -= $shippingDiffTaxExcl;
+        if (!$orderDetail->delete()) {
+            throw new DeleteProductFromOrderException('Could not delete order detail');
         }
+        if (count($order->getProductsDetail()) == 0) {
+            $history = new OrderHistory();
+            $history->id_order = (int) $order->id;
+            $history->changeIdOrderState(Configuration::get('PS_OS_CANCELED'), $order);
+            if (!$history->addWithemail()) {
+                // email failure must not block order update process
+                $this->logger->warning(
+                    $this->translator->trans(
+                        'Order history email could not be sent, test your email configuration in the Advanced Parameters > E-mail section of your back office.',
+                        [],
+                        'Admin.Orderscustomers.Notification'
+                    )
+                );
+            }
+        }
+
+        $order->update();
     }
 
     /**
      * @param Order $order
      * @param OrderDetail $orderDetail
-     * @param int $quantity
      */
-    private function deleteCustomization(Order $order, OrderDetail $orderDetail, int $quantity)
+    private function deleteCustomization(Order $order, OrderDetail $orderDetail)
     {
         if (!(int) $order->getCurrentState()) {
             throw new DeleteCustomizedProductFromOrderException('Could not get a valid Order state before deletion');
         }
-
-        if ($order->hasBeenDelivered()) {
-            return Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'customization` SET `quantity_returned` = `quantity_returned` + ' . (int) $quantity . ' WHERE `id_customization` = ' . (int) $orderDetail->id_customization . ' AND `id_cart` = ' . (int) $order->id_cart . ' AND `id_product` = ' . (int) $orderDetail->product_id);
-        } elseif ($order->hasBeenPaid()) {
-            return Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'customization` SET `quantity_refunded` = `quantity_refunded` + ' . (int) $quantity . ' WHERE `id_customization` = ' . (int) $orderDetail->id_customization . ' AND `id_cart` = ' . (int) $order->id_cart . ' AND `id_product` = ' . (int) $orderDetail->product_id);
-        }
-        if (!Db::getInstance()->execute('UPDATE `' . _DB_PREFIX_ . 'customization` SET `quantity` = `quantity` - ' . (int) $quantity . ' WHERE `id_customization` = ' . (int) $orderDetail->id_customization . ' AND `id_cart` = ' . (int) $order->id_cart . ' AND `id_product` = ' . (int) $orderDetail->product_id)) {
-            throw new DeleteCustomizedProductFromOrderException('Could not update customization quantity in database.');
-        }
-        if (!Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customization` WHERE `quantity` = 0')) {
+        if (!Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customization` WHERE `id_customization` = ' . (int) $orderDetail->id_customization . ' AND `id_cart` = ' . (int) $order->id_cart . ' AND `id_product` = ' . (int) $orderDetail->product_id)) {
             throw new DeleteCustomizedProductFromOrderException('Could not delete customization from database.');
+        }
+    }
+
+    /**
+     * The deleted OrderCartRule are ignored by CartRule:autoAdd and CartRule:autoRemove so it is not able to clean
+     * them when the product is removed, hence the discount could never be re applied. So we manually check and remove
+     * them.
+     *
+     * @param Order $order
+     * @param OrderDetail $orderDetail
+     * @param Cart $cart
+     */
+    private function deleteOrderCartRule(
+        Order $order,
+        OrderDetail $orderDetail,
+        Cart $cart
+    ): void {
+        $orderCartRules = $order->getDeletedCartRules();
+        if (empty($orderCartRules)) {
+            return;
+        }
+
+        $removedOrderCartRules = [];
+        foreach ($orderCartRules as $orderCartRule) {
+            $cartRule = new CartRule($orderCartRule['id_cart_rule']);
+            $discountedProducts = $cartRule->checkProductRestrictionsFromCart($cart, true, true, true);
+            foreach ($discountedProducts as $discountedProduct) {
+                // The return value is the concatenation of productId and attributeId, but the attributeId is always replaced by 0
+                if ($discountedProduct === $orderDetail->product_id . '-0') {
+                    if (!in_array($orderCartRule['id_order_cart_rule'], $removedOrderCartRules)) {
+                        $removedOrderCartRules[] = $orderCartRule['id_order_cart_rule'];
+                    }
+                }
+            }
+        }
+
+        foreach ($removedOrderCartRules as $removedOrderCartRuleId) {
+            $orderCartRule = new OrderCartRule($removedOrderCartRuleId);
+            $orderCartRule->delete();
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -501,6 +501,96 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
+  Scenario: Add product with associated discount to order, I remove the discount of this product, if I remove the propduct and add it again the discount is applied again
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should have 0 invoices
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
+    And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product With Percent Discount |
+      | amount        | 1                                  |
+      | price         | 350.00                             |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 175.00 |
+      | total_discounts_tax_incl | 185.50 |
+      | total_paid_tax_excl      | 205.80 |
+      | total_paid_tax_incl      | 218.15 |
+      | total_paid               | 218.15 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I remove cart rule "CartRulePercentForSpecificProduct" from order "bo_order1"
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    And order "bo_order1" should not have cart rule "CartRulePercentForSpecificProduct"
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 0.000  |
+      | total_discounts_tax_incl | 0.000  |
+      | total_paid_tax_excl      | 380.80 |
+      | total_paid_tax_incl      | 403.65 |
+      | total_paid               | 403.65 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I remove product "Test Product With Percent Discount" from order "bo_order1"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should contain 0 product "Test Product With Percent Discount"
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product With Percent Discount |
+      | amount        | 1                                  |
+      | price         | 350.00                             |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 175.00 |
+      | total_discounts_tax_incl | 185.50 |
+      | total_paid_tax_excl      | 205.80 |
+      | total_paid_tax_incl      | 218.15 |
+      | total_paid               | 218.15 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+
   Scenario: Add discount to the specific order, then remove it When I perform add/remove product actions the discount is not reapplied
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     Then order "bo_order1" should have 2 products in total

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -319,26 +319,9 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_incl  | 7.42   |
     # The cart rule is removed but added again automatically when the order is synced with cart and shop cart rules
     When I remove cart rule "CartRuleAmountOnEveryOrder" from order "bo_order1"
-    Then order "bo_order1" should have 1 cart rule
-    Then order "bo_order1" should have cart rule "CartRuleAmountOnEveryOrder" with amount "$19.40"
-    Then order "bo_order1" should have following details:
-      | total_products           | 38.800 |
-      | total_products_wt        | 41.130 |
-      | total_discounts_tax_excl | 19.400 |
-      | total_discounts_tax_incl | 20.570 |
-      | total_paid_tax_excl      | 26.4   |
-      | total_paid_tax_incl      | 27.980 |
-      | total_paid               | 27.980 |
-      | total_paid_real          | 0.0    |
-      | total_shipping_tax_excl  | 7.0    |
-      | total_shipping_tax_incl  | 7.42   |
-    # Now that the cart rule is disabled it can be removed
-    When cart rule "CartRuleAmountOnEveryOrder" is disabled
-    And I remove cart rule "CartRuleAmountOnEveryOrder" from order "bo_order1"
     Then order "bo_order1" should have 0 cart rule
     And order "bo_order1" should not have cart rule "CartRuleAmountOnEveryOrder"
-    And order "bo_order1" should have 3 products in total
-    And order "bo_order1" should have following details:
+    Then order "bo_order1" should have following details:
       | total_products           | 38.800 |
       | total_products_wt        | 41.130 |
       | total_discounts_tax_excl | 0.0000 |
@@ -438,6 +421,82 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_excl      | 29.610 |
       | total_paid_tax_incl      | 31.390 |
       | total_paid               | 31.390 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: Add product with associated discount to order, Add discount to the specific order, I remove the discount of this product, if I add the product again the discount is still removed
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Then order "bo_order1" should have 2 products in total
+    Then order "bo_order1" should have 0 invoices
+    Then order "bo_order1" should have 0 cart rule
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a product in the catalog named "Test Product With Percent Discount" with a price of 350.00 and 100 items in stock
+    Given there is a cart rule named "CartRulePercentForSpecificProduct" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
+    And cart rule "CartRulePercentForSpecificProduct" is restricted to product "Test Product With Percent Discount"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Product With Percent Discount |
+      | amount        | 1                                  |
+      | price         | 350.00                             |
+      | free_shipping | true                               |
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 175.00 |
+      | total_discounts_tax_incl | 185.50 |
+      | total_paid_tax_excl      | 205.80 |
+      | total_paid_tax_incl      | 218.15 |
+      | total_paid               | 218.15 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I add discount to order "bo_order1" with following details:
+      | name      | discount five-percent |
+      | type      | percent               |
+      | value     | 5                     |
+    Then order "bo_order1" should have 2 cart rule
+    Then order "bo_order1" should have cart rule "CartRulePercentForSpecificProduct" with amount "$175.00"
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$9.94"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 184.94 |
+      | total_discounts_tax_incl | 196.04 |
+      | total_paid_tax_excl      | 195.86 |
+      | total_paid_tax_incl      | 207.61 |
+      | total_paid               | 207.61 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    When I remove cart rule "CartRulePercentForSpecificProduct" from order "bo_order1"
+    Then order "bo_order1" should have 3 products in total
+    Then order "bo_order1" should contain 1 product "Test Product With Percent Discount"
+    And order "bo_order1" should not have cart rule "CartRulePercentForSpecificProduct"
+    Then order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "discount five-percent" with amount "$18.69"
+    Then order "bo_order1" should have following details:
+      | total_products           | 373.80 |
+      | total_products_wt        | 396.23 |
+      | total_discounts_tax_excl | 18.69  |
+      | total_discounts_tax_incl | 19.81  |
+      | total_paid_tax_excl      | 362.11 |
+      | total_paid_tax_incl      | 383.84 |
+      | total_paid               | 383.84 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Manage soft delete on OrderCartRule this allows to persist this state and avoid to auto add the cart rule after it has been removed
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20246
| How to test?  | See issue for detailed scenario, but basically create a cart rule associated to a product (without code), when the product is added the discount is automatically added, you should be able to remove the discount while keeping the product You can perform the same test for a cart rule applied on all orders (without code)<br>To make sure the discount is not permanently disabled try the same scenario on several orders, on second order the discount must be applied even if it was removed in the first one

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20335)
<!-- Reviewable:end -->
