### PR TITLE
Add GetProductSupplierOptions query. Remove it from ProductForEditing

### DIFF
--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -41,16 +41,10 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductOptions;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInformation;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSupplierOption;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSupplierOptions;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
-use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSuppliersForEditing;
-use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryHandler\GetProductSuppliersForEditingHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryResult\ProductSupplierForEditing;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractorException;
 use Product;
-use Supplier;
 use Tag;
 
 /**
@@ -64,20 +58,12 @@ class GetProductForEditingHandler extends AbstractProductHandler implements GetP
     private $numberExtractor;
 
     /**
-     * @var GetProductSuppliersForEditingHandlerInterface
-     */
-    private $getProductSuppliersForEditingHandler;
-
-    /**
      * @param NumberExtractor $numberExtractor
-     * @param GetProductSuppliersForEditingHandlerInterface $getProductSuppliersForEditingHandler
      */
     public function __construct(
-        NumberExtractor $numberExtractor,
-        GetProductSuppliersForEditingHandlerInterface $getProductSuppliersForEditingHandler
+        NumberExtractor $numberExtractor
     ) {
         $this->numberExtractor = $numberExtractor;
-        $this->getProductSuppliersForEditingHandler = $getProductSuppliersForEditingHandler;
     }
 
     /**
@@ -95,8 +81,7 @@ class GetProductForEditingHandler extends AbstractProductHandler implements GetP
             $this->getCategoriesInformation($product),
             $this->getPricesInformation($product),
             $this->getOptions($product),
-            $this->getShippingInformation($product),
-            $this->getSupplierOptions($product)
+            $this->getShippingInformation($product)
         );
     }
 
@@ -263,59 +248,5 @@ class GetProductForEditingHandler extends AbstractProductHandler implements GetP
             default:
                 return ProductCustomizationOptions::createNotCustomizable();
         }
-    }
-
-    /**
-     * @param Product $product
-     *
-     * @return ProductSupplierOptions
-     */
-    private function getSupplierOptions(Product $product): ProductSupplierOptions
-    {
-        $productSuppliersForEditing = $this->getProductSuppliersForEditingHandler->handle(new GetProductSuppliersForEditing((int) $product->id));
-        $supplierOptions = [];
-
-        $processedSuppliers = [];
-        foreach ($productSuppliersForEditing as $productSupplierForEditing) {
-            $supplierId = $productSupplierForEditing->getSupplierId();
-
-            if (in_array($supplierId, $processedSuppliers)) {
-                continue;
-            }
-
-            $supplierOptions[] = new ProductSupplierOption(
-                Supplier::getNameById($supplierId),
-                $supplierId,
-                $this->filterProductSuppliersBySupplier($supplierId, $productSuppliersForEditing)
-            );
-            $processedSuppliers[] = $supplierId;
-        }
-
-        return new ProductSupplierOptions(
-            (int) $product->id_supplier,
-            $product->supplier_reference,
-            $supplierOptions
-        );
-    }
-
-    /**
-     * Gets EditableProductSuppliers list for its supplier
-     *
-     * @param int $supplierId
-     * @param ProductSupplierForEditing[] $productSuppliersForEditing
-     *
-     * @return ProductSupplierForEditing[]
-     */
-    private function filterProductSuppliersBySupplier(int $supplierId, array $productSuppliersForEditing): array
-    {
-        $productSuppliersBySupplier = [];
-
-        foreach ($productSuppliersForEditing as $productSupplierForEditing) {
-            if ($productSupplierForEditing->getSupplierId() === $supplierId) {
-                $productSuppliersBySupplier[] = $productSupplierForEditing;
-            }
-        }
-
-        return $productSuppliersBySupplier;
     }
 }

--- a/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSupplierOption;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSupplierOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSuppliersForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryHandler\GetProductSupplierOptionsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryResult\ProductSupplierForEditing;
+use Supplier;
+
+/**
+ * Handles @see GetProductSupplierOptions query
+ */
+final class GetProductSupplierOptionsHandler extends AbstractProductHandler implements GetProductSupplierOptionsHandlerInterface
+{
+    /**
+     * @var GetProductSuppliersForEditingHandler
+     */
+    private $getProductSuppliersForEditingHandler;
+
+    /**
+     * @param GetProductSuppliersForEditingHandler $getProductSuppliersForEditingHandler
+     */
+    public function __construct(GetProductSuppliersForEditingHandler $getProductSuppliersForEditingHandler)
+    {
+        $this->getProductSuppliersForEditingHandler = $getProductSuppliersForEditingHandler;
+    }
+
+    /**
+     * @param GetProductSupplierOptions $query
+     *
+     * @return ProductSupplierOptions
+     */
+    public function handle(GetProductSupplierOptions $query): ProductSupplierOptions
+    {
+        $product = $this->getProduct($query->getProductId());
+        $productSuppliersForEditing = $this->getProductSuppliersForEditingHandler->handle(new GetProductSuppliersForEditing((int) $product->id));
+        $supplierOptions = [];
+
+        $processedSuppliers = [];
+        foreach ($productSuppliersForEditing as $productSupplierForEditing) {
+            $supplierId = $productSupplierForEditing->getSupplierId();
+
+            if (in_array($supplierId, $processedSuppliers)) {
+                continue;
+            }
+
+            $supplierOptions[] = new ProductSupplierOption(
+                Supplier::getNameById($supplierId),
+                $supplierId,
+                $this->filterProductSuppliersBySupplier($supplierId, $productSuppliersForEditing)
+            );
+            $processedSuppliers[] = $supplierId;
+        }
+
+        return new ProductSupplierOptions(
+            (int) $product->id_supplier,
+            $supplierOptions
+        );
+    }
+
+    /**
+     * Gets EditableProductSuppliers list for its supplier
+     *
+     * @param int $supplierId
+     * @param ProductSupplierForEditing[] $productSuppliersForEditing
+     *
+     * @return ProductSupplierForEditing[]
+     */
+    private function filterProductSuppliersBySupplier(int $supplierId, array $productSuppliersForEditing): array
+    {
+        $productSuppliersBySupplier = [];
+
+        foreach ($productSuppliersForEditing as $productSupplierForEditing) {
+            if ($productSupplierForEditing->getSupplierId() === $supplierId) {
+                $productSuppliersBySupplier[] = $productSupplierForEditing;
+            }
+        }
+
+        return $productSuppliersBySupplier;
+    }
+}

--- a/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
@@ -82,6 +82,7 @@ final class GetProductSupplierOptionsHandler extends AbstractProductHandler impl
 
         return new ProductSupplierOptions(
             (int) $product->id_supplier,
+            $product->supplier_reference,
             $supplierOptions
         );
     }

--- a/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSupplierOptions
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSuppliersForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryHandler\GetProductSupplierOptionsHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryResult\ProductSupplierForEditing;
 use Supplier;
 
 /**
@@ -77,7 +76,9 @@ final class GetProductSupplierOptionsHandler extends AbstractProductHandler impl
             $supplierOptions[] = new ProductSupplierOption(
                 Supplier::getNameById($supplierId),
                 $supplierId,
-                $this->filterProductSuppliersBySupplier($supplierId, $productSuppliersForEditing)
+                array_filter($productSuppliersForEditing, function ($value) use ($supplierId): bool {
+                    return $value->getSupplierId() === $supplierId;
+                })
             );
             $processedSuppliers[] = $supplierId;
         }
@@ -87,26 +88,5 @@ final class GetProductSupplierOptionsHandler extends AbstractProductHandler impl
             $product->supplier_reference,
             $supplierOptions
         );
-    }
-
-    /**
-     * Gets EditableProductSuppliers list for its supplier
-     *
-     * @param int $supplierId
-     * @param ProductSupplierForEditing[] $productSuppliersForEditing
-     *
-     * @return ProductSupplierForEditing[]
-     */
-    private function filterProductSuppliersBySupplier(int $supplierId, array $productSuppliersForEditing): array
-    {
-        $productSuppliersBySupplier = [];
-
-        foreach ($productSuppliersForEditing as $productSupplierForEditing) {
-            if ($productSupplierForEditing->getSupplierId() === $supplierId) {
-                $productSuppliersBySupplier[] = $productSupplierForEditing;
-            }
-        }
-
-        return $productSuppliersBySupplier;
     }
 }

--- a/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductSupplierOptionsHandler.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
 
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;

--- a/src/Core/Domain/Product/QueryResult/ProductForEditing.php
+++ b/src/Core/Domain/Product/QueryResult/ProductForEditing.php
@@ -67,11 +67,6 @@ class ProductForEditing
     private $customizationOptions;
 
     /**
-     * @var ProductSupplierOptions
-     */
-    private $productSupplierOptions;
-
-    /**
      * @var ProductShippingInformation
      */
     private $shippingInformation;
@@ -85,7 +80,6 @@ class ProductForEditing
      * @param ProductPricesInformation $pricesInformation
      * @param ProductOptions $options
      * @param ProductShippingInformation $shippingInformation
-     * @param ProductSupplierOptions $productSupplierOptions
      */
     public function __construct(
         int $productId,
@@ -95,8 +89,7 @@ class ProductForEditing
         ProductCategoriesInformation $categoriesInformation,
         ProductPricesInformation $pricesInformation,
         ProductOptions $options,
-        ProductShippingInformation $shippingInformation,
-        ProductSupplierOptions $productSupplierOptions
+        ProductShippingInformation $shippingInformation
     ) {
         $this->productId = $productId;
         $this->active = $active;
@@ -106,7 +99,6 @@ class ProductForEditing
         $this->pricesInformation = $pricesInformation;
         $this->options = $options;
         $this->shippingInformation = $shippingInformation;
-        $this->productSupplierOptions = $productSupplierOptions;
     }
 
     /**
@@ -171,13 +163,5 @@ class ProductForEditing
     public function getShippingInformation(): ProductShippingInformation
     {
         return $this->shippingInformation;
-    }
-
-    /**
-     * @return ProductSupplierOptions
-     */
-    public function getProductSupplierOptions(): ProductSupplierOptions
-    {
-        return $this->productSupplierOptions;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/ProductSupplierOptions.php
+++ b/src/Core/Domain/Product/QueryResult/ProductSupplierOptions.php
@@ -39,20 +39,28 @@ class ProductSupplierOptions
     private $defaultSupplierId;
 
     /**
+     * @var
+     */
+    private $defaultSupplierReference;
+
+    /**
      * @var ProductSupplierOption[]
      */
     private $optionsBySupplier;
 
     /**
      * @param int $defaultSupplierId
+     * @param string $defaultSupplierReference
      * @param ProductSupplierOption[] $optionsBySupplier
      */
     public function __construct(
         int $defaultSupplierId,
+        string $defaultSupplierReference,
         array $optionsBySupplier
     ) {
         $this->defaultSupplierId = $defaultSupplierId;
         $this->optionsBySupplier = $optionsBySupplier;
+        $this->defaultSupplierReference = $defaultSupplierReference;
     }
 
     /**
@@ -61,6 +69,14 @@ class ProductSupplierOptions
     public function getDefaultSupplierId(): int
     {
         return $this->defaultSupplierId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDefaultSupplierReference()
+    {
+        return $this->defaultSupplierReference;
     }
 
     /**

--- a/src/Core/Domain/Product/QueryResult/ProductSupplierOptions.php
+++ b/src/Core/Domain/Product/QueryResult/ProductSupplierOptions.php
@@ -39,7 +39,7 @@ class ProductSupplierOptions
     private $defaultSupplierId;
 
     /**
-     * @var
+     * @var string
      */
     private $defaultSupplierReference;
 
@@ -72,9 +72,9 @@ class ProductSupplierOptions
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getDefaultSupplierReference()
+    public function getDefaultSupplierReference(): string
     {
         return $this->defaultSupplierReference;
     }

--- a/src/Core/Domain/Product/Supplier/Query/GetProductSupplierOptions.php
+++ b/src/Core/Domain/Product/Supplier/Query/GetProductSupplierOptions.php
@@ -26,48 +26,33 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
 /**
- * Transfers product suppliers data
+ * Provides product supplier options
  */
-class ProductSupplierOptions
+class GetProductSupplierOptions
 {
     /**
-     * @var int
+     * @var ProductId
      */
-    private $defaultSupplierId;
+    private $productId;
 
     /**
-     * @var ProductSupplierOption[]
+     * @param int $productId
      */
-    private $optionsBySupplier;
-
-    /**
-     * @param int $defaultSupplierId
-     * @param ProductSupplierOption[] $optionsBySupplier
-     */
-    public function __construct(
-        int $defaultSupplierId,
-        array $optionsBySupplier
-    ) {
-        $this->defaultSupplierId = $defaultSupplierId;
-        $this->optionsBySupplier = $optionsBySupplier;
+    public function __construct(int $productId)
+    {
+        $this->productId = $productId;
     }
 
     /**
-     * @return int
+     * @return ProductId
      */
-    public function getDefaultSupplierId(): int
+    public function getProductId(): ProductId
     {
-        return $this->defaultSupplierId;
-    }
-
-    /**
-     * @return ProductSupplierOption[]
-     */
-    public function getOptionsBySupplier(): array
-    {
-        return $this->optionsBySupplier;
+        return $this->productId;
     }
 }

--- a/src/Core/Domain/Product/Supplier/Query/GetProductSupplierOptions.php
+++ b/src/Core/Domain/Product/Supplier/Query/GetProductSupplierOptions.php
@@ -45,7 +45,7 @@ class GetProductSupplierOptions
      */
     public function __construct(int $productId)
     {
-        $this->productId = new ProductId($productId);
+        $this->productId = $productId;
     }
 
     /**

--- a/src/Core/Domain/Product/Supplier/Query/GetProductSupplierOptions.php
+++ b/src/Core/Domain/Product/Supplier/Query/GetProductSupplierOptions.php
@@ -45,7 +45,7 @@ class GetProductSupplierOptions
      */
     public function __construct(int $productId)
     {
-        $this->productId = $productId;
+        $this->productId = new ProductId($productId);
     }
 
     /**

--- a/src/Core/Domain/Product/Supplier/QueryHandler/GetProductSupplierOptionsHandlerInterface.php
+++ b/src/Core/Domain/Product/Supplier/QueryHandler/GetProductSupplierOptionsHandlerInterface.php
@@ -24,50 +24,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-declare(strict_types=1);
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryHandler;
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSupplierOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions;
 
 /**
- * Transfers product suppliers data
+ * Defines cotntract to handle @see GetProductSupplierOptions
  */
-class ProductSupplierOptions
+interface GetProductSupplierOptionsHandlerInterface
 {
-    /**
-     * @var int
-     */
-    private $defaultSupplierId;
-
-    /**
-     * @var ProductSupplierOption[]
-     */
-    private $optionsBySupplier;
-
-    /**
-     * @param int $defaultSupplierId
-     * @param ProductSupplierOption[] $optionsBySupplier
-     */
-    public function __construct(
-        int $defaultSupplierId,
-        array $optionsBySupplier
-    ) {
-        $this->defaultSupplierId = $defaultSupplierId;
-        $this->optionsBySupplier = $optionsBySupplier;
-    }
-
-    /**
-     * @return int
-     */
-    public function getDefaultSupplierId(): int
-    {
-        return $this->defaultSupplierId;
-    }
-
-    /**
-     * @return ProductSupplierOption[]
-     */
-    public function getOptionsBySupplier(): array
-    {
-        return $this->optionsBySupplier;
-    }
+    public function handle(GetProductSupplierOptions $query): ProductSupplierOptions;
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -70,7 +70,6 @@ services:
       class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductForEditingHandler
       arguments:
         - '@prestashop.core.util.number.number_extractor'
-        - '@prestashop.adapter.product.query_handler.get_product_suppliers_for_editing_handler'
       tags:
         - name: tactician.handler
           command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing
@@ -175,6 +174,14 @@ services:
       tags:
         - name: tactician.handler
           command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSuppliersForEditing
+
+    prestashop.adapter.product.query_handler.get_product_supplier_options_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductSupplierOptionsHandler
+        arguments:
+            - '@prestashop.adapter.product.query_handler.get_product_suppliers_for_editing_handler'
+        tags:
+            -   name: tactician.handler
+                command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions
 
     prestashop.adapter.product.command_handler.add_product_supplier_handler:
       class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductSupplierHandler

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -40,6 +40,7 @@ Feature: Update product suppliers from Back Office (BO)
       | is_virtual | false                                     |
     And product product1 type should be standard
     And product product1 should not have any suppliers assigned
+    And product product1 default supplier reference should be empty
     When I update product product1 suppliers with following values:
       | reference         | supplier reference    | product supplier reference     | currency      | price tax excluded |
       | product1supplier1 | supplier1             | my first supplier for product1 | USD           | 10                 |
@@ -48,6 +49,7 @@ Feature: Update product suppliers from Back Office (BO)
       | my first supplier for product1 | USD           | 10                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier1                      |
+      | default supplier reference | my first supplier for product1 |
     When I update product product1 suppliers with following values:
       | reference         | supplier reference    | product supplier reference      | currency      | price tax excluded |
       | product1supplier1 | supplier1             | my first supplier for product1  | USD           | 10                 |
@@ -59,6 +61,7 @@ Feature: Update product suppliers from Back Office (BO)
       | my second supplier for product1 | EUR           | 11                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier2                       |
+      | default supplier reference | my second supplier for product1 |
 
   Scenario: Remove product suppliers
     Given product product1 type should be standard
@@ -68,17 +71,21 @@ Feature: Update product suppliers from Back Office (BO)
       | my second supplier for product1 | EUR           | 11                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier2                       |
+      | default supplier reference | my second supplier for product1 |
     When I delete all product product1 suppliers
     Then product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
+    And product product1 default supplier reference should be empty
 
   Scenario: Update product default supplier when it is not assigned to product
     Given product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
+    And product product1 default supplier reference should be empty
     When I set product product1 default supplier to supplier2
     Then I should get error that I cannot update default supplier
     And product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
+    And product product1 default supplier reference should be empty
 
   Scenario: Update combination product suppliers
     Given I add product "product2" with following information:
@@ -90,6 +97,7 @@ Feature: Update product suppliers from Back Office (BO)
       | whiteL    | 13       | Size:L;Color:White |
     And product product2 type should be combination
     And product product2 should not have any suppliers assigned
+    And product product2 default supplier reference should be empty
     And product "product2" has following combinations:
       | reference | quantity | attributes          |
       | whiteM    | 15       | Size:M;Color:White  |
@@ -102,3 +110,4 @@ Feature: Update product suppliers from Back Office (BO)
       | product supplier reference        | currency      | price tax excluded | combination |
       | sup white shirt M 1               | USD           | 5                  | whiteM      |
       | sup white shirt L 2               | USD           | 3                  | whiteL      |
+    Then product product2 default supplier reference should be empty

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -40,7 +40,6 @@ Feature: Update product suppliers from Back Office (BO)
       | is_virtual | false                                     |
     And product product1 type should be standard
     And product product1 should not have any suppliers assigned
-    And product product1 default supplier reference should be empty
     When I update product product1 suppliers with following values:
       | reference         | supplier reference    | product supplier reference     | currency      | price tax excluded |
       | product1supplier1 | supplier1             | my first supplier for product1 | USD           | 10                 |
@@ -49,7 +48,6 @@ Feature: Update product suppliers from Back Office (BO)
       | my first supplier for product1 | USD           | 10                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier1                      |
-      | default supplier reference | my first supplier for product1 |
     When I update product product1 suppliers with following values:
       | reference         | supplier reference    | product supplier reference      | currency      | price tax excluded |
       | product1supplier1 | supplier1             | my first supplier for product1  | USD           | 10                 |
@@ -61,7 +59,6 @@ Feature: Update product suppliers from Back Office (BO)
       | my second supplier for product1 | EUR           | 11                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier2                       |
-      | default supplier reference | my second supplier for product1 |
 
   Scenario: Remove product suppliers
     Given product product1 type should be standard
@@ -71,21 +68,17 @@ Feature: Update product suppliers from Back Office (BO)
       | my second supplier for product1 | EUR           | 11                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier2                       |
-      | default supplier reference | my second supplier for product1 |
     When I delete all product product1 suppliers
     Then product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
-    And product product1 default supplier reference should be empty
 
   Scenario: Update product default supplier when it is not assigned to product
     Given product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
-    And product product1 default supplier reference should be empty
     When I set product product1 default supplier to supplier2
     Then I should get error that I cannot update default supplier
     And product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
-    And product product1 default supplier reference should be empty
 
   Scenario: Update combination product suppliers
     Given I add product "product2" with following information:
@@ -97,7 +90,6 @@ Feature: Update product suppliers from Back Office (BO)
       | whiteL    | 13       | Size:L;Color:White |
     And product product2 type should be combination
     And product product2 should not have any suppliers assigned
-    And product product2 default supplier reference should be empty
     And product "product2" has following combinations:
       | reference | quantity | attributes          |
       | whiteM    | 15       | Size:M;Color:White  |
@@ -110,4 +102,3 @@ Feature: Update product suppliers from Back Office (BO)
       | product supplier reference        | currency      | price tax excluded | combination |
       | sup white shirt M 1               | USD           | 5                  | whiteM      |
       | sup white shirt L 2               | USD           | 3                  | whiteL      |
-    Then product product2 default supplier reference should be empty


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We want to be able to load product suppliers separately and later improve it by adding pagination. It cannot rest in common object as ProductForEditing, it deserves a separate query because it is related to the number of combinations so it can become quite huge with a lot of combinations.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | related #20299 
| How to test?  | Behats must pass.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20553)
<!-- Reviewable:end -->
