### PR TITLE
Bug when cart empty

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3704,7 +3704,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return isset(self::$_totalWeight[(int) $this->id]) ? self::$_totalWeight[(int) $this->id] : 0;
+        return (float) (self::$_totalWeight[(int) $this->id] ?? 0);
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3704,7 +3704,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return (float) (self::$_totalWeight[(int) $this->id] ?? 0);
+        return self::$_totalWeight[(int) $this->id] ?? 0;
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3704,7 +3704,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return self::$_totalWeight[(int) $this->id];
+        return (isset(self::$_totalWeight[$this->id]) ? self::$_totalWeight[$this->id] : 0);
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3704,7 +3704,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return isset(self::$_totalWeight[$this->id]) ? self::$_totalWeight[$this->id] : 0;
+        return isset(self::$_totalWeight[(int) $this->id]) ? self::$_totalWeight[(int) $this->id] : 0;
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3704,7 +3704,7 @@ class CartCore extends ObjectModel
             $this->updateProductWeight($this->id);
         }
 
-        return (isset(self::$_totalWeight[$this->id]) ? self::$_totalWeight[$this->id] : 0);
+        return isset(self::$_totalWeight[$this->id]) ? self::$_totalWeight[$this->id] : 0;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When cart empty i want call method for get total cart
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20496.
| How to test?  | Create new cart. Call method getOrderTotal

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20497)
<!-- Reviewable:end -->
