### PR TITLE
Allow admin user to configure the SameSite cookie attribute

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -385,10 +385,6 @@ class CookieCore
         }
 
         $sameSite = Configuration::get('PS_COOKIE_SAMESITE');
-        // SameSite=None is only available when Secure is set
-        if (empty($sameSite) || ($sameSite === Cookie::SAMESITE_NONE && !$this->_secure)) {
-            $sameSite = Cookie::SAMESITE_LAX;
-        }
 
         /*
          * The alternative signature supporting an options array is only available since

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -332,6 +332,9 @@
   <configuration id="PS_COOKIE_CHECKIP" name="PS_COOKIE_CHECKIP">
     <value>1</value>
   </configuration>
+  <configuration id="PS_COOKIE_SAMESITE" name="PS_COOKIE_SAMESITE">
+    <value>Lax</value>
+  </configuration>
   <configuration id="PS_USE_ECOTAX" name="PS_USE_ECOTAX">
     <value>0</value>
   </configuration>

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -15,3 +15,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionOverrideEmployeeImage', 'Override Employee Image', 'This hook is used to override the employee image', '1')
 ;
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;
+
+INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
+    ('PS_COOKIE_SAMESITE', 'Lax', NOW(), NOW())
+;

--- a/src/Adapter/GeneralConfiguration.php
+++ b/src/Adapter/GeneralConfiguration.php
@@ -111,7 +111,7 @@ class GeneralConfiguration implements DataConfigurationInterface
 
     /**
      * Validate SameSite.
-     * The SameSite=None is only working when Secure is settle
+     * The SameSite=None is only working when Secure is settled
      *
      * @param string $sameSite
      *

--- a/src/Adapter/GeneralConfiguration.php
+++ b/src/Adapter/GeneralConfiguration.php
@@ -119,7 +119,7 @@ class GeneralConfiguration implements DataConfigurationInterface
      */
     protected function validateSameSite(string $sameSite): bool
     {
-        $forceSsl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
+        $forceSsl = $this->configuration->get('PS_SSL_ENABLED') && $this->configuration->get('PS_SSL_ENABLED_EVERYWHERE');
         if ($sameSite === Cookie::SAMESITE_NONE) {
             return $forceSsl;
         }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -26,8 +26,10 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
+use Cookie;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -51,6 +53,10 @@ class GeneralType extends TranslatorAwareType
             ])
             ->add('back_cookie_lifetime', TextType::class, [
                 'required' => true,
+            ])
+            ->add('cookie_samesite', ChoiceType::class, [
+                'required' => true,
+                'choices' => Cookie::SAMESITE_AVAILABLE_VALUES,
             ]);
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -76,7 +76,9 @@ services:
 
     prestashop.adapter.general.configuration:
         class: 'PrestaShop\PrestaShop\Adapter\GeneralConfiguration'
-        arguments: ['@prestashop.adapter.legacy.configuration']
+        arguments:
+            - '@prestashop.adapter.legacy.configuration'
+            - '@=service("prestashop.adapter.legacy.context").getContext().cookie'
 
     prestashop.adapter.maintenance.configuration:
         class: 'PrestaShop\PrestaShop\Adapter\Shop\MaintenanceConfiguration'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -64,6 +64,13 @@
                   {{ form_widget(generalForm.back_cookie_lifetime) }}
                 </div>
               </div>
+              <div class="form-group row">
+                {{ ps.label_with_help(('Cookie SameSite'|trans), ('Allows you to declare if your cookie should be restricted to a first-party or same-site context.'|trans({}, 'Admin.Advparameters.Help'))) }}
+                <div class="col-sm">
+                  {{ form_errors(generalForm.cookie_samesite) }}
+                  {{ form_widget(generalForm.cookie_samesite) }}
+                </div>
+              </div>
               {{ form_rest(generalForm) }}
             </div>
           </div>

--- a/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Controller/Admin/SurvivalTest.php
@@ -26,6 +26,7 @@
 
 namespace LegacyTests\Integration\PrestaShopBundle\Controller\Admin;
 
+use Cookie;
 use LegacyTests\Integration\PrestaShopBundle\Test\WebTestCase;
 use PrestaShopBundle\Security\Admin\Employee as LoggedEmployee;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
@@ -227,6 +228,10 @@ class SurvivalTest extends WebTestCase
         $tokenStorageMock->method('getToken')
             ->willReturn($tokenMock);
 
-        self::$kernel->getContainer()->set('security.token_storage', $tokenStorageMock);
+        $container = self::$kernel->getContainer();
+        $container->set('security.token_storage', $tokenStorageMock);
+
+        $cookie = new Cookie('psAdmin', '', 3600);
+        $container->get('prestashop.adapter.legacy.context')->getContext()->cookie = $cookie;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Regarding this article https://web.dev/samesite-cookies-explained/ we must provide a way to allow admin user to configure the SameSite cookie attribute. There is a BC about the `GeneralConfiguration` which is now require `Cookie` in construct parameter.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | yes
| Deprecations? | no
| How to test?  | Make a fresh install, the `PS_COOKIE_SAMESITE` must have the `Lax` value. Then, when a user is connected, in FO or BO you should be able to check your cookie and see something like that: ![image](https://user-images.githubusercontent.com/1462701/90271055-81d79180-de5b-11ea-8dee-86a14fe6a8ef.png)<br> Must be tested with PHP 7.1 & PHP 7.3


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20601)
<!-- Reviewable:end -->
