### PR TITLE
Prevent deleting address being used in the cart

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -84,6 +84,20 @@ class AddressControllerCore extends FrontController
         }
 
         if (Tools::getValue('delete')) {
+            if ($this->context->cart) {
+                if (
+                    $this->context->cart->id_address_invoice == $id_address
+                    || $this->context->cart->id_address_delivery == $id_address
+                ) {
+                    $this->errors[] = $this->trans(
+                        'Could not delete address. You use it in the shopping cart',
+                        array(),
+                        'Shop.Notifications.Error'
+                    );
+                    return;
+                }
+            }
+            
             $ok = $this->makeAddressPersister()->delete(
                 new Address($id_address, $this->context->language->id),
                 Tools::getValue('token')

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -91,13 +91,13 @@ class AddressControllerCore extends FrontController
                 ) {
                     $this->errors[] = $this->trans(
                         'Could not delete address. You use it in the shopping cart',
-                        array(),
+                        [],
                         'Shop.Notifications.Error'
                     );
                     return;
                 }
             }
-            
+
             $ok = $this->makeAddressPersister()->delete(
                 new Address($id_address, $this->context->language->id),
                 Tools::getValue('token')

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -90,7 +90,7 @@ class AddressControllerCore extends FrontController
                 || $this->context->cart->id_address_delivery == $id_address)
             ) {
                 $this->errors[] = $this->trans(
-                    'Could not delete address. You use it in the shopping cart',
+                    'Could not delete the address since it is used in the shopping cart.',
                     [],
                     'Shop.Notifications.Error'
                 );

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -84,18 +84,18 @@ class AddressControllerCore extends FrontController
         }
 
         if (Tools::getValue('delete')) {
-            if ($this->context->cart) {
-                if (
-                    $this->context->cart->id_address_invoice == $id_address
-                    || $this->context->cart->id_address_delivery == $id_address
-                ) {
-                    $this->errors[] = $this->trans(
-                        'Could not delete address. You use it in the shopping cart',
-                        [],
-                        'Shop.Notifications.Error'
-                    );
-                    return;
-                }
+            if (
+                Validate::isLoadedObject($this->context->cart)
+                && $this->context->cart->id_address_invoice == $id_address
+                || $this->context->cart->id_address_delivery == $id_address
+            ) {
+                $this->errors[] = $this->trans(
+                    'Could not delete address. You use it in the shopping cart',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+
+                return;
             }
 
             $ok = $this->makeAddressPersister()->delete(

--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -86,8 +86,8 @@ class AddressControllerCore extends FrontController
         if (Tools::getValue('delete')) {
             if (
                 Validate::isLoadedObject($this->context->cart)
-                && $this->context->cart->id_address_invoice == $id_address
-                || $this->context->cart->id_address_delivery == $id_address
+                && ($this->context->cart->id_address_invoice == $id_address
+                || $this->context->cart->id_address_delivery == $id_address)
             ) {
                 $this->errors[] = $this->trans(
                     'Could not delete address. You use it in the shopping cart',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | You can delete the address you are using in the basket. What is wrong, after that the client will not be able to place an order
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20365.
| How to test?  | Create customer. Create address. Use in shopping cart. Delete address by link site.ru/address?id_address=ID&delete=1&token=TOKEN

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20366)
<!-- Reviewable:end -->
