### PR TITLE
Remove call to updateOrderInvoice - not needed anymore

### DIFF
--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -144,8 +144,6 @@ class OrderProductQuantityUpdater
 
             // Update prices on the order after cart rules are recomputed
             $this->orderAmountUpdater->update($order, $cart, null !== $orderInvoice ? (int) $orderInvoice->id : null);
-
-            $this->updateOrderInvoice($orderDetail, $orderInvoice);
         } finally {
             $this->contextStateManager->restoreContext();
         }

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -397,47 +397,6 @@ class OrderProductQuantityUpdater
     }
 
     /**
-     * @todo The invoice update is managed through the OrderAmountUpdater now, this method
-     * existed before. The only use case where it can be usefull is if the OrderDetail->id_order_invoice
-     * can be different from the Invoice fetched from the command value in the UpdateProductQuantityHandler
-     * This is the last use case that requires manual update of the invoice If it is not needed, this method
-     * along with the command should be cleaned so that the invoice id is ALWAYS the one from the OrderDetail
-     *
-     * @param OrderDetail $orderDetail
-     * @param OrderInvoice|null $orderInvoice
-     *
-     * @throws \PrestaShopDatabaseException
-     * @throws \PrestaShopException
-     */
-    private function updateOrderInvoice(OrderDetail $orderDetail, ?OrderInvoice $orderInvoice): void
-    {
-        if ($orderDetail->id_order_invoice != 0) {
-            $orderDetailInvoice = new OrderInvoice($orderDetail->id_order_invoice);
-            // @todo: use https://github.com/PrestaShop/decimal for price computations
-            $orderDetailInvoice->total_paid_tax_excl -= $orderDetail->total_price_tax_excl;
-            $orderDetailInvoice->total_paid_tax_incl -= $orderDetail->total_price_tax_incl;
-            $orderDetailInvoice->total_products -= $orderDetail->total_price_tax_excl;
-            $orderDetailInvoice->total_products_wt -= $orderDetail->total_price_tax_incl;
-
-            $orderDetailInvoice->update();
-        }
-
-        // Apply change on OrderInvoice
-        if (isset($orderInvoice) && $orderDetail->id_order_invoice != $orderInvoice->id) {
-            $orderInvoice->total_products += $orderDetail->total_price_tax_excl;
-            $orderInvoice->total_products_wt += $orderDetail->total_price_tax_incl;
-
-            $orderInvoice->total_paid_tax_excl += $orderDetail->total_price_tax_excl;
-            $orderInvoice->total_paid_tax_incl += $orderDetail->total_price_tax_incl;
-
-            $orderDetail->id_order_invoice = $orderInvoice->id;
-
-            $orderInvoice->update();
-            $orderDetail->update();
-        }
-    }
-
-    /**
      * @param Cart $cart
      *
      * @return Country


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Remove call to updateOrderInvoice - not needed anymore and it fixes a bug
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20467
| How to test?  | See ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20492)
<!-- Reviewable:end -->
