### PR TITLE
Allow Prestashop to fill product_supplier table onto webservice product add or update

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7340,8 +7340,11 @@ class ProductCore extends ObjectModel
     public function addWs($autodate = true, $null_values = false)
     {
         $success = $this->add($autodate, $null_values);
-        if ($success && Configuration::get('PS_SEARCH_INDEXATION')) {
-            Search::indexation(false, $this->id);
+        if ($success) {
+            $this->addSupplierReference($this->id_supplier, $this->id_product_attribute, $this->supplier_reference, $this->wholesale_price);
+            if (Configuration::get('PS_SEARCH_INDEXATION')) {
+                Search::indexation(false, $this->id);
+            }
         }
 
         return $success;
@@ -7362,9 +7365,13 @@ class ProductCore extends ObjectModel
             $this->unit_price = ($this->unit_price_ratio != 0 ? $this->price / $this->unit_price_ratio : 0);
         }
 
-        $success = parent::update($null_values);
-        if ($success && Configuration::get('PS_SEARCH_INDEXATION')) {
-            Search::indexation(false, $this->id);
+        $success = parent::update($null_values);die(print_r($this, true));
+        if ($success) {
+            $this->deleteFromSupplier();
+            $this->addSupplierReference($this->id_supplier, 0, $this->supplier_reference, $this->wholesale_price);
+            if (Configuration::get('PS_SEARCH_INDEXATION')) {
+                Search::indexation(false, $this->id);
+            }
         }
         Hook::exec('actionProductUpdate', ['id_product' => (int) $this->id]);
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7365,7 +7365,7 @@ class ProductCore extends ObjectModel
             $this->unit_price = ($this->unit_price_ratio != 0 ? $this->price / $this->unit_price_ratio : 0);
         }
 
-        $success = parent::update($null_values);die(print_r($this, true));
+        $success = parent::update($null_values);
         if ($success) {
             $this->deleteFromSupplier();
             $this->addSupplierReference($this->id_supplier, 0, $this->supplier_reference, $this->wholesale_price);

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1091,11 +1091,10 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
-		if (empty($siret)) { 
-			return true; 
-		}
-		
-		if (Tools::strlen($siret) != 14) {
+        if (empty($siret)) {
+            return true;
+        }
+        if (Tools::strlen($siret) != 14) {
             return false;
         }
         $sum = 0;

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1091,7 +1091,11 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
-        if (Tools::strlen($siret) != 14) {
+		if (empty($siret)) { 
+			return true; 
+		}
+		
+		if (Tools::strlen($siret) != 14) {
             return false;
         }
         $sum = 0;

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1225,9 +1225,6 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
-        if (empty($siret)) {
-            return true;
-        }
         if (Tools::strlen($siret) != 14) {
             return false;
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This fix allow an add or an update product's action throw webservice to fill product_supplier table
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |  #20731, #16086
| How to test?  | Try to add or update a product with a supplier throw webservice. Product_supplier table must be filled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20736)
<!-- Reviewable:end -->
