### PR TITLE
Fix bug on Invoices tax detail 

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2586,6 +2586,7 @@ class OrderCore extends ObjectModel
                     'total_tax_base' => $total_tax_base,
                     'unit_amount' => $unit_amount,
                     'total_amount' => $total_amount,
+                    'id_order_invoice' => $order_detail['id_order_invoice'],
                 ];
             }
         }

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -359,6 +359,9 @@ class OrderInvoiceCore extends ObjectModel
         if ($sum_composite_taxes) {
             $grouped_details = [];
             foreach ($details as $row) {
+                if ($this->id !== (int) $row['id_order_invoice']) {
+                    continue;
+                }
                 if (!isset($grouped_details[$row['id_order_detail']])) {
                     $grouped_details[$row['id_order_detail']] = [
                         'tax_rate' => 0,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The Tax Detail frame inside the invoice PDF should only contain tax details for the current invoice, not tax details of all products of all invoices in this order.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20393
| How to test?  | See issue #20393 for steps and screen captures

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20408)
<!-- Reviewable:end -->
