### PR TITLE
Fix faker data - Title's name should take at most 20 characters 

### DIFF
--- a/tests/UI/campaigns/data/faker/title.js
+++ b/tests/UI/campaigns/data/faker/title.js
@@ -4,7 +4,7 @@ const genders = ['Male', 'Female', 'Neutral'];
 
 module.exports = class Title {
   constructor(titleToCreate = {}) {
-    this.name = titleToCreate.name || faker.random.word();
+    this.name = (titleToCreate.name || faker.random.word()).substring(0, 19);
     this.frName = titleToCreate.frName || this.name;
     this.gender = titleToCreate.gender || faker.random.arrayElement(genders);
     this.imageName = titleToCreate.imageName || `${this.name}.png`;

--- a/tests/UI/campaigns/data/faker/title.js
+++ b/tests/UI/campaigns/data/faker/title.js
@@ -4,6 +4,7 @@ const genders = ['Male', 'Female', 'Neutral'];
 
 module.exports = class Title {
   constructor(titleToCreate = {}) {
+    // Title name should contain at most 20 characters
     this.name = (titleToCreate.name || faker.random.word()).substring(0, 19);
     this.frName = titleToCreate.frName || this.name;
     this.gender = titleToCreate.gender || faker.random.arrayElement(genders);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix faker data - Title's name should take at most 20 characters 
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/13_shopParameters/04_customerSettings/03_titles/02_CRUDTitles" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20683)
<!-- Reviewable:end -->
