### PR TITLE
Wrong install redirection when we are in admin directory

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4423,9 +4423,17 @@ exit;
     public static function redirectToInstall()
     {
         if (file_exists(__DIR__ . '/../install')) {
-            header('Location: install/');
+            if (defined('_PS_ADMIN_DIR_')) {
+                header('Location: ../install/');
+            } else {
+                header('Location: install/');
+            }
         } elseif (file_exists(__DIR__ . '/../install-dev')) {
-            header('Location: install-dev/');
+            if (defined('_PS_ADMIN_DIR_')) {
+                header('Location: ../install-dev/');
+            } else {
+                header('Location: install-dev/');
+            }
         } else {
             die('Error: "install" directory is missing');
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes this bug: Remove app/config/parameters.* when you're in /admin-dev directory, reload the page, an infinite loop is coming to /install-dev/install-dev
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Before the PR: Remove app/config/parameters.* when you're in /admin-dev directory, reload the page, an infinite loop is coming to /install-dev/install-dev.<br/> After the PR: it's alright 😄 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20638)
<!-- Reviewable:end -->
