### PR TITLE
Carrier field in invoice must not be displayed if order is virtual

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -357,6 +357,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'ps_price_compute_precision' => Context::getContext()->getComputingPrecision(),
             'round_type' => $round_type,
             'legal_free_text' => $legal_free_text,
+            'is_virtual_order' => $this->order->isVirtual()
         ];
 
         if (Tools::getValue('debug')) {

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -357,7 +357,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'ps_price_compute_precision' => Context::getContext()->getComputingPrecision(),
             'round_type' => $round_type,
             'legal_free_text' => $legal_free_text,
-            'is_virtual_order' => $this->order->isVirtual()
+            'is_virtual_order' => $this->order->isVirtual(),
         ];
 
         if (Tools::getValue('debug')) {

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -98,6 +98,7 @@
 		<td colspan="1">&nbsp;</td>
 	</tr>
 
+{if isset($is_virtual_order) && $is_virtual_order}
 	<tr>
 		<td colspan="6" class="left">
 
@@ -106,6 +107,7 @@
 		</td>
 		<td colspan="1">&nbsp;</td>
 	</tr>
+{/if}
 
 	<tr>
 		<td colspan="12" height="10">&nbsp;</td>

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -98,7 +98,7 @@
 		<td colspan="1">&nbsp;</td>
 	</tr>
 
-  {if isset($is_virtual_order) && $is_virtual_order}
+  {if isset($is_virtual_order) && !$is_virtual_order}
   <tr>
     <td colspan="6" class="left">
 

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -99,14 +99,14 @@
 	</tr>
 
   {if isset($is_virtual_order) && $is_virtual_order}
-	  <tr>
-		  <td colspan="6" class="left">
+  <tr>
+    <td colspan="6" class="left">
 
-			  {$shipping_tab}
+      {$shipping_tab}
 
-		  </td>
-		  <td colspan="1">&nbsp;</td>
-	  </tr>
+    </td>
+    <td colspan="1">&nbsp;</td>
+  </tr>
   {/if}
 
 	<tr>

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -98,16 +98,16 @@
 		<td colspan="1">&nbsp;</td>
 	</tr>
 
-{if isset($is_virtual_order) && $is_virtual_order}
-	<tr>
-		<td colspan="6" class="left">
+  {if isset($is_virtual_order) && $is_virtual_order}
+	  <tr>
+		  <td colspan="6" class="left">
 
-			{$shipping_tab}
+			  {$shipping_tab}
 
-		</td>
-		<td colspan="1">&nbsp;</td>
-	</tr>
-{/if}
+		  </td>
+		  <td colspan="1">&nbsp;</td>
+	  </tr>
+  {/if}
 
 	<tr>
 		<td colspan="12" height="10">&nbsp;</td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The Carrier field in the invoice must not be displayed if an order is virtual i.e if all products of an order are virtual.
https://prnt.sc/u1sfdh
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20636 
| How to test?  | Go to the front end and add one or more than one virtual product in the cart. Make a successful order. Now go to the back-office and download invoice for that order. Since the order contains all virtual products that mean no shipping is required but the string is appearing https://prnt.sc/u1sfdh that is incorrect.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20637)
<!-- Reviewable:end -->
