### PR TITLE
Fix FormSubmitButton method

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form-submit-button.js
+++ b/admin-dev/themes/new-theme/js/components/form-submit-button.js
@@ -81,7 +81,7 @@ export default class FormSubmitButton {
 
       const $form = $('<form>', {
         action: $btn.data('form-submit-url'),
-        method: method,
+        method,
       });
 
       if (addInput) {

--- a/admin-dev/themes/new-theme/js/components/form-submit-button.js
+++ b/admin-dev/themes/new-theme/js/components/form-submit-button.js
@@ -74,14 +74,14 @@ export default class FormSubmitButton {
           addInput = $('<input>', {
             type: '_hidden',
             name: '_method',
-            value: method,
+            value: btnMethod,
           });
         }
       }
 
       const $form = $('<form>', {
         action: $btn.data('form-submit-url'),
-        method: 'POST',
+        method: method,
       });
 
       if (addInput) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 1. Fix form method: Before, always 'POST' (I think it was lost in some Merge)<br>2. Fix _method value to btnMethod. Previously only GET or POST even if the button had another
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | https://github.com/PrestaShop/PrestaShop/pull/20508#issuecomment-686628912

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20508)
<!-- Reviewable:end -->
