### PR TITLE
Fixed the reset of the unit_price_ratio when the product is activated / deactivated from the product listing page

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -697,7 +697,9 @@ class ProductCore extends ObjectModel
     {
         $fields = parent::getFieldsShop();
         if (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price']))) {
-            $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
+            if ($this->unit_price != null) {
+                $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
+            }
         }
         $fields['unity'] = pSQL($this->unity);
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -697,7 +697,7 @@ class ProductCore extends ObjectModel
     {
         $fields = parent::getFieldsShop();
         if (null === $this->update_fields || (!empty($this->update_fields['price']) && !empty($this->update_fields['unit_price']))) {
-            if ($this->unit_price != null) {
+            if ($this->unit_price !== null) {
                 $fields['unit_price_ratio'] = (float) $this->unit_price > 0 ? $this->price / $this->unit_price : 0;
             }
         }


### PR DESCRIPTION
Fixes #20679

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When the product is activated / deactivated from the product listing page, the unit_price_ratio is reset to 0, this PR fixes this
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #10792, #20679
| How to test?  | See issue description..

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20680)
<!-- Reviewable:end -->
