### PR TITLE
Translate Country in ps_country_lang

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1456,7 +1456,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             }
             $territoryData = $territories[$country['iso_code']];
             $sql = 'UPDATE `' . _DB_PREFIX_ . 'country_lang`
-                    SET `name` = "' . pSQL(ucwords($territoryData->getName())) . '"
+                    SET `name` = "' . pSQL(mb_ucwords($territoryData->getName())) . '"
                     WHERE `id_country` = "' . (int) $country['id_country'] . '"
                     AND `id_lang` = "' . (int) $lang->id . '" LIMIT 1;';
             Db::getInstance()->execute($sql);

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1436,32 +1436,30 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
     public static function updateMultilangFromCldr($lang)
     {
-        $cldrLocale = $lang->getLocale();
-        $cldrFile = _PS_TRANSLATIONS_DIR_ . 'cldr/datas/main/' . $cldrLocale . '/territories.json';
+        $translatableCountries = Db::getInstance()->executeS('SELECT c.`iso_code`, cl.* FROM `' . _DB_PREFIX_ . 'country` c
+            INNER JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON c.`id_country` = cl.`id_country`
+            WHERE cl.`id_lang` = "' . (int) $lang->id . '" ', true, false);
 
-        if (file_exists($cldrFile)) {
-            $cldrContent = json_decode(file_get_contents($cldrFile), true);
+        if (empty($translatableCountries)) {
+            return;
+        }
 
-            if (!empty($cldrContent)) {
-                $translatableCountries = Db::getInstance()->executeS('SELECT c.`iso_code`, cl.* FROM `' . _DB_PREFIX_ . 'country` c
-                    INNER JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON c.`id_country` = cl.`id_country`
-                    WHERE cl.`id_lang` = "' . (int) $lang->id . '" ', true, false);
+        $container = SymfonyContainer::getInstance();
+        /** @var LocaleRepository $localeRepoCLDR */
+        $localeRepoCLDR = $container->get('prestashop.core.localization.cldr.locale_repository');
+        $localeCLDR = $localeRepoCLDR->getLocale($lang->locale);
+        $territories = $localeCLDR->getAllTerritories();
 
-                if (!empty($translatableCountries)) {
-                    $cldrLanguages = $cldrContent['main'][$cldrLocale]['localeDisplayNames']['territories'];
-
-                    foreach ($translatableCountries as $country) {
-                        if (isset($cldrLanguages[$country['iso_code']]) &&
-                            !empty($cldrLanguages[$country['iso_code']])
-                        ) {
-                            $sql = 'UPDATE `' . _DB_PREFIX_ . 'country_lang`
-                                SET `name` = "' . pSQL(ucwords($cldrLanguages[$country['iso_code']])) . '"
-                                WHERE `id_country` = "' . (int) $country['id_country'] . '" AND `id_lang` = "' . (int) $lang->id . '" LIMIT 1;';
-                            Db::getInstance()->execute($sql);
-                        }
-                    }
-                }
+        foreach ($translatableCountries as $country) {
+            if (empty($territories[$country['iso_code']])) {
+                continue;
             }
+            $territoryData = $territories[$country['iso_code']];
+            $sql = 'UPDATE `' . _DB_PREFIX_ . 'country_lang`
+                    SET `name` = "' . pSQL(ucwords($territoryData->getName())) . '"
+                    WHERE `id_country` = "' . (int) $country['id_country'] . '"
+                    AND `id_lang` = "' . (int) $lang->id . '" LIMIT 1;';
+            Db::getInstance()->execute($sql);
         }
     }
 

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -402,13 +402,14 @@ class LocalizationPackCore
             foreach ($xml->languages->language as $data) {
                 /** @var SimpleXMLElement $data */
                 $attributes = $data->attributes();
+                $isoCode = (string) $attributes['iso_code'];
                 // if we are not in an installation context or if the pack is not available in the local directory
-                if (Language::getIdByIso($attributes['iso_code']) && !$install_mode) {
+                if (Language::getIdByIso($isoCode) && !$install_mode) {
                     continue;
                 }
 
-                $freshInstall = empty(Language::getIdByIso($attributes['iso_code']));
-                $errors = Language::downloadAndInstallLanguagePack($attributes['iso_code'], $attributes['version'], $attributes, $freshInstall);
+                $freshInstall = empty(Language::getIdByIso($isoCode));
+                $errors = Language::downloadAndInstallLanguagePack($isoCode, $attributes['version'], $attributes, $freshInstall);
                 if ($errors !== true && is_array($errors)) {
                     $this->_errors = array_merge($this->_errors, $errors);
                 }

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -403,7 +403,7 @@ class LocalizationPackCore
                 /** @var SimpleXMLElement $data */
                 $attributes = $data->attributes();
                 $isoCode = (string) $attributes['iso_code'];
-                // if we are not in an installation context or if the pack is not available in the local directory
+                // if we are not in an installation context or if the pack is available in the local directory
                 if (Language::getIdByIso($isoCode) && !$install_mode) {
                     continue;
                 }

--- a/src/Core/Localization/CLDR/Locale.php
+++ b/src/Core/Localization/CLDR/Locale.php
@@ -107,6 +107,13 @@ final class Locale implements LocaleInterface
      */
     protected $currencies;
 
+    /**
+     * All territories, by ISO code.
+     *
+     * @var TerritoryData[]
+     */
+    protected $territories;
+
     public function __construct(LocaleData $localeData)
     {
         $this->localeCode = $localeData->getLocaleCode();
@@ -118,6 +125,7 @@ final class Locale implements LocaleInterface
         $this->percentPatterns = $localeData->getPercentPatterns();
         $this->currencyPatterns = $localeData->getCurrencyPatterns();
         $this->currencies = $localeData->getCurrencies();
+        $this->territories = $localeData->getTerritories();
     }
 
     /**
@@ -300,5 +308,15 @@ final class Locale implements LocaleInterface
     public function getAllCurrencies()
     {
         return $this->currencies;
+    }
+
+    /**
+     * Get CLDR data of all territories.
+     *
+     * @return TerritoryData[] Data of all territories
+     */
+    public function getAllTerritories()
+    {
+        return $this->territories;
     }
 }

--- a/src/Core/Localization/CLDR/Locale.php
+++ b/src/Core/Localization/CLDR/Locale.php
@@ -125,7 +125,7 @@ final class Locale implements LocaleInterface
         $this->percentPatterns = $localeData->getPercentPatterns();
         $this->currencyPatterns = $localeData->getCurrencyPatterns();
         $this->currencies = $localeData->getCurrencies();
-        $this->territories = $localeData->getTerritories();
+        $this->territories = $localeData->getTerritories() ?: [];
     }
 
     /**

--- a/src/Core/Localization/CLDR/Locale.php
+++ b/src/Core/Localization/CLDR/Locale.php
@@ -315,7 +315,7 @@ final class Locale implements LocaleInterface
      *
      * @return TerritoryData[] Data of all territories
      */
-    public function getAllTerritories()
+    public function getAllTerritories(): array
     {
         return $this->territories;
     }

--- a/src/Core/Localization/CLDR/LocaleData.php
+++ b/src/Core/Localization/CLDR/LocaleData.php
@@ -109,9 +109,9 @@ class LocaleData
     /**
      * All territories, by ISO code.
      *
-     * @var TerritoryData[]
+     * @var TerritoryData[]|null
      */
-    protected $territories = [];
+    protected $territories;
 
     /**
      * Override this object's data with another LocaleData object.
@@ -178,7 +178,10 @@ class LocaleData
         }
 
         if (null !== $localeData->getTerritories()) {
-            $this->territories = array_merge($this->territories, $localeData->getTerritories());
+            if (null === $this->territories) {
+                $this->territories = [];
+            }
+            $this->setTerritories(array_merge($this->territories, $localeData->getTerritories()));
         }
 
         return $this;
@@ -381,9 +384,9 @@ class LocaleData
     }
 
     /**
-     * @return TerritoryData[]
+     * @return TerritoryData[]|null
      */
-    public function getTerritories(): array
+    public function getTerritories(): ?array
     {
         return $this->territories;
     }

--- a/src/Core/Localization/CLDR/LocaleData.php
+++ b/src/Core/Localization/CLDR/LocaleData.php
@@ -107,6 +107,13 @@ class LocaleData
     protected $currencies;
 
     /**
+     * All territories, by ISO code.
+     *
+     * @var TerritoryData[]
+     */
+    protected $territories;
+
+    /**
      * Override this object's data with another LocaleData object.
      *
      * @param LocaleData $localeData Locale data to use for the override
@@ -168,6 +175,13 @@ class LocaleData
                 }
                 $this->currencies[$code]->overrideWith($currencyData);
             }
+        }
+
+        if (null !== $localeData->getTerritories()) {
+            if (null === $this->territories) {
+                $this->territories = [];
+            }
+            $this->territories = array_merge($this->territories, $localeData->getTerritories());
         }
 
         return $this;
@@ -365,6 +379,26 @@ class LocaleData
     public function setCurrencies($currencies)
     {
         $this->currencies = $currencies;
+
+        return $this;
+    }
+
+    /**
+     * @return TerritoryData[]
+     */
+    public function getTerritories()
+    {
+        return $this->territories;
+    }
+
+    /**
+     * @param TerritoryData[] $territories
+     *
+     * @return LocaleData
+     */
+    public function setTerritories(array $territories)
+    {
+        $this->territories = $territories;
 
         return $this;
     }

--- a/src/Core/Localization/CLDR/LocaleData.php
+++ b/src/Core/Localization/CLDR/LocaleData.php
@@ -111,7 +111,7 @@ class LocaleData
      *
      * @var TerritoryData[]
      */
-    protected $territories;
+    protected $territories = [];
 
     /**
      * Override this object's data with another LocaleData object.
@@ -178,9 +178,6 @@ class LocaleData
         }
 
         if (null !== $localeData->getTerritories()) {
-            if (null === $this->territories) {
-                $this->territories = [];
-            }
             $this->territories = array_merge($this->territories, $localeData->getTerritories());
         }
 
@@ -386,7 +383,7 @@ class LocaleData
     /**
      * @return TerritoryData[]
      */
-    public function getTerritories()
+    public function getTerritories(): array
     {
         return $this->territories;
     }

--- a/src/Core/Localization/CLDR/LocaleInterface.php
+++ b/src/Core/Localization/CLDR/LocaleInterface.php
@@ -145,4 +145,11 @@ interface LocaleInterface
      * @return CurrencyData[] Data of all currencies
      */
     public function getAllCurrencies();
+
+    /**
+     * Get CLDR data of all territories.
+     *
+     * @return TerritoryData[] Data of all territories
+     */
+    public function getAllTerritories();
 }

--- a/src/Core/Localization/CLDR/LocaleInterface.php
+++ b/src/Core/Localization/CLDR/LocaleInterface.php
@@ -151,5 +151,5 @@ interface LocaleInterface
      *
      * @return TerritoryData[] Data of all territories
      */
-    public function getAllTerritories();
+    public function getAllTerritories(): array;
 }

--- a/src/Core/Localization/CLDR/Reader.php
+++ b/src/Core/Localization/CLDR/Reader.php
@@ -583,8 +583,10 @@ class Reader implements ReaderInterface
             $territories = [];
             foreach ($localeDisplayNamesData->territories->children() as $territoryNode) {
                 $territoryCode = (string) $territoryNode->attributes()->type;
-                $variant = (string) $territoryNode->attributes()->variant;
-                if (!empty($territories[$territoryCode]) && empty($variant)) {
+                $alt = (string) $territoryNode->attributes()->alt;
+                // Check if the territoryData is not already in array
+                // Check if it's not an alternative name
+                if (!empty($territories[$territoryCode]) || !empty($alt)) {
                     continue;
                 }
                 $territoryData = new TerritoryData();

--- a/src/Core/Localization/CLDR/Reader.php
+++ b/src/Core/Localization/CLDR/Reader.php
@@ -577,6 +577,24 @@ class Reader implements ReaderInterface
             $localeData->setCurrencies($currencies);
         }
 
+        // Territories
+        $localeDisplayNamesData = $xmlLocaleData->localeDisplayNames;
+        if (isset($localeDisplayNamesData->territories)) {
+            $territories = [];
+            foreach ($localeDisplayNamesData->territories->children() as $territoryNode) {
+                $territoryCode = (string) $territoryNode->attributes()->type;
+                $variant = (string) $territoryNode->attributes()->variant;
+                if (!empty($territories[$territoryCode]) && empty($variant)) {
+                    continue;
+                }
+                $territoryData = new TerritoryData();
+                $territoryData->setIsoCode($territoryCode);
+                $territoryData->setName((string) $territoryNode);
+                $territories[$territoryCode] = $territoryData;
+            }
+            $localeData->setTerritories($territories);
+        }
+
         return $localeData;
     }
 

--- a/src/Core/Localization/CLDR/TerritoryData.php
+++ b/src/Core/Localization/CLDR/TerritoryData.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Localization\CLDR;
+
+/**
+ * The TerritoryData class is the exact representation of Territory's data structure inside CLDR xml data files.
+ */
+class TerritoryData
+{
+    /**
+     * Alphabetic ISO 4217 territory code.
+     *
+     * @var string
+     */
+    protected $isoCode;
+
+    /**
+     * Territory code.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Override this object's data with another TerritoryData object.
+     *
+     * @param TerritoryData $territoryData Currency data to use for the override
+     *
+     * @return $this Fluent interface
+     */
+    public function overrideWith(TerritoryData $territoryData)
+    {
+        if (null !== $territoryData->getIsoCode()) {
+            $this->setIsoCode($territoryData->getIsoCode());
+        }
+
+        if (null !== $territoryData->getName()) {
+            $this->setName($territoryData->getName());
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIsoCode()
+    {
+        return $this->isoCode;
+    }
+
+    /**
+     * @param string $isoCode
+     *
+     * @return TerritoryData
+     */
+    public function setIsoCode($isoCode)
+    {
+        $this->isoCode = $isoCode;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return TerritoryData
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/Core/Localization/CLDR/TerritoryData.php
+++ b/src/Core/Localization/CLDR/TerritoryData.php
@@ -25,6 +25,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Localization\CLDR;
 
 /**
@@ -69,7 +71,7 @@ class TerritoryData
     /**
      * @return string
      */
-    public function getIsoCode()
+    public function getIsoCode(): string
     {
         return $this->isoCode;
     }
@@ -79,7 +81,7 @@ class TerritoryData
      *
      * @return TerritoryData
      */
-    public function setIsoCode($isoCode)
+    public function setIsoCode(string $isoCode): self
     {
         $this->isoCode = $isoCode;
 
@@ -89,7 +91,7 @@ class TerritoryData
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -99,7 +101,7 @@ class TerritoryData
      *
      * @return TerritoryData
      */
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 

--- a/src/Core/Localization/CLDR/TerritoryData.php
+++ b/src/Core/Localization/CLDR/TerritoryData.php
@@ -37,14 +37,14 @@ class TerritoryData
     /**
      * Alphabetic ISO 4217 territory code.
      *
-     * @var string
+     * @var string|null
      */
     protected $isoCode;
 
     /**
      * Territory code.
      *
-     * @var string
+     * @var string|null
      */
     protected $name;
 
@@ -69,9 +69,9 @@ class TerritoryData
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getIsoCode(): string
+    public function getIsoCode(): ?string
     {
         return $this->isoCode;
     }
@@ -89,9 +89,9 @@ class TerritoryData
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/tests/Unit/Core/Localization/CLDR/LocaleDataTest.php
+++ b/tests/Unit/Core/Localization/CLDR/LocaleDataTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\Core\Localization\CLDR;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleData;
+
+class LocaleDataTest extends TestCase
+{
+    /**
+     * @var LocaleData
+     */
+    private $localeData;
+
+    /**
+     * Setup tested dependency
+     */
+    public function setUp()
+    {
+        $this->localeData = new LocaleData();
+    }
+
+    /**
+     * @param array|null $territoriesInitial
+     * @param array|null $territoriesOverride
+     * @param array $territoriesExpected
+     *
+     * @dataProvider providerTerritories
+     */
+    public function testOverrideWithTerritories(
+        ?array $territoriesInitial,
+        ?array $territoriesOverride,
+        array $territoriesExpected
+    ) {
+        // Initial
+        if (null !== $territoriesInitial) {
+            $this->localeData->setTerritories($territoriesInitial);
+        }
+
+        // Override
+        $localeData = new LocaleData();
+        if (null !== $territoriesOverride) {
+            $localeData->setTerritories($territoriesOverride);
+        }
+
+        // Result
+        $result = $this->localeData->overrideWith($localeData);
+        $this->assertInstanceOf(LocaleData::class, $result);
+        $this->assertEquals($territoriesExpected, $result->getTerritories());
+    }
+
+    public function providerTerritories(): Generator
+    {
+        yield [
+            null,
+            [],
+            [],
+        ];
+        yield [
+            null,
+            ['FR'],
+            ['FR'],
+        ];
+        yield [
+            [],
+            [],
+            [],
+        ];
+        yield [
+            [],
+            ['FR'],
+            ['FR'],
+        ];
+        yield [
+            ['FR'],
+            ['DK'],
+            ['FR', 'DK'],
+        ];
+        yield [
+            ['FR', 'EC'],
+            ['DK'],
+            ['FR', 'EC', 'DK'],
+        ];
+        yield [
+            ['FR'],
+            ['EC', 'DK'],
+            ['FR', 'EC', 'DK'],
+        ];
+    }
+}

--- a/tests/Unit/Core/Localization/CLDR/LocaleTest.php
+++ b/tests/Unit/Core/Localization/CLDR/LocaleTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\Core\Localization\CLDR;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\Locale;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleData;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\TerritoryData;
+
+class LocaleTest extends TestCase
+{
+    /**
+     * @param LocaleData $localeData
+     * @param array|null $expected
+     *
+     * @dataProvider getLocaleDataTerritories
+     */
+    public function testTerritories(LocaleData $localeData, ?array $expected)
+    {
+        $locale = new Locale($localeData);
+        $this->assertIsArray($locale->getAllTerritories());
+        $this->assertEquals($expected, $locale->getAllTerritories());
+    }
+
+    public function getLocaleDataTerritories(): Generator
+    {
+        yield [
+            new LocaleData(),
+            [],
+        ];
+
+        $territoriesData = [
+            (new TerritoryData())->setIsoCode('DK')->setName('Denmark'),
+            (new TerritoryData())->setIsoCode('EC')->setName('Ecuador'),
+            (new TerritoryData())->setIsoCode('FR')->setName('France'),
+        ];
+        yield [
+            (new LocaleData())->setTerritories($territoriesData),
+            $territoriesData,
+        ];
+    }
+}

--- a/tests/Unit/Core/Localization/CLDR/TerritoryDataTest.php
+++ b/tests/Unit/Core/Localization/CLDR/TerritoryDataTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\Core\Localization\CLDR;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\TerritoryData;
+
+class TerritoryDataTest extends TestCase
+{
+    /**
+     * @var TerritoryData
+     */
+    private $territoryData;
+
+    /**
+     * Setup tested dependency
+     */
+    public function setUp()
+    {
+        $this->territoryData = new TerritoryData();
+    }
+
+    /**
+     * @param string|null $initial
+     * @param string|null $override
+     * @param string $expected
+     *
+     * @dataProvider providerIsoCode
+     */
+    public function testOverrideIsoCode(
+        ?string $initial,
+        ?string $override,
+        string $expected
+    ) {
+        // Initial
+        if (null !== $initial) {
+            $this->territoryData->setIsoCode($initial);
+        }
+
+        // Override
+        $territoryData = new TerritoryData();
+        if (null !== $override) {
+            $territoryData->setIsoCode($override);
+        }
+
+        // Result
+        $result = $this->territoryData->overrideWith($territoryData);
+        $this->assertInstanceOf(TerritoryData::class, $result);
+        $this->assertEquals($expected, $result->getIsoCode());
+    }
+
+    public function providerIsoCode(): Generator
+    {
+        yield [
+            null,
+            'FR',
+            'FR',
+        ];
+        yield [
+            null,
+            '',
+            '',
+        ];
+        yield [
+            'FR',
+            null,
+            'FR',
+        ];
+        yield [
+            '',
+            null,
+            '',
+        ];
+        yield [
+            'FR',
+            'FR',
+            'FR',
+        ];
+        yield [
+            'FR',
+            'DK',
+            'DK',
+        ];
+    }
+
+    /**
+     * @param string|null $initial
+     * @param string|null $override
+     * @param string $expected
+     *
+     * @dataProvider providerName
+     */
+    public function testOverrideName(
+        ?string $initial,
+        ?string $override,
+        string $expected
+    ) {
+        if (null !== $initial) {
+            $this->territoryData->setName($initial);
+        }
+
+        // Override
+        $territoryData = new TerritoryData();
+        if (null !== $override) {
+            $territoryData->setName($override);
+        }
+
+        // Result
+        $result = $this->territoryData->overrideWith($territoryData);
+        $this->assertInstanceOf(TerritoryData::class, $result);
+        $this->assertEquals($expected, $result->getName());
+    }
+
+    public function providerName(): Generator
+    {
+        yield [
+            null,
+            '',
+            '',
+        ];
+        yield [
+            null,
+            'France',
+            'France',
+        ];
+        yield [
+            '',
+            null,
+            '',
+        ];
+        yield [
+            'France',
+            null,
+            'France',
+        ];
+        yield [
+            'France',
+            'France',
+            'France',
+        ];
+        yield [
+            'France',
+            'Denmark',
+            'Denmark',
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Translate Country in ps_country_lang
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18929
| How to test?  | 0. Build assets<br>1. Install PrestaShop in French<br>2. In DB, the table `ps_country_lang` has countries in French<br>3. In BO, add the localization pack for Algeria<br>4. In DB, the table `ps_country_lang` has countries in French and in Arabic<br>5. In BO, add the localization pack for England<br>6. In DB, the table `ps_country_lang` has countries in French, English and Arabic<br>

:notebook: **BC Break :**
* Added a method `getAllTerritories` to the interface `PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleInterface`
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20379)
<!-- Reviewable:end -->
