### PR TITLE
Search combination by ean

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -407,6 +407,31 @@ class CombinationCore extends ObjectModel
     }
 
     /**
+     * For a given ean13 reference, returns the corresponding id.
+     *
+     * @param string $ean13
+     *
+     * @return int|string Product attribute identifier
+     */
+    public static function getIdByEan13($ean13)
+    {
+        if (empty($ean13)) {
+            return 0;
+        }
+
+        if (!Validate::isEan13($ean13)) {
+            return 0;
+        }
+
+        $query = new DbQuery();
+        $query->select('pa.id_product_attribute');
+        $query->from('product_attribute', 'pa');
+        $query->where('pa.ean13 = \'' . pSQL($ean13) . '\'');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+    }
+
+    /**
      * For a given product_attribute reference, returns the corresponding id.
      *
      * @param int $idProduct


### PR DESCRIPTION
* Mainly, it's backport from product class
* By default we can't find combination by their ean identifier

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         |  improvement
| Category?     | CO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? |  not relevant
| How to test?  | not relevant

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20453)
<!-- Reviewable:end -->
