### PR TITLE
Fix links in footer - https is better than http

### DIFF
--- a/admin-dev/themes/default/template/footer.tpl
+++ b/admin-dev/themes/default/template/footer.tpl
@@ -29,7 +29,7 @@
 <div id="footer" class="bootstrap hide">
 
 	<div class="col-sm-2 hidden-xs">
-		<a href="http://www.prestashop.com/" class="_blank">PrestaShop&trade;</a>
+		<a href="https://www.prestashop.com/" class="_blank">PrestaShop&trade;</a>
 		-
 		<span id="footer-load-time"><i class="icon-time" title="{l s='Load time:' d='Admin.Navigation.Footer'}"></i> {number_format(microtime(true) - $timer_start, 3, '.', '')}s</span>
 	</div>
@@ -52,7 +52,7 @@
 	</div>
 	<div class="col-sm-5">
 		<div class="footer-contact">
-			<a href="http://www.prestashop.com/en/contact_us?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
+			<a href="https://www.prestashop.com/en/contact_us?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
 				<i class="icon-envelope"></i>
 				{l s='Contact' d='Admin.Navigation.Footer'}
 			</a>
@@ -67,12 +67,12 @@
 				{l s='User Club' d='Admin.Navigation.Footer'}
 			</a>
 			/&nbsp;
-			<a href="http://feedback.prestashop.com/forums/387864-prestashop-1-7-x?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
+			<a href="https://feedback.prestashop.com/forums/387864-prestashop-1-7-x?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
 				<i class="icon-lightbulb"></i>
 				{l s='Feature Requests' d='Admin.Navigation.Footer'}
 			</a>
 			/&nbsp;
-			<a href="http://www.prestashop.com/forums/?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
+			<a href="https://www.prestashop.com/forums/?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
 				<i class="icon-comments"></i>
 				{l s='Forum' d='Admin.Navigation.Footer'}
 			</a>
@@ -82,7 +82,7 @@
 				{l s='Addons' d='Admin.Navigation.Footer'}
 			</a>
 			/&nbsp;
-			<a href="http://www.prestashop.com/en/training-prestashop?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
+			<a href="https://www.prestashop.com/en/training-prestashop?utm_source=back-office&amp;utm_medium=footer&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="footer_link _blank">
 				<i class="icon-book"></i>
 				{l s='Training' d='Admin.Navigation.Footer'}
 			</a>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | While debugging issues on 177x I noticed some http links that should be https in the footer
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No need for QA

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20529)
<!-- Reviewable:end -->
