### PR TITLE
Use sharedStorage for exceptions in behat domain contexts

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -28,7 +28,6 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Behat\Testwork\Tester\Result\TestResult;
 use Exception;
@@ -47,16 +46,6 @@ abstract class AbstractDomainFeatureContext implements Context
      * Shared storage key for last thrown exception
      */
     const LAST_EXCEPTION_STORAGE_KEY = 'LAST_EXCEPTION';
-
-    /**
-     * @var Exception|null
-     */
-    protected $lastException;
-
-    /**
-     * @var int
-     */
-    protected $lastErrorCode;
 
     /**
      * @BeforeSuite
@@ -84,7 +73,7 @@ abstract class AbstractDomainFeatureContext implements Context
     /**
      * @BeforeScenario
      */
-    public function cleanLastException(BeforeScenarioScope $scope)
+    public function cleanLastException()
     {
         $this->getSharedStorage()->set(self::LAST_EXCEPTION_STORAGE_KEY, null);
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -28,6 +28,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Behat\Testwork\Tester\Result\TestResult;
 use Exception;
@@ -80,6 +81,14 @@ abstract class AbstractDomainFeatureContext implements Context
         }
     }
 
+    /**
+     * @BeforeScenario
+     */
+    public function cleanLastException(BeforeScenarioScope $scope)
+    {
+        $this->getSharedStorage()->set(self::LAST_EXCEPTION_STORAGE_KEY, null);
+    }
+
     protected function setLastException(Exception $e): void
     {
         $this->getSharedStorage()->set(self::LAST_EXCEPTION_STORAGE_KEY, $e);
@@ -91,7 +100,11 @@ abstract class AbstractDomainFeatureContext implements Context
             return null;
         }
 
-        return $this->getSharedStorage()->get(self::LAST_EXCEPTION_STORAGE_KEY);
+        if (!$e = $this->getSharedStorage()->get(self::LAST_EXCEPTION_STORAGE_KEY)) {
+            return null;
+        }
+
+        return $e;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -43,6 +43,11 @@ use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 abstract class AbstractDomainFeatureContext implements Context
 {
     /**
+     * Shared storage key for last thrown exception
+     */
+    const LAST_EXCEPTION_STORAGE_KEY = 'LAST_EXCEPTION';
+
+    /**
      * @var Exception|null
      */
     protected $lastException;
@@ -68,9 +73,25 @@ abstract class AbstractDomainFeatureContext implements Context
      */
     public function checkLastException(AfterScenarioScope $scope)
     {
-        if (TestResult::FAILED === $scope->getTestResult()->getResultCode() && null !== $this->lastException) {
-            throw new RuntimeException(sprintf('Might be related to the last exception: %s %s', get_class($this->lastException), $this->lastException->getTraceAsString()));
+        $e = $this->getLastException();
+
+        if (TestResult::FAILED === $scope->getTestResult()->getResultCode() && null !== $e) {
+            throw new RuntimeException(sprintf('Might be related to the last exception: %s %s', get_class($e), $e->getTraceAsString()));
         }
+    }
+
+    protected function setLastException(Exception $e): void
+    {
+        $this->getSharedStorage()->set(self::LAST_EXCEPTION_STORAGE_KEY, $e);
+    }
+
+    protected function getLastException(): ?Exception
+    {
+        if (!$this->getSharedStorage()->exists(self::LAST_EXCEPTION_STORAGE_KEY)) {
+            return null;
+        }
+
+        return $this->getSharedStorage()->get(self::LAST_EXCEPTION_STORAGE_KEY);
     }
 
     /**
@@ -104,8 +125,10 @@ abstract class AbstractDomainFeatureContext implements Context
 
     protected function assertLastErrorIsNull()
     {
-        if (null !== $this->lastException) {
-            throw new RuntimeException(sprintf('An unexpected exception was thrown %s: %s', get_class($this->lastException), $this->lastException->getMessage()), 0, $this->lastException);
+        $e = $this->getLastException();
+
+        if (null !== $e) {
+            throw new RuntimeException(sprintf('An unexpected exception was thrown %s: %s', get_class($e), $e->getMessage()), 0, $e);
         }
     }
 
@@ -115,11 +138,13 @@ abstract class AbstractDomainFeatureContext implements Context
      */
     protected function assertLastErrorIs($expectedError, $errorCode = null)
     {
-        if (!$this->lastException instanceof $expectedError) {
-            throw new RuntimeException(sprintf('Last error should be "%s", but got "%s"', $expectedError, $this->lastException ? get_class($this->lastException) : 'null'), 0, $this->lastException);
+        $e = $this->getLastException();
+
+        if (!$e instanceof $expectedError) {
+            throw new RuntimeException(sprintf('Last error should be "%s", but got "%s"', $expectedError, $e ? get_class($e) : 'null'), 0, $e);
         }
-        if (null !== $errorCode && $this->lastException->getCode() !== $errorCode) {
-            throw new RuntimeException(sprintf('Last error should have code "%s", but has "%s"', $errorCode, $this->lastException ? $this->lastException->getCode() : 'null'), 0, $this->lastException);
+        if (null !== $errorCode && $e->getCode() !== $errorCode) {
+            throw new RuntimeException(sprintf('Last error should have code "%s", but has "%s"', $errorCode, $e? $e->getCode() : 'null'), 0, $e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -144,7 +144,7 @@ abstract class AbstractDomainFeatureContext implements Context
             throw new RuntimeException(sprintf('Last error should be "%s", but got "%s"', $expectedError, $e ? get_class($e) : 'null'), 0, $e);
         }
         if (null !== $errorCode && $e->getCode() !== $errorCode) {
-            throw new RuntimeException(sprintf('Last error should have code "%s", but has "%s"', $errorCode, $e? $e->getCode() : 'null'), 0, $e);
+            throw new RuntimeException(sprintf('Last error should have code "%s", but has "%s"', $errorCode, $e ? $e->getCode() : 'null'), 0, $e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -356,7 +356,7 @@ class CartFeatureContext extends AbstractDomainFeatureContext
                 $productId
             ));
         } catch (CartException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -101,13 +101,12 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         ]);
 
         try {
-            $this->lastException = null;
             /** @var CurrencyId $currencyId */
             $currencyId = $this->getCommandBus()->handle($command);
 
             SharedStorage::getStorage()->set($reference, new Currency($currencyId->getValue()));
         } catch (CoreException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -160,12 +159,11 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         }
 
         try {
-            $this->lastException = null;
             $this->getCommandBus()->handle($command);
 
             SharedStorage::getStorage()->set($reference, new Currency($currency->id));
         } catch (CoreException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -178,10 +176,9 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         $currency = SharedStorage::getStorage()->get($reference);
 
         try {
-            $this->lastException = null;
             $this->getCommandBus()->handle(new ToggleCurrencyStatusCommand((int) $currency->id));
         } catch (CannotDisableDefaultCurrencyException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -194,10 +191,9 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         $currency = SharedStorage::getStorage()->get($reference);
 
         try {
-            $this->lastException = null;
             $this->getCommandBus()->handle(new DeleteCurrencyCommand((int) $currency->id));
         } catch (CannotDeleteDefaultCurrencyException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -207,10 +203,9 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
     public function getCurrencyReferenceData($currencyIsoCode)
     {
         try {
-            $this->lastException = null;
             $this->currencyData = $this->getCommandBus()->handle(new GetReferenceCurrency($currencyIsoCode));
         } catch (CurrencyException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/FeatureFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/FeatureFeatureContext.php
@@ -92,7 +92,7 @@ class FeatureFeatureContext extends AbstractDomainFeatureContext
 
             $this->getCommandBus()->handle($editFeatureCommand);
         } catch (Exception $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -128,7 +128,7 @@ class FeatureFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->createProductFeature('');
         } catch (Exception $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/MetaFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/MetaFeatureContext.php
@@ -61,7 +61,7 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
 
             SharedStorage::getStorage()->set($reference, new Meta($metaId->getValue()));
         } catch (Exception $exception) {
-            $this->lastException = $exception;
+            $this->setLastException($exception);
             $this->lastErrorCode = $exception->getCode();
         }
     }
@@ -80,7 +80,7 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
 
             SharedStorage::getStorage()->set("editable_{$reference}", $editableMeta);
         } catch (Exception $exception) {
-            $this->lastException = $exception;
+            $this->setLastException($exception);
             $this->lastErrorCode = $exception->getCode();
         }
     }
@@ -101,7 +101,7 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
 
             SharedStorage::getStorage()->set($reference, new Meta((int) $data['metaId']));
         } catch (Exception $exception) {
-            $this->lastException = $exception;
+            $this->setLastException($exception);
             $this->lastErrorCode = $exception->getCode();
         }
     }
@@ -121,7 +121,7 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getCommandBus()->handle($command);
         } catch (Exception $exception) {
-            $this->lastException = $exception;
+            $this->setLastException($exception);
             $this->lastErrorCode = $exception->getCode();
         }
     }
@@ -141,7 +141,7 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getCommandBus()->handle($command);
         } catch (Exception $exception) {
-            $this->lastException = $exception;
+            $this->setLastException($exception);
             $this->lastErrorCode = $exception->getCode();
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/MetaFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/MetaFeatureContext.php
@@ -62,7 +62,6 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
             SharedStorage::getStorage()->set($reference, new Meta($metaId->getValue()));
         } catch (Exception $exception) {
             $this->setLastException($exception);
-            $this->lastErrorCode = $exception->getCode();
         }
     }
 
@@ -81,7 +80,6 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
             SharedStorage::getStorage()->set("editable_{$reference}", $editableMeta);
         } catch (Exception $exception) {
             $this->setLastException($exception);
-            $this->lastErrorCode = $exception->getCode();
         }
     }
 
@@ -102,7 +100,6 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
             SharedStorage::getStorage()->set($reference, new Meta((int) $data['metaId']));
         } catch (Exception $exception) {
             $this->setLastException($exception);
-            $this->lastErrorCode = $exception->getCode();
         }
     }
 
@@ -122,7 +119,6 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
             $this->getCommandBus()->handle($command);
         } catch (Exception $exception) {
             $this->setLastException($exception);
-            $this->lastErrorCode = $exception->getCode();
         }
     }
 
@@ -142,7 +138,6 @@ class MetaFeatureContext extends AbstractDomainFeatureContext
             $this->getCommandBus()->handle($command);
         } catch (Exception $exception) {
             $this->setLastException($exception);
-            $this->lastErrorCode = $exception->getCode();
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -188,9 +188,9 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 )
             );
         } catch (InvalidProductQuantityException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         } catch (ProductOutOfStockException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -231,7 +231,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 new DeleteProductFromOrderCommand($orderId, $orderDetailId)
             );
         } catch (OrderException | OrderNotFoundException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -265,7 +265,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 )
             );
         } catch (InvalidProductQuantityException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -452,9 +452,9 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 )
             );
         } catch (InvalidProductQuantityException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         } catch (ProductOutOfStockException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -855,7 +855,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 $data['value']
             ));
         } catch (InvalidCartRuleDiscountValueException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
@@ -142,7 +142,6 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
         $data = $table->getRowsHash();
 
         try {
-            $this->lastException = null;
             $this->getCommandBus()->handle(
                 new AddPaymentCommand(
                     $orderId,
@@ -155,7 +154,7 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
                 )
             );
         } catch (NegativePaymentAmountException $exception) {
-            $this->lastException = $exception;
+            $this->setLastException($exception);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderRefundFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderRefundFeatureContext.php
@@ -80,7 +80,6 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
         $refundData = $table->getColumnsHash();
 
         try {
-            $this->lastException = null;
             $command = $this->createIssuePartialRefundCommand(
                 $orderId,
                 $refundData,
@@ -91,7 +90,7 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
 
             $this->getCommandBus()->handle($command);
         } catch (OrderException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -115,7 +114,6 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
         $refundData = $table->getColumnsHash();
 
         try {
-            $this->lastException = null;
             $command = $this->createIssueStandardRefundCommand(
                 $orderId,
                 $refundData,
@@ -125,7 +123,7 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
 
             $this->getCommandBus()->handle($command);
         } catch (OrderException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -152,7 +150,6 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
         $refundData = $table->getColumnsHash();
 
         try {
-            $this->lastException = null;
             $command = $this->createIssueReturnProductCommand(
                 $orderId,
                 $refundData,
@@ -163,7 +160,7 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
 
             $this->getCommandBus()->handle($command);
         } catch (OrderException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -241,8 +238,8 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
             InvalidCancelProductException::class,
             InvalidCancelProductException::QUANTITY_TOO_HIGH
         );
-        if ($maxRefund !== $this->lastException->getRefundableQuantity()) {
-            throw new RuntimeException(sprintf('Invalid refundable quantity in exception, expected %s but got %s', $maxRefund, $this->lastException->getRefundableQuantity()));
+        if ($maxRefund !== $this->getLastException()->getRefundableQuantity()) {
+            throw new RuntimeException(sprintf('Invalid refundable quantity in exception, expected %s but got %s', $maxRefund, $this->getLastException()->getRefundableQuantity()));
         }
     }
 
@@ -514,7 +511,7 @@ class OrderRefundFeatureContext extends AbstractDomainFeatureContext
 
             $this->getCommandBus()->handle($command);
         } catch (OrderException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -105,7 +105,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
 
             $this->getSharedStorage()->set($productReference, $productId->getValue());
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -142,7 +142,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getCommandBus()->handle(UpdateProductPackCommand::cleanPack($packId));
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -237,7 +237,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -257,7 +257,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
             $this->setUpdateOptionsCommandData($data, $command);
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -283,7 +283,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
 
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -593,7 +593,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getCommandBus()->handle(new UpdateProductTagsCommand($productId, $localizedTagsList));
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -634,7 +634,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getQueryBus()->handle($command);
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -654,7 +654,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -720,7 +720,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         try {
             $this->updateProductCustomizationFields($productReference, ['name'], $fieldsForUpdate);
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -1012,7 +1012,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
                 $this->getSharedStorage()->set($fieldReferences[$key], $customizationField->getCustomizationFieldId());
             }
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -1095,7 +1095,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
                 $products
             ));
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 
@@ -1461,7 +1461,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
                 $categoryIds
             ));
         } catch (ProductException $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/WebserviceKeyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/WebserviceKeyFeatureContext.php
@@ -97,7 +97,7 @@ class WebserviceKeyFeatureContext extends AbstractDomainFeatureContext
 
             SharedStorage::getStorage()->set($reference, new WebserviceKey($webserviceKeyId->getValue()));
         } catch (Exception $e) {
-            $this->lastException = $e;
+            $this->setLastException($e);
         }
 
         SharedStorage::getStorage()->clear($propertiesKey);


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As ProductFeatureContext is growing, we want to split it to couple smaller contexts. However this is impossible if we keep using $this->lastException to handle errors, because it must be shared between contexts. This PR refactors the last exception in all occurences of Domain contexts to allow splitting ProductFeatureContext in another PR.
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | none (ALL BEHATS MUST PASS)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20407)
<!-- Reviewable:end -->
