### PR TITLE
Check for address id before creating CartAddress

### DIFF
--- a/src/Adapter/Cart/QueryHandler/GetCartInformationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartInformationHandler.php
@@ -162,13 +162,13 @@ final class GetCartInformationHandler extends AbstractCartHandler implements Get
         }
 
         // Add addresses already assigned to cart if absent (in case they are deleted)
-        if (!isset($cartAddresses[$cart->id_address_delivery])) {
+        if (0 !== (int) $cart->id_address_delivery && !isset($cartAddresses[$cart->id_address_delivery])) {
             $cartAddresses[$cart->id_address_delivery] = $this->buildCartAddress(
                 $cart->id_address_delivery,
                 $cart
             );
         }
-        if (!isset($cartAddresses[$cart->id_address_invoice])) {
+        if (0 !== (int) $cart->id_address_invoice && !isset($cartAddresses[$cart->id_address_invoice])) {
             $cartAddresses[$cart->id_address_invoice] = $this->buildCartAddress(
                 $cart->id_address_invoice,
                 $cart


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When creating an order in the BO with a freshly created customer (that didn't have any address yet), it was impossible to select it. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20643
| How to test?  | See #20643

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20644)
<!-- Reviewable:end -->
