### PR TITLE
Set CartRule amount with tax in BO instead of without tax

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1967,23 +1967,23 @@ class CartCore extends ObjectModel
             $cartRules = $this->getTotalCalculationCartRules($type, $type == Cart::BOTH);
         }
 
-        $calculator = $this->newCalculator($products, $cartRules, $id_carrier);
         $computePrecision = Context::getContext()->getComputingPrecision();
+        $calculator = $this->newCalculator($products, $cartRules, $id_carrier, $computePrecision);
         switch ($type) {
             case Cart::ONLY_SHIPPING:
                 $calculator->calculateRows();
-                $calculator->calculateFees($computePrecision);
+                $calculator->calculateFees();
                 $amount = $calculator->getFees()->getInitialShippingFees();
 
                 break;
             case Cart::ONLY_WRAPPING:
                 $calculator->calculateRows();
-                $calculator->calculateFees($computePrecision);
+                $calculator->calculateFees();
                 $amount = $calculator->getFees()->getInitialWrappingFees();
 
                 break;
             case Cart::BOTH:
-                $calculator->processCalculation($computePrecision);
+                $calculator->processCalculation();
                 $amount = $calculator->getTotal();
 
                 break;
@@ -1999,7 +1999,7 @@ class CartCore extends ObjectModel
 
                 break;
             case Cart::ONLY_DISCOUNTS:
-                $calculator->processCalculation($computePrecision);
+                $calculator->processCalculation();
                 $amount = $calculator->getDiscountTotal();
 
                 break;
@@ -2022,12 +2022,13 @@ class CartCore extends ObjectModel
      * @param array $products list of products to calculate on
      * @param array $cartRules list of cart rules to apply
      * @param int $id_carrier carrier id (fees calculation)
+     * @param int|null $computePrecision
      *
      * @return \PrestaShop\PrestaShop\Core\Cart\Calculator
      */
-    public function newCalculator($products, $cartRules, $id_carrier)
+    public function newCalculator($products, $cartRules, $id_carrier, $computePrecision = null)
     {
-        $calculator = new Calculator($this, $id_carrier);
+        $calculator = new Calculator($this, $id_carrier, $computePrecision);
 
         /** @var PriceCalculator $priceCalculator */
         $priceCalculator = ServiceLocator::get(PriceCalculator::class);

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1114,8 +1114,8 @@ abstract class PaymentModuleCore extends Module
         $computingPrecision = Context::getContext()->getComputingPrecision();
 
         // prepare cart calculator to correctly get the value of each cart rule
-        $calculator = $cart->newCalculator($order->product_list, $cart->getCartRules(), $order->id_carrier);
-        $calculator->processCalculation($computingPrecision);
+        $calculator = $cart->newCalculator($order->product_list, $cart->getCartRules(), $order->id_carrier, $computingPrecision);
+        $calculator->processCalculation();
         $cartRulesData = $calculator->getCartRulesData();
 
         $cart_rules_list = [];

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -41,7 +41,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderDiscountType;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShopException;
-use Tools;
 use Validate;
 
 /**

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -101,11 +101,8 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
             $cartRuleObj->reduction_percent = (float) (string) $command->getDiscountValue();
         } elseif ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_AMOUNT) {
             $discountValueTaxIncluded = (float) (string) $command->getDiscountValue();
-            $discountValueTaxExcluded = Tools::ps_round(
-                $discountValueTaxIncluded / (1 + ($order->getTaxesAverageUsed() / 100)),
-                $precision
-            );
-            $cartRuleObj->reduction_amount = $discountValueTaxExcluded;
+            $cartRuleObj->reduction_amount = $discountValueTaxIncluded;
+            $cartRuleObj->reduction_tax = 1;
         } elseif ($command->getCartRuleType() === OrderDiscountType::FREE_SHIPPING) {
             $cartRuleObj->free_shipping = 1;
         }

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -172,8 +172,8 @@ class OrderAmountUpdater
         $newCartRules = $cart->getCartRules();
         // We need the calculator to compute the discuont on the whole products because they can interact with each
         // other so they can't be computed independently
-        $calculator = $cart->newCalculator($order->getCartProducts(), $newCartRules, null);
-        $calculator->processCalculation($computingPrecision);
+        $calculator = $cart->newCalculator($order->getCartProducts(), $newCartRules, null, $computingPrecision);
+        $calculator->processCalculation();
 
         foreach ($order->getCartRules() as $orderCartRuleData) {
             /** @var CartRuleData $cartRuleData */

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -27,7 +27,8 @@
 namespace PrestaShop\PrestaShop\Core\Cart;
 
 use Cart;
-use Context;
+use Currency;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use Tools;
 
 /**
@@ -87,7 +88,8 @@ class Calculator
         $this->cartRuleCalculator = new CartRuleCalculator();
 
         if (null === $computePrecision) {
-            $computePrecision = Context::getContext()->getComputingPrecision();
+            $currency = new Currency((int) $cart->id_currency);
+            $computePrecision = (new ComputingPrecision())->getPrecision($currency->precision);
         }
         $this->computePrecision = $computePrecision;
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
@@ -51,9 +51,7 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Then cart rule "cartrule2" has a contextual reduction value of 29.72
     When I use the discount "cartrule3"
     Then cart rule "cartrule3" has a contextual reduction value of 5.944
-    Then my cart total should be 33.7462 tax included
-    #known to fail on previous
-    #Then my cart total using previous calculation method should be 33.75 tax included
+    Then my cart total should be precisely 33.75 tax included
 
   @cumulative-percent-reduction
   Scenario: 3 products in cart, several quantities, 2x % global cartRules

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -108,16 +108,16 @@ Feature: Add discounts to order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0   |
       | total_shipping_tax_incl  | 7.42  |
       | total_discounts_tax_excl | 15.4  |
-      | total_discounts_tax_incl | 16.33 |
+      | total_discounts_tax_incl | 16.32 |
       | total_paid_tax_excl      | 15.4  |
-      | total_paid_tax_incl      | 16.32 |
-      | total_paid               | 16.32 |
+      | total_paid_tax_incl      | 16.33 |
+      | total_paid               | 16.33 |
       | total_paid_real          | 0     |
     Then Order "bo_order1" should have following prices:
       | products      | $23.80 |
       | discounts     | $15.40 |
       | shipping      | $7.00  |
-      | taxes         | $0.92  |
+      | taxes         | $0.93  |
       | total         | $15.40 |
 
   Scenario: Add amount discount matching fifty percent on products only
@@ -133,16 +133,16 @@ Feature: Add discounts to order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0   |
       | total_shipping_tax_incl  | 7.42  |
       | total_discounts_tax_excl | 11.9  |
-      | total_discounts_tax_incl | 12.62 |
+      | total_discounts_tax_incl | 12.61 |
       | total_paid_tax_excl      | 18.9  |
-      | total_paid_tax_incl      | 20.03 |
-      | total_paid               | 20.03 |
+      | total_paid_tax_incl      | 20.04 |
+      | total_paid               | 20.04 |
       | total_paid_real          | 0     |
     Then Order "bo_order1" should have following prices:
       | products      | $23.80 |
       | discounts     | $11.90 |
       | shipping      | $7.00  |
-      | taxes         | $1.13  |
+      | taxes         | $1.14  |
       | total         | $18.90 |
 
   Scenario: Add amount type discount to order and update single invoice

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -300,8 +300,8 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_discounts_tax_excl | 55.100 |
       | total_discounts_tax_incl | 58.410 |
       | total_paid_tax_excl      | 62.100 |
-      | total_paid_tax_incl      | 65.830 |
-      | total_paid               | 65.830 |
+      | total_paid_tax_incl      | 65.820 |
+      | total_paid               | 65.820 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Since we compute all the cart rules when editing/adding/deleting products in the BO, because of the way cart rules amount added in the BO was saved we miss precision and that led to incorrect discount amount. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes (function parameter ignored)
| Deprecations? | no
| Fixed ticket? | Fixes #20462
| How to test?  | 1. Create a product with Price tax included= 14.30, Tax rule =20%<br>2. Go to FO, add the last product created to the cart => complete the order<br>3. Go to the BO => Orders => View the last Order created<br>4. Add a new discount 10 euro => You should see the total discount = 10€ (same thing on the invoice)<br>5. Try to update the product's price with 15€, 17€ & 20€ (TTC) and check that the discount value is still 10€

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20482)
<!-- Reviewable:end -->
