### PR TITLE
Update _PS_JQUERY_VERSION_ to match the included jQuery version

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -217,7 +217,7 @@ define('_PS_SMARTY_CONSOLE_OPEN_BY_URL_', 1);
 define('_PS_SMARTY_CONSOLE_OPEN_', 2);
 
 if (!defined('_PS_JQUERY_VERSION_')) {
-    define('_PS_JQUERY_VERSION_', '1.11.0');
+    define('_PS_JQUERY_VERSION_', '3.4.1');
 }
 
 define('_PS_CACHE_CA_CERT_FILE_', _PS_CACHE_DIR_.'cacert.pem');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | We forgot to update the constant `_PS_JQUERY_VERSION_`. It's used by the [Media class](https://github.com/PrestaShop/PrestaShop/blob/1.7.7.x/classes/Media.php).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Nothing to test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20570)
<!-- Reviewable:end -->
