### PR TITLE
Refactor Tax calculation with VAT numbers

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -786,10 +786,7 @@ class ProductCore extends ObjectModel
             }
             $address_infos = Address::getCountryAndState($id_address);
 
-            if (self::$_taxCalculationMethod != PS_TAX_EXC
-                && !empty($address_infos['vat_number'])
-                && $address_infos['id_country'] != Configuration::get('VATNUMBER_COUNTRY')
-                && Configuration::get('VATNUMBER_MANAGEMENT')) {
+            if (self::$_taxCalculationMethod != PS_TAX_EXC && Tax::vatIsTaxExemptable($address_infos['vat_number'], $address_infos['id_country'])) {
                 self::$_taxCalculationMethod = PS_TAX_EXC;
             }
         } else {
@@ -3545,10 +3542,7 @@ class ProductCore extends ObjectModel
             $usetax = false;
         }
 
-        if ($usetax != false
-            && !empty($address->vat_number)
-            && $address->id_country != Configuration::get('VATNUMBER_COUNTRY')
-            && Configuration::get('VATNUMBER_MANAGEMENT')) {
+        if ($usetax != false && Tax::vatIsTaxExemptable($address->vat_number, $address->id_country)) {
             $usetax = false;
         }
 

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -391,9 +391,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         $debug = Tools::getValue('debug');
 
         $address = new Address((int) $this->order->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $tax_exempt = Configuration::get('VATNUMBER_MANAGEMENT')
-                            && !empty($address->vat_number)
-                            && $address->id_country != Configuration::get('VATNUMBER_COUNTRY');
+        $tax_exempt = Tax::vatIsTaxExemptable($address->vat_number, $address->id_country);
         $carrier = new Carrier($this->order->id_carrier);
 
         $data = [

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -211,9 +211,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
     public function getTaxTabContent()
     {
         $address = new Address((int) $this->order->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $tax_exempt = Configuration::get('VATNUMBER_MANAGEMENT')
-                            && !empty($address->vat_number)
-                            && $address->id_country != Configuration::get('VATNUMBER_COUNTRY');
+        $tax_exempt = Tax::vatIsTaxExemptable($address->vat_number, $address->id_country);
 
         $this->smarty->assign([
             'tax_exempt' => $tax_exempt,

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -290,5 +290,4 @@ class TaxCore extends ObjectModel
 
         return true;
     }
-
 }

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -265,4 +265,30 @@ class TaxCore extends ObjectModel
 
         return $tax_calculator->getTotalRate();
     }
+
+    /**
+     * Determines whether a vat number should be exempted from taxes, considering the merchant's country.
+     *
+     * @param int $vat_number
+     * @param int $id_country
+     *
+     * @return bool
+     */
+    public static function vatIsTaxExemptable($vat_number, $id_country)
+    {
+        if (empty($vat_number)) {
+            return false;
+        }
+
+        if (!Configuration::get('VATNUMBER_MANAGEMENT')) {
+            return false;
+        }
+
+        if ((int) $id_country === (int) Configuration::get('VATNUMBER_COUNTRY')) {
+            return false;
+        }
+
+        return true;
+    }
+
 }


### PR DESCRIPTION
Previously, the check for the vatnumbers module was done in several different places. This change adds a single method on the Tax class that deteremines the following criteria:  
- Is the VAT number specified?
- Is VAT management even enabled?
- Is the VAT from another country than the merchant?

This refactor has two main benefits:  
- Code is clearer and more readable, and the concern of the VAT is in the Tax class, where it belongs;
- Now this is trivially overriddable, for example it allows to perform a VIES check on the fly if necessary, and not only on data-entry.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Previously, the check for the vatnumbers module was done in several different places. This change adds a single method on the Tax class that deteremines the following criteria: Is the VAT number specified? Is VAT management even enabled? Is the VAT from another country than the merchant? This refactor has two main benefits: Code is clearer and more readable, and the concern of the VAT is in the Tax class, where it belongs; Now this is trivially overriddable, for example it allows to perform a VIES check on the fly if necessary, and not only on data-entry.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | - Create a customer with 3 billing addresses, one with a correct vat, one with a bad vat, one without a vatnumber.<br>- Install the vatnumber module and activate it;<br>- make sure it works as expected before and after this change: both the addresses with vat numbers should exempt you from taxes, while the one without vat should charge you taxes.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20655)
<!-- Reviewable:end -->
