### PR TITLE
Functional tests - Avoid 'home' as new category to create

### DIFF
--- a/tests/UI/campaigns/data/faker/category.js
+++ b/tests/UI/campaigns/data/faker/category.js
@@ -4,7 +4,7 @@ const {groupAccess} = require('@data/demo/groupAccess');
 
 module.exports = class Category {
   constructor(categoryToCreate = {}) {
-    this.name = categoryToCreate.name || faker.commerce.department();
+    this.name = categoryToCreate.name || `${faker.commerce.color()} ${faker.commerce.department()}`;
     this.displayed = categoryToCreate.displayed === undefined ? true : categoryToCreate.displayed;
     this.description = faker.lorem.sentence();
     this.metaTitle = categoryToCreate.metaTitle || faker.name.title();


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | 'Home' is part of `faker.commerce.department()` used to create fake categories data, so when a new category called 'home' is created, test get confused on which category should be viewed
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Tests not needed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20439)
<!-- Reviewable:end -->
