### PR TITLE
Do not reconvert discounts

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -570,19 +570,6 @@ class CartPresenter implements PresenterInterface
             } else {
                 $freeShippingOnly = false;
                 $totalCartVoucherReduction = $this->includeTaxes() ? $cartVoucher['value_real'] : $cartVoucher['value_tax_exc'];
-                $currencyFrom = new \Currency($cartVoucher['reduction_currency']);
-                $currencyTo = new \Currency($cart->id_currency);
-                if ($currencyFrom->conversion_rate == 0) {
-                    $totalCartVoucherReduction = 0;
-                } else {
-                    // convert to default currency
-                    $defaultCurrencyId = (int) Configuration::get('PS_CURRENCY_DEFAULT');
-                    $totalCartVoucherReduction /= $currencyFrom->conversion_rate;
-                    if ($defaultCurrencyId == $currencyTo->id) {
-                        // convert to destination currency
-                        $totalCartVoucherReduction *= $currencyTo->conversion_rate;
-                    }
-                }
             }
 
             // when a voucher has only a shipping reduction, the value displayed must be "Free Shipping"
@@ -593,7 +580,7 @@ class CartPresenter implements PresenterInterface
                     'Admin.Shipping.Feature'
                 );
             } else {
-                $cartVoucher['reduction_formatted'] = '-' . $this->priceFormatter->convertAndFormat($totalCartVoucherReduction);
+                $cartVoucher['reduction_formatted'] = '-' . $this->priceFormatter->format($totalCartVoucherReduction);
             }
             $vouchers[$cartVoucher['id_cart_rule']]['reduction_formatted'] = $cartVoucher['reduction_formatted'];
             $vouchers[$cartVoucher['id_cart_rule']]['delete_url'] = $this->link->getPageLink(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In the FO, when adding a discount created with a different currency than the one used in the FO, the amount of the reduction could be wrong. It seems that we were converting an already converted amount to the current currency. This PR fixes it.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20594
| How to test?  | See #20594, Also, be sure that #9914 is still fixed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20598)
<!-- Reviewable:end -->
