### PR TITLE
Dont show root category on category grid search results

### DIFF
--- a/src/Core/Grid/Query/CategoryQueryBuilder.php
+++ b/src/Core/Grid/Query/CategoryQueryBuilder.php
@@ -48,6 +48,13 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
     private $contextShopId;
 
     /**
+     * @var int|null
+     *
+     * Can be null for backward-compatibility
+     */
+    private $rootCategoryId;
+
+    /**
      * @var DoctrineSearchCriteriaApplicator
      */
     private $searchCriteriaApplicator;
@@ -70,6 +77,7 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param int $contextShopId
      * @param MultistoreContextCheckerInterface $multistoreContextChecker
      * @param FeatureInterface $multistoreFeature
+     * @param int|null $rootCategoryId
      */
     public function __construct(
         Connection $connection,
@@ -78,12 +86,14 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
         $contextLangId,
         $contextShopId,
         MultistoreContextCheckerInterface $multistoreContextChecker,
-        FeatureInterface $multistoreFeature
+        FeatureInterface $multistoreFeature,
+        $rootCategoryId = null
     ) {
         parent::__construct($connection, $dbPrefix);
 
         $this->contextLangId = $contextLangId;
         $this->contextShopId = $contextShopId;
+        $this->rootCategoryId = $rootCategoryId;
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
         $this->multistoreContextChecker = $multistoreContextChecker;
         $this->multistoreFeature = $multistoreFeature;
@@ -154,6 +164,12 @@ final class CategoryQueryBuilder extends AbstractDoctrineQueryBuilder
                 $qb->setParameter($filterName, $filterValue);
 
                 continue;
+            }
+
+            // exclude root category from search results
+            if ($this->rootCategoryId !== null) {
+                $qb->andWhere('c.id_category != :root_category_id');
+                $qb->setParameter('root_category_id', $this->rootCategoryId);
             }
 
             if ('name' === $filterName) {

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -136,6 +136,7 @@ services:
             - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
             - '@prestashop.adapter.shop.context'
             - '@prestashop.adapter.feature.multistore'
+            - "@=service('prestashop.adapter.legacy.configuration').get('PS_ROOT_CATEGORY')"
         public: true
 
     prestashop.core.grid.query_builder.cms_page:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This PR excludes "root category" from "category grid search" in BO. This PR is the last milestone to obtain a fully green build on https://nightly.prestashop.com/ for PS 1.7.7
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20067
| How to test?  | See ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20433)
<!-- Reviewable:end -->
