### PR TITLE
Add selectors in Order page for modules

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -31,7 +31,7 @@
   </div>
 
   <div class="card-body">
-    <div class="info-block">
+    <div id="customerBasicInformations" class="info-block">
       <div class="row">
         {% if orderForViewing.customer is not null %}
         <div class="col-md-6">
@@ -61,8 +61,8 @@
       </div>
     </div>
     {% if orderForViewing.customer is not null %}
-    <div class="row mt-3">
-      <div class="col-md-6">
+    <div id="customerDetailedInformationsBlock" class="row mt-3">
+      <div id="customerAccountBlock" class="col-md-6">
         <p class="mb-1">
           <strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong>
         </p>
@@ -79,7 +79,7 @@
           <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
         {% endif %}
       </div>
-      <div class="col-md-6">
+      <div id="customerOrdersBlock" class="col-md-6">
         <p class="mb-1">
           <strong>{{ 'Validated orders placed:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
         </p>
@@ -98,10 +98,10 @@
       </div>
     </div>
     {% endif %}
-    <div class="info-block mt-2">
+    <div id="customerAddressesBlock" class="info-block mt-2">
       <div class="row">
         {% if orderForViewing.virtual is same as(false) %}
-        <div class="info-block-col col-xl-6">
+        <div id="addressShipping" class="info-block-col col-xl-6">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
             {% if orderForViewing.customer is not null %}
@@ -150,7 +150,7 @@
           </p>
         </div>
         {% endif %}
-        <div class="info-block-col {% if orderForViewing.virtual %}col-md-12{% else %}col-md-6{% endif %}">
+        <div id="addressInvoice" class="info-block-col {% if orderForViewing.virtual %}col-md-12{% else %}col-md-6{% endif %}">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Invoice address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 
@@ -202,7 +202,7 @@
       </div>
     </div>
     {% if orderForViewing.customer is not null %}
-    <div class="mt-2 info-block">
+    <div id="customerPrivateNotesBlock" class="mt-2 info-block">
       <div class="row">
         {% set isPrivateNoteOpen = not orderForViewing.customer.privateNote is empty %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -39,8 +39,8 @@
   {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }} ({{ orderForViewing.returns.orderReturns|length }})
 {% endset %}
 
-<div class="mt-2">
-  <ul class="nav nav nav-tabs d-print-none" role="tablist">
+<div id="orderTabs" class="mt-2">
+  <ul id="orderTabTitles" class="nav nav nav-tabs d-print-none" role="tablist">
     <li class="nav-item">
       <a class="nav-link active show" id="historyTab" data-toggle="tab" href="#historyTabContent" role="tab" aria-controls="historyTabContent" aria-expanded="true" aria-selected="false">
         <i class="material-icons">history</i>
@@ -67,7 +67,7 @@
     </li>
   </ul>
 
-  <div class="tab-content">
+  <div id="orderTabContents" class="tab-content">
     <div class="tab-pane d-print-block fade show active" id="historyTabContent" role="tabpanel" aria-labelledby="historyTab">
       {% embed '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details_card.html.twig' %}
         {% block header %}
@@ -114,7 +114,7 @@
 {% set displayAdminOrderTabLink = renderhook('displayAdminOrderTabLink', {'id_order': orderForViewing.id}) %}
 {% set displayAdminOrderTabContent = renderhook('displayAdminOrderTabContent', {'id_order': orderForViewing.id}) %}
 {% if displayAdminOrderTabLink is not empty or displayAdminOrderTabContent is not empty%}
-  <div class="mt-2" id="order_hook_tabs">
+  <div id="orderHookTabs" class="mt-2" id="order_hook_tabs">
     <ul class="nav nav nav-tabs" role="tablist">
       {# Rendering of hook displayAdminOrderTabLink, we expect tab links #}
       {{ displayAdminOrderTabLink|raw }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<table class="table discountList{% if discounts is empty %} d-none{% endif %}">
+<table id="orderDiscountList" class="table discountList{% if discounts is empty %} d-none{% endif %}">
   <thead>
   <tr>
     <th>{{ 'Name'|trans({}, 'Admin.Global') }}</th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<table class="table mb-3">
+<table id="orderDocuments" class="table mb-3">
   <thead>
   <tr>
     <th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<table class="table">
+<table id="orderHistory" class="table">
   <tbody>
     {% for status in orderForViewing.history.statuses %}
     <tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig
@@ -25,7 +25,7 @@
 
 {% if not orderForViewing.virtual %}
   {% if orderForViewing.returns.orderReturns is not empty %}
-    <table class="table">
+    <table id="orderReturns" class="table">
       <thead>
       <tr>
         <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig
@@ -27,7 +27,7 @@
 
 {% set messagesToShow = 4 %}
 
-<div class="card mt-2 d-print-none">
+<div id="customerMessagesBlock" class="card mt-2 d-print-none">
   <div class="card-header">
     <div class="row">
       <div class="col-md-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig
@@ -30,7 +30,7 @@
     }
   }) }}
 
-  <div class="input-group">
+  <div id="orderActions" class="input-group">
     {% set backgroundColor = '#ffffff' %}
     {% set isBright = true %}
     {% for choice in updateOrderStatusActionBarForm.new_order_status_id.vars.choices %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -26,7 +26,7 @@
 {% if not orderForViewing.virtual %}
 
     {% if orderForViewing.shipping.giftMessage %}
-      <div class="row col-lg-12">
+      <div id="orderGitMessage" class="row col-lg-12">
         <label>
           {{ 'Gift message:'|trans({}, 'Admin.Global') }}
         </label>
@@ -36,7 +36,7 @@
       </div>
     {% endif %}
 
-    <table class="table">
+    <table id="orderShipping" class="table">
     <thead>
       <tr>
         <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
@@ -24,7 +24,7 @@
  *#}
 
   {% if orderForViewing.sources.sources is not empty %}
-    <div class="card mt-2 d-print-none">
+    <div id="orderSources" class="card mt-2 d-print-none">
       <div class="card-header">
         <div class="row">
           <div class="col-md-6">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add selectors in Order page for modules. This selectors make it easy for modules to manipulate the DOM for extension purposes.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/18776 and https://github.com/PrestaShop/PrestaShop/issues/20605 when used in combination with https://github.com/PrestaShopCorp/psgdpr/pull/96/files PR on psgdpr module
| How to test?  | See ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20493)
<!-- Reviewable:end -->
