### PR TITLE
Fix cache class

### DIFF
--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -350,7 +350,7 @@ abstract class CacheCore
             return;
         }
 
-        if (empty($result) || $result === false) {
+        if (empty($result)) {
             $result = [];
         }
 

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -415,9 +415,9 @@ abstract class CacheCore
      *
      * @param string $key query hash
      * @param string $table table name
-     * @param array $tables the tables associated with the query
+     * @param array $otherTables the tables associated with the query
      */
-    private function addQueryKeyToTableMap($key, $table, $tables)
+    private function addQueryKeyToTableMap($key, $table, $otherTables)
     {
         // the name of the cache entry which cache the table map
         $cacheKey = $this->getTableMapCacheKey($table);
@@ -429,8 +429,7 @@ abstract class CacheCore
                 $this->adjustTableCacheSize($table);
             }
 
-            $otherTables = $tables;
-            unset($otherTables[array_search($table, $tables)]);
+            unset($otherTables[array_search($table, $otherTables)]);
             $this->sql_tables_cached[$table][$key] = [
                 'count' => 1,
                 'otherTables' => $otherTables,

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -484,6 +484,7 @@ abstract class CacheCore
         $invalidKeys = [];
         if (isset($this->sql_tables_cached[$table])) {
             if ($keyToKeep && isset($this->sql_tables_cached[$table][$keyToKeep])) {
+                $toKeep = $this->sql_tables_cached[$table][$keyToKeep];
                 // remove the key we plan to keep before adjusting the table cache size
                 unset($this->sql_tables_cached[$table][$keyToKeep]);
             }
@@ -511,7 +512,7 @@ abstract class CacheCore
             $this->_deleteMulti($invalidKeys);
 
             if ($keyToKeep) {
-                $this->sql_tables_cached[$table][$keyToKeep] = 1;
+                $this->sql_tables_cached[$table][$keyToKeep] = $toKeep;
             }
         }
         $this->adjustTableCacheSize = false;

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -425,7 +425,7 @@ abstract class CacheCore
         $this->initializeTableCache($table);
 
         if (!isset($this->sql_tables_cached[$table][$key])) {
-            if ((count($this->sql_tables_cached[$table]) + 1) > $this->maxCachedObjectsByTable) {
+            if (count($this->sql_tables_cached[$table]) >= $this->maxCachedObjectsByTable) {
                 $this->adjustTableCacheSize($table);
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix<br> PHP Warning:  Invalid argument supplied for foreach() in /classes/cache/Cache.php on line 567 <br>PHP Warning:  Cannot use a scalar value as an array in /classes/cache/Cache.php on line 463
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14119
| How to test?  | Enable APC cache in performance section and watch logs. If you dont see anything before this patch, maybe yo have a small shop. it is need to overpass the limit `$maxCachedObjectsByTable = 10000`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20446)
<!-- Reviewable:end -->
