### PR TITLE
Fix facets.js pendingQuery was always false

### DIFF
--- a/themes/_core/js/facets.js
+++ b/themes/_core/js/facets.js
@@ -40,27 +40,27 @@ function handleError () {
 function makeQuery (url) {
     if (pendingQuery) {
         // wait for current results
-    } else {
-
-        // We need to add a parameter to the URL
-        // to make it different from the one we're on,
-        // otherwise when you do "duplicate tab" under chrome
-        // it mixes up the cache between the AJAX request (that
-        // returns JSON) and the non-AJAX request (that returns
-        // HTML) and you just get a mess of JSON on the duplicated tab.
-
-        const slightlyDifferentURL = [
-            url,
-            url.indexOf('?') >= 0 ? '&' : '?',
-            'from-xhr'
-        ].join('');
-
-        $
-          .get(slightlyDifferentURL, null, null, 'json')
-          .then(updateResults)
-          .fail(handleError)
-        ;
+        return;
     }
+
+    // We need to add a parameter to the URL
+    // to make it different from the one we're on,
+    // otherwise when you do "duplicate tab" under chrome
+    // it mixes up the cache between the AJAX request (that
+    // returns JSON) and the non-AJAX request (that returns
+    // HTML) and you just get a mess of JSON on the duplicated tab.
+    
+    const slightlyDifferentURL = [
+        url,
+        url.indexOf('?') >= 0 ? '&' : '?',
+        'from-xhr'
+    ].join('');
+
+    $
+        .get(slightlyDifferentURL, null, null, 'json')
+        .then(updateResults)
+        .fail(handleError)
+    ;
 }
 
 $(document).ready(function () {

--- a/themes/_core/js/facets.js
+++ b/themes/_core/js/facets.js
@@ -51,12 +51,8 @@ function makeQuery (url) {
     // it mixes up the cache between the AJAX request (that
     // returns JSON) and the non-AJAX request (that returns
     // HTML) and you just get a mess of JSON on the duplicated tab.
-    
-    const slightlyDifferentURL = [
-        url,
-        url.indexOf('?') >= 0 ? '&' : '?',
-        'from-xhr'
-    ].join('');
+    const separator = url.indexOf('?') >= 0 ? '&' : '?';
+    const slightlyDifferentURL = url + separator + 'from-xhr';
 
     $
         .get(slightlyDifferentURL, null, null, 'json')

--- a/themes/_core/js/facets.js
+++ b/themes/_core/js/facets.js
@@ -43,6 +43,8 @@ function makeQuery (url) {
         return;
     }
 
+    pendingQuery = true
+
     // We need to add a parameter to the URL
     // to make it different from the one we're on,
     // otherwise when you do "duplicate tab" under chrome


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | 1. pendingQuery was always false. ~~I set it to true when there is a pending request.~~<br>2. [Return early pattern](https://forum.freecodecamp.org/t/the-return-early-pattern-explained-with-javascript-examples/19364)<br>3. Ignoring successive requests because one is in progress can confuse the user. Better to abort the previous request and continue only the last one
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Test that the facets in FO work as before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20530)
<!-- Reviewable:end -->
