### PR TITLE
Refactor behats ProductFeatureContext to multiple smaller contexts

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -736,11 +736,14 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @Then product :productName in order :orderReference has following details:
+     * @Then product :productReference named :productName in order :orderReference has following details:
      *
      * @param string $orderReference
      * @param string $productName
+     * @param TableNode $table
+     * @param string|null $productReference saves product reference to shared storage if provided
      */
-    public function checkProductDetailsWithReference(string $orderReference, string $productName, TableNode $table)
+    public function checkProductDetailsWithReference(string $orderReference, string $productName, TableNode $table, ?string $productReference = null)
     {
         $productOrderDetail = $this->getOrderDetailFromOrder($productName, $orderReference);
         $expectedDetails = $table->getRowsHash();
@@ -756,6 +759,10 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                     $productOrderDetail[$detailName]
                 )
             );
+        }
+
+        if ($productReference) {
+            $this->getSharedStorage()->set($productReference, $this->getProductIdByName($productName));
         }
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Domain\AbstractDomainFeatureContext;
+
+abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @param string $reference
+     *
+     * @return ProductForEditing
+     */
+    protected function getProductForEditing(string $reference): ProductForEditing
+    {
+        $productId = $this->getSharedStorage()->get($reference);
+
+        return $this->getQueryBus()->handle(new GetProductForEditing(
+            $productId
+        ));
+    }
+
+    /**
+     * Extracts corresponding field value from ProductForEditing DTO
+     *
+     * @param ProductForEditing $productForEditing
+     * @param string $propertyName
+     *
+     * @return mixed
+     */
+    protected function extractValueFromProductForEditing(ProductForEditing $productForEditing, string $propertyName)
+    {
+        $pathsByNames = [
+            'name' => 'basicInformation.localizedNames',
+            'description' => 'basicInformation.localizedDescriptions',
+            'description_short' => 'basicInformation.localizedShortDescriptions',
+            'active' => 'active',
+            'visibility' => 'options.visibility',
+            'available_for_order' => 'options.availableForOrder',
+            'online_only' => 'options.onlineOnly',
+            'show_price' => 'options.showPrice',
+            'condition' => 'options.condition',
+            'isbn' => 'options.isbn',
+            'upc' => 'options.upc',
+            'ean13' => 'options.ean13',
+            'mpn' => 'options.mpn',
+            'reference' => 'options.reference',
+            'tags' => 'options.localizedTags',
+        ];
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        return $propertyAccessor->getValue($productForEditing, $pathsByNames[$propertyName]);
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -28,8 +28,12 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
+use Context;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
+use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Domain\AbstractDomainFeatureContext;
 
@@ -47,6 +51,26 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
         return $this->getQueryBus()->handle(new GetProductForEditing(
             $productId
         ));
+    }
+
+    /**
+     * @param string $productName
+     *
+     * @return int
+     */
+    protected function getProductIdByName(string $productName): int
+    {
+        /** @var FoundProduct[] */
+        $products = $this->getQueryBus()->handle(new SearchProducts($productName, 1, Context::getContext()->currency->iso_code));
+
+        if (empty($products)) {
+            throw new RuntimeException(sprintf('Product with name "%s" was not found', $productName));
+        }
+
+        /** @var FoundProduct $product */
+        $product = reset($products);
+
+        return $product->getProductId();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AddProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AddProductFeatureContext.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class AddProductFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I add product :productReference with following information:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function addProduct(string $productReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+
+        try {
+            $productId = $this->getCommandBus()->handle(new AddProductCommand(
+                $this->parseLocalizedArray($data['name']),
+                PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual'])
+            ));
+
+            $this->getSharedStorage()->set($productReference, $productId->getValue());
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -27,40 +27,18 @@
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
-use Cache;
 use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
-use Product;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
-use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
-    /**
-     * @Then I set tax rule group :taxRulesGroupReference to product :productReference
-     *
-     * @param string $taxRulesGroupReference
-     * @param string $productName
-     */
-    public function setProductTaxRulesGroup(string $taxRulesGroupReference, string $productName)
-    {
-        $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
-        $productId = $this->getProductIdByName($productName);
-
-        $product = new Product($productId);
-        $product->id_tax_rules_group = $taxRulesGroupId;
-        $product->save();
-
-        // Important to clean this cache or Product::getIdTaxRulesGroupByIdProduct still returns the initial value
-        Cache::clean('product_id_tax_rules_group_*');
-    }
-
     /**
      * @Then /^product "(.+)" localized "(.+)" should be "(.+)"$/
      * @Given /^product "(.+)" localized "(.+)" is "(.+)"$/

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
@@ -113,12 +112,10 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
         $this->assertStringProperty($productForEditing, $data, 'mpn');
         $this->assertStringProperty($productForEditing, $data, 'reference');
 
-        $this->assertTaxRulesGroup($data, $productForEditing);
-
         // Assertions checking isset() can hide some errors if it doesn't find array key,
         // to make sure all provided fields were checked we need to unset every asserted field
         // and finally, if provided data is not empty, it means there are some unnasserted values left
-        Assert::assertEmpty($data, sprintf('Some provided fields haven\'t been asserted: %s', implode(',', $data)));
+        Assert::assertEmpty($data, sprintf('Some provided product fields haven\'t been asserted: %s', implode(',', $data)));
     }
 
     /**
@@ -211,38 +208,6 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
 
             unset($data[$propertyName]);
         }
-    }
-
-    /**
-     * @param array $data
-     * @param ProductForEditing $productForEditing
-     */
-    private function assertTaxRulesGroup(array &$data, ProductForEditing $productForEditing)
-    {
-        if (!isset($data['tax rules group'])) {
-            return;
-        }
-
-        $expectedName = $data['tax rules group'];
-
-        if ('' === $expectedName) {
-            $expectedId = 0;
-        } else {
-            $expectedId = (int) TaxRulesGroupFeatureContext::getTaxRulesGroupByName($expectedName)->id;
-        }
-        $actualId = $productForEditing->getPricesInformation()->getTaxRulesGroupId();
-
-        if ($expectedId !== $actualId) {
-            throw new RuntimeException(
-                sprintf(
-                    'Expected tax rules group "%s", but got "%s"',
-                    $expectedName,
-                    TaxRulesGroupFeatureContext::getTaxRulesGroupByName($actualId)->name
-                )
-            );
-        }
-
-        unset($data['tax rules group']);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -24,29 +24,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\Integration\Behaviour\Features\Context\Domain;
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
 use Cache;
-use Context;
 use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use Product;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
-use Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class ProductFeatureContext extends AbstractProductFeatureContext
+class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @Then I set tax rule group :taxRulesGroupReference to product :productReference
@@ -312,37 +306,5 @@ class ProductFeatureContext extends AbstractProductFeatureContext
         }
 
         return $constraintErrorFieldMap[$fieldName];
-    }
-
-    /**
-     * @param string $productName
-     *
-     * @return int
-     */
-    private function getProductIdByName(string $productName): int
-    {
-        /** @var FoundProduct[] */
-        $products = $this->getQueryBus()->handle(new SearchProducts($productName, 1, Context::getContext()->currency->iso_code));
-
-        if (empty($products)) {
-            throw new RuntimeException(sprintf('Product with name "%s" was not found', $productName));
-        }
-
-        /** @var FoundProduct $product */
-        $product = reset($products);
-
-        return $product->getProductId();
-    }
-
-    /**
-     * @param string $productReference
-     *
-     * @return CustomizationField[]
-     */
-    private function getProductCustomizationFields(string $productReference): array
-    {
-        return $this->getQueryBus()->handle(new GetProductCustomizationFields(
-            $this->getSharedStorage()->get($productReference)
-        ));
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference basic information with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductBasicInfo(string $productReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+        $productId = $this->getSharedStorage()->get($productReference);
+        $command = new UpdateProductBasicInformationCommand($productId);
+
+        if (isset($data['name'])) {
+            $command->setLocalizedNames($this->parseLocalizedArray($data['name']));
+        }
+
+        if (isset($data['is_virtual'])) {
+            $command->setVirtual(PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual']));
+        }
+
+        if (isset($data['description'])) {
+            $command->setLocalizedDescriptions($this->parseLocalizedArray($data['description']));
+        }
+
+        if (isset($data['description_short'])) {
+            $command->setLocalizedShortDescriptions($this->parseLocalizedArray($data['description_short']));
+        }
+
+        try {
+            $this->getCommandBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCategoriesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use RuntimeException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I assign product :productReference to following categories:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function assignToCategoriesIncludingNonExistingOnes(string $productReference, TableNode $table)
+    {
+        $data = $table->getRowsHash();
+        $categoryReferences = PrimitiveUtils::castStringArrayIntoArray($data['categories']);
+
+        // this random number is used on purpose to mimic non existing category id
+        $nonExistingCategoryId = 50000;
+        $categoryIds = [];
+        foreach ($categoryReferences as $categoryReference) {
+            if ($this->getSharedStorage()->exists($categoryReference)) {
+                $categoryIds[] = $this->getSharedStorage()->get($categoryReference);
+            } else {
+                $categoryIds[] = $nonExistingCategoryId;
+                ++$nonExistingCategoryId;
+            }
+        }
+
+        if ($this->getSharedStorage()->exists($data['default category'])) {
+            $defaultCategoryId = $this->getSharedStorage()->get($data['default category']);
+        } else {
+            $defaultCategoryId = $nonExistingCategoryId;
+        }
+
+        $this->assignProductToCategories(
+            $this->getSharedStorage()->get($productReference),
+            $defaultCategoryId,
+            $categoryIds
+        );
+    }
+
+    /**
+     * @Then product :productReference should be assigned to following categories:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function assertProductCategories(string $productReference, TableNode $table)
+    {
+        $data = $table->getRowsHash();
+        $productForEditing = $actualCategoryIds = $this->getProductForEditing($productReference);
+        $actualCategoryIds = $productForEditing->getCategoriesInformation()->getCategoryIds();
+        sort($actualCategoryIds);
+
+        $expectedCategoriesRef = PrimitiveUtils::castStringArrayIntoArray($data['categories']);
+        $expectedCategoryIds = array_map(function (string $categoryReference) {
+            return $this->getSharedStorage()->get($categoryReference);
+        }, $expectedCategoriesRef);
+        sort($expectedCategoryIds);
+
+        $expectedDefaultCategoryId = $this->getSharedStorage()->get($data['default category']);
+        $actualDefaultCategoryId = $productForEditing->getCategoriesInformation()->getDefaultCategoryId();
+
+        Assert::assertEquals($expectedDefaultCategoryId, $actualDefaultCategoryId, 'Unexpected default category assigned to product');
+        Assert::assertEquals($actualCategoryIds, $expectedCategoryIds, 'Unexpected categories assigned to product');
+    }
+
+    /**
+     * @Then product :productReference should be assigned to default category
+     *
+     * @param string $productReference
+     */
+    public function assertProductAssignedToDefaultCategory(string $productReference)
+    {
+        $context = $this->getContainer()->get('prestashop.adapter.legacy.context')->getContext();
+        $defaultCategoryId = (int) $context->shop->id_category;
+
+        $productForEditing = $this->getProductForEditing($productReference);
+        $productCategoriesInfo = $productForEditing->getCategoriesInformation();
+
+        $belongsToDefaultCategory = false;
+        foreach ($productCategoriesInfo->getCategoryIds() as $categoryId) {
+            if ($categoryId === $defaultCategoryId) {
+                $belongsToDefaultCategory = true;
+
+                break;
+            }
+        }
+
+        if ($productCategoriesInfo->getDefaultCategoryId() !== $defaultCategoryId || !$belongsToDefaultCategory) {
+            throw new RuntimeException('Product is not assigned to default category');
+        }
+    }
+
+    /**
+     * @Then I should get error that assigning product to categories failed
+     */
+    public function assertFailedUpdateCategoriesError()
+    {
+        $this->assertLastErrorIs(
+            CannotUpdateProductException::class,
+            CannotUpdateProductException::FAILED_UPDATE_CATEGORIES
+        );
+    }
+
+    /**
+     * @param int $productId
+     * @param int $defaultCategoryId
+     * @param array $categoryIds
+     */
+    private function assignProductToCategories(int $productId, int $defaultCategoryId, array $categoryIds): void
+    {
+        try {
+            $this->getCommandBus()->handle(new UpdateProductCategoriesCommand(
+                $productId,
+                $defaultCategoryId,
+                $categoryIds
+            ));
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use Language;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldType;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use RuntimeException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference with following customization fields:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateCustomizationFields(string $productReference, TableNode $table)
+    {
+        $customizationFields = $table->getColumnsHash();
+        $fieldsForUpdate = [];
+        $fieldReferences = [];
+
+        foreach ($customizationFields as $customizationField) {
+            $addedByModule = isset($customizationField['added by module']) ?
+                PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['added by module']) :
+                false
+            ;
+            $fieldReference = $customizationField['reference'];
+            $id = $this->getSharedStorage()->exists($fieldReference) ? $this->getSharedStorage()->get($fieldReference) : null;
+
+            $fieldReferences[] = $fieldReference;
+            $fieldsForUpdate[] = [
+                'id' => $id,
+                'type' => $customizationField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT,
+                'localized_names' => $this->parseLocalizedArray($customizationField['name']),
+                'is_required' => PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['is required']),
+                'added_by_module' => $addedByModule,
+            ];
+        }
+
+        $this->updateProductCustomizationFields(
+            $productReference,
+            $fieldReferences,
+            $fieldsForUpdate
+        );
+    }
+
+    /**
+     * @When I update product :productReference customization field name with text containing :nameLength symbols
+     *
+     * @param string $productReference
+     * @param int $nameLength
+     */
+    public function addCustomizationFieldWithTooLongName(string $productReference, int $nameLength)
+    {
+        $fieldsForUpdate = [];
+        foreach (Language::getIDs() as $langId) {
+            $langId = (int) $langId;
+            $fieldsForUpdate[] = [
+                'id' => null,
+                'type' => CustomizationFieldType::TYPE_TEXT,
+                'is_required' => false,
+                'added_by_module' => false,
+                'localized_names' => [
+                    $langId => PrimitiveUtils::generateRandomString($nameLength),
+                ],
+            ];
+        }
+
+        try {
+            $this->updateProductCustomizationFields($productReference, ['name'], $fieldsForUpdate);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I delete all customization fields from product :productReference
+     *
+     * @param string $productReference
+     */
+    public function updateCustomizationFieldsWithEmptyArray(string $productReference)
+    {
+        $this->updateProductCustomizationFields($productReference, [], []);
+    }
+
+    /**
+     * @Then /^product "(.+)" should (not be customizable|allow customization|require customization)$/
+     *
+     * @param string $productReference
+     * @param string $customizability
+     */
+    public function assertCustomizability(string $productReference, string $customizability)
+    {
+        $customizationOptions = $this->getProductForEditing($productReference)->getCustomizationOptions();
+
+        switch ($customizability) {
+            case 'not be customizable':
+                Assert::assertTrue(
+                    $customizationOptions->isNotCustomizable(),
+                    sprintf('Expected product "%s" to be not customizable', $productReference)
+                );
+
+                break;
+            case 'allow customization':
+                Assert::assertTrue(
+                    $customizationOptions->allowsCustomization(),
+                    sprintf('Expected product "%s" to allow customization', $productReference)
+                );
+
+                break;
+            case 'require customization':
+                Assert::assertTrue(
+                    $customizationOptions->requiresCustomization(),
+                    sprintf('Expected product "%s" to require customization', $productReference)
+                );
+
+                break;
+            default:
+                throw new RuntimeException(sprintf('Invalid customizability "%s" provided in test scenario', $customizability));
+        }
+    }
+
+    /**
+     * @Then product :productReference should have following customization fields:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function assertCustomizationFields(string $productReference, TableNode $table)
+    {
+        $data = $table->getColumnsHash();
+        /** @var CustomizationField[] $actualFields */
+        $actualFields = $this->getProductCustomizationFields($productReference);
+        $notFoundExpectedFields = [];
+
+        foreach ($data as $expectedField) {
+            $expectedId = $this->getSharedStorage()->get($expectedField['reference']);
+            $foundExpectedField = false;
+
+            foreach ($actualFields as $key => $actualField) {
+                if ($expectedId === $actualField->getCustomizationFieldId()) {
+                    $foundExpectedField = true;
+                    $expectedType = $expectedField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT;
+                    $expectedLocalizedNames = $this->parseLocalizedArray($expectedField['name']);
+                    $expectedRequired = PrimitiveUtils::castStringBooleanIntoBoolean($expectedField['is required']);
+                    Assert::assertEquals($expectedType, $actualField->getType(), 'Unexpected customization type');
+                    Assert::assertEquals(
+                        $expectedLocalizedNames,
+                        $actualField->getLocalizedNames(),
+                        sprintf('Unexpected product "%s" customization field name', $productReference)
+                    );
+
+                    if ($expectedRequired !== $actualField->isRequired()) {
+                        throw new RuntimeException(
+                            sprintf(
+                                'Expected customization field #%d to be %s',
+                                $expectedId,
+                                $expectedRequired ? 'required' : 'not required'
+                            )
+                        );
+                    }
+
+                    if (isset($expectedField['added by module'])) {
+                        $expectedByModule = PrimitiveUtils::castStringBooleanIntoBoolean($expectedField['added by module']);
+                        if ($expectedByModule !== $actualField->isAddedByModule()) {
+                            throw new RuntimeException(
+                                sprintf(
+                                    'Expected customization field #%d to be added %s',
+                                    $actualField->getCustomizationFieldId(),
+                                    $expectedByModule ? 'by module' : 'not by module'
+                                )
+                            );
+                        }
+                    }
+                    //unset this asserted customization field so we can check if there any left after loop
+                    unset($actualFields[$key]);
+
+                    continue;
+                }
+            }
+
+            if (!$foundExpectedField) {
+                $notFoundExpectedFields[] = $expectedField;
+            }
+        }
+
+        if (!empty($notFoundExpectedFields)) {
+            throw new RuntimeException(sprintf(
+                'Following customization fields were not found for product %s: %s',
+                $productReference,
+                var_export($notFoundExpectedFields)
+            ));
+        }
+
+        if (!empty($actualFields)) {
+            throw new RuntimeException(sprintf(
+                'Product "%s" contains unexpected customization fields: %s',
+                $productReference,
+                var_export($actualFields)
+            ));
+        }
+    }
+
+    /**
+     * @Then product :productReference should have :expectedCount customizable :customizationType field(s)
+     *
+     * @param string $productReference
+     * @param int $expectedCount
+     * @param string $customizationType
+     */
+    public function assertCustomizationOptions(string $productReference, int $expectedCount, string $customizationType)
+    {
+        if (!in_array($customizationType, array_keys(CustomizationFieldType::AVAILABLE_TYPES))) {
+            throw new RuntimeException(sprintf('Invalid customization type "%s" provided in test scenario', $customizationType));
+        }
+
+        $productForEditing = $this->getProductForEditing($productReference);
+
+        if ('file' === $customizationType) {
+            Assert::assertEquals(
+                $expectedCount,
+                $productForEditing->getCustomizationOptions()->getAvailableFileCustomizationsCount(),
+                'Unexpected customizable file fields count'
+            );
+        } else {
+            Assert::assertEquals(
+                $expectedCount,
+                $productForEditing->getCustomizationOptions()->getAvailableTextCustomizationsCount(),
+                'Unexpected customizable text fields count'
+            );
+        }
+    }
+
+    /**
+     * @Then I should get error that product customization field name is invalid
+     */
+    public function assertCustomizationFieldNameError(): void
+    {
+        $this->assertLastErrorIs(
+            CustomizationFieldConstraintException::class,
+            CustomizationFieldConstraintException::INVALID_NAME
+        );
+    }
+
+    /**
+     * @param string $productReference
+     * @param array $fieldReferences
+     * @param array $fieldsForUpdate
+     */
+    private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate): void
+    {
+        try {
+            $newCustomizationFields = $this->getCommandBus()->handle(new UpdateProductCustomizationFieldsCommand(
+                $this->getSharedStorage()->get($productReference),
+                $fieldsForUpdate
+            ));
+
+            Assert::assertSameSize(
+                $fieldReferences,
+                $newCustomizationFields,
+                'Cannot set references in shared storage. References and actual customization fields doesn\'t match.'
+            );
+
+            /** @var CustomizationField $customizationField */
+            foreach ($newCustomizationFields as $key => $customizationField) {
+                $this->getSharedStorage()->set($fieldReferences[$key], $customizationField->getCustomizationFieldId());
+            }
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -33,6 +33,7 @@ use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
@@ -274,6 +275,18 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
             CustomizationFieldConstraintException::class,
             CustomizationFieldConstraintException::INVALID_NAME
         );
+    }
+
+    /**
+     * @param string $productReference
+     *
+     * @return CustomizationField[]
+     */
+    private function getProductCustomizationFields(string $productReference): array
+    {
+        return $this->getQueryBus()->handle(new GetProductCustomizationFields(
+            $this->getSharedStorage()->get($productReference)
+        ));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateOptionsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateOptionsFeatureContext.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdateOptionsFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference options with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductOptions(string $productReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+        $productId = $this->getSharedStorage()->get($productReference);
+
+        try {
+            $command = new UpdateProductOptionsCommand($productId);
+            $this->setUpdateOptionsCommandData($data, $command);
+            $this->getCommandBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @param array $data
+     * @param UpdateProductOptionsCommand $command
+     */
+    private function setUpdateOptionsCommandData(array $data, UpdateProductOptionsCommand $command): void
+    {
+        if (isset($data['visibility'])) {
+            $command->setVisibility($data['visibility']);
+        }
+
+        if (isset($data['available_for_order'])) {
+            $command->setAvailableForOrder(PrimitiveUtils::castStringBooleanIntoBoolean($data['available_for_order']));
+        }
+
+        if (isset($data['online_only'])) {
+            $command->setOnlineOnly(PrimitiveUtils::castStringBooleanIntoBoolean($data['online_only']));
+        }
+
+        if (isset($data['show_price'])) {
+            $command->setShowPrice(PrimitiveUtils::castStringBooleanIntoBoolean($data['show_price']));
+        }
+
+        if (isset($data['condition'])) {
+            $command->setCondition($data['condition']);
+        }
+
+        if (isset($data['isbn'])) {
+            $command->setIsbn($data['isbn']);
+        }
+
+        if (isset($data['upc'])) {
+            $command->setUpc($data['upc']);
+        }
+
+        if (isset($data['ean13'])) {
+            $command->setEan13($data['ean13']);
+        }
+
+        if (isset($data['mpn'])) {
+            $command->setMpn($data['mpn']);
+        }
+
+        if (isset($data['reference'])) {
+            $command->setReference($data['reference']);
+        }
+
+        if (isset($data['mpn'])) {
+            $command->setMpn($data['mpn']);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPackCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductPackException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetPackedProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\PackedProduct;
+use RuntimeException;
+
+class UpdatePackFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update pack :packReference with following product quantities:
+     *
+     * @param string $packReference
+     * @param TableNode $table
+     */
+    public function updateProductPack(string $packReference, TableNode $table)
+    {
+        $data = $table->getRowsHash();
+
+        $products = [];
+        foreach ($data as $productReference => $quantity) {
+            $products[] = [
+                'product_id' => $this->getSharedStorage()->get($productReference),
+                'quantity' => (int) $quantity,
+            ];
+        }
+
+        $packId = $this->getSharedStorage()->get($packReference);
+
+        $this->upsertPack($packId, $products);
+    }
+
+    /**
+     * @When I clean pack :packReference
+     *
+     * @param string $packReference
+     */
+    public function cleanPack(string $packReference)
+    {
+        $packId = $this->getSharedStorage()->get($packReference);
+
+        try {
+            $this->getCommandBus()->handle(UpdateProductPackCommand::cleanPack($packId));
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then pack :packReference should contain products with following quantities:
+     *
+     * @param string $packReference
+     * @param TableNode $table
+     */
+    public function assertPackContents(string $packReference, TableNode $table)
+    {
+        $data = $table->getRowsHash();
+        $packId = $this->getSharedStorage()->get($packReference);
+        $packedProducts = $this->getQueryBus()->handle(new GetPackedProducts($packId));
+        $notExistingProducts = [];
+
+        foreach ($data as $productReference => $quantity) {
+            $expectedQty = (int) $quantity;
+            $expectedPackedProductId = $this->getSharedStorage()->get($productReference);
+            $foundProduct = false;
+
+            /**
+             * @var int
+             * @var PackedProduct $packedProduct
+             */
+            foreach ($packedProducts as $key => $packedProduct) {
+                //@todo: check && combination id when asserting combinations.
+                if ($packedProduct->getProductId() === $expectedPackedProductId) {
+                    $foundProduct = true;
+                    Assert::assertEquals(
+                        $expectedQty,
+                        $packedProduct->getQuantity(),
+                        sprintf('Unexpected quantity of packed product "%s"', $productReference)
+                    );
+
+                    //unset asserted product to check if there was any excessive actual products after loops
+                    unset($packedProducts[$key]);
+                    break;
+                }
+            }
+
+            if (!$foundProduct) {
+                $notExistingProducts[$productReference] = $quantity;
+            }
+        }
+
+        if (!empty($notExistingProducts)) {
+            throw new RuntimeException(sprintf(
+                'Failed to find following packed products: %s',
+                implode(',', array_keys($notExistingProducts))
+            ));
+        }
+
+        if (!empty($packedProducts)) {
+            throw new RuntimeException(sprintf(
+                'Following packed products were not expected: %s',
+                implode(',', array_map(function ($packedProduct) {
+                    return $packedProduct->name;
+                }, $packedProducts))
+            ));
+        }
+    }
+
+    /**
+     * @Then I should get error that product for packing quantity is invalid
+     */
+    public function assertPackProductQuantityError()
+    {
+        $this->assertLastErrorIs(
+            ProductPackException::class,
+            ProductPackException::INVALID_QUANTITY
+        );
+    }
+
+    /**
+     * @Then I should get error that I cannot add pack into a pack
+     */
+    public function assertAddingPackToPackError()
+    {
+        $this->assertLastErrorIs(
+            ProductPackException::class,
+            ProductPackException::CANNOT_ADD_PACK_INTO_PACK
+        );
+    }
+
+    /**
+     * @param int $packId
+     * @param array $products
+     */
+    private function upsertPack(int $packId, array $products): void
+    {
+        try {
+            $this->getCommandBus()->handle(UpdateProductPackCommand::upsertPack(
+                $packId,
+                $products
+            ));
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdatePricesFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference prices with following information:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductPrices(string $productReference, TableNode $table)
+    {
+        $data = $table->getRowsHash();
+        $command = new UpdateProductPricesCommand($this->getSharedStorage()->get($productReference));
+
+        if (isset($data['price'])) {
+            $command->setPrice($data['price']);
+        }
+        if (isset($data['ecotax'])) {
+            $command->setEcotax($data['ecotax']);
+        }
+        if (isset($data['tax rules group'])) {
+            $taxRulesGroupId = (int) TaxRulesGroupFeatureContext::getTaxRulesGroupByName($data['tax rules group'])->id;
+            $command->setTaxRulesGroupId($taxRulesGroupId);
+        }
+        if (isset($data['on_sale'])) {
+            $command->setOnSale(PrimitiveUtils::castStringBooleanIntoBoolean($data['on_sale']));
+        }
+        if (isset($data['wholesale_price'])) {
+            $command->setWholesalePrice($data['wholesale_price']);
+        }
+        if (isset($data['unit_price'])) {
+            $command->setUnitPrice($data['unit_price']);
+        }
+        if (isset($data['unity'])) {
+            $command->setUnity($data['unity']);
+        }
+
+        try {
+            $this->getQueryBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
+use Cache;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
@@ -60,6 +61,7 @@ class UpdatePricesFeatureContext extends AbstractProductFeatureContext
         if (isset($data['tax rules group'])) {
             $taxRulesGroupId = (int) TaxRulesGroupFeatureContext::getTaxRulesGroupByName($data['tax rules group'])->id;
             $command->setTaxRulesGroupId($taxRulesGroupId);
+            Cache::clean('product_id_tax_rules_group_*');
         }
         if (isset($data['on_sale'])) {
             $command->setOnSale(PrimitiveUtils::castStringBooleanIntoBoolean($data['on_sale']));

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
@@ -29,8 +29,12 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\Decimal\Number;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
@@ -74,6 +78,78 @@ class UpdatePricesFeatureContext extends AbstractProductFeatureContext
             $this->getQueryBus()->handle($command);
         } catch (ProductException $e) {
             $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then product :productReference should have following prices information:
+     *
+     * @param string $productReference
+     * @param TableNode $tableNode
+     */
+    public function assertPriceFields(string $productReference, TableNode $tableNode): void
+    {
+        $data = $tableNode->getRowsHash();
+        $pricesInfo = $this->getProductForEditing($productReference)->getPricesInformation();
+
+        if (isset($data['on_sale'])) {
+            $expectedOnSale = PrimitiveUtils::castStringBooleanIntoBoolean($data['on_sale']);
+            $onSaleInWords = $expectedOnSale ? 'to be on sale' : 'not to be on sale';
+
+            Assert::assertEquals(
+                $expectedOnSale,
+                $pricesInfo->isOnSale(),
+                sprintf('Expected product %s', $onSaleInWords)
+            );
+
+            unset($data['on_sale']);
+        }
+
+        if (isset($data['unity'])) {
+            $expectedUnity = $data['unity'];
+            $actualUnity = $pricesInfo->getUnity();
+
+            Assert::assertEquals(
+                $expectedUnity,
+                $actualUnity,
+                sprintf('Tax rules group expected to be "%s", but got "%s"', $expectedUnity, $actualUnity)
+            );
+
+            unset($data['unity']);
+        }
+
+        $this->assertNumberPriceFields($data, $pricesInfo);
+    }
+
+    /**
+     * @param array $expectedPrices
+     * @param ProductPricesInformation $actualPrices
+     */
+    private function assertNumberPriceFields(array &$expectedPrices, ProductPricesInformation $actualPrices)
+    {
+        $numberPriceFields = [
+            'price',
+            'ecotax',
+            'wholesale_price',
+            'unit_price',
+            'unit_price_ratio',
+        ];
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($numberPriceFields as $field) {
+            if (isset($expectedPrices[$field])) {
+                $expectedNumber = new Number((string) $expectedPrices[$field]);
+                $actualNumber = $propertyAccessor->getValue($actualPrices, $field);
+
+                if (!$expectedNumber->equals($actualNumber)) {
+                    throw new RuntimeException(
+                        sprintf('Product %s expected to be "%s", but is "%s"', $field, $expectedNumber, $actualNumber)
+                    );
+                }
+
+                unset($expectedPrices[$field]);
+            }
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use Carrier;
+use PHPUnit\Framework\Assert;
+use PrestaShop\Decimal\Number;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNotesType;
+use RuntimeException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdateShippingFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference shipping information with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductShipping(string $productReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+        $productId = $this->getSharedStorage()->get($productReference);
+
+        try {
+            $command = new UpdateProductShippingCommand($productId);
+            $unhandledData = $this->setUpdateShippingCommandData($data, $command);
+
+            Assert::assertEmpty(
+                $unhandledData,
+                sprintf('Not all provided values handled in scenario. %s', var_export($unhandledData))
+            );
+
+            $this->getCommandBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then product :productReference should have no carriers assigned
+     *
+     * @param string $productReference
+     */
+    public function assertProductHasNoCarriers(string $productReference)
+    {
+        $productForEditing = $this->getProductForEditing($productReference);
+
+        Assert::assertEmpty(
+            $productForEditing->getShippingInformation()->getCarrierReferences(),
+            sprintf('Expected product "%s" to have no carriers assigned', $productReference)
+        );
+    }
+
+    /**
+     * @Then product :productReference should have following shipping information:
+     *
+     * @param string $productReference
+     * @param TableNode $tableNode
+     */
+    public function assertShippingInformation(string $productReference, TableNode $tableNode): void
+    {
+        $data = $tableNode->getRowsHash();
+        $productShippingInformation = $this->getProductForEditing($productReference)->getShippingInformation();
+
+        if (isset($data['carriers'])) {
+            $expectedReferenceIds = $this->getCarrierReferenceIds($data['carriers']);
+            $actualReferenceIds = $productShippingInformation->getCarrierReferences();
+
+            Assert::assertEquals(
+                $expectedReferenceIds,
+                $actualReferenceIds,
+                'Unexpected carrier references in product shipping information'
+            );
+
+            unset($data['carriers']);
+        }
+
+        $this->assertNumberShippingFields($data, $productShippingInformation);
+        $this->assertDeliveryTimeNotes($data, $productShippingInformation);
+        //@todo: check if all fields were asserted
+    }
+
+    /**
+     * @param array $expectedValues
+     * @param ProductShippingInformation $actualValues
+     */
+    private function assertNumberShippingFields(array &$expectedValues, ProductShippingInformation $actualValues)
+    {
+        $numberShippingFields = [
+            'width',
+            'height',
+            'depth',
+            'weight',
+            'additional_shipping_cost',
+        ];
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($numberShippingFields as $field) {
+            if (isset($expectedValues[$field])) {
+                $expectedNumber = new Number((string) $expectedValues[$field]);
+                $actualNumber = $propertyAccessor->getValue($actualValues, $field);
+
+                if (!$expectedNumber->equals($actualNumber)) {
+                    throw new RuntimeException(
+                        sprintf('Product %s expected to be "%s", but is "%s"', $field, $expectedNumber, $actualNumber)
+                    );
+                }
+
+                unset($expectedValues[$field]);
+            }
+        }
+    }
+
+    /**
+     * @param array $data
+     * @param ProductShippingInformation $productShippingInformation
+     */
+    private function assertDeliveryTimeNotes(array &$data, ProductShippingInformation $productShippingInformation)
+    {
+        $notesTypeNamedValues = [
+            'none' => DeliveryTimeNotesType::TYPE_NONE,
+            'default' => DeliveryTimeNotesType::TYPE_DEFAULT,
+            'specific' => DeliveryTimeNotesType::TYPE_SPECIFIC,
+        ];
+
+        if (isset($data['delivery time notes type'])) {
+            $expectedType = $notesTypeNamedValues[$data['delivery time notes type']];
+            $actualType = $productShippingInformation->getDeliveryTimeNotesType();
+            Assert::assertEquals($expectedType, $actualType, 'Unexpected delivery time notes type value');
+
+            unset($data['delivery time notes type']);
+        }
+
+        if (isset($data['delivery time in stock notes'])) {
+            $expectedLocalizedOutOfStockNotes = $this->parseLocalizedArray($data['delivery time in stock notes']);
+            $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeInStockNotes();
+            Assert::assertEquals(
+                $expectedLocalizedOutOfStockNotes,
+                $actualLocalizedOutOfStockNotes,
+                'Unexpected product delivery time in stock notes'
+            );
+
+            unset($data['delivery time in stock notes']);
+        }
+
+        if (isset($data['delivery time out of stock notes'])) {
+            $expectedLocalizedOutOfStockNotes = $this->parseLocalizedArray($data['delivery time out of stock notes']);
+            $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeOutOfStockNotes();
+            Assert::assertEquals(
+                $expectedLocalizedOutOfStockNotes,
+                $actualLocalizedOutOfStockNotes,
+                'Unexpected product delivery time out of stock notes'
+            );
+
+            unset($data['delivery time out of stock notes']);
+        }
+    }
+
+    /**
+     * @param array $data
+     * @param UpdateProductShippingCommand $command
+     *
+     * @return array values that was provided, but wasn't handled
+     */
+    private function setUpdateShippingCommandData(array $data, UpdateProductShippingCommand $command): array
+    {
+        $unhandledValues = $data;
+
+        if (isset($data['width'])) {
+            $command->setWidth($data['width']);
+            unset($unhandledValues['width']);
+        }
+
+        if (isset($data['height'])) {
+            $command->setHeight($data['height']);
+            unset($unhandledValues['height']);
+        }
+
+        if (isset($data['depth'])) {
+            $command->setDepth($data['depth']);
+            unset($unhandledValues['depth']);
+        }
+
+        if (isset($data['weight'])) {
+            $command->setWeight($data['weight']);
+            unset($unhandledValues['weight']);
+        }
+
+        if (isset($data['additional_shipping_cost'])) {
+            $command->setAdditionalShippingCost($data['additional_shipping_cost']);
+            unset($unhandledValues['additional_shipping_cost']);
+        }
+
+        if (isset($data['delivery time notes type'])) {
+            $command->setDeliveryTimeNotesType(DeliveryTimeNotesType::ALLOWED_TYPES[$data['delivery time notes type']]);
+            unset($unhandledValues['delivery time notes type']);
+        }
+
+        if (isset($data['delivery time in stock notes'])) {
+            $command->setLocalizedDeliveryTimeInStockNotes(
+                $this->parseLocalizedArray($data['delivery time in stock notes'])
+            );
+            unset($unhandledValues['delivery time in stock notes']);
+        }
+
+        if (isset($data['delivery time out of stock notes'])) {
+            $command->setLocalizedDeliveryTimeOutOfStockNotes(
+                $this->parseLocalizedArray($data['delivery time out of stock notes'])
+            );
+            unset($unhandledValues['delivery time out of stock notes']);
+        }
+
+        if (isset($data['carriers'])) {
+            $command->setCarrierReferences($this->getCarrierReferenceIds($data['carriers']));
+            unset($unhandledValues['carriers']);
+        }
+
+        return $unhandledValues;
+    }
+
+    /**
+     * @param string $carrierReferencesInput
+     *
+     * @return int[]
+     */
+    private function getCarrierReferenceIds(string $carrierReferencesInput): array
+    {
+        $referenceIds = [];
+        foreach (PrimitiveUtils::castStringArrayIntoArray($carrierReferencesInput) as $carrierReference) {
+            $carrier = new Carrier($this->getSharedStorage()->get($carrierReference));
+            $referenceIds[] = (int) $carrier->id_reference;
+        }
+
+        return $referenceIds;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
@@ -34,7 +34,6 @@ use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags as LocalizedTagsDto;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use RuntimeException;
 
 class UpdateTagsFeatureContext extends AbstractProductFeatureContext
@@ -71,20 +70,15 @@ class UpdateTagsFeatureContext extends AbstractProductFeatureContext
      *
      * @param array $localizedTagStrings key value pairs where key is language id and value is string representation of array separated by comma
      *                                   e.g. [1 => 'hello,goodbye', 2 => 'bonjour,Au revoir']
-     * @param ProductForEditing $productForEditing
+     * @param LocalizedTagsDto[] $actualLocalizedTagsList
      */
-    private function assertLocalizedTags(array $localizedTagStrings, ProductForEditing $productForEditing)
+    public static function assertLocalizedTags(array $localizedTagStrings, array $actualLocalizedTagsList)
     {
-        $fieldName = 'tags';
-        /** @var LocalizedTagsDto[] $actualLocalizedTags */
-        $actualLocalizedTagsList = $this->extractValueFromProductForEditing($productForEditing, $fieldName);
-
         foreach ($localizedTagStrings as $langId => $tagsString) {
             $langIso = Language::getIsoById($langId);
 
             if (empty($tagsString)) {
                 // if tags string is empty, then we should not have any actual value in this language
-                /** @var LocalizedTagsDto $actualLocalizedTags */
                 foreach ($actualLocalizedTagsList as $actualLocalizedTags) {
                     if ($actualLocalizedTags->getLanguageId() === $langId) {
                         throw new RuntimeException(sprintf(
@@ -111,8 +105,7 @@ class UpdateTagsFeatureContext extends AbstractProductFeatureContext
                     $expectedTags,
                     $actualLocalizedTags->getTags(),
                     sprintf(
-                        'Expected %s in "%s" language was "%s", but got "%s"',
-                        $fieldName,
+                        'Expected tags in "%s" language was "%s", but got "%s"',
                         $langIso,
                         var_export($expectedTags, true),
                         var_export($actualLocalizedTags->getTags(), true)

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use Behat\Gherkin\Node\TableNode;
+use Language;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags as LocalizedTagsDto;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
+use RuntimeException;
+
+class UpdateTagsFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference tags with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductTags(string $productReference, TableNode $table)
+    {
+        $productId = $this->getSharedStorage()->get($productReference);
+        $data = $table->getRowsHash();
+
+        $localizedTagStrings = $this->parseLocalizedArray($data['tags']);
+        $localizedTagsList = [];
+
+        foreach ($localizedTagStrings as $langId => $localizedTagString) {
+            $localizedTagsList[$langId] = explode(',', $localizedTagString);
+        }
+
+        try {
+            $this->getCommandBus()->handle(new UpdateProductTagsCommand($productId, $localizedTagsList));
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * Product tags differs from other localized properties, because each locale can have an array of tags
+     * (whereas common property will have one value per language)
+     * This is why it needs some additional parsing
+     *
+     * @param array $localizedTagStrings key value pairs where key is language id and value is string representation of array separated by comma
+     *                                   e.g. [1 => 'hello,goodbye', 2 => 'bonjour,Au revoir']
+     * @param ProductForEditing $productForEditing
+     */
+    private function assertLocalizedTags(array $localizedTagStrings, ProductForEditing $productForEditing)
+    {
+        $fieldName = 'tags';
+        /** @var LocalizedTagsDto[] $actualLocalizedTags */
+        $actualLocalizedTagsList = $this->extractValueFromProductForEditing($productForEditing, $fieldName);
+
+        foreach ($localizedTagStrings as $langId => $tagsString) {
+            $langIso = Language::getIsoById($langId);
+
+            if (empty($tagsString)) {
+                // if tags string is empty, then we should not have any actual value in this language
+                /** @var LocalizedTagsDto $actualLocalizedTags */
+                foreach ($actualLocalizedTagsList as $actualLocalizedTags) {
+                    if ($actualLocalizedTags->getLanguageId() === $langId) {
+                        throw new RuntimeException(sprintf(
+                                'Expected no tags in %s language, but got "%s"',
+                                $langIso,
+                                var_export($actualLocalizedTags->getTags(), true))
+                        );
+                    }
+                }
+
+                // if above code passed it means tags in this lang is empty as expected and we can continue
+                continue;
+            }
+
+            // convert filled tags to array
+            $expectedTags = array_map('trim', explode(',', $tagsString));
+            $valueInLangExists = false;
+            foreach ($actualLocalizedTagsList as $actualLocalizedTags) {
+                if ($actualLocalizedTags->getLanguageId() !== $langId) {
+                    continue;
+                }
+
+                Assert::assertEquals(
+                    $expectedTags,
+                    $actualLocalizedTags->getTags(),
+                    sprintf(
+                        'Expected %s in "%s" language was "%s", but got "%s"',
+                        $fieldName,
+                        $langIso,
+                        var_export($expectedTags, true),
+                        var_export($actualLocalizedTags->getTags(), true)
+                    )
+                );
+                $valueInLangExists = true;
+            }
+
+            // All empty values have ben filtered out above,
+            // so if this lang value doesn't exist, it means it didn't meet the expectations
+            if (!$valueInLangExists) {
+                throw new RuntimeException(sprintf(
+                    'Expected localized tags value "%s" is not set in %s language',
+                    var_export($expectedTags, true),
+                    $langIso
+                ));
+            }
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -28,45 +28,27 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
 use Cache;
-use Carrier;
 use Context;
 use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\Number;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCategoriesCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPackCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldType;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductPackException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetPackedProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags as LocalizedTagsDto;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\PackedProduct;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInformation;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNotesType;
 use Product;
 use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class ProductFeatureContext extends AbstractDomainFeatureContext
+class ProductFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @Then I set tax rule group :taxRulesGroupReference to product :productReference
@@ -85,268 +67,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
 
         // Important to clean this cache or Product::getIdTaxRulesGroupByIdProduct still returns the initial value
         Cache::clean('product_id_tax_rules_group_*');
-    }
-
-    /**
-     * @When I add product :productReference with following information:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function addProduct(string $productReference, TableNode $table): void
-    {
-        $data = $table->getRowsHash();
-
-        try {
-            $productId = $this->getCommandBus()->handle(new AddProductCommand(
-                $this->parseLocalizedArray($data['name']),
-                PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual'])
-            ));
-
-            $this->getSharedStorage()->set($productReference, $productId->getValue());
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When I update pack :packReference with following product quantities:
-     *
-     * @param string $packReference
-     * @param TableNode $table
-     */
-    public function updateProductPack(string $packReference, TableNode $table)
-    {
-        $data = $table->getRowsHash();
-
-        $products = [];
-        foreach ($data as $productReference => $quantity) {
-            $products[] = [
-                'product_id' => $this->getSharedStorage()->get($productReference),
-                'quantity' => (int) $quantity,
-            ];
-        }
-
-        $packId = $this->getSharedStorage()->get($packReference);
-
-        $this->upsertPack($packId, $products);
-    }
-
-    /**
-     * @When I clean pack :packReference
-     */
-    public function cleanPack(string $packReference)
-    {
-        $packId = $this->getSharedStorage()->get($packReference);
-
-        try {
-            $this->getCommandBus()->handle(UpdateProductPackCommand::cleanPack($packId));
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @Then pack :packReference should contain products with following quantities:
-     *
-     * @param string $packReference
-     * @param TableNode $table
-     */
-    public function assertPackContents(string $packReference, TableNode $table)
-    {
-        $data = $table->getRowsHash();
-        $packId = $this->getSharedStorage()->get($packReference);
-        $packedProducts = $this->getQueryBus()->handle(new GetPackedProducts($packId));
-        $notExistingProducts = [];
-
-        foreach ($data as $productReference => $quantity) {
-            $expectedQty = (int) $quantity;
-            $expectedPackedProductId = $this->getSharedStorage()->get($productReference);
-            $foundProduct = false;
-
-            /**
-             * @var int
-             * @var PackedProduct $packedProduct
-             */
-            foreach ($packedProducts as $key => $packedProduct) {
-                //@todo: check && combination id when asserting combinations.
-                if ($packedProduct->getProductId() === $expectedPackedProductId) {
-                    $foundProduct = true;
-                    Assert::assertEquals(
-                        $expectedQty,
-                        $packedProduct->getQuantity(),
-                        sprintf('Unexpected quantity of packed product "%s"', $productReference)
-                    );
-
-                    //unset asserted product to check if there was any excessive actual products after loops
-                    unset($packedProducts[$key]);
-                    break;
-                }
-            }
-
-            if (!$foundProduct) {
-                $notExistingProducts[$productReference] = $quantity;
-            }
-        }
-
-        if (!empty($notExistingProducts)) {
-            throw new RuntimeException(sprintf(
-                'Failed to find following packed products: %s',
-                implode(',', array_keys($notExistingProducts))
-            ));
-        }
-
-        if (!empty($packedProducts)) {
-            throw new RuntimeException(sprintf(
-                'Following packed products were not expected: %s',
-                implode(',', array_map(function ($packedProduct) {
-                    return $packedProduct->name;
-                }, $packedProducts))
-            ));
-        }
-    }
-
-    /**
-     * @When I update product :productReference basic information with following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductBasicInfo(string $productReference, TableNode $table): void
-    {
-        $data = $table->getRowsHash();
-        $productId = $this->getSharedStorage()->get($productReference);
-        $command = new UpdateProductBasicInformationCommand($productId);
-
-        if (isset($data['name'])) {
-            $command->setLocalizedNames($this->parseLocalizedArray($data['name']));
-        }
-
-        if (isset($data['is_virtual'])) {
-            $command->setVirtual(PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual']));
-        }
-
-        if (isset($data['description'])) {
-            $command->setLocalizedDescriptions($this->parseLocalizedArray($data['description']));
-        }
-
-        if (isset($data['description_short'])) {
-            $command->setLocalizedShortDescriptions($this->parseLocalizedArray($data['description_short']));
-        }
-
-        try {
-            $this->getCommandBus()->handle($command);
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When I update product :productReference options with following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductOptions(string $productReference, TableNode $table): void
-    {
-        $data = $table->getRowsHash();
-        $productId = $this->getSharedStorage()->get($productReference);
-
-        try {
-            $command = new UpdateProductOptionsCommand($productId);
-            $this->setUpdateOptionsCommandData($data, $command);
-            $this->getCommandBus()->handle($command);
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When I update product :productReference shipping information with following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductShipping(string $productReference, TableNode $table): void
-    {
-        $data = $table->getRowsHash();
-        $productId = $this->getSharedStorage()->get($productReference);
-
-        try {
-            $command = new UpdateProductShippingCommand($productId);
-            $unhandledData = $this->setUpdateShippingCommandData($data, $command);
-
-            Assert::assertEmpty(
-                $unhandledData,
-                sprintf('Not all provided values handled in scenario. %s', var_export($unhandledData))
-            );
-
-            $this->getCommandBus()->handle($command);
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @param array $data
-     * @param UpdateProductShippingCommand $command
-     *
-     * @return array values that was provided, but wasn't handled
-     */
-    private function setUpdateShippingCommandData(array $data, UpdateProductShippingCommand $command): array
-    {
-        $unhandledValues = $data;
-
-        if (isset($data['width'])) {
-            $command->setWidth($data['width']);
-            unset($unhandledValues['width']);
-        }
-
-        if (isset($data['height'])) {
-            $command->setHeight($data['height']);
-            unset($unhandledValues['height']);
-        }
-
-        if (isset($data['depth'])) {
-            $command->setDepth($data['depth']);
-            unset($unhandledValues['depth']);
-        }
-
-        if (isset($data['weight'])) {
-            $command->setWeight($data['weight']);
-            unset($unhandledValues['weight']);
-        }
-
-        if (isset($data['additional_shipping_cost'])) {
-            $command->setAdditionalShippingCost($data['additional_shipping_cost']);
-            unset($unhandledValues['additional_shipping_cost']);
-        }
-
-        if (isset($data['delivery time notes type'])) {
-            $command->setDeliveryTimeNotesType(DeliveryTimeNotesType::ALLOWED_TYPES[$data['delivery time notes type']]);
-            unset($unhandledValues['delivery time notes type']);
-        }
-
-        if (isset($data['delivery time in stock notes'])) {
-            $command->setLocalizedDeliveryTimeInStockNotes(
-                $this->parseLocalizedArray($data['delivery time in stock notes'])
-            );
-            unset($unhandledValues['delivery time in stock notes']);
-        }
-
-        if (isset($data['delivery time out of stock notes'])) {
-            $command->setLocalizedDeliveryTimeOutOfStockNotes(
-                $this->parseLocalizedArray($data['delivery time out of stock notes'])
-            );
-            unset($unhandledValues['delivery time out of stock notes']);
-        }
-
-        if (isset($data['carriers'])) {
-            $command->setCarrierReferences($this->getCarrierReferenceIds($data['carriers']));
-            unset($unhandledValues['carriers']);
-        }
-
-        return $unhandledValues;
     }
 
     /**
@@ -397,148 +117,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then product :productReference should be assigned to following categories:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function assertProductCategories(string $productReference, TableNode $table)
-    {
-        $data = $table->getRowsHash();
-        $productForEditing = $actualCategoryIds = $this->getProductForEditing($productReference);
-        $actualCategoryIds = $productForEditing->getCategoriesInformation()->getCategoryIds();
-        sort($actualCategoryIds);
-
-        $expectedCategoriesRef = PrimitiveUtils::castStringArrayIntoArray($data['categories']);
-        $expectedCategoryIds = array_map(function (string $categoryReference) {
-            return $this->getSharedStorage()->get($categoryReference);
-        }, $expectedCategoriesRef);
-        sort($expectedCategoryIds);
-
-        $expectedDefaultCategoryId = $this->getSharedStorage()->get($data['default category']);
-        $actualDefaultCategoryId = $productForEditing->getCategoriesInformation()->getDefaultCategoryId();
-
-        Assert::assertEquals($expectedDefaultCategoryId, $actualDefaultCategoryId, 'Unexpected default category assigned to product');
-        Assert::assertEquals($actualCategoryIds, $expectedCategoryIds, 'Unexpected categories assigned to product');
-    }
-
-    /**
-     * @When I assign product :productReference to following categories:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function assignToCategoriesIncludingNonExistingOnes(string $productReference, TableNode $table)
-    {
-        $data = $table->getRowsHash();
-        $categoryReferences = PrimitiveUtils::castStringArrayIntoArray($data['categories']);
-
-        // this random number is used on purpose to mimic non existing category id
-        $nonExistingCategoryId = 50000;
-        $categoryIds = [];
-        foreach ($categoryReferences as $categoryReference) {
-            if ($this->getSharedStorage()->exists($categoryReference)) {
-                $categoryIds[] = $this->getSharedStorage()->get($categoryReference);
-            } else {
-                $categoryIds[] = $nonExistingCategoryId;
-                ++$nonExistingCategoryId;
-            }
-        }
-
-        if ($this->getSharedStorage()->exists($data['default category'])) {
-            $defaultCategoryId = $this->getSharedStorage()->get($data['default category']);
-        } else {
-            $defaultCategoryId = $nonExistingCategoryId;
-        }
-
-        $this->assignProductToCategories(
-            $this->getSharedStorage()->get($productReference),
-            $defaultCategoryId,
-            $categoryIds
-        );
-    }
-
-    /**
-     * @Then I should get error that assigning product to categories failed
-     */
-    public function assertFailedUpdateCategoriesError()
-    {
-        $this->assertLastErrorIs(
-            CannotUpdateProductException::class,
-            CannotUpdateProductException::FAILED_UPDATE_CATEGORIES
-        );
-    }
-
-    /**
-     * Product tags differs from other localized properties, because each locale can have an array of tags
-     * (whereas common property will have one value per language)
-     * This is why it needs some additional parsing
-     *
-     * @param array $localizedTagStrings key value pairs where key is language id and value is string representation of array separated by comma
-     *                                   e.g. [1 => 'hello,goodbye', 2 => 'bonjour,Au revoir']
-     * @param ProductForEditing $productForEditing
-     */
-    private function assertLocalizedTags(array $localizedTagStrings, ProductForEditing $productForEditing)
-    {
-        $fieldName = 'tags';
-        /** @var LocalizedTagsDto[] $actualLocalizedTags */
-        $actualLocalizedTagsList = $this->extractValueFromProductForEditing($productForEditing, $fieldName);
-
-        foreach ($localizedTagStrings as $langId => $tagsString) {
-            $langIso = Language::getIsoById($langId);
-
-            if (empty($tagsString)) {
-                // if tags string is empty, then we should not have any actual value in this language
-                /** @var LocalizedTagsDto $actualLocalizedTags */
-                foreach ($actualLocalizedTagsList as $actualLocalizedTags) {
-                    if ($actualLocalizedTags->getLanguageId() === $langId) {
-                        throw new RuntimeException(sprintf(
-                                'Expected no tags in %s language, but got "%s"',
-                                $langIso,
-                                var_export($actualLocalizedTags->getTags(), true))
-                        );
-                    }
-                }
-
-                // if above code passed it means tags in this lang is empty as expected and we can continue
-                continue;
-            }
-
-            // convert filled tags to array
-            $expectedTags = array_map('trim', explode(',', $tagsString));
-            $valueInLangExists = false;
-            foreach ($actualLocalizedTagsList as $actualLocalizedTags) {
-                if ($actualLocalizedTags->getLanguageId() !== $langId) {
-                    continue;
-                }
-
-                Assert::assertEquals(
-                    $expectedTags,
-                    $actualLocalizedTags->getTags(),
-                    sprintf(
-                        'Expected %s in "%s" language was "%s", but got "%s"',
-                        $fieldName,
-                        $langIso,
-                        var_export($expectedTags, true),
-                        var_export($actualLocalizedTags->getTags(), true)
-                    )
-                );
-                $valueInLangExists = true;
-            }
-
-            // All empty values have ben filtered out above,
-            // so if this lang value doesn't exist, it means it didn't meet the expectations
-            if (!$valueInLangExists) {
-                throw new RuntimeException(sprintf(
-                    'Expected localized tags value "%s" is not set in %s language',
-                    var_export($expectedTags, true),
-                    $langIso
-                ));
-            }
-        }
-    }
-
-    /**
      * @Then product :productReference should have following values:
      * @Then product :productReference has following values:
      *
@@ -564,78 +142,11 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
 
         $this->assertTaxRulesGroup($data, $productForEditing);
         $this->assertPriceFields($data, $productForEditing->getPricesInformation());
-        $this->assertShippingInformation($data, $productForEditing->getShippingInformation());
 
         // Assertions checking isset() can hide some errors if it doesn't find array key,
         // to make sure all provided fields were checked we need to unset every asserted field
         // and finally, if provided data is not empty, it means there are some unnasserted values left
         Assert::assertEmpty($data, sprintf('Some provided fields haven\'t been asserted: %s', implode(',', $data)));
-    }
-
-    /**
-     * @When I update product :productReference tags with following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductTags(string $productReference, TableNode $table)
-    {
-        $productId = $this->getSharedStorage()->get($productReference);
-        $data = $table->getRowsHash();
-
-        $localizedTagStrings = $this->parseLocalizedArray($data['tags']);
-        $localizedTagsList = [];
-
-        foreach ($localizedTagStrings as $langId => $localizedTagString) {
-            $localizedTagsList[$langId] = explode(',', $localizedTagString);
-        }
-
-        try {
-            $this->getCommandBus()->handle(new UpdateProductTagsCommand($productId, $localizedTagsList));
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When I update product :productReference prices with following information:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductPrices(string $productReference, TableNode $table)
-    {
-        $data = $table->getRowsHash();
-        $command = new UpdateProductPricesCommand($this->getSharedStorage()->get($productReference));
-
-        if (isset($data['price'])) {
-            $command->setPrice($data['price']);
-        }
-        if (isset($data['ecotax'])) {
-            $command->setEcotax($data['ecotax']);
-        }
-        if (isset($data['tax rules group'])) {
-            $taxRulesGroupId = (int) TaxRulesGroupFeatureContext::getTaxRulesGroupByName($data['tax rules group'])->id;
-            $command->setTaxRulesGroupId($taxRulesGroupId);
-        }
-        if (isset($data['on_sale'])) {
-            $command->setOnSale(PrimitiveUtils::castStringBooleanIntoBoolean($data['on_sale']));
-        }
-        if (isset($data['wholesale_price'])) {
-            $command->setWholesalePrice($data['wholesale_price']);
-        }
-        if (isset($data['unit_price'])) {
-            $command->setUnitPrice($data['unit_price']);
-        }
-        if (isset($data['unity'])) {
-            $command->setUnity($data['unity']);
-        }
-
-        try {
-            $this->getQueryBus()->handle($command);
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
     }
 
     /**
@@ -655,190 +166,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
             $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When I update product :productReference with following customization fields:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateCustomizationFields(string $productReference, TableNode $table)
-    {
-        $customizationFields = $table->getColumnsHash();
-        $fieldsForUpdate = [];
-        $fieldReferences = [];
-
-        foreach ($customizationFields as $customizationField) {
-            $addedByModule = isset($customizationField['added by module']) ?
-                PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['added by module']) :
-                false
-            ;
-            $fieldReference = $customizationField['reference'];
-            $id = $this->getSharedStorage()->exists($fieldReference) ? $this->getSharedStorage()->get($fieldReference) : null;
-
-            $fieldReferences[] = $fieldReference;
-            $fieldsForUpdate[] = [
-                'id' => $id,
-                'type' => $customizationField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT,
-                'localized_names' => $this->parseLocalizedArray($customizationField['name']),
-                'is_required' => PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['is required']),
-                'added_by_module' => $addedByModule,
-            ];
-        }
-
-        $this->updateProductCustomizationFields(
-            $productReference,
-            $fieldReferences,
-            $fieldsForUpdate
-        );
-    }
-
-    /**
-     * @When I update product :productReference customization field name with text containing :nameLength symbols
-     *
-     * @param string $productReference
-     * @param int $nameLength
-     */
-    public function addCustomizationFieldWithTooLongName(string $productReference, int $nameLength)
-    {
-        $fieldsForUpdate = [];
-        foreach (Language::getIDs() as $langId) {
-            $langId = (int) $langId;
-            $fieldsForUpdate[] = [
-                'id' => null,
-                'type' => CustomizationFieldType::TYPE_TEXT,
-                'is_required' => false,
-                'added_by_module' => false,
-                'localized_names' => [
-                    $langId => PrimitiveUtils::generateRandomString($nameLength),
-                ],
-            ];
-        }
-
-        try {
-            $this->updateProductCustomizationFields($productReference, ['name'], $fieldsForUpdate);
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @When I delete all customization fields from product :productReference
-     *
-     * @param string $productReference
-     */
-    public function updateCustomizationFieldsWithEmptyArray(string $productReference)
-    {
-        $this->updateProductCustomizationFields($productReference, [], []);
-    }
-
-    /**
-     * @Then product :productReference should have following customization fields:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function assertCustomizationFields(string $productReference, TableNode $table)
-    {
-        $data = $table->getColumnsHash();
-        /** @var CustomizationField[] $actualFields */
-        $actualFields = $this->getProductCustomizationFields($productReference);
-        $notFoundExpectedFields = [];
-
-        foreach ($data as $expectedField) {
-            $expectedId = $this->getSharedStorage()->get($expectedField['reference']);
-            $foundExpectedField = false;
-
-            foreach ($actualFields as $key => $actualField) {
-                if ($expectedId === $actualField->getCustomizationFieldId()) {
-                    $foundExpectedField = true;
-                    $expectedType = $expectedField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT;
-                    $expectedLocalizedNames = $this->parseLocalizedArray($expectedField['name']);
-                    $expectedRequired = PrimitiveUtils::castStringBooleanIntoBoolean($expectedField['is required']);
-                    Assert::assertEquals($expectedType, $actualField->getType(), 'Unexpected customization type');
-                    Assert::assertEquals(
-                        $expectedLocalizedNames,
-                        $actualField->getLocalizedNames(),
-                        sprintf('Unexpected product "%s" customization field name', $productReference)
-                    );
-
-                    if ($expectedRequired !== $actualField->isRequired()) {
-                        throw new RuntimeException(
-                            sprintf(
-                                'Expected customization field #%d to be %s',
-                                $expectedId,
-                                $expectedRequired ? 'required' : 'not required'
-                            )
-                        );
-                    }
-
-                    if (isset($expectedField['added by module'])) {
-                        $expectedByModule = PrimitiveUtils::castStringBooleanIntoBoolean($expectedField['added by module']);
-                        if ($expectedByModule !== $actualField->isAddedByModule()) {
-                            throw new RuntimeException(
-                                sprintf(
-                                    'Expected customization field #%d to be added %s',
-                                    $actualField->getCustomizationFieldId(),
-                                    $expectedByModule ? 'by module' : 'not by module'
-                                )
-                            );
-                        }
-                    }
-                    //unset this asserted customization field so we can check if there any left after loop
-                    unset($actualFields[$key]);
-
-                    continue;
-                }
-            }
-
-            if (!$foundExpectedField) {
-                $notFoundExpectedFields[] = $expectedField;
-            }
-        }
-
-        if (!empty($notFoundExpectedFields)) {
-            throw new RuntimeException(sprintf(
-                'Following customization fields were not found for product %s: %s',
-                $productReference,
-                var_export($notFoundExpectedFields)
-            ));
-        }
-
-        if (!empty($actualFields)) {
-            throw new RuntimeException(sprintf(
-                'Product "%s" contains unexpected customization fields: %s',
-                $productReference,
-                var_export($actualFields)
-            ));
-        }
-    }
-
-    /**
-     * @Then product :productReference should be assigned to default category
-     *
-     * @param string $productReference
-     */
-    public function assertProductAssignedToDefaultCategory(string $productReference)
-    {
-        $context = $this->getContainer()->get('prestashop.adapter.legacy.context')->getContext();
-        $defaultCategoryId = (int) $context->shop->id_category;
-
-        $productForEditing = $this->getProductForEditing($productReference);
-        $productCategoriesInfo = $productForEditing->getCategoriesInformation();
-
-        $belongsToDefaultCategory = false;
-        foreach ($productCategoriesInfo->getCategoryIds() as $categoryId) {
-            if ($categoryId === $defaultCategoryId) {
-                $belongsToDefaultCategory = true;
-
-                break;
-            }
-        }
-
-        if ($productCategoriesInfo->getDefaultCategoryId() !== $defaultCategoryId || !$belongsToDefaultCategory) {
-            throw new RuntimeException('Product is not assigned to default category');
         }
     }
 
@@ -863,110 +190,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then /^product "(.+)" should (not be customizable|allow customization|require customization)$/
-     *
-     * @param string $productReference
-     * @param string $customizability
-     */
-    public function assertCustomizability(string $productReference, string $customizability)
-    {
-        $customizationOptions = $this->getProductForEditing($productReference)->getCustomizationOptions();
-
-        switch ($customizability) {
-            case 'not be customizable':
-                Assert::assertTrue(
-                    $customizationOptions->isNotCustomizable(),
-                    sprintf('Expected product "%s" to be not customizable', $productReference)
-                );
-
-                break;
-            case 'allow customization':
-                Assert::assertTrue(
-                    $customizationOptions->allowsCustomization(),
-                    sprintf('Expected product "%s" to allow customization', $productReference)
-                );
-
-                break;
-            case 'require customization':
-                Assert::assertTrue(
-                    $customizationOptions->requiresCustomization(),
-                    sprintf('Expected product "%s" to require customization', $productReference)
-                );
-
-                break;
-            default:
-                throw new RuntimeException(sprintf('Invalid customizability "%s" provided in test scenario', $customizability));
-        }
-    }
-
-    /**
-     * @Then product :productReference should have :expectedCount customizable :customizationType field(s)
-     *
-     * @param string $productReference
-     * @param int $expectedCount
-     * @param string $customizationType
-     */
-    public function assertCustomizationOptions(string $productReference, int $expectedCount, string $customizationType)
-    {
-        if (!in_array($customizationType, array_keys(CustomizationFieldType::AVAILABLE_TYPES))) {
-            throw new RuntimeException(sprintf('Invalid customization type "%s" provided in test scenario', $customizationType));
-        }
-
-        $productForEditing = $this->getProductForEditing($productReference);
-
-        if ('file' === $customizationType) {
-            Assert::assertEquals(
-                $expectedCount,
-                $productForEditing->getCustomizationOptions()->getAvailableFileCustomizationsCount(),
-                'Unexpected customizable file fields count'
-            );
-        } else {
-            Assert::assertEquals(
-                $expectedCount,
-                $productForEditing->getCustomizationOptions()->getAvailableTextCustomizationsCount(),
-                'Unexpected customizable text fields count'
-            );
-        }
-    }
-
-    /**
-     * @Then product :productReference should have no carriers assigned
-     *
-     * @param string $productReference
-     */
-    public function assertProductHasNoCarriers(string $productReference)
-    {
-        $productForEditing = $this->getProductForEditing($productReference);
-
-        Assert::assertEmpty(
-            $productForEditing->getShippingInformation()->getCarrierReferences(),
-            sprintf('Expected product "%s" to have no carriers assigned', $productReference)
-        );
-    }
-
-    /**
-     * @Then I should get error that product for packing quantity is invalid
-     */
-    public function assertPackProductQuantityError()
-    {
-        $this->assertLastErrorIs(
-            ProductPackException::class,
-            ProductPackException::INVALID_QUANTITY
-        );
-    }
-
-    /**
-     * @Then I should get error that I cannot add pack into a pack
-     */
-    public function assertAddingPackToPackError()
-    {
-        $this->assertLastErrorIs(
-            ProductPackException::class,
-            ProductPackException::CANNOT_ADD_PACK_INTO_PACK
-        );
-    }
-
-    /**
      * @Then I should get error that product :fieldName is invalid
      */
     public function assertConstraintError(string $fieldName): void
@@ -978,124 +201,69 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then I should get error that product customization field name is invalid
+     * @param array $data
+     * @param ProductPricesInformation $pricesInfo
      */
-    public function assertCustomizationFieldNameError(): void
+    private function assertPriceFields(array &$data, ProductPricesInformation $pricesInfo): void
     {
-        $this->assertLastErrorIs(
-            CustomizationFieldConstraintException::class,
-            CustomizationFieldConstraintException::INVALID_NAME
-        );
-    }
+        if (isset($data['on_sale'])) {
+            $expectedOnSale = PrimitiveUtils::castStringBooleanIntoBoolean($data['on_sale']);
+            $onSaleInWords = $expectedOnSale ? 'to be on sale' : 'not to be on sale';
 
-    /**
-     * @param string $productReference
-     * @param array $fieldReferences
-     * @param array $fieldsForUpdate
-     */
-    private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate): void
-    {
-        try {
-            $newCustomizationFields = $this->getCommandBus()->handle(new UpdateProductCustomizationFieldsCommand(
-                $this->getSharedStorage()->get($productReference),
-                $fieldsForUpdate
-            ));
-
-            Assert::assertSameSize(
-                $fieldReferences,
-                $newCustomizationFields,
-                'Cannot set references in shared storage. References and actual customization fields doesn\'t match.'
+            Assert::assertEquals(
+                $expectedOnSale,
+                $pricesInfo->isOnSale(),
+                sprintf('Expected product %s', $onSaleInWords)
             );
 
-            /** @var CustomizationField $customizationField */
-            foreach ($newCustomizationFields as $key => $customizationField) {
-                $this->getSharedStorage()->set($fieldReferences[$key], $customizationField->getCustomizationFieldId());
+            unset($data['on_sale']);
+        }
+
+        if (isset($data['unity'])) {
+            $expectedUnity = $data['unity'];
+            $actualUnity = $pricesInfo->getUnity();
+
+            Assert::assertEquals(
+                $expectedUnity,
+                $actualUnity,
+                sprintf('Tax rules group expected to be "%s", but got "%s"', $expectedUnity, $actualUnity)
+            );
+
+            unset($data['unity']);
+        }
+
+        $this->assertNumberPriceFields($data, $pricesInfo);
+    }
+
+    /**
+     * @param array $expectedPrices
+     * @param ProductPricesInformation $actualPrices
+     */
+    private function assertNumberPriceFields(array &$expectedPrices, ProductPricesInformation $actualPrices)
+    {
+        $numberPriceFields = [
+            'price',
+            'ecotax',
+            'wholesale_price',
+            'unit_price',
+            'unit_price_ratio',
+        ];
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($numberPriceFields as $field) {
+            if (isset($expectedPrices[$field])) {
+                $expectedNumber = new Number((string) $expectedPrices[$field]);
+                $actualNumber = $propertyAccessor->getValue($actualPrices, $field);
+
+                if (!$expectedNumber->equals($actualNumber)) {
+                    throw new RuntimeException(
+                        sprintf('Product %s expected to be "%s", but is "%s"', $field, $expectedNumber, $actualNumber)
+                    );
+                }
+
+                unset($expectedPrices[$field]);
             }
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @param string $carrierReferencesInput
-     *
-     * @return int[]
-     */
-    private function getCarrierReferenceIds(string $carrierReferencesInput): array
-    {
-        $referenceIds = [];
-        foreach (PrimitiveUtils::castStringArrayIntoArray($carrierReferencesInput) as $carrierReference) {
-            $carrier = new Carrier($this->getSharedStorage()->get($carrierReference));
-            $referenceIds[] = (int) $carrier->id_reference;
-        }
-
-        return $referenceIds;
-    }
-
-    /**
-     * @param array $data
-     * @param UpdateProductOptionsCommand $command
-     */
-    private function setUpdateOptionsCommandData(array $data, UpdateProductOptionsCommand $command): void
-    {
-        if (isset($data['visibility'])) {
-            $command->setVisibility($data['visibility']);
-        }
-
-        if (isset($data['available_for_order'])) {
-            $command->setAvailableForOrder(PrimitiveUtils::castStringBooleanIntoBoolean($data['available_for_order']));
-        }
-
-        if (isset($data['online_only'])) {
-            $command->setOnlineOnly(PrimitiveUtils::castStringBooleanIntoBoolean($data['online_only']));
-        }
-
-        if (isset($data['show_price'])) {
-            $command->setShowPrice(PrimitiveUtils::castStringBooleanIntoBoolean($data['show_price']));
-        }
-
-        if (isset($data['condition'])) {
-            $command->setCondition($data['condition']);
-        }
-
-        if (isset($data['isbn'])) {
-            $command->setIsbn($data['isbn']);
-        }
-
-        if (isset($data['upc'])) {
-            $command->setUpc($data['upc']);
-        }
-
-        if (isset($data['ean13'])) {
-            $command->setEan13($data['ean13']);
-        }
-
-        if (isset($data['mpn'])) {
-            $command->setMpn($data['mpn']);
-        }
-
-        if (isset($data['reference'])) {
-            $command->setReference($data['reference']);
-        }
-
-        if (isset($data['mpn'])) {
-            $command->setMpn($data['mpn']);
-        }
-    }
-
-    /**
-     * @param int $packId
-     * @param array $products
-     */
-    private function upsertPack(int $packId, array $products): void
-    {
-        try {
-            $this->getCommandBus()->handle(UpdateProductPackCommand::upsertPack(
-                $packId,
-                $products
-            ));
-        } catch (ProductException $e) {
-            $this->setLastException($e);
         }
     }
 
@@ -1173,173 +341,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @param array $data
-     * @param ProductPricesInformation $pricesInfo
-     */
-    private function assertPriceFields(array &$data, ProductPricesInformation $pricesInfo): void
-    {
-        if (isset($data['on_sale'])) {
-            $expectedOnSale = PrimitiveUtils::castStringBooleanIntoBoolean($data['on_sale']);
-            $onSaleInWords = $expectedOnSale ? 'to be on sale' : 'not to be on sale';
-
-            Assert::assertEquals(
-                $expectedOnSale,
-                $pricesInfo->isOnSale(),
-                sprintf('Expected product %s', $onSaleInWords)
-            );
-
-            unset($data['on_sale']);
-        }
-
-        if (isset($data['unity'])) {
-            $expectedUnity = $data['unity'];
-            $actualUnity = $pricesInfo->getUnity();
-
-            Assert::assertEquals(
-                $expectedUnity,
-                $actualUnity,
-                sprintf('Tax rules group expected to be "%s", but got "%s"', $expectedUnity, $actualUnity)
-            );
-
-            unset($data['unity']);
-        }
-
-        $this->assertNumberPriceFields($data, $pricesInfo);
-    }
-
-    /**
-     * @param array $expectedPrices
-     * @param ProductPricesInformation $actualPrices
-     */
-    private function assertNumberPriceFields(array &$expectedPrices, ProductPricesInformation $actualPrices)
-    {
-        $numberPriceFields = [
-            'price',
-            'ecotax',
-            'wholesale_price',
-            'unit_price',
-            'unit_price_ratio',
-        ];
-
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        foreach ($numberPriceFields as $field) {
-            if (isset($expectedPrices[$field])) {
-                $expectedNumber = new Number((string) $expectedPrices[$field]);
-                $actualNumber = $propertyAccessor->getValue($actualPrices, $field);
-
-                if (!$expectedNumber->equals($actualNumber)) {
-                    throw new RuntimeException(
-                        sprintf('Product %s expected to be "%s", but is "%s"', $field, $expectedNumber, $actualNumber)
-                    );
-                }
-
-                unset($expectedPrices[$field]);
-            }
-        }
-    }
-
-    /**
-     * @param array $data
-     * @param ProductShippingInformation $productShippingInformation
-     */
-    private function assertShippingInformation(array &$data, ProductShippingInformation $productShippingInformation): void
-    {
-        if (isset($data['carriers'])) {
-            $expectedReferenceIds = $this->getCarrierReferenceIds($data['carriers']);
-            $actualReferenceIds = $productShippingInformation->getCarrierReferences();
-
-            Assert::assertEquals(
-                $expectedReferenceIds,
-                $actualReferenceIds,
-                'Unexpected carrier references in product shipping information'
-            );
-
-            unset($data['carriers']);
-        }
-
-        $this->assertNumberShippingFields($data, $productShippingInformation);
-        $this->assertDeliveryTimeNotes($data, $productShippingInformation);
-    }
-
-    /**
-     * @param array $expectedValues
-     * @param ProductShippingInformation $actualValues
-     */
-    private function assertNumberShippingFields(array &$expectedValues, ProductShippingInformation $actualValues)
-    {
-        $numberShippingFields = [
-            'width',
-            'height',
-            'depth',
-            'weight',
-            'additional_shipping_cost',
-        ];
-
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        foreach ($numberShippingFields as $field) {
-            if (isset($expectedValues[$field])) {
-                $expectedNumber = new Number((string) $expectedValues[$field]);
-                $actualNumber = $propertyAccessor->getValue($actualValues, $field);
-
-                if (!$expectedNumber->equals($actualNumber)) {
-                    throw new RuntimeException(
-                        sprintf('Product %s expected to be "%s", but is "%s"', $field, $expectedNumber, $actualNumber)
-                    );
-                }
-
-                unset($expectedValues[$field]);
-            }
-        }
-    }
-
-    /**
-     * @param array $data
-     * @param ProductShippingInformation $productShippingInformation
-     */
-    private function assertDeliveryTimeNotes(array &$data, ProductShippingInformation $productShippingInformation)
-    {
-        $notesTypeNamedValues = [
-            'none' => DeliveryTimeNotesType::TYPE_NONE,
-            'default' => DeliveryTimeNotesType::TYPE_DEFAULT,
-            'specific' => DeliveryTimeNotesType::TYPE_SPECIFIC,
-        ];
-
-        if (isset($data['delivery time notes type'])) {
-            $expectedType = $notesTypeNamedValues[$data['delivery time notes type']];
-            $actualType = $productShippingInformation->getDeliveryTimeNotesType();
-            Assert::assertEquals($expectedType, $actualType, 'Unexpected delivery time notes type value');
-
-            unset($data['delivery time notes type']);
-        }
-
-        if (isset($data['delivery time in stock notes'])) {
-            $expectedLocalizedOutOfStockNotes = $this->parseLocalizedArray($data['delivery time in stock notes']);
-            $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeInStockNotes();
-            Assert::assertEquals(
-                $expectedLocalizedOutOfStockNotes,
-                $actualLocalizedOutOfStockNotes,
-                'Unexpected product delivery time in stock notes'
-            );
-
-            unset($data['delivery time in stock notes']);
-        }
-
-        if (isset($data['delivery time out of stock notes'])) {
-            $expectedLocalizedOutOfStockNotes = $this->parseLocalizedArray($data['delivery time out of stock notes']);
-            $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeOutOfStockNotes();
-            Assert::assertEquals(
-                $expectedLocalizedOutOfStockNotes,
-                $actualLocalizedOutOfStockNotes,
-                'Unexpected product delivery time out of stock notes'
-            );
-
-            unset($data['delivery time out of stock notes']);
-        }
-    }
-
-    /**
      * @param string $fieldName
      *
      * @return int
@@ -1381,39 +382,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * Extracts corresponding field value from ProductForEditing DTO
-     *
-     * @param ProductForEditing $productForEditing
-     * @param string $propertyName
-     *
-     * @return mixed
-     */
-    private function extractValueFromProductForEditing(ProductForEditing $productForEditing, string $propertyName)
-    {
-        $pathsByNames = [
-            'name' => 'basicInformation.localizedNames',
-            'description' => 'basicInformation.localizedDescriptions',
-            'description_short' => 'basicInformation.localizedShortDescriptions',
-            'active' => 'active',
-            'visibility' => 'options.visibility',
-            'available_for_order' => 'options.availableForOrder',
-            'online_only' => 'options.onlineOnly',
-            'show_price' => 'options.showPrice',
-            'condition' => 'options.condition',
-            'isbn' => 'options.isbn',
-            'upc' => 'options.upc',
-            'ean13' => 'options.ean13',
-            'mpn' => 'options.mpn',
-            'reference' => 'options.reference',
-            'tags' => 'options.localizedTags',
-        ];
-
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        return $propertyAccessor->getValue($productForEditing, $pathsByNames[$propertyName]);
-    }
-
-    /**
      * @param string $productName
      *
      * @return int
@@ -1431,38 +399,6 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         $product = reset($products);
 
         return $product->getProductId();
-    }
-
-    /**
-     * @param string $reference
-     *
-     * @return ProductForEditing
-     */
-    private function getProductForEditing(string $reference): ProductForEditing
-    {
-        $productId = $this->getSharedStorage()->get($reference);
-
-        return $this->getQueryBus()->handle(new GetProductForEditing(
-            $productId
-        ));
-    }
-
-    /**
-     * @param int $productId
-     * @param int $defaultCategoryId
-     * @param array $categoryIds
-     */
-    private function assignProductToCategories(int $productId, int $defaultCategoryId, array $categoryIds): void
-    {
-        try {
-            $this->getCommandBus()->handle(new UpdateProductCategoriesCommand(
-                $productId,
-                $defaultCategoryId,
-                $categoryIds
-            ));
-        } catch (ProductException $e) {
-            $this->setLastException($e);
-        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -42,6 +42,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use Product;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
@@ -80,7 +81,10 @@ class ProductFeatureContext extends AbstractProductFeatureContext
         $expectedLocalizedValues = $this->parseLocalizedArray($localizedValues);
 
         if ('tags' === $fieldName) {
-            $this->assertLocalizedTags($expectedLocalizedValues, $productForEditing);
+            UpdateTagsFeatureContext::assertLocalizedTags(
+                $expectedLocalizedValues,
+                $this->extractValueFromProductForEditing($productForEditing, $fieldName)
+            );
 
             return;
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -824,9 +824,9 @@ Feature: Refund Order from Back Office (BO)
       | message             | test             |
       | payment module name | dummy_payment    |
       | status              | Payment accepted |
-    And product "Mug The best is yet to come" in order "bo_order_refund" has following details:
+    And product "product_mug_best_to_come" named "Mug The best is yet to come" in order bo_order_refund has following details:
       | product_quantity            | 2 |
-    And product "Mug Today is a good day" in order "bo_order_refund" has following details:
+    And product "product_mug_good_day" named "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
     And there are 1 less "Mug Today is a good day" in stock
@@ -838,7 +838,8 @@ Feature: Refund Order from Back Office (BO)
       | name         | US-FL Rate (10%) |
       | country      | US               |
       | state        | FL               |
-    And I set tax rule group "US-FL Rate (10%)" to product "Mug The best is yet to come"
+    And I update product product_mug_best_to_come prices with following information:
+      | tax rules group | US-FL Rate (10%) |
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 11.9   |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -8,7 +8,7 @@ Feature: Update product price fields from Back Office (BO).
     Given I add product "product1" with following information:
       | name       | en-US:magic staff   |
       | is_virtual | false               |
-    And product "product1" should have following values:
+    And product product1 should have following prices information:
       | price              | 0           |
       | ecotax             | 0           |
       | tax rules group    |             |
@@ -26,7 +26,7 @@ Feature: Update product price fields from Back Office (BO).
       | wholesale_price    | 70              |
       | unit_price         | 900             |
       | unity              | bag of ten      |
-    Then product "product1" should have following values:
+    Then product product1 should have following prices information:
       | price              | 100.99          |
       | ecotax             | 0               |
       | tax rules group    | US-AL Rate (4%) |
@@ -38,7 +38,7 @@ Feature: Update product price fields from Back Office (BO).
       | unit_price_ratio   | 0.112211    |
 
     Scenario: I partially update product prices, providing only those values which I want to update
-      Given product "product1" has following values:
+      Given product product1 should have following prices information:
         | price              | 100.99          |
         | ecotax             | 0               |
         | tax rules group    | US-AL Rate (4%) |
@@ -50,7 +50,7 @@ Feature: Update product price fields from Back Office (BO).
         | unit_price_ratio   | 0.112211    |
       When I update product "product1" prices with following information:
         | price              | 200         |
-      Then product "product1" should have following values:
+      Then product product1 should have following prices information:
         | price              | 200             |
         | ecotax             | 0               |
         | tax rules group    | US-AL Rate (4%) |
@@ -63,7 +63,7 @@ Feature: Update product price fields from Back Office (BO).
       When I update product "product1" prices with following information:
         | ecotax              | 5.5            |
         | on_sale             | false          |
-      Then product "product1" should have following values:
+      Then product product1 should have following prices information:
         | price              | 200             |
         | ecotax             | 5.5             |
         | tax rules group    | US-AL Rate (4%) |
@@ -80,7 +80,7 @@ Feature: Update product price fields from Back Office (BO).
           | is_virtual | false             |
         And I update product "product2" prices with following information:
           | price           | 50           |
-        And product "product2" has following values:
+        And product product2 should have following prices information:
           | price           | 50           |
           | ecotax          | 0            |
           | wholesale_price | 0            |
@@ -102,12 +102,12 @@ Feature: Update product price fields from Back Office (BO).
         Given I add product "product3" with following information:
           | name       | en-US: black hat  |
           | is_virtual | false             |
-        And product "product3" has following values:
+        And product product3 should have following prices information:
           | price           | 0            |
           | unit_price      | 0            |
         When I update product "product3" prices with following information:
           | unit_price      | 300          |
-        Then product "product3" has following values:
+        Then product product3 should have following prices information:
           | price           | 0            |
           | unit_price      | 0            |
 
@@ -115,20 +115,20 @@ Feature: Update product price fields from Back Office (BO).
         Given I add product "product4" with following information:
           | name       | en-US: blue dress  |
           | is_virtual | false              |
-        And product "product4" has following values:
+        And product product4 should have following prices information:
           | price            | 0            |
           | unit_price       | 0            |
         When I update product "product4" prices with following information:
           | price            | 20           |
           | unit_price       | 500          |
-        Then product "product4" should have following values:
+        Then product product4 should have following prices information:
           | price            | 20           |
           | unit_price       | 500          |
           | unit_price_ratio | 0.04         |
         When I update product "product4" prices with following information:
           | price            | 0            |
           | unit_price       | 500          |
-        Then product "product4" should have following values:
+        Then product product4 should have following prices information:
           | price            | 0            |
           | unit_price       | 0            |
           | unit_price_ratio | 0            |
@@ -137,7 +137,7 @@ Feature: Update product price fields from Back Office (BO).
         Given I add product "product5" with following information:
           | name       | en-US: black tie     |
           | is_virtual | false                |
-        And product "product4" has following values:
+        And product product5 should have following prices information:
           | tax rules group |           |
         When I update product "product5" prices and apply non-existing tax rules group
         Then I should get error that product "tax rules group" is invalid

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
@@ -8,7 +8,7 @@ Feature: Update product shipping options from Back Office (BO)
     Given I add product "product1" with following information:
       | name       | en-US:Last samurai dvd |
       | is_virtual | false                  |
-    And product product1 should have following values:
+    And product product1 should have following shipping information:
       | width                            | 0                 |
       | height                           | 0                 |
       | depth                            | 0                 |
@@ -30,7 +30,7 @@ Feature: Update product shipping options from Back Office (BO)
       | delivery time in stock notes     | en-US:product in stock     |
       | delivery time out of stock notes | en-US:product out of stock |
       | carriers                         | [carrier1,carrier2]        |
-    Then product product1 should have following values:
+    Then product product1 should have following shipping information:
       | width                            | 10.5                       |
       | height                           | 6                          |
       | depth                            | 7                          |
@@ -42,7 +42,7 @@ Feature: Update product shipping options from Back Office (BO)
       | carriers                         | [carrier1,carrier2]        |
 
   Scenario: Only update product dimensions without changing other values
-    Given product product1 should have following values:
+    Given product product1 should have following shipping information:
       | width                            | 10.5                       |
       | height                           | 6                          |
       | depth                            | 7                          |
@@ -57,7 +57,7 @@ Feature: Update product shipping options from Back Office (BO)
       | height                           | 5                          |
       | depth                            | 4                          |
       | weight                           | 2                          |
-    Then product product1 should have following values:
+    Then product product1 should have following shipping information:
       | width                            | 15                         |
       | height                           | 5                          |
       | depth                            | 4                          |
@@ -69,7 +69,7 @@ Feature: Update product shipping options from Back Office (BO)
       | carriers                         | [carrier1,carrier2]        |
 
   Scenario: Provide negative product dimensions
-    Given product product1 should have following values:
+    Given product product1 should have following shipping information:
       | width                            | 15                         |
       | height                           | 5                          |
       | depth                            | 4                          |
@@ -86,21 +86,21 @@ Feature: Update product shipping options from Back Office (BO)
     When I update product product1 shipping information with following values:
       | weight                            | -2                        |
     Then I should get error that product weight is invalid
-    And product product1 should have following values:
+    And product product1 should have following shipping information:
       | width                            | 15                         |
       | height                           | 5                          |
       | depth                            | 4                          |
       | weight                           | 2                          |
 
   Scenario: Provide negative additional shipping cost
-    Given product product1 should have following values:
+    Given product product1 should have following shipping information:
       | additional_shipping_cost         | 12                         |
     When I update product product1 shipping information with following values:
       | additional_shipping_cost         | -12                        |
     Then I should get error that product additional_shipping_cost is invalid
 
   Scenario: Provide invalid delivery notes
-    Given product product1 should have following values:
+    Given product product1 should have following shipping information:
       | delivery time in stock notes     | en-US:product in stock     |
       | delivery time out of stock notes | en-US:product out of stock |
     When I update product product1 shipping information with following values:
@@ -109,19 +109,19 @@ Feature: Update product shipping options from Back Office (BO)
     When I update product product1 shipping information with following values:
       | delivery time out of stock notes | en-US:ble ble >= |
     Then I should get error that product delivery_out_stock is invalid
-    And product product1 should have following values:
+    And product product1 should have following shipping information:
       | delivery time in stock notes     | en-US:product in stock     |
       | delivery time out of stock notes | en-US:product out of stock |
 
   Scenario: Remove delivery time notes, but still have specific notes type
-    Given product product1 should have following values:
+    Given product product1 should have following shipping information:
       | delivery time notes type         | specific                   |
       | delivery time in stock notes     | en-US:product in stock     |
       | delivery time out of stock notes | en-US:product out of stock |
     When I update product product1 shipping information with following values:
       | delivery time in stock notes     | en-US:                     |
       | delivery time out of stock notes | en-US:                     |
-    Given product product1 should have following values:
+    Given product product1 should have following shipping information:
       | delivery time notes type         | specific                   |
       | delivery time in stock notes     | en-US:                     |
       | delivery time out of stock notes | en-US:                     |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -80,7 +80,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\AddressFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderRefundFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
@@ -187,7 +187,7 @@ default:
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -188,6 +188,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -80,7 +80,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\AddressFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderRefundFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePricesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -189,6 +189,14 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateBasicInformationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateOptionsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePricesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PR only modifies behat tests. ProductFeatureContext was split to multiple smaller contexts: addProductFeatureContext, UpdateBasicInformationFeatureContext, UpdateCategoriesFeatureContext etc..
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | none. Behats must pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20427)
<!-- Reviewable:end -->
