### PR TITLE
Filter variations by qty at FO

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -676,13 +676,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                             $id_product_attributes[] = $row['id_product_attribute'];
                         }
                     }
-                    $id_attributes = Db::getInstance()->executeS('SELECT pac2.`id_attribute` FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac2'.
-                        ((!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && Configuration::get('PS_DISP_UNAVAILABLE_ATTR') == 0) ?
-                        ' INNER JOIN `' . _DB_PREFIX_ . 'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
+                    $id_attributes = Db::getInstance()->executeS('SELECT pac2.`id_attribute` FROM `'._DB_PREFIX_.'product_attribute_combination` pac2'.
+                        ((!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && 0 == Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) ?
+                        ' INNER JOIN `'._DB_PREFIX_.'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
                         WHERE pa.quantity > 0 AND ' :
                         ' WHERE ').
-                        'pac2.`id_product_attribute` IN (' . implode(',', array_map('intval', $id_product_attributes)) . ')
-                        AND pac2.id_attribute NOT IN (' . implode(',', array_map('intval', $current_selected_attributes)) . ')');
+                        'pac2.`id_product_attribute` IN ('.implode(',', array_map('intval', $id_product_attributes)).')
+                        AND pac2.id_attribute NOT IN ('.implode(',', array_map('intval', $current_selected_attributes)).')');
                     foreach ($id_attributes as $k => $row) {
                         $id_attributes[$k] = (int) $row['id_attribute'];
                     }
@@ -998,7 +998,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         }
                     );
                     if (count($checkProductAttribute)) {
-                        $alternativeProductAttribute = array();
+                        $alternativeProductAttribute = [];
                         foreach ($checkProductAttribute as $key => $attribute) {
                             $alternativeAttribute = array_filter(
                                 $availableProductAttributes,
@@ -1010,16 +1010,18 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                                 $alternativeProductAttribute[$key] = $value;
                             }
                         }
-    
+
                         if (count($alternativeProductAttribute)) {
-                            usort($alternativeProductAttribute, function($a, $b) {
+                            usort($alternativeProductAttribute, function ($a, $b) {
                                 $aValue = $a['quantity'];
                                 $bValue = $b['quantity'];
                                 if ($a == $b) {
                                     return 0;
                                 }
+
                                 return ($a > $b) ? -1 : 1;
                             });
+
                             return (int) array_shift($alternativeProductAttribute)['id_product_attribute'];
                         }
                     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * Copyright since 2007 PrestaShop SA and Contributors

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
@@ -677,13 +676,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                             $id_product_attributes[] = $row['id_product_attribute'];
                         }
                     }
-                    $id_attributes = Db::getInstance()->executeS('SELECT pac2.`id_attribute` FROM `'._DB_PREFIX_.'product_attribute_combination` pac2'.
+                    $id_attributes = Db::getInstance()->executeS('SELECT pac2.`id_attribute` FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac2' .
                         ((!Product::isAvailableWhenOutOfStock($this->product->out_of_stock) && 0 == Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) ?
-                        ' INNER JOIN `'._DB_PREFIX_.'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
+                        ' INNER JOIN `' . _DB_PREFIX_ . 'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
                         WHERE pa.quantity > 0 AND ' :
-                        ' WHERE ').
-                        'pac2.`id_product_attribute` IN ('.implode(',', array_map('intval', $id_product_attributes)).')
-                        AND pac2.id_attribute NOT IN ('.implode(',', array_map('intval', $current_selected_attributes)).')');
+                        ' WHERE ') .
+                        'pac2.`id_product_attribute` IN (' . implode(',', array_map('intval', $id_product_attributes)) . ')
+                        AND pac2.id_attribute NOT IN (' . implode(',', array_map('intval', $current_selected_attributes)) . ')');
                     foreach ($id_attributes as $k => $row) {
                         $id_attributes[$k] = (int) $row['id_attribute'];
                     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -990,7 +990,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             );
 
             if (empty($availableProductAttribute) && count($availableProductAttributes)) {
+                // if selected combination is NOT available ($availableProductAttribute) but they are other alternatives ($availableProductAttributes), then we'll try to get the closest.
                 if (!Product::isAvailableWhenOutOfStock($this->product->out_of_stock)) {
+                    // first lets get information of the selected combination.
                     $checkProductAttribute = array_filter(
                         $productCombinations,
                         function ($elem) use ($checkedIdProductAttribute) {
@@ -998,6 +1000,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         }
                     );
                     if (count($checkProductAttribute)) {
+                        // now lets find other combinations for the selected attributes.
                         $alternativeProductAttribute = [];
                         foreach ($checkProductAttribute as $key => $attribute) {
                             $alternativeAttribute = array_filter(
@@ -1012,6 +1015,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         }
 
                         if (count($alternativeProductAttribute)) {
+                            // if alternative combination is found, order the list by quantity to use the one with more stock.
                             usort($alternativeProductAttribute, function ($a, $b) {
                                 if ($a['quantity'] == $b['quantity']) {
                                     return 0;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -980,6 +980,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         return $elem['quantity'] > 0;
                     }
                 );
+            } else {
+                $availableProductAttributes = $productCombinations;
             }
 
             $availableProductAttribute = array_filter(

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1013,13 +1013,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
                         if (count($alternativeProductAttribute)) {
                             usort($alternativeProductAttribute, function ($a, $b) {
-                                $aValue = $a['quantity'];
-                                $bValue = $b['quantity'];
-                                if ($a == $b) {
+                                if ($a['quantity'] == $b['quantity']) {
                                     return 0;
                                 }
 
-                                return ($a > $b) ? -1 : 1;
+                                return ($a['quantity'] > $b['quantity']) ? -1 : 1;
                             });
 
                             return (int) array_shift($alternativeProductAttribute)['id_product_attribute'];


### PR DESCRIPTION
If enable, only show variations with quantities at FO. Also, if the variation is not available when the user change an attribute, look for something similar instead of always going back to the default.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  |  The current implementation is not handling well the product combination changes at FO. The ProductController tries to match the exact variation when the user change an attribute. But, when combinations have more than one attribute and the user only is able to change one attribute per action, the ProductController may not find the combination available and fallback into the default one, even if it is totally different and the FO then has to resets the user selection completely. Also, the FO is currently showing variations with no quantity available. When the user selects an attribute with no quantity, the FO fallback SILENTLY into the default combination provoking incorrect orders.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Didn't find the ticket but many people complain about this at the forums. Per example: https://www.prestashop.com/forums/topic/308751-hide-unavailable-combinations/ // Think is related to https://github.com/PrestaShop/PrestaShop/issues/9948
| How to test?  | To test this, you need to have a product with multiple combinations. The stock of those combinations should variate and some should have 0 elements. The change includes the conditions to offer out of stock if it is configured so that must be tested too. If this works and the product only allows order when in stock, the FO should only display what is available and the user should be able to change the attributes successfully switching to other combinations that has stock available.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20565)
<!-- Reviewable:end -->
