### PR TITLE
Use static factories for bulk product update commands

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductCategoriesHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductCategoriesHandler.php
@@ -83,7 +83,7 @@ final class UpdateProductCategoriesHandler extends AbstractProductHandler implem
      */
     private function updateOnlyDefaultCategory(Product $product, int $defaultCategoryId): void
     {
-        $currentProductCategories = Product::getProductCategories();
+        $currentProductCategories = array_map('intval', $product->getCategories());
         $currentProductCategories[] = $defaultCategoryId;
 
         $this->updateCategories($product, $currentProductCategories);

--- a/src/Adapter/Product/CommandHandler/UpdateProductSuppliersHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductSuppliersHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use LogicException;
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CombinationConstraintException;
@@ -91,7 +90,6 @@ final class UpdateProductSuppliersHandler extends AbstractProductHandler impleme
      */
     public function handle(UpdateProductSuppliersCommand $command): array
     {
-        $this->assertCommandIsNotEmpty($command);
         $productId = $command->getProductId();
 
         if (null !== $command->getProductSuppliers()) {
@@ -119,7 +117,7 @@ final class UpdateProductSuppliersHandler extends AbstractProductHandler impleme
         $defaultSupplierId = $command->getDefaultSupplierId();
         $defaultSupplierIsProvided = null !== $defaultSupplierId;
 
-        if (!$defaultSupplierIsProvided) {
+        if (!$defaultSupplierIsProvided && !empty($command->getProductSuppliers())) {
             $firstSupplier = $command->getProductSuppliers()[0];
             $this->updateDefaultSupplier($productId, $firstSupplier->getSupplierId());
 
@@ -306,20 +304,5 @@ final class UpdateProductSuppliersHandler extends AbstractProductHandler impleme
         }
 
         return $productSupplierIds;
-    }
-
-    /**
-     * @param UpdateProductSuppliersCommand $command
-     */
-    private function assertCommandIsNotEmpty(UpdateProductSuppliersCommand $command): void
-    {
-        if (null !== $command->getDefaultSupplierId() || null !== $command->getProductSuppliers()) {
-            return;
-        }
-
-        throw new LogicException(sprintf(
-            '%s command properties are empty. You must set at least one property to update',
-            UpdateProductSuppliersCommand::class
-        ));
     }
 }

--- a/src/Core/Domain/Product/Command/UpdateProductCategoriesCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCategoriesCommand.php
@@ -96,9 +96,9 @@ class UpdateProductCategoriesCommand
     }
 
     /**
-     * @return CategoryId
+     * @return CategoryId|null
      */
-    public function getDefaultCategoryId(): CategoryId
+    public function getDefaultCategoryId(): ?CategoryId
     {
         return $this->defaultCategoryId;
     }

--- a/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductTagsCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
+use LogicException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
@@ -48,16 +49,6 @@ class UpdateProductTagsCommand
     private $localizedTagsList;
 
     /**
-     * @param int $productId
-     * @param array $localizedTags
-     */
-    public function __construct(int $productId, array $localizedTags)
-    {
-        $this->productId = new ProductId($productId);
-        $this->setLocalizedTagsList($localizedTags);
-    }
-
-    /**
      * @return ProductId
      */
     public function getProductId(): ProductId
@@ -71,6 +62,49 @@ class UpdateProductTagsCommand
     public function getLocalizedTagsList(): array
     {
         return $this->localizedTagsList;
+    }
+
+    /**
+     * Builds command to replace all existing localized tags with provided ones for product
+     *
+     * @param int $productId
+     * @param array[] $localizedTagsList key-value pairs where each key represents language id and value is the array of tags
+     *
+     * @return static
+     */
+    public static function replace(int $productId, array $localizedTagsList): self
+    {
+        if (empty($localizedTagsList)) {
+            throw new LogicException(sprintf(
+                'Providing empty array will remove all tags. Use %s::deleteAll()', self::class
+            ));
+        }
+
+        return new self($productId, $localizedTagsList);
+    }
+
+    /**
+     * Builds command to delete all existing tags for product
+     *
+     * @param int $productId
+     *
+     * @return static
+     */
+    public static function deleteAll(int $productId): self
+    {
+        return new self($productId, []);
+    }
+
+    /**
+     * Use static factories to initiate this class
+     *
+     * @param int $productId
+     * @param array $localizedTags
+     */
+    private function __construct(int $productId, array $localizedTags)
+    {
+        $this->productId = new ProductId($productId);
+        $this->setLocalizedTagsList($localizedTags);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -85,6 +85,20 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @When I assign product :productReference to default category :categoryReference
+     *
+     * @param string $productReference
+     * @param string $categoryReference
+     */
+    public function updateOnlyDefaultCategory(string $productReference, string $categoryReference)
+    {
+        $this->assignProductToCategories(
+            $this->getSharedStorage()->get($productReference),
+            $this->getSharedStorage()->get($categoryReference)
+        );
+    }
+
+    /**
      * @Then product :productReference should be assigned to following categories:
      *
      * @param string $productReference

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -75,6 +75,16 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @When I delete all categories from product :productReference except the default one
+     *
+     * @param string $productReference
+     */
+    public function deleteAllProductCategoriesExceptDefault(string $productReference)
+    {
+        $this->assignProductToCategories($this->getSharedStorage()->get($productReference));
+    }
+
+    /**
      * @Then product :productReference should be assigned to following categories:
      *
      * @param string $productReference
@@ -143,7 +153,7 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
      * @param int $defaultCategoryId
      * @param array $categoryIds
      */
-    private function assignProductToCategories(int $productId, int $defaultCategoryId, array $categoryIds): void
+    private function assignProductToCategories(int $productId, ?int $defaultCategoryId = null, array $categoryIds = []): void
     {
         try {
             if (empty($categoryIds) && !empty($defaultCategoryId)) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -146,11 +146,15 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
     private function assignProductToCategories(int $productId, int $defaultCategoryId, array $categoryIds): void
     {
         try {
-            $this->getCommandBus()->handle(new UpdateProductCategoriesCommand(
-                $productId,
-                $defaultCategoryId,
-                $categoryIds
-            ));
+            if (empty($categoryIds) && !empty($defaultCategoryId)) {
+                $command = UpdateProductCategoriesCommand::updateOnlyDefault($productId, $defaultCategoryId);
+            } elseif (empty($categoryIds) && empty($defaultCategoryId)) {
+                $command = UpdateProductCategoriesCommand::deleteAllExceptDefault($productId);
+            } else {
+                $command = UpdateProductCategoriesCommand::replace($productId, $defaultCategoryId, $categoryIds);
+            }
+
+            $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -54,6 +54,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
             $products[] = [
                 'product_id' => $this->getSharedStorage()->get($productReference),
                 'quantity' => (int) $quantity,
+                'combination_id' => isset($data['combination']) ? $this->getSharedStorage()->get($data['combination']) : null,
             ];
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -72,7 +72,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
         $packId = $this->getSharedStorage()->get($packReference);
 
         try {
-            $this->getCommandBus()->handle(UpdateProductPackCommand::cleanPack($packId));
+            $this->getCommandBus()->handle(UpdateProductPackCommand::deleteAll($packId));
         } catch (ProductException $e) {
             $this->setLastException($e);
         }
@@ -167,7 +167,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
     private function upsertPack(int $packId, array $products): void
     {
         try {
-            $this->getCommandBus()->handle(UpdateProductPackCommand::upsertPack(
+            $this->getCommandBus()->handle(UpdateProductPackCommand::replace(
                 $packId,
                 $products
             ));

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
@@ -57,7 +57,13 @@ class UpdateTagsFeatureContext extends AbstractProductFeatureContext
         }
 
         try {
-            $this->getCommandBus()->handle(new UpdateProductTagsCommand($productId, $localizedTagsList));
+            if (empty($localizedTagsList)) {
+                $command = UpdateProductTagsCommand::deleteAll($productId);
+            } else {
+                $command = UpdateProductTagsCommand::replace($productId, $localizedTagsList);
+            }
+
+            $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
@@ -89,3 +89,13 @@ Feature: Update product categories from Back Office (BO)
       And product product3 should be assigned to following categories:
         | categories       | [women, accessories] |
         | default category | accessories          |
+
+    Scenario: I delete all categories from product except the default one
+      Given product product3 should be assigned to following categories:
+        | categories       | [women, accessories] |
+        | default category | accessories          |
+      When I delete all categories from product product3 except the default one
+      And product product3 should be assigned to following categories:
+        | categories       | [accessories] |
+        | default category | accessories   |
+#    Scenario: Update only default category which exists, but is not yet assigned to product

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
@@ -98,4 +98,12 @@ Feature: Update product categories from Back Office (BO)
       And product product3 should be assigned to following categories:
         | categories       | [accessories] |
         | default category | accessories   |
-#    Scenario: Update only default category which exists, but is not yet assigned to product
+
+    Scenario: Update only default category which exists, but is not yet assigned to product
+      Given product product3 should be assigned to following categories:
+        | categories       | [accessories] |
+        | default category | accessories   |
+      When I assign product product3 to default category "men"
+      Then product product3 should be assigned to following categories:
+        | categories       | [accessories, men] |
+        | default category | men                |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Static factories improves code readability. Change for UpdateProductSuppliersCommand, UpdateProductTagsCommand, UpdateProductPack, UpdateProductCategoriesCommand. (UpdateCustomizationFieldsCommand changed using same convention in another pr). In addition this also provides partial update endpoint for categories
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | none. Behats must pass

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20501)
<!-- Reviewable:end -->
