### PR TITLE
Allow to disable make usage and use .env file

### DIFF
--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-echo "\n* Running composer ...";
-runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
+if [ "${DISABLE_MAKE}" != "1" ]; then
+  echo "\n* Running composer ...";
+  runuser -g www-data -u www-data -- /usr/local/bin/composer install --no-interaction
 
-echo "\n* Build assets ...";
-runuser -g www-data -u www-data -- /usr/bin/make assets
+  echo "\n* Build assets ...";
+  runuser -g www-data -u www-data -- /usr/bin/make assets
+fi
 
 if [ "$DB_SERVER" = "<to be defined>" -a $PS_INSTALL_AUTO = 1 ]; then
     echo >&2 'error: You requested automatic PrestaShop installation but MySQL server address is not provided '

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 volumes:
   db-data:
@@ -19,13 +19,14 @@ services:
   prestashop-git:
     build: .docker
     environment:
-      PS_INSTALL_AUTO: 1
-      DB_PASSWD: prestashop
-      DB_NAME: prestashop
-      DB_SERVER: mysql
-      PS_DOMAIN: localhost:8001
-      PS_FOLDER_INSTALL: install-dev
-      PS_FOLDER_ADMIN: admin-dev
+      DISABLE_MAKE: ${DISABLE_MAKE:-0}
+      PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}
+      DB_PASSWD: ${DB_PASSWD:-prestashop}
+      DB_NAME: ${DB_NAME:-prestashop}
+      DB_SERVER: ${DB_SERVER:-mysql}
+      PS_DOMAIN: ${PS_DOMAIN:-localhost:8001}
+      PS_FOLDER_INSTALL: ${PS_FOLDER_INSTALL:-install-dev}
+      PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Optimize docker-compose variables. You can now use `DISABLE_MAKE` environment variable to disable the `make install`
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Run `docker-compose up` it will install a PrestaShop shop. Stop the instance after everything is ok. Then create a `.env` file with `DISABLE_MAKE=1` the `composer install` and `make assets` must not appear in the log. Don't forget to run `docker-compose build` before everything to make sure it has the latest version of `docker_run.git`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20634)
<!-- Reviewable:end -->
