### PR TITLE
Use SymfonyContainer::getInstance() instead of ContainerBuilder::getContainer('admin')

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -23,7 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
@@ -4718,7 +4718,7 @@ class AdminControllerCore extends Controller
      */
     protected function buildContainer()
     {
-        return ContainerBuilder::getContainer('admin', _PS_MODE_DEV_);
+        return SymfonyContainer::getInstance();
     }
 
     /**

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Container\LegacyContainer;
 use PrestaShop\PrestaShop\Adapter\Container\LegacyContainerBuilder;
 use PrestaShop\PrestaShop\Core\EnvironmentInterface;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
+use PrestaShopBundle\Exception\ServiceContainerException;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
@@ -90,6 +91,11 @@ class ContainerBuilder
      */
     public static function getContainer($containerName, $isDebug)
     {
+        if ($containerName === 'admin') {
+            throw new ServiceContainerException(
+                'You should use `SymfonyContainer::getInstance()` instead of `ContainerBuilder::getContainer(\'admin\')`'
+            );
+        }
         if (!isset(self::$containers[$containerName])) {
             $builder = new ContainerBuilder(new Environment($isDebug));
             self::$containers[$containerName] = $builder->buildContainer($containerName);

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -41,22 +41,27 @@ class ThemeManagerBuilder
 {
     private $context;
     private $db;
+    private $themeValidator;
 
-    public function __construct(Context $context, Db $db)
+    public function __construct(Context $context, Db $db, ThemeValidator $themeValidator = null)
     {
         $this->context = $context;
         $this->db = $db;
+        $this->themeValidator = $themeValidator;
     }
 
     public function build()
     {
         $configuration = new Configuration();
         $configuration->restrictUpdatesTo($this->context->shop);
+        if (null === $this->themeValidator) {
+            $this->themeValidator = new ThemeValidator($this->context->getTranslator(), new Configuration());
+        }
 
         return new ThemeManager(
             $this->context->shop,
             $configuration,
-            new ThemeValidator($this->context->getTranslator(), new Configuration()),
+            $this->themeValidator,
             $this->context->getTranslator(),
             $this->context->employee,
             new Filesystem(),

--- a/src/PrestaShopBundle/Exception/ServiceContainerException.php
+++ b/src/PrestaShopBundle/Exception/ServiceContainerException.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Exception;
+
+use Exception;
+
+class ServiceContainerException extends Exception
+{
+}

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -5,4 +5,5 @@ imports:
     - { resource: services/bundle/*.yml }
     - { resource: services/core/*.yml }
     - { resource: services/adapter/*.yml }
+    - { resource: services/legacy.yml }
     - { resource: services/alias.yml }

--- a/src/PrestaShopBundle/Resources/config/services/alias.yml
+++ b/src/PrestaShopBundle/Resources/config/services/alias.yml
@@ -11,3 +11,12 @@ services:
 
     prestashop.twig.extension.dataFormatter:
         alias: prestashop.twig.extension.data_formatter
+
+    hashing:
+      alias: prestashop.core.crypto.hashing
+
+    hook_provider:
+      alias: prestashop.adapter.legacy.hook
+
+    theme_manager:
+      alias: prestashop.core.addon.theme.theme_manager

--- a/src/PrestaShopBundle/Resources/config/services/alias.yml
+++ b/src/PrestaShopBundle/Resources/config/services/alias.yml
@@ -20,3 +20,6 @@ services:
 
     theme_manager:
       alias: prestashop.core.addon.theme.theme_manager
+
+    theme_validator:
+      alias: prestashop.core.addon.theme.theme_validator

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -30,11 +30,19 @@ services:
           - "@prestashop.core.admin.lang.repository"
           - "@prestashop.translation.theme.exporter"
 
+
+    prestashop.core.addon.theme.theme_validator:
+        class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeValidator
+        arguments:
+          - '@translator'
+          - '@prestashop.adapter.legacy.configuration'
+
     prestashop.core.addon.theme.theme_manager_builder:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder
         arguments:
             - '@=service("prestashop.adapter.legacy.context").getContext()'
             - '@prestashop.adapter.legacy_db'
+            - '@prestashop.core.addon.theme.theme_validator'
 
     prestashop.core.addon.theme.theme_manager:
         class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager

--- a/src/PrestaShopBundle/Resources/config/services/legacy.yml
+++ b/src/PrestaShopBundle/Resources/config/services/legacy.yml
@@ -1,0 +1,21 @@
+services:
+  _defaults:
+    public: true
+
+  context.static:
+    class: Context
+
+  finder:
+    class: Symfony\Component\Finder\Finder
+
+  hook_repository:
+    class: PrestaShop\PrestaShop\Core\Module\HookRepository
+    arguments:
+      - "@hook_provider"
+      - "@=service('prestashop.adapter.legacy.context').getContext().shop"
+      - "@prestashop.adapter.legacy_db"
+
+  hook_configurator:
+    class: PrestaShop\PrestaShop\Core\Module\HookConfigurator
+    arguments:
+      - "@hook_repository"

--- a/tests/Integration/Adapter/ContainerBuilderTest.php
+++ b/tests/Integration/Adapter/ContainerBuilderTest.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\Module\Banner\Repository\FrontRepository;
 use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
+use PrestaShopBundle\Exception\ServiceContainerException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
@@ -91,5 +92,11 @@ class ContainerBuilderTest extends TestCase
 
         $container = ContainerBuilder::getContainer('front', true);
         $container->get('ps_banner.admin_repository');
+    }
+
+    public function testBuildContainerAdminThrowException()
+    {
+        $this->expectException(ServiceContainerException::class);
+        ContainerBuilder::getContainer('admin', false);
     }
 }

--- a/tests/Integration/Adapter/ContainerBuilderTest.php
+++ b/tests/Integration/Adapter/ContainerBuilderTest.php
@@ -29,7 +29,6 @@ namespace Tests\Integration\Adapter;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
-use PrestaShop\Module\Banner\Repository\AdminRepository;
 use PrestaShop\Module\Banner\Repository\FrontRepository;
 use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -47,21 +46,6 @@ class ContainerBuilderTest extends TestCase
     public function testFrontContainerContainsAnEntityManager()
     {
         $container = ContainerBuilder::getContainer('front', true);
-        $entityManager = $container->get('doctrine.orm.entity_manager');
-        $this->assertNotNull($entityManager);
-        $this->assertInstanceOf(EntityManagerInterface::class, $entityManager);
-    }
-
-    public function testGetAdminContainer()
-    {
-        $container = ContainerBuilder::getContainer('admin', true);
-        $this->assertNotNull($container);
-        $this->assertInstanceOf(ContainerInterface::class, $container);
-    }
-
-    public function testGetAdminContainerContainsAnEntityManager()
-    {
-        $container = ContainerBuilder::getContainer('admin', true);
         $entityManager = $container->get('doctrine.orm.entity_manager');
         $this->assertNotNull($entityManager);
         $this->assertInstanceOf(EntityManagerInterface::class, $entityManager);
@@ -101,27 +85,11 @@ class ContainerBuilderTest extends TestCase
         $this->assertInstanceOf(FrontRepository::class, $frontRepository);
     }
 
-    public function testAdminModuleServices()
-    {
-        $container = ContainerBuilder::getContainer('admin', true);
-        $adminRepository = $container->get('ps_banner.admin_repository');
-        $this->assertNotNull($adminRepository);
-        $this->assertInstanceOf(AdminRepository::class, $adminRepository);
-    }
-
     public function testNoAdminServicesInFront()
     {
         $this->expectException(ServiceNotFoundException::class);
 
         $container = ContainerBuilder::getContainer('front', true);
         $container->get('ps_banner.admin_repository');
-    }
-
-    public function testNoFrontServicesInAdmin()
-    {
-        $this->expectException(ServiceNotFoundException::class);
-
-        $container = ContainerBuilder::getContainer('admin', true);
-        $container->get('ps_banner.front_repository');
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the BO, there were 2 containers. 1 `SymfonyContainer` and 1 `AdminContainer` living in parallel when we are in a migrated page in back office. This PR aims to delete the use of `AdminContainer` as `SymfonyContainer` is available everywhere in the BO. More details on #14995
| Type?         | improvement
| Category?     | BO
| BC breaks?    | yes - An exception is now thrown if you try to use `ContainerBuilder::getContainer()` with `$containerName = 'admin'`
| Deprecations? | no
| Fixed ticket? | Fixes #14995
| How to test?  | It's kinda hard to say how to test but the BO should be working exactly like before

As @jolelievre mentioned [here](https://github.com/PrestaShop/PrestaShop/issues/14995#issuecomment-518309252), some services available in `AdminContainer` were not available in `SymfonyContainer`. Here are the list : 
- context.static
- finder
- hashing
- hook_configurator
- hook_provider
- hook_repository
- theme_manager
- theme_validator

Most of them have been added by an alias or a service declaration except for `theme_validator` as it was already unavailable since [this commit](https://github.com/PrestaShop/PrestaShop/commit/c31300e9cf32de246eb6ed43626d69ed57fc9cc6?branch=c31300e9cf32de246eb6ed43626d69ed57fc9cc6&diff=unified#diff-cda73c4a10a5a7c3778451b0401f5d9dR43) as the service declaration hasn't been updated.

:notebook: **BC Break**
- An exception is now thrown if you try to use ContainerBuilder::getContainer() with $containerName = 'admin'
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20413)
<!-- Reviewable:end -->
