### PR TITLE
Fix quantity column head width in order invoice

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -196,11 +196,9 @@ $search-border-color: #bbcdd2
 		padding: 0
 		margin-right: 0
 		margin-bottom: 0
+		margin-left: 0
 		display: flex
 		align-items: center
-
-		.mobile &
-			display: none
 
 		#employee_infos
 			list-style-type: none
@@ -219,14 +217,6 @@ $search-border-color: #bbcdd2
 						width: 3.8rem
 						height: 3.8rem
 
-				@media (max-width: $screen-sm)
-					li
-						color: white
-						font-size: 1.2em
-						text-transform: uppercase
-						i
-							font-size: 1.3em
-							color: $brand-primary
 				.employee-wrapper
 					&-avatar
 						float: left

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -259,13 +259,13 @@
               <ul id="header_shop" class="shop-state">
                 <li class="dropdown">
                   <i class="material-icons">visibility</i>
-                  {$shop_list}
+                  <span>{$shop_list}</span>
                 </li>
               </ul>
             {else}
               <a id="header_shopname" class="shop-state" href="{$base_url|escape:'html':'UTF-8'}" target="_blank">
                 <i class="material-icons">visibility</i>
-                {l s='View my shop' d='Admin.Navigation.Header'}
+                <span>{l s='View my shop' d='Admin.Navigation.Header'}</span>
               </a>
             {/if}
           </li>
@@ -348,7 +348,7 @@
 
       {* Employee *}
       <ul id="header_employee_box" class="component">
-        <li id="employee_infos" class="dropdown hidden-xs">
+        <li id="employee_infos" class="dropdown">
           <a href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}"
              class="employee_name dropdown-toggle"
              data-toggle="dropdown"

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -107,7 +107,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
                 'width' => 40,
             ],
             'quantity' => [
-                'width' => 8,
+                'width' => 12,
             ],
             'tax_code' => [
                 'width' => 8,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Quantity head width was too small in certain langs, I added some percent missing
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20545 .
| How to test?  | Download an order invoice, and see if the "Quantité" column is on one line only (see screen inside the issue).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20668)
<!-- Reviewable:end -->
