### PR TITLE
Set secure_key in invoice links for guests

### DIFF
--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -84,8 +84,8 @@ class HistoryControllerCore extends FrontController
 
         if ((bool) Configuration::get('PS_INVOICE') && OrderState::invoiceAvailable($order->current_state) && count($order->getInvoicesCollection())) {
             $url_to_invoice = $context->link->getPageLink('pdf-invoice', true, null, 'id_order=' . $order->id);
-            if ($context->cookie->is_guest) {
-                $url_to_invoice .= '&amp;secure_key=' . $order->secure_key;
+            if (!$context->customer->isLogged()) {
+                $url_to_invoice .= '&secure_key=' . $order->secure_key;
             }
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR fixes the check for whether or not the current customer is a guest in `HistoryController::getUrlToInvoice`, allowing guests to download invoices without having to log in.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9650.
| How to test?  | In private browsing/incognito mode, place a new order as a guest with a payment method that marks an order as paid. On the order confirmation page, the success message should have a "download your invoice" link. AND/OR Navigate to /guest-tracking and enter the order reference and email you placed the order with. The tracking page should also have a "Download your invoice as a PDF file" link. Click it and download the invoice PDF. Prior to this fix you would've been prompted to log in after clicking the download invoice link.

Fix proposed by @BitcoinMitchell [here](https://github.com/PrestaShop/PrestaShop/issues/9650#issuecomment-659693010). I have confirmed the fix works for both contexts in which I have encountered the issue.

### Original Issue:
Links to invoices for guests on the order confirmation and guest tracking pages did not have their secure_key set, prompting them to log in.
### Cause:
`$context->cookie->is_guest` does not appear to be set in those contexts. Also, the generated link contains a pre-encoded ampersand which prevents the link from functioning when `secure_key` is set.

### Alternative fixes (may be more "correct"):
- [WORKS] Check for `$context->customer->id_guest` in `HistoryController.php:87` (Works in both order confirmation and guest tracking pages.)
- [DOESN'T WORK] Check `$context->customer->is_guest` (Set properly in order confirmation page but not in guest tracking if the viewer does not have cookies from the previous session.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20616)
<!-- Reviewable:end -->
