### PR TITLE
Remove useless assignment of logout_url in MyAccountController

### DIFF
--- a/controllers/front/MyAccountController.php
+++ b/controllers/front/MyAccountController.php
@@ -37,6 +37,13 @@ class MyAccountControllerCore extends FrontController
      */
     public function initContent()
     {
+        /*
+        * @deprecated since 1.7.8
+        */
+        $this->context->smarty->assign([
+            'logout_url' => $this->context->link->getPageLink('index', true, null, 'mylogout'),
+        ]);
+
         parent::initContent();
         $this->setTemplate('customer/my-account');
     }

--- a/controllers/front/MyAccountController.php
+++ b/controllers/front/MyAccountController.php
@@ -37,10 +37,6 @@ class MyAccountControllerCore extends FrontController
      */
     public function initContent()
     {
-        $this->context->smarty->assign([
-            'logout_url' => $this->context->link->getPageLink('index', true, null, 'mylogout'),
-        ]);
-
         parent::initContent();
         $this->setTemplate('customer/my-account');
     }

--- a/themes/classic/modules/ps_customersignin/ps_customersignin.tpl
+++ b/themes/classic/modules/ps_customersignin/ps_customersignin.tpl
@@ -27,7 +27,7 @@
     {if $logged}
       <a
         class="logout hidden-sm-down"
-        href="{$logout_url}"
+        href="{$urls.actions.logout}"
         rel="nofollow"
       >
         <i class="material-icons">&#xE7FF;</i>

--- a/themes/classic/modules/ps_customersignin/ps_customersignin.tpl
+++ b/themes/classic/modules/ps_customersignin/ps_customersignin.tpl
@@ -35,7 +35,7 @@
       </a>
       <a
         class="account"
-        href="{$my_account_url}"
+        href="{$urls.pages.my_account}"
         title="{l s='View my customer account' d='Shop.Theme.Customeraccount'}"
         rel="nofollow"
       >
@@ -44,7 +44,7 @@
       </a>
     {else}
       <a
-        href="{$my_account_url}"
+        href="{$urls.pages.my_account}"
         title="{l s='Log in to your customer account' d='Shop.Theme.Customeraccount'}"
         rel="nofollow"
       >

--- a/themes/classic/templates/customer/my-account.tpl
+++ b/themes/classic/templates/customer/my-account.tpl
@@ -103,7 +103,7 @@
 {block name='page_footer'}
   {block name='my_account_links'}
     <div class="text-sm-center">
-      <a href="{$logout_url}" >
+      <a href="{$urls.actions.logout}" >
         {l s='Sign out' d='Shop.Theme.Actions'}
       </a>
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Remove useless assignment of `logout_url` in MyAccountController to use `$urls.actions.logout `
| Type?         | improvement
| Category?     | FO 
| BC breaks?    | yes 
| Deprecations? | yes
| Fixed ticket? | Fixes 
| How to test?  | Go to My Account page and test to logout

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20403)
<!-- Reviewable:end -->
