### PR TITLE
Include product name and employee name in out of stock email

### DIFF
--- a/mails/themes/modern/core/productoutofstock.html.twig
+++ b/mails/themes/modern/core/productoutofstock.html.twig
@@ -173,7 +173,7 @@
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">{{ 'There are now less than [1]{last_qty}[/1] items in stock.'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}</div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">{{ 'There are now less than [1]{last_qty}[/1] of [1]{product}[/1] in stock.'|trans({'[1]': '<span class="label">', '[/1]': '</span>'}, 'Emails.Body', locale)|raw }}</div>
                                       </td>
                                     </tr>
                                     <tr>

--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -306,32 +306,31 @@ class StockManager
             '{last_qty}' => $lowStockThreshold,
             '{product}' => $productName,
         ];
-        // get emails on employees who have right to run stock page
-        $emails = [];
-        $employees = Employee::getEmployees();
-        foreach ($employees as $employeeData) {
+
+        // send email to every employee who have permission for this
+        foreach (Employee::getEmployees() as $employeeData) {
             $employee = new Employee($employeeData['id_employee']);
+
             if (Access::isGranted('ROLE_MOD_TAB_ADMINSTOCKMANAGEMENT_READ', $employee->id_profile)) {
-                $emails[] = $employee->email;
+                $templateVars['{firstname}'] = $employee->firstname;
+                $templateVars['{lastname}'] = $employee->lastname;
+
+                Mail::Send(
+                    $idLang,
+                    'productoutofstock',
+                    Mail::l('Product out of stock', $idLang),
+                    $templateVars,
+                    $employee->email,
+                    null,
+                    (string) $configuration['PS_SHOP_EMAIL'],
+                    (string) $configuration['PS_SHOP_NAME'],
+                    null,
+                    null,
+                    __DIR__ . '/mails/',
+                    false,
+                    $idShop
+                );
             }
-        }
-        // Send 1 email by merchant mail, because Mail::Send doesn't work with an array of recipients
-        foreach ($emails as $email) {
-            Mail::Send(
-                $idLang,
-                'productoutofstock',
-                Mail::l('Product out of stock', $idLang),
-                $templateVars,
-                $email,
-                null,
-                (string) $configuration['PS_SHOP_EMAIL'],
-                (string) $configuration['PS_SHOP_NAME'],
-                null,
-                null,
-                __DIR__ . '/mails/',
-                false,
-                $idShop
-            );
         }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix issue when instead displaying employee name, {firstname} and {lastname} is shown instead. Also add product name to email.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes #20445.
| How to test?  | Email should now have product name included and display correct employee name.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20457)
<!-- Reviewable:end -->
