### PR TITLE
FrontOffice - Wrong base price in Invoice

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2551,6 +2551,11 @@ class OrderCore extends ObjectModel
                 $tax_rates[$tax->id] = $tax->rate;
             }
 
+             // deduct product price from $expected_total_base if there is no tax in product
+            if (empty($tax_calculator->getTaxesAmount($discounted_price_tax_excl))) {
+                $expected_total_base -= $discounted_price_tax_excl;
+            }
+
             foreach ($tax_calculator->getTaxesAmount($discounted_price_tax_excl) as $id_tax => $unit_amount) {
                 $total_tax_base = 0;
                 switch ($round_type) {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2551,7 +2551,7 @@ class OrderCore extends ObjectModel
                 $tax_rates[$tax->id] = $tax->rate;
             }
 
-             // deduct product price from $expected_total_base if there is no tax in product
+            // deduct product price from $expected_total_base if there is no tax in product
             if (empty($tax_calculator->getTaxesAmount($discounted_price_tax_excl))) {
                 $expected_total_base -= $discounted_price_tax_excl;
             }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Invoice is showing the wrong Base price in product tax breakdown when purchasing 2 (or more) products in which one (or more) product is without tax.https://prnt.sc/tryle8. This issue does not occur if tax rule applied to each product.https://prnt.sc/trymai . For more details see this issue #20415
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20415 .
| How to test?  | We made some corrections in the order.php file. You can add our code to resolve this issue.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20474)
<!-- Reviewable:end -->
