### PR TITLE
Search reference in all combinations

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -408,9 +408,9 @@ class CombinationCore extends ObjectModel
 
     /**
      * For a given product_attribute reference, returns the corresponding id.
-     * if idProduct is empty|0 search is done in all combinations
+     * if idProduct is empty(0/null) search is done in all combinations
      *
-     * @param int $idProduct
+     * @param int|null $idProduct
      * @param string $reference
      *
      * @return int id

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -408,6 +408,7 @@ class CombinationCore extends ObjectModel
 
     /**
      * For a given product_attribute reference, returns the corresponding id.
+     * if idProduct is empty|0 search is done in all combinations
      *
      * @param int $idProduct
      * @param string $reference
@@ -424,7 +425,9 @@ class CombinationCore extends ObjectModel
         $query->select('pa.id_product_attribute');
         $query->from('product_attribute', 'pa');
         $query->where('pa.reference LIKE \'%' . pSQL($reference) . '%\'');
-        $query->where('pa.id_product = ' . (int) $idProduct);
+        if (!empty($idProduct)) {
+            $query->where('pa.id_product = ' . (int) $idProduct);
+        }
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
     }


### PR DESCRIPTION
solve #20454

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | * Prevent a PHP error when idproduct is not set<br>* Allow search in all combinations, when product is unknown
| Type?         | bug fix 
| Category?     | CO 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes #20454
| How to test?  | Do a code as Combination::getIdByReference(0,1234) or Combination::getIdByReference('',1234), <br> Thanks to check if those issues are fixed: https://github.com/PrestaShop/PrestaShop/issues/20443 & https://github.com/PrestaShop/PrestaShop/issues/9727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20455)
<!-- Reviewable:end -->
