### PR TITLE
Show profile icon on mobile and hide see my shop text

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -196,11 +196,9 @@ $search-border-color: #bbcdd2
 		padding: 0
 		margin-right: 0
 		margin-bottom: 0
+		margin-left: 0
 		display: flex
 		align-items: center
-
-		.mobile &
-			display: none
 
 		#employee_infos
 			list-style-type: none
@@ -219,14 +217,6 @@ $search-border-color: #bbcdd2
 						width: 3.8rem
 						height: 3.8rem
 
-				@media (max-width: $screen-sm)
-					li
-						color: white
-						font-size: 1.2em
-						text-transform: uppercase
-						i
-							font-size: 1.3em
-							color: $brand-primary
 				.employee-wrapper
 					&-avatar
 						float: left

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -259,13 +259,13 @@
               <ul id="header_shop" class="shop-state">
                 <li class="dropdown">
                   <i class="material-icons">visibility</i>
-                  {$shop_list}
+                  <span>{$shop_list}</span>
                 </li>
               </ul>
             {else}
               <a id="header_shopname" class="shop-state" href="{$base_url|escape:'html':'UTF-8'}" target="_blank">
                 <i class="material-icons">visibility</i>
-                {l s='View my shop' d='Admin.Navigation.Header'}
+                <span>{l s='View my shop' d='Admin.Navigation.Header'}</span>
               </a>
             {/if}
           </li>
@@ -348,7 +348,7 @@
 
       {* Employee *}
       <ul id="header_employee_box" class="component">
-        <li id="employee_infos" class="dropdown hidden-xs">
+        <li id="employee_infos" class="dropdown">
           <a href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}"
              class="employee_name dropdown-toggle"
              data-toggle="dropdown"

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -7,7 +7,7 @@ $header-text-color: #4e6167 !default;
   align-items: stretch;
   width: 100%;
   height: $size-header-height;
-  font-size: .8125rem;
+  font-size: 0.8125rem;
   color: $header-text-color;
   background: #fff;
 
@@ -23,10 +23,10 @@ $header-text-color: #4e6167 !default;
       margin-right: 0;
     }
     .notification-center .dropdown-menu {
-      margin-top: .3125rem;
+      margin-top: 0.3125rem;
     }
     > .material-icons:not(.js-mobile-menu) {
-      padding-top: .625rem;
+      padding-top: 0.625rem;
       font-size: 1.313rem;
     }
   }
@@ -46,9 +46,9 @@ $header-text-color: #4e6167 !default;
 
   #shop_version {
     position: absolute;
-    top: .9375rem;
+    top: 0.9375rem;
     left: 11.25rem;
-    font-size: .625rem;
+    font-size: 0.625rem;
 
     // hide if viewport <= tablet portrait size
     @include media-breakpoint-down("md") {
@@ -80,7 +80,7 @@ $header-text-color: #4e6167 !default;
       letter-spacing: normal;
       font: {
         weight: normal;
-        size: .8125rem;
+        size: 0.8125rem;
       }
 
       &:hover {
@@ -89,7 +89,7 @@ $header-text-color: #4e6167 !default;
       }
 
       &::after {
-        margin-left: -.313rem;
+        margin-left: -0.313rem;
       }
     }
   }
@@ -106,11 +106,11 @@ $header-text-color: #4e6167 !default;
     form {
       width: 100%; // needed for transition
       height: 1.875rem; // necessary because of elements stretching vertically
-      @include transition(width .5s ease-in-out);
+      @include transition(width 0.5s ease-in-out);
 
       .btn {
         opacity: 1;
-        @include transition(all .5s);
+        @include transition(all 0.5s);
       }
 
       // behavior when the search form is collapsed
@@ -119,11 +119,10 @@ $header-text-color: #4e6167 !default;
 
         input#bo_query {
           padding-left: 2rem; // leave out space for the loupe
-          @include border-radius(.983rem);
+          @include border-radius(0.983rem);
         }
 
         .input-group {
-
           // loupe icon
           &::before {
             margin-top: -(1.25rem / 2);
@@ -145,13 +144,13 @@ $header-text-color: #4e6167 !default;
 
     // search input
     input#bo_query {
-      font-size: .75rem;
+      font-size: 0.75rem;
       border: 1px solid #bbcdd2;
-      @include border-left-radius(.983rem);
-      @include transition(padding-left .5s);
+      @include border-left-radius(0.983rem);
+      @include transition(padding-left 0.5s);
       padding: {
-        top: .375rem;
-        bottom: .375rem;
+        top: 0.375rem;
+        bottom: 0.375rem;
       }
 
       &::placeholder {
@@ -161,18 +160,17 @@ $header-text-color: #4e6167 !default;
     }
 
     .input-group {
-
       // loupe icon (hidden by default)
       &::before {
         @extend .material-icons;
         position: absolute;
         top: 50%;
-        left: .563rem;
+        left: 0.563rem;
         z-index: 5;
         font-size: 0;
         content: "search";
         opacity: 0;
-        @include transition(all .5s);
+        @include transition(all 0.5s);
       }
 
       button:not(:first-of-type) {
@@ -183,10 +181,10 @@ $header-text-color: #4e6167 !default;
     .btn,
     .btn-primary {
       font: {
-        size: .75rem;
+        size: 0.75rem;
         weight: normal;
       }
-      padding: .313rem .625rem;
+      padding: 0.313rem 0.625rem;
       color: $medium-gray;
       text-transform: none;
       letter-spacing: normal;
@@ -206,8 +204,8 @@ $header-text-color: #4e6167 !default;
     // search button
     .btn-primary {
       border: {
-        top-right-radius: .983rem;
-        bottom-right-radius: .983rem;
+        top-right-radius: 0.983rem;
+        bottom-right-radius: 0.983rem;
       }
       padding: {
         right: 1rem;
@@ -231,20 +229,20 @@ $header-text-color: #4e6167 !default;
 
     .dropdown-menu {
       font: {
-        size: .75rem;
+        size: 0.75rem;
       }
       min-width: 15.625rem;
-      padding: .313rem 0;
+      padding: 0.313rem 0;
       color: $gray-dark;
 
       .material-icons {
-        padding-right: .5rem;
+        padding-right: 0.5rem;
         color: $medium-gray;
         vertical-align: text-bottom;
       }
 
       > a {
-        padding: .438rem .938rem{
+        padding: 0.438rem 0.938rem {
           right: 1.5rem;
         }
         color: inherit;
@@ -261,7 +259,7 @@ $header-text-color: #4e6167 !default;
       }
 
       > .dropdown-divider {
-        margin: .313rem 0;
+        margin: 0.313rem 0;
       }
     }
   }
@@ -271,8 +269,8 @@ $header-text-color: #4e6167 !default;
     align-items: center;
 
     margin: {
-      right: .5rem;
-      left: .5rem;
+      right: 0.5rem;
+      left: 0.5rem;
     }
 
     // hide on very small screens
@@ -285,8 +283,8 @@ $header-text-color: #4e6167 !default;
     &.header-right-component,
     &.gamification-component {
       margin: {
-        right: .3125rem;
-        left: .3125rem;
+        right: 0.3125rem;
+        left: 0.3125rem;
       }
     }
     > .stores .ps-dropdown-menu {
@@ -301,7 +299,7 @@ $header-text-color: #4e6167 !default;
     display: flex;
     align-items: center;
     height: 100%;
-    font-size: .8125rem;
+    font-size: 0.8125rem;
     color: $header-text-color;
     white-space: nowrap;
 
@@ -316,7 +314,7 @@ $header-text-color: #4e6167 !default;
       font-size: 1.25rem;
       color: $medium-gray;
       padding: {
-        right: .3125rem;
+        right: 0.3125rem;
       }
     }
 
@@ -331,25 +329,26 @@ $header-text-color: #4e6167 !default;
   .shop-list {
     > .link {
       > .material-icons {
-        padding-right: .3125rem;
+        padding-right: 0.3125rem;
         font-size: 1.25rem;
         color: $primary;
+      }
+    }
+
+    @media (max-width: breakpoint-max("lg")) {
+      span {
+        display: none;
       }
     }
   }
 
   #header-employee-container {
-    margin-right: .3125rem;
-
-    .mobile & {
-      display: none;
-    }
+    margin-right: 0.3125rem;
   }
 
   #header-notification-container {
     min-width: $size-header-height;
   }
-
 }
 
 // multishop
@@ -365,7 +364,7 @@ $header-text-color: #4e6167 !default;
     }
 
     .selected-item {
-      font-size: .8125rem;
+      font-size: 0.8125rem;
       line-height: 17px;
       .material-icons {
         top: -1px;
@@ -389,7 +388,7 @@ $header-text-color: #4e6167 !default;
     font-size: 13px;
     border: 1px solid #bbcdd2;
     @include border-radius(0);
-    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .1);
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.1);
 
     .items-list {
       max-height: 500px;
@@ -402,7 +401,7 @@ $header-text-color: #4e6167 !default;
       }
       li:first-child a {
         padding-left: 0;
-        font-size: .875rem;
+        font-size: 0.875rem;
         font-weight: 600;
         color: $brand-info;
 
@@ -415,13 +414,13 @@ $header-text-color: #4e6167 !default;
         a:not(.link-shop) {
           display: inline-block;
           width: inherit;
-          padding-top: .3125rem;
-          padding-bottom: .3125rem;
+          padding-top: 0.3125rem;
+          padding-bottom: 0.3125rem;
         }
       }
       .group {
         a {
-          padding-left: .625rem;
+          padding-left: 0.625rem;
         }
       }
       .shop {
@@ -444,17 +443,17 @@ $header-text-color: #4e6167 !default;
           i.material-icons {
             width: inherit;
             height: inherit;
-            padding: .125rem .625em;
+            padding: 0.125rem 0.625em;
             font-size: 1.25rem;
             color: $gray-medium;
             cursor: pointer;
             border: solid 1px $gray-light;
-            @include border-radius(.0625rem);
+            @include border-radius(0.0625rem);
           }
         }
       }
       .material-icons {
-        margin-right: .625rem;
+        margin-right: 0.625rem;
         vertical-align: middle;
       }
       li {
@@ -493,7 +492,7 @@ $header-text-color: #4e6167 !default;
 }
 .employee-dropdown {
   > .person {
-    margin-right: .625rem;
+    margin-right: 0.625rem;
     cursor: pointer;
     .material-icons {
       font-size: 1.5rem;
@@ -503,8 +502,8 @@ $header-text-color: #4e6167 !default;
   }
   .dropdown-menu {
     /* stylelint-disable declaration-no-important */
-    top: .9rem !important;
-    left: .3rem !important;
+    top: 0.9rem !important;
+    left: 0.3rem !important;
     /* stylelint-enable declaration-no-important */
 
     min-width: 17.5rem;
@@ -543,8 +542,8 @@ $header-text-color: #4e6167 !default;
     }
 
     .employee-avatar {
-      padding: .687rem 0 1rem;
-      margin-bottom: .46875rem;
+      padding: 0.687rem 0 1rem;
+      margin-bottom: 0.46875rem;
       font-weight: 600;
       text-align: center;
     }
@@ -609,14 +608,14 @@ $header-text-color: #4e6167 !default;
       content: "";
       border-right: 7px solid transparent;
       border-bottom: 7px solid #ccc;
-      border-bottom-color: rgba(0, 0, 0, .2);
+      border-bottom-color: rgba(0, 0, 0, 0.2);
       border-left: 7px solid transparent;
     }
 
     .avatar {
       width: 3.8rem;
       height: 3.8rem;
-      margin-bottom: .3125rem;
+      margin-bottom: 0.3125rem;
       cursor: pointer;
     }
 

--- a/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
@@ -34,7 +34,7 @@
       <span class="employee_profile">{l s='Welcome back %name%' sprintf=['%name%' => $employee->firstname] d='Admin.Navigation.Header'}</span>
       <a class="dropdown-item employee-link profile-link" href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}">
       <i class="material-icons">settings</i>
-      {l s='Your profile' d='Admin.Navigation.Header'}
+      <span>{l s='Your profile' d='Admin.Navigation.Header'}</span>
     </a>
     </div>
 

--- a/admin-dev/themes/new-theme/template/components/layout/shop_list.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/shop_list.tpl
@@ -51,7 +51,7 @@
   <div class="shop-list">
     <a class="link" id="header_shopname" href="{$base_url|escape:'html':'UTF-8'}" target= "_blank">
       <i class="material-icons">visibility</i>
-      {l s='View my shop' d='Admin.Navigation.Header'}
+      <span>{l s='View my shop' d='Admin.Navigation.Header'}</span>
     </a>
   </div>
 {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Profile icon was not visible on mobile so you couldn't access you'r profile on migrated pages
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20522.
| How to test?  | Go on the BO, resize to low screen as in the issue, and see if you can see the profile icon, click on it and everything should work pretty well

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20688)
<!-- Reviewable:end -->

![image](https://user-images.githubusercontent.com/14963751/91051434-69683380-e620-11ea-99df-87cc5d681c01.png)

@PrestaShop/prestashop-product-team I've been forced to hide the "See my shop" sentence on mobile as we don't have any space anymore