### PR TITLE
The delivery note's name is wrong after the download 

### DIFF
--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -163,6 +163,6 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
      */
     public function getFilename()
     {
-        return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop) . sprintf('%06d', $this->order->delivery_number) . '.pdf';
+        return Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id, null, $this->order->id_shop) . sprintf('%06d', $this->order_invoice->delivery_number) . '.pdf';
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | An order with multiple delivery slip after been downloaded have the same file name.The delivery slip file name is defined by the reference number of the delivery note.When I download #DE00001 and #DE00002 from the order page, I have 2 files named #DE00002 by @MatShir 
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no 
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20432.
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/20432 by @MatShir 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20592)
<!-- Reviewable:end -->
