### PR TITLE
Try to use the real command to clear the cache when the kernel is available

### DIFF
--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -27,6 +27,10 @@
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Tools;
 
 /**
@@ -41,6 +45,23 @@ final class SymfonyCacheClearer implements CacheClearerInterface
      */
     public function clear()
     {
-        Tools::clearSf2Cache();
+        /*  @var KernelInterface */
+        global $kernel;
+
+        if (empty($kernel)) {
+            Tools::clearSf2Cache();
+
+            return;
+        }
+
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $input = new ArrayInput([
+            'command' => 'cache:pool:prune',
+        ]);
+
+        $output = new NullOutput();
+        $application->run($input, $output);
     }
 }

--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 
+use Hook;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -58,10 +59,12 @@ final class SymfonyCacheClearer implements CacheClearerInterface
         $application->setAutoExit(false);
 
         $input = new ArrayInput([
-            'command' => 'cache:pool:prune',
+            'command' => 'cache:clear',
+            '--no-warmup',
         ]);
 
         $output = new NullOutput();
         $application->run($input, $output);
+        Hook::exec('actionClearSf2Cache');
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Use Symfony command `cache:clear` instead of an hard `rm -rf` against the `var/cache` directory. It's maybe not the best way to do it.
| Type?         | bug fix
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11105
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20689)
<!-- Reviewable:end -->
