### PR TITLE
Fix guest tracking without friendly URLs

### DIFF
--- a/themes/classic/templates/customer/guest-login.tpl
+++ b/themes/classic/templates/customer/guest-login.tpl
@@ -35,6 +35,8 @@
     </header>
 
     <section class="form-fields">
+    
+      <input type="hidden" name="controller" value="guest-tracking" >
 
       <div class="form-group row">
         <label class="col-md-3 form-control-label required">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | This PR fixes the bug described in #20194 adding the name of the controller as a hidden input
| Type?         | bug fix 
| Category?     | FO 
| Fixed ticket? | Fixes #20194
| How to test?  |  - Disable friendly URL <br> - Go to 'index.php?controller=guest-tracking' <br> - Complete the fields with a valid order_id and e-mail <br> - Submit <br> - the redirection must go to the tracking page instead of the store's main page as described [here](https://github.com/PrestaShop/PrestaShop/issues/20194#issuecomment-663527670) 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20338)
<!-- Reviewable:end -->
