### PR TITLE
Add undeclared variables in AdminController

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -410,10 +410,10 @@ class AdminControllerCore extends Controller
     const AUTH_COOKIE_LIFETIME = 3600;
     
     /** @var array */
-    protected $_conf;
+    public $_conf;
 
     /** @var float @var */
-    protected $timer_start;
+    public $timer_start;
 
     public function __construct($forceControllerName = '', $default_theme_name = 'default')
     {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -408,7 +408,7 @@ class AdminControllerCore extends Controller
 
     /** @var int Auth cookie lifetime */
     const AUTH_COOKIE_LIFETIME = 3600;
-    
+
     /** @var array */
     public $_conf;
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -408,6 +408,12 @@ class AdminControllerCore extends Controller
 
     /** @var int Auth cookie lifetime */
     const AUTH_COOKIE_LIFETIME = 3600;
+    
+    /** @var array */
+    protected $_conf;
+
+    /** @var float @var */
+    protected $timer_start;
 
     public function __construct($forceControllerName = '', $default_theme_name = 'default')
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Variables `$_conf` and `$timer_start` are used but not declared in AdminController neither in parent. Declaring them is better for maintainability and IDE indexing
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Open AdminController with your IDE and see used variables are not declared

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20449)
<!-- Reviewable:end -->
