### PR TITLE
Replace index.php?controller=404 by pagenotfound

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -68,7 +68,7 @@ class CustomerAddressFormCore extends AbstractForm
         $this->address = new Address($id_address, $this->language->id);
 
         if ($this->address->id === null) {
-            return Tools::redirect('index.php?controller=404');
+            return Tools::redirect('pagenotfound');
         }
 
         if (!$context->customer->isLogged() && !$context->customer->isGuest()) {
@@ -76,7 +76,7 @@ class CustomerAddressFormCore extends AbstractForm
         }
 
         if ($this->address->id_customer != $context->customer->id) {
-            return Tools::redirect('index.php?controller=404');
+            return Tools::redirect('pagenotfound');
         }
 
         $params = get_object_vars($this->address);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -99,7 +99,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
 
         if (!Validate::isLoadedObject($this->product)) {
-            Tools::redirect('index.php?controller=404');
+            Tools::redirect('pagenotfound');
         } else {
             $this->canonicalRedirection();
             /*

--- a/controllers/front/listing/BestSalesController.php
+++ b/controllers/front/listing/BestSalesController.php
@@ -43,7 +43,7 @@ class BestSalesControllerCore extends ProductListingFrontController
         if (Configuration::get('PS_DISPLAY_BEST_SELLERS')) {
             parent::init();
         } else {
-            Tools::redirect('index.php?controller=404');
+            Tools::redirect('pagenotfound');
         }
     }
 

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -86,7 +86,7 @@ class CategoryControllerCore extends ProductListingFrontController
         );
 
         if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
-            Tools::redirect('index.php?controller=404');
+            Tools::redirect('pagenotfound');
         }
 
         parent::init();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Replace `Tools::redirect('index.php?controller=404')` by `Tools::redirect('pagenotfound')`
| Type?         | improvement
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #
| How to test?  | You can go to a product URL which not exists and see the redirect to the real 404 url page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20410)
<!-- Reviewable:end -->
