### PR TITLE
Fix invoice address selection at checkout

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -103,11 +103,8 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                 $id_address = $this->addressForm->getAddress()->id;
                 if ($requestParams['saveAddress'] === 'delivery') {
                     $this->getCheckoutSession()->setIdAddressDelivery($id_address);
-                    if ($this->use_same_address) {
-                        $this->getCheckoutSession()->setIdAddressInvoice($id_address);
-                    } else {
-                        $this->getCheckoutSession()->setIdAddressInvoice(null);
-                    }
+                    $idAddressInvoice = $this->use_same_address ? $id_address : null;
+                    $this->getCheckoutSession()->setIdAddressInvoice($idAddressInvoice);
                 } else {
                     $this->getCheckoutSession()->setIdAddressInvoice($id_address);
                 }

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -105,6 +105,8 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                     $this->getCheckoutSession()->setIdAddressDelivery($id_address);
                     if ($this->use_same_address) {
                         $this->getCheckoutSession()->setIdAddressInvoice($id_address);
+                    } else {
+                        $this->getCheckoutSession()->setIdAddressInvoice(null);
                     }
                 } else {
                     $this->getCheckoutSession()->setIdAddressInvoice($id_address);

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -189,9 +189,16 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             if (!$this->getCheckoutProcess()->hasErrors()) {
                 $this->setNextStepAsCurrent();
                 $this->setComplete(
+                    !isset($requestParams['saveAddress']) &&
                     $this->getCheckoutSession()->getIdAddressInvoice() &&
                     $this->getCheckoutSession()->getIdAddressDelivery()
                 );
+
+                 // if we just pushed the invoice address form, we are using another address for invoice
+                 // (param 'id_address_delivery' is only pushed in invoice address form)
+                 if (isset($requestParams['saveAddress']) && isset($requestParams['id_address_delivery'])) {
+                    $this->use_same_address = false;
+                }
             }
         }
 

--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -194,9 +194,9 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                     $this->getCheckoutSession()->getIdAddressDelivery()
                 );
 
-                 // if we just pushed the invoice address form, we are using another address for invoice
-                 // (param 'id_address_delivery' is only pushed in invoice address form)
-                 if (isset($requestParams['saveAddress']) && isset($requestParams['id_address_delivery'])) {
+                // if we just pushed the invoice address form, we are using another address for invoice
+                // (param 'id_address_delivery' is only pushed in invoice address form)
+                if (isset($requestParams['saveAddress'], $requestParams['id_address_delivery'])) {
                     $this->use_same_address = false;
                 }
             }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -398,7 +398,6 @@ class FrontControllerCore extends Controller
                 $cart->update();
             }
             /* Select an address if not set */
-
         }
 
         if (!isset($cart) || !$cart->id) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -172,7 +172,7 @@ class FrontControllerCore extends Controller
 
     /**
      * Set this parameter to false if you don't want cart's invoice address
-     * to be set automatically (this bad behavior is kept for legacy and BC purpose)
+     * to be set automatically (this behavior is kept for legacy and BC purpose)
      *
      * @var bool automaticallyAllocateInvoiceAddress
      */

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -179,6 +179,14 @@ class FrontControllerCore extends Controller
     protected $automaticallyAllocateInvoiceAddress = true;
 
     /**
+     * Set this parameter to false if you don't want cart's delivery address
+     * to be set automatically (this behavior is kept for legacy and BC purpose)
+     *
+     * @var bool automaticallyAllocateDeliveryAddress
+     */
+    protected $automaticallyAllocateDeliveryAddress = true;
+
+    /**
      * Controller constructor.
      *
      * @global bool $useSSL SSL connection flag
@@ -409,7 +417,7 @@ class FrontControllerCore extends Controller
             if (isset($cart) && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0 ||
                     !isset($cart->id_address_invoice) || $cart->id_address_invoice == 0) && $this->context->cookie->id_customer) {
                 $to_update = false;
-                if (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0) {
+                if ($this->automaticallyAllocateDeliveryAddress && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0)) {
                     $to_update = true;
                     $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
                 }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -398,21 +398,7 @@ class FrontControllerCore extends Controller
                 $cart->update();
             }
             /* Select an address if not set */
-            if (isset($cart) && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0 ||
-                !isset($cart->id_address_invoice) || $cart->id_address_invoice == 0) && $this->context->cookie->id_customer) {
-                $to_update = false;
-                if (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0) {
-                    $to_update = true;
-                    $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
-                }
-                if (!isset($cart->id_address_invoice) || $cart->id_address_invoice == 0) {
-                    $to_update = true;
-                    $cart->id_address_invoice = (int) Address::getFirstCustomerAddressId($cart->id_customer);
-                }
-                if ($to_update) {
-                    $cart->update();
-                }
-            }
+
         }
 
         if (!isset($cart) || !$cart->id) {

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -53,6 +53,13 @@ class OrderControllerCore extends FrontController
     protected $automaticallyAllocateInvoiceAddress = false;
 
     /**
+     * Overrides the same parameter in FrontController
+     *
+     * @var bool
+     */
+    protected $automaticallyAllocateDeliveryAddress = false;
+
+    /**
      * Initialize order controller.
      *
      * @see FrontController::init()

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -46,6 +46,13 @@ class OrderControllerCore extends FrontController
     protected $cartChecksum;
 
     /**
+     * Overrides the same parameter in FrontController
+     *
+     * @var bool automaticallyAllocateInvoiceAddress
+     */
+    protected $automaticallyAllocateInvoiceAddress = false;
+
+    /**
      * Initialize order controller.
      *
      * @see FrontController::init()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | At checkout (FO), when you have more than one address and you edit the delivery address, if you uncheck "Use this address for invoice too" and click "Save", after the page refreshes you are in the delivery step, instead of being presented with a different invoicing address to choose from.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | yes, we do not perform the automatic address assignment in OrderController
| Deprecations? | no
| Fixed ticket? | Fixes #11595
| How to test?  | See #11595, but we should also check<br/>- using/setting adresses behaviors as a whole (checkout, customer addresses in FO, in BO...)<br/>- if possible test with modules that interact with Checkout Process and might alter adresses data (auto-set a data ? use a map to allow user to pick its address ?)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20606)
<!-- Reviewable:end -->

:notebook: BC Break
* In the FrontController, the forceful assignment of the invoice address id is now disabled for OrderController.
Before:
`if (!isset($cart->id_address_invoice) || $cart->id_address_invoice == 0) {`
After:
`if ($this->automaticallyAllocateInvoiceAddress && (!isset($cart->id_address_invoice) || $cart->id_address_invoice == 0)) {`