### PR TITLE
Refresh when change combination product.js 

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -172,7 +172,7 @@ function updateProduct(event, eventType, updateUrl) {
         ajax: 1,
         action: 'refresh',
         quantity_wanted:
-          eventType === 'updatedProductCombination' ? $quantityWantedInput.attr('min') : $quantityWantedInput.val(),
+          eventType === 'updatedProductCombination' ? 1 : $quantityWantedInput.val(),
       },
       dataType: 'json',
       beforeSend() {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | On product page, when you change combination from a combination with a minimum quantity > minimum quantity of the new combination, the message "not enough product in stock appear". Solve it.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14744
| How to test?  | Change combination from a combination with a minimum quantity > minimum quantity of the other combination.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20720)
<!-- Reviewable:end -->
