### PR TITLE
Fix selectors for Seo options form after merge 1.7.7.x into develop

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig
@@ -49,7 +49,9 @@
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">
-        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        <button class="btn btn-primary" id="meta_settings_seo_options_form_save_button">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
       </div>
     </div>
   </div>

--- a/tests/UI/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
+++ b/tests/UI/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
@@ -56,9 +56,9 @@ class SeoAndUrls extends BOBasePage {
     this.paginationPreviousLink = `${this.gridPanel} [aria-label='Previous']`;
 
     // Seo options form
-    this.switchDisplayAttributesLabel = toggle => 'label[for=\'meta_settings_form_seo_options_product'
+    this.switchDisplayAttributesLabel = toggle => 'label[for=\'meta_settings_seo_options_form_product'
       + `_attributes_in_title_${toggle}']`;
-    this.saveSeoOptionsFormButton = '#main-div form:nth-child(1) div:nth-child(4) div.card-footer button';
+    this.saveSeoOptionsFormButton = '#meta_settings_seo_options_form_save_button';
   }
 
   /* header methods */
@@ -166,7 +166,7 @@ class SeoAndUrls extends BOBasePage {
   async confirmDeleteSeoUrlPage(page) {
     await this.clickAndWaitForNavigation(page, this.confirmDeleteButton);
   }
-  
+
   /* Sort functions */
   /**
    * Sort table by clicking on column name


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix selectors for seo options form after merge 1.7.7.x into develop
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/13_shopParameters/06_trafficAndSeo/01_seoAndUrls/05_seoOptions/01_displayAttributesInProductMetaTitle" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20647)
<!-- Reviewable:end -->
