### PR TITLE
Wrong validation while uploading product image more than defined size limit.

### DIFF
--- a/app/Resources/translations/default/AdminNotificationsError.xlf
+++ b/app/Resources/translations/default/AdminNotificationsError.xlf
@@ -1617,8 +1617,8 @@ Comment: check if some ids are in list_skip_actions and forbid deletion</note>
   <file original="src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="a9e0d1b71fb7197367e0518bb6b34fdd">
-        <source>The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2].</source>
-        <target>The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2].</target>
+        <source>The file is too large. Maximum size allowed is: [1] MB. The file you are trying to upload is [2] MB.</source>
+        <target>The file is too large. Maximum size allowed is: [1] MB. The file you are trying to upload is [2] MB.</target>
         <note>Line: 339</note>
       </trans-unit>
     </body>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -336,7 +336,7 @@
 "Form update success": "Settings updated."|trans({}, 'Admin.Notifications.Success'),
 "Form update errors": "Unable to update settings."|trans({}, 'Admin.Notifications.Error'),
 "Delete": "Delete"|trans({}, 'Admin.Actions'),
-"ToLargeFile": "The file is too large. Maximum size allowed is: [1]. The file you are trying to upload is [2]."|trans({}, 'Admin.Notifications.Error')|replace({ '[1]': '{{maxFilesize}}', '[2]': '{{filesize}}' }),
+"ToLargeFile": "The file is too large. Maximum size allowed is: [1] MB. The file you are trying to upload is [2] MB."|trans({}, 'Admin.Notifications.Error')|replace({ '[1]': '{{maxFilesize}}', '[2]': '{{filesize}}' }),
 "Drop images here": "Drop images here"|trans({}, 'Admin.Catalog.Feature'),
 "or select files": "or select files"|trans({}, 'Admin.Catalog.Feature'),
 "files recommandations": "Recommended size 800 x 800px for default theme."|trans({}, 'Admin.Catalog.Feature'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Wrong validation while uploading product image more than the defined size limit.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20613 .
| How to test?  | Go to Advanced parameters and check product image upload size limit https://prnt.sc/u14x0j (currently 2 MB).Now go to the Admin Product page and upload an image size more than 2 MB.Now you will get this message:https://prnt.sc/u14ugsThe above message is not correct here size unit is not defined (i.e, it is KB or MB nothing defined).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20614)
<!-- Reviewable:end -->
