### PR TITLE
Fix order cart rule deletion

### DIFF
--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -70,11 +70,6 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
             throw new OrderException('Invalid cart provided.');
         }
 
-        $cartRule = new CartRule($orderCartRule->id_cart_rule);
-        if (!Validate::isLoadedObject($cartRule)) {
-            throw new OrderException('Invalid cart rule provided.');
-        }
-
         // Delete Order Cart Rule and update Order
         $orderCartRule->softDelete();
         $cart->removeCartRule($orderCartRule->id_cart_rule);

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Cart;
-use CartRule;
 use OrderCartRule;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | An OrderCartRule should be deletable even if it's related CartRule doesn't exist anymore.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20534
| How to test?  | 1. Create a cart rule (Any type)<br>2. Go to FO => add some product to the cart => apply the cart rule created previously<br>3. Proceed to checkout<br>4. Go to BO => Catalog => Cart rules page<br>5. Delete the cart rule just applied<br>6. Go to BO => Order details page => try to remove the discount<br>7. There should be no error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20538)
<!-- Reviewable:end -->
