### PR TITLE
Fix UpdateCustomizationFieldsHandler todo

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductCustomizationFieldsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductCustomizationFieldsHandler.php
@@ -38,8 +38,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\Delet
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\UpdateCustomizationFieldHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\UpdateProductCustomizationFieldsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationField;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryHandler\GetProductCustomizationFieldsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
@@ -105,11 +105,11 @@ class UpdateProductCustomizationFieldsHandler extends AbstractCustomizationField
         }
 
         $this->deleteCustomizationFields($deletableFieldIds);
+        $product = $this->getProduct($command->getProductId());
 
-        //@todo: return only ids instead.
-        return $this->getProductCustomizationFieldsHandler->handle(
-            new GetProductCustomizationFields($command->getProductId()->getValue())
-        );
+        return array_map(function ($customizationFieldId) {
+            return new CustomizationFieldId($customizationFieldId);
+        }, $product->getNonDeletedCustomizationFieldIds());
     }
 
     /**

--- a/src/Adapter/Product/CommandHandler/UpdateProductCustomizationFieldsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductCustomizationFieldsHandler.php
@@ -38,7 +38,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\Delet
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\UpdateCustomizationFieldHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\UpdateProductCustomizationFieldsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationField;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryHandler\GetProductCustomizationFieldsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
@@ -65,26 +64,18 @@ class UpdateProductCustomizationFieldsHandler extends AbstractCustomizationField
     private $deleteCustomizationFieldHandler;
 
     /**
-     * @var GetProductCustomizationFieldsHandlerInterface
-     */
-    private $getProductCustomizationFieldsHandler;
-
-    /**
      * @param AddCustomizationFieldHandlerInterface $addCustomizationFieldHandler
      * @param UpdateCustomizationFieldHandlerInterface $updateCustomizationFieldHandler
      * @param DeleteCustomizationFieldHandlerInterface $deleteCustomizationFieldHandler
-     * @param GetProductCustomizationFieldsHandlerInterface $getProductCustomizationFieldsHandler
      */
     public function __construct(
         AddCustomizationFieldHandlerInterface $addCustomizationFieldHandler,
         UpdateCustomizationFieldHandlerInterface $updateCustomizationFieldHandler,
-        DeleteCustomizationFieldHandlerInterface $deleteCustomizationFieldHandler,
-        GetProductCustomizationFieldsHandlerInterface $getProductCustomizationFieldsHandler
+        DeleteCustomizationFieldHandlerInterface $deleteCustomizationFieldHandler
     ) {
         $this->addCustomizationFieldHandler = $addCustomizationFieldHandler;
         $this->updateCustomizationFieldHandler = $updateCustomizationFieldHandler;
         $this->deleteCustomizationFieldHandler = $deleteCustomizationFieldHandler;
-        $this->getProductCustomizationFieldsHandler = $getProductCustomizationFieldsHandler;
     }
 
     /**

--- a/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command;
 
+use LogicException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
@@ -47,13 +48,37 @@ class UpdateProductCustomizationFieldsCommand
     private $customizationFields = [];
 
     /**
+     * Builds command to replace existing customization fields with provided ones.
+     *
      * @param int $productId
      * @param array $customizationFields
+     *
+     * @return static
      */
-    public function __construct(int $productId, array $customizationFields)
+    public static function replace(int $productId, array $customizationFields): self
     {
-        $this->productId = new ProductId($productId);
-        $this->setCustomizationFields($customizationFields);
+        if (empty($customizationFields)) {
+            throw new LogicException(sprintf(
+                'Providing empty array will remove all customization fields. Use %s::deleteAll()', self::class
+            ));
+        }
+
+        return new self(
+            $productId,
+            $customizationFields
+        );
+    }
+
+    /**
+     * Builds command to delete all existing CustomizationFields for provided product
+     *
+     * @param int $productId
+     *
+     * @return UpdateProductCustomizationFieldsCommand
+     */
+    public static function deleteAll(int $productId): self
+    {
+        return new self($productId, []);
     }
 
     /**
@@ -70,6 +95,18 @@ class UpdateProductCustomizationFieldsCommand
     public function getCustomizationFields(): array
     {
         return $this->customizationFields;
+    }
+
+    /**
+     * Use static factories to initiate this class
+     *
+     * @param int $productId
+     * @param array $customizationFields
+     */
+    private function __construct(int $productId, array $customizationFields)
+    {
+        $this->productId = new ProductId($productId);
+        $this->setCustomizationFields($customizationFields);
     }
 
     /**

--- a/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command;
 
-use LogicException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
@@ -48,37 +47,13 @@ class UpdateProductCustomizationFieldsCommand
     private $customizationFields = [];
 
     /**
-     * Builds command to replace existing customization fields with provided ones.
-     *
      * @param int $productId
      * @param array $customizationFields
-     *
-     * @return static
      */
-    public static function replace(int $productId, array $customizationFields): self
+    public function __construct(int $productId, array $customizationFields)
     {
-        if (empty($customizationFields)) {
-            throw new LogicException(sprintf(
-                'Providing empty array will remove all customization fields. Use %s::deleteAll()', self::class
-            ));
-        }
-
-        return new self(
-            $productId,
-            $customizationFields
-        );
-    }
-
-    /**
-     * Builds command to delete all existing CustomizationFields for provided product
-     *
-     * @param int $productId
-     *
-     * @return UpdateProductCustomizationFieldsCommand
-     */
-    public static function deleteAll(int $productId): self
-    {
-        return new self($productId, []);
+        $this->productId = new ProductId($productId);
+        $this->setCustomizationFields($customizationFields);
     }
 
     /**
@@ -95,18 +70,6 @@ class UpdateProductCustomizationFieldsCommand
     public function getCustomizationFields(): array
     {
         return $this->customizationFields;
-    }
-
-    /**
-     * Use static factories to initiate this class
-     *
-     * @param int $productId
-     * @param array $customizationFields
-     */
-    private function __construct(int $productId, array $customizationFields)
-    {
-        $this->productId = new ProductId($productId);
-        $this->setCustomizationFields($customizationFields);
     }
 
     /**

--- a/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
@@ -78,14 +78,12 @@ class UpdateProductCustomizationFieldsCommand
     private function setCustomizationFields(array $customizationFields): void
     {
         foreach ($customizationFields as $customizationField) {
-            $byModule = isset($customizationField['added_by_module']) ? (bool) $customizationField['added_by_module'] : false;
-
             $this->customizationFields[] = new CustomizationField(
                 (int) $customizationField['type'],
                 $customizationField['localized_names'],
                 (bool) $customizationField['is_required'],
-                !empty($customizationField['id']) ? (int) $customizationField['id'] : null,
-                $byModule
+                (bool) $customizationField['added_by_module'],
+                (int) $customizationField['id'] ?? null
             );
         }
     }

--- a/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
@@ -51,7 +51,9 @@ class UpdateProductCustomizationFieldsCommand
      * Builds command to replace existing customization fields with provided ones.
      *
      * @param int $productId
-     * @param array $customizationFields
+     * @param array[] $customizationFields
+     *
+     * @see UpdateProductCustomizationFieldsCommand::setCustomizationFields() for $customizationFields array structure.
      *
      * @return static
      */

--- a/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/UpdateProductCustomizationFieldsCommand.php
@@ -51,9 +51,7 @@ class UpdateProductCustomizationFieldsCommand
      * Builds command to replace existing customization fields with provided ones.
      *
      * @param int $productId
-     * @param array[] $customizationFields
-     *
-     * @see UpdateProductCustomizationFieldsCommand::setCustomizationFields() for $customizationFields array structure.
+     * @param array $customizationFields
      *
      * @return static
      */

--- a/src/Core/Domain/Product/Customization/CommandHandler/UpdateProductCustomizationFieldsHandlerInterface.php
+++ b/src/Core/Domain/Product/Customization/CommandHandler/UpdateProductCustomizationFieldsHandlerInterface.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
 
 /**
  * Defines contract to handle @var UpdateProductCustomizationFieldsCommand
@@ -39,7 +39,7 @@ interface UpdateProductCustomizationFieldsHandlerInterface
     /**
      * @param UpdateProductCustomizationFieldsCommand $command
      *
-     * @return CustomizationField[]
+     * @return CustomizationFieldId[]
      */
     public function handle(UpdateProductCustomizationFieldsCommand $command): array;
 }

--- a/src/Core/Domain/Product/Customization/CustomizationField.php
+++ b/src/Core/Domain/Product/Customization/CustomizationField.php
@@ -49,43 +49,34 @@ class CustomizationField
     private $required;
 
     /**
-     * @var int|null
-     */
-    private $customizationFieldId;
-
-    /**
      * @var bool
      */
     private $addedByModule;
 
     /**
+     * @var int|null
+     */
+    private $customizationFieldId;
+
+    /**
      * @param int $type
      * @param string[] $localizedNames
      * @param bool $required
-     * @param int|null $customizationFieldId
      * @param bool $addedByModule
-     * @todo: require all fields except the id.
+     * @param int|null $customizationFieldId If provided, means that its existing CustomizationField and should be updated
      */
     public function __construct(
         int $type,
         array $localizedNames,
         bool $required,
-        ?int $customizationFieldId = null,
-        bool $addedByModule = false
+        bool $addedByModule = false,
+        ?int $customizationFieldId = null
     ) {
         $this->type = $type;
         $this->localizedNames = $localizedNames;
         $this->required = $required;
-        $this->customizationFieldId = $customizationFieldId ?? null;
         $this->addedByModule = $addedByModule;
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getCustomizationFieldId(): ?int
-    {
-        return $this->customizationFieldId;
+        $this->customizationFieldId = $customizationFieldId ?? null;
     }
 
     /**
@@ -118,5 +109,13 @@ class CustomizationField
     public function isAddedByModule(): bool
     {
         return $this->addedByModule;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getCustomizationFieldId(): ?int
+    {
+        return $this->customizationFieldId;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -160,7 +160,6 @@ services:
         - '@prestashop.adapter.product.command_handler.add_customization_field_handler'
         - '@prestashop.adapter.product.command_handler.update_customization_field_handler'
         - '@prestashop.adapter.product.command_handler.delete_customization_field_handler'
-        - '@prestashop.adapter.product.query_handler.get_product_customization_fields_handler'
       tags:
         - name: tactician.handler
           command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -297,11 +297,16 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      */
     private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate): void
     {
+        $productId = $this->getSharedStorage()->get($productReference);
+
         try {
-            $newCustomizationFieldIds = $this->getCommandBus()->handle(new UpdateProductCustomizationFieldsCommand(
-                $this->getSharedStorage()->get($productReference),
-                $fieldsForUpdate
-            ));
+            if (empty($fieldsForUpdate)) {
+                $command = UpdateProductCustomizationFieldsCommand::deleteAll($productId);
+            } else {
+                $command = UpdateProductCustomizationFieldsCommand::replace($productId, $fieldsForUpdate);
+            }
+
+            $newCustomizationFieldIds = $this->getCommandBus()->handle($command);
 
             Assert::assertSameSize(
                 $fieldReferences,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProduc
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use RuntimeException;
@@ -297,20 +298,20 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
     private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate): void
     {
         try {
-            $newCustomizationFields = $this->getCommandBus()->handle(new UpdateProductCustomizationFieldsCommand(
+            $newCustomizationFieldIds = $this->getCommandBus()->handle(new UpdateProductCustomizationFieldsCommand(
                 $this->getSharedStorage()->get($productReference),
                 $fieldsForUpdate
             ));
 
             Assert::assertSameSize(
                 $fieldReferences,
-                $newCustomizationFields,
+                $newCustomizationFieldIds,
                 'Cannot set references in shared storage. References and actual customization fields doesn\'t match.'
             );
 
-            /** @var CustomizationField $customizationField */
-            foreach ($newCustomizationFields as $key => $customizationField) {
-                $this->getSharedStorage()->set($fieldReferences[$key], $customizationField->getCustomizationFieldId());
+            /** @var CustomizationFieldId $customizationFieldId */
+            foreach ($newCustomizationFieldIds as $key => $customizationFieldId) {
+                $this->getSharedStorage()->set($fieldReferences[$key], $customizationFieldId->getValue());
             }
         } catch (ProductException $e) {
             $this->setLastException($e);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -297,16 +297,11 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      */
     private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate): void
     {
-        $productId = $this->getSharedStorage()->get($productReference);
-
         try {
-            if (empty($fieldsForUpdate)) {
-                $command = UpdateProductCustomizationFieldsCommand::deleteAll($productId);
-            } else {
-                $command = UpdateProductCustomizationFieldsCommand::replace($productId, $fieldsForUpdate);
-            }
-
-            $newCustomizationFieldIds = $this->getCommandBus()->handle($command);
+            $newCustomizationFieldIds = $this->getCommandBus()->handle(new UpdateProductCustomizationFieldsCommand(
+                $this->getSharedStorage()->get($productReference),
+                $fieldsForUpdate
+            ));
 
             Assert::assertSameSize(
                 $fieldReferences,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes todo. See below
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #19681
| How to test?  | none. Behats must pass

(Fixes #19681)

## Description

**1.** To be closer to current convention (`Add` commands used to always return new resource id, so such new type of Bulk update command should do the same), instead of returning array of DTO's(CustomizationField) , the UpdateCustomizationFieldsHandler now returns array of CustomizationFieldIds.
**2.** requires all properties except id in CustomizationField DTO which is used in UpdateCustomizationFieldsHandler. The handler is complex and it decides weather to add, update or delete resource, so it is less confusing to just let the id be optional, but require all other fields.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20491)
<!-- Reviewable:end -->
