### PR TITLE
Do not proceed setCurrentState if order already has the right state

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1673,8 +1673,11 @@ class OrderCore extends ObjectModel
      */
     public function setCurrentState($id_order_state, $id_employee = 0)
     {
-        if (empty($id_order_state)) {
+        if (empty($id_order_state) || $id_order_state == $this->current_state) {
             return false;
+        }
+        if ($id_order_state == $this->current_state) {
+            return;
         }
         $history = new OrderHistory();
         $history->id_order = (int) $this->id;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1676,9 +1676,6 @@ class OrderCore extends ObjectModel
         if (empty($id_order_state) || $id_order_state == $this->current_state) {
             return false;
         }
-        if ($id_order_state == $this->current_state) {
-            return;
-        }
         $history = new OrderHistory();
         $history->id_order = (int) $this->id;
         $history->id_employee = (int) $id_employee;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1673,7 +1673,7 @@ class OrderCore extends ObjectModel
      */
     public function setCurrentState($id_order_state, $id_employee = 0)
     {
-        if (empty($id_order_state) || $id_order_state == $this->current_state) {
+        if (empty($id_order_state) || (int) $id_order_state === (int) $this->current_state) {
             return false;
         }
         $history = new OrderHistory();


### PR DESCRIPTION
This fix avoids executing the setCurrentState body if the order already has that id_order_state

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It happens at every webservice PUT request for updating any order field. The order_state is reprocessed without checking if the order already has the state, sending the state's email and triggering all related hooks.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20623
| How to test?  | Create an order state with the email sending option set to on, put an order to this state and then, send again the same put request using the WS. You will receive two emails because the order has changed twice to the same state.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20622)
<!-- Reviewable:end -->
