### PR TITLE
Remove overwritten property: context

### DIFF
--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -257,7 +257,6 @@ product_tabs['Combinations'] = new function(){
 					ajax: true,
 					action: 'editProductAttribute'
 				},
-				context: document.body,
 				dataType: 'json',
 				context: this,
 				async: false,
@@ -340,7 +339,6 @@ product_tabs['Combinations'] = new function(){
 				action: 'defaultProductAttribute',
 				ajax: true
 			},
-			context: document.body,
 			dataType: 'json',
 			context: this,
 			async: false,
@@ -372,7 +370,6 @@ product_tabs['Combinations'] = new function(){
 				action: 'deleteProductAttribute',
 				ajax: true
 			},
-			context: document.body,
 			dataType: 'json',
 			context: this,
 			async: false,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | All `context: document.body` are overwritten by `context: this`.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | It is not necessary

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20472)
<!-- Reviewable:end -->
