### PR TITLE
Functional tests - Add browser listeners to tests

### DIFF
--- a/tests/UI/campaigns/utils/globals.js
+++ b/tests/UI/campaigns/utils/globals.js
@@ -36,4 +36,5 @@ global.BROWSER = {
     timeout: 0,
     slowMo: parseInt(process.env.SLOWMO, 10) || 5,
   },
+  interceptErrors: JSON.parse(process.env.INTERCEPT_ERRORS || false),
 };

--- a/tests/UI/campaigns/utils/setup.js
+++ b/tests/UI/campaigns/utils/setup.js
@@ -1,12 +1,22 @@
 require('module-alias/register');
 
 const helper = require('@utils/helpers');
+const files = require('@utils/files');
 
 /**
  * Create unique browser for all mocha run
  */
 before(async function () {
   this.browser = await helper.createBrowser();
+
+  // Create object for browser errors
+  if (global.BROWSER.interceptErrors) {
+    global.browserErrors = {
+      responses: [],
+      js: [],
+      console: [],
+    };
+  }
 });
 
 /**
@@ -14,4 +24,16 @@ before(async function () {
  */
 after(async function () {
   await helper.closeBrowser(this.browser);
+
+  if (global.BROWSER.interceptErrors) {
+    // Delete duplicated errors and create json report
+    const browserErrors = {
+      responses: [...new Set(global.browserErrors.responses)],
+      js: [...new Set(global.browserErrors.js)],
+      console: [...new Set(global.browserErrors.console)],
+    };
+
+    const reportName = await files.generateReportFilename();
+    await files.createFile('.', `${reportName}.json`, JSON.stringify(browserErrors));
+  }
 });


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Get all browser errors in report when running campaigns
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | First step for #20359 
| How to test?  | Run `INTERCEPT_ERRORS=true URL_FO=shopUrl/ npm run sanity-tests` and get report

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20367)
<!-- Reviewable:end -->
