### PR TITLE
Correct stylelint browsers on new-theme

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_button.scss
+++ b/admin-dev/themes/new-theme/scss/components/_button.scss
@@ -3,7 +3,7 @@
     color: #576c72;
     background-color: #fff;
     @include border-radius(4px);
-    box-shadow: 0 0 10px 0 rgba(0, 0, 0, .1);
+    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 
     &:disabled,
     &.disabled {

--- a/admin-dev/themes/new-theme/scss/components/_modulescards.scss
+++ b/admin-dev/themes/new-theme/scss/components/_modulescards.scss
@@ -141,6 +141,7 @@
       height: 96px;
       background: #f6f7f8;
       background: #eee;
+      // stylelint-disable-next-line
       background: linear-gradient(to right, #eee 8%, #ddd 18%, #eee 33%);
       background-size: 800px 104px;
       animation-name: placeHolderShimmer;

--- a/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_configuration.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_configuration.scss
@@ -13,7 +13,7 @@
       line-height: normal;
       color: #4a4a4a;
       text-align: center;
-      letter-spacing: -.01875rem;
+      letter-spacing: -0.01875rem;
     }
 
     .tab-content {
@@ -27,13 +27,13 @@
     .logo-card-description {
       height: 34px;
       margin-top: 20px;
-      font-size: .75rem;
+      font-size: 0.75rem;
       font-style: normal;
       font-weight: 400;
       font-stretch: normal;
       line-height: normal;
       color: #6c868e;
-      letter-spacing: -.0125rem;
+      letter-spacing: -0.0125rem;
     }
 
     .logo-image-container {
@@ -55,13 +55,13 @@
         width: 2.41875rem;
         height: 2.41875rem;
         border: 1px solid transparent;
-        box-shadow: 0 0 6px 0 rgba(0, 0, 0, .3);
+        box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.3);
       }
     }
   }
 
   .logo-card:not(:last-child) {
-    border-right: .0625rem solid #dedede;
+    border-right: 0.0625rem solid #dedede;
   }
 
   .nav-pills {

--- a/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_theme_card.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_theme_card.scss
@@ -4,7 +4,7 @@
   width: 100%;
   height: 100%;
   background-color: #000;
-  opacity: .25;
+  opacity: 0.25;
 }
 
 @mixin card-width() {
@@ -17,7 +17,7 @@
 
 @mixin card-width-and-height() {
   height: 15.125rem;
-  @include card-width ();
+  @include card-width();
 }
 
 @mixin action-button {
@@ -33,7 +33,7 @@
   line-height: normal;
   color: #363a41;
   text-align: center;
-  letter-spacing: -.01875rem;
+  letter-spacing: -0.01875rem;
 }
 
 .theme-card {
@@ -44,13 +44,13 @@
       display: block;
     }
     display: none;
-    @include theme-card-overlay ();
+    @include theme-card-overlay();
   }
 
-  @include card-width-and-height ();
+  @include card-width-and-height();
 
   overflow-y: hidden;
-  @include border-radius(.25rem);
+  @include border-radius(0.25rem);
 
   img {
     max-width: 100%;
@@ -71,14 +71,14 @@
     }
 
     .action-button {
-      @include action-button ();
+      @include action-button();
       font-style: normal;
       font-weight: 400;
       font-stretch: normal;
       line-height: normal;
       color: #363a41;
       text-align: center;
-      letter-spacing: -.0125rem;
+      letter-spacing: -0.0125rem;
 
       .icon-current-theme {
         color: #25b9d7;
@@ -88,13 +88,12 @@
     .action-button:disabled {
       i,
       span {
-        opacity: .5;
+        opacity: 0.5;
       }
-
     }
 
     .delete-button {
-      @include action-button ();
+      @include action-button();
       position: relative;
       width: 2.5rem;
       i {
@@ -108,34 +107,34 @@
     .delete-button:hover {
       color: #fff;
       background-color: #3ed1f0;
-      box-shadow: 0 0 .9375rem 0 rgba(0, 0, 0, .2);
+      box-shadow: 0 0 0.9375rem 0 rgba(0, 0, 0, 0.2);
     }
   }
 }
 
 .theme-card-description {
-  @include card-width ();
+  @include card-width();
 }
 
 .theme-name {
   font-weight: 700;
-  @include theme-name-and-version ();
+  @include theme-name-and-version();
 }
 
 .theme-version {
-  @include theme-name-and-version ();
+  @include theme-name-and-version();
 }
 
 .theme-author {
   padding-bottom: 1.6875rem;
-  font-size: .8125rem;
+  font-size: 0.8125rem;
   font-style: normal;
   font-weight: 400;
   font-stretch: normal;
   line-height: normal;
   color: #618596;
   text-align: center;
-  letter-spacing: -.01875rem;
+  letter-spacing: -0.01875rem;
 }
 
 .theme-catalog-card {
@@ -144,13 +143,12 @@
     padding-top: 3.7rem;
   }
   .catalog-description {
-    padding-top: .975rem;
+    padding-top: 0.975rem;
   }
 }
 
 // actions
 .theme-card:hover .active-card-overlay,
-.theme-card:hover .actions-container
-{
+.theme-card:hover .actions-container {
   display: block;
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We need to correct some things in order to get no-unsupported-browsers-features in our eslint configuration
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | It's globally touching new-theme (migrated pages) style, but nothing really risky, QA should at least look the theme page, modules cards

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20375)
<!-- Reviewable:end -->
