### PR TITLE
Order return states grid - Remove unnecessary filters merge

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -66,9 +66,7 @@ class OrderStateController extends FrameworkBundleAdminController
         $orderStatesGrid = $orderStatesGridFactory->getGrid($orderStatesFilters);
 
         $orderReturnStatesGridFactory = $this->get('prestashop.core.grid.factory.order_return_states');
-        $orderReturnStatesGrid = $orderReturnStatesGridFactory->getGrid(
-            $this->buildFiltersParamsByRequest($request, $orderReturnStatesFilters)
-        );
+        $orderReturnStatesGrid = $orderReturnStatesGridFactory->getGrid($orderReturnStatesFilters);
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/OrderStates/index.html.twig', [
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Grid\GridInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
-use PrestaShop\PrestaShop\Core\Search\Filters;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -43,7 +42,6 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -527,23 +525,5 @@ class FrameworkBundleAdminController extends Controller
             $exceptionCode,
             $e->getMessage()
         );
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return Filters
-     */
-    protected function buildFiltersParamsByRequest(Request $request, Filters $filters)
-    {
-        $filtersParams = is_array($request->query->get($filters->getFilterId())) ?
-            array_merge($filters::getDefaults(), $request->query->get($filters->getFilterId())) :
-            $filters::getDefaults()
-        ;
-        foreach (array_keys($filters::getDefaults()) as $key) {
-            $filters->set($key, $filtersParams[$key]);
-        }
-
-        return $filters;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | No need to merge filters with request filters (removing the method fix visibility issue)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20372 
| How to test?  | /admin-dev/index.php/configure/shop/order-states/ <br>Check that filters work well in the 2 grids individually and combined

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20381)
<!-- Reviewable:end -->
