### PR TITLE
Restore selectors in Order Page for GDPR to make GDPR module compliant with 1.7.7.0

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -101,7 +101,7 @@
     <div class="info-block mt-2">
       <div class="row">
         {% if orderForViewing.virtual is same as(false) %}
-        <div class="info-block-col col-xl-6">
+        <div id="addressShipping" class="info-block-col col-xl-6">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
             {% if orderForViewing.customer is not null %}
@@ -150,7 +150,7 @@
           </p>
         </div>
         {% endif %}
-        <div class="info-block-col {% if orderForViewing.virtual %}col-md-12{% else %}col-md-6{% endif %}">
+        <div id="addressInvoice" class="info-block-col {% if orderForViewing.virtual %}col-md-12{% else %}col-md-6{% endif %}">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Invoice address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Restore some legacy selectors for View an order page that are used by PrestaShop GDPR module
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes all issues listed in https://github.com/PrestaShopCorp/psgdpr/issues/103 when used in combination with https://github.com/PrestaShopCorp/psgdpr/pull/96/ PR on psgdpr module
| How to test?  | See the scenario described in https://github.com/PrestaShop/PrestaShop/issues/20605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20628)
<!-- Reviewable:end -->
