### PR TITLE
Fix empty optional customization exception when creating BO order

### DIFF
--- a/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
@@ -79,7 +79,7 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
                 $command->getCustomizationsByFieldIds()
             ));
             if (null !== $customizationIdVO) {
-                $combinationId = $customizationIdVO->getValue();
+                $customizationId = $customizationIdVO->getValue();
             }
         }
 

--- a/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
@@ -73,11 +73,14 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
         $customizationId = null;
 
         if (!empty($command->getCustomizationsByFieldIds())) {
-            $customizationId = $this->addCustomizationHandler->handle(new AddCustomizationCommand(
+            $customizationIdVO = $this->addCustomizationHandler->handle(new AddCustomizationCommand(
                 $cartIdValue,
                 $command->getProductId()->getValue(),
                 $command->getCustomizationsByFieldIds()
-            ))->getValue();
+            ));
+            if (null !== $customizationIdVO) {
+                $combinationId = $customizationIdVO->getValue();
+            }
         }
 
         $cart = $this->getCart($command->getCartId());


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When creating an order in the BO, an exception was thrown when adding a product with an empty **optional** customization field. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | Fixes #20671
| How to test?  | See #20671

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20684)
<!-- Reviewable:end -->
