### PR TITLE
Fix cumulative free gift + percentage discounts

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -476,7 +476,7 @@ class CartCore extends ObjectModel
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')
-                . ' ORDER by cr.priority ASC'
+                . ' ORDER by cr.priority ASC, cr.gift_product DESC'
             );
             Cache::store($cache_key, $result);
         } else {
@@ -546,7 +546,7 @@ class CartCore extends ObjectModel
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')
-                . ' ORDER BY cr.priority ASC'
+                . ' ORDER BY cr.priority ASC, cr.gift_product DESC'
             );
             Cache::store($cache_key, $result);
         } else {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1395,7 +1395,7 @@ class CartRuleCore extends ObjectModel
                         || CartRule::$only_one_gift[$this->id . '-' . $this->gift_product] == 0
                         || $id_address == 0
                         || !$use_cache) {
-                        $reduction_value += ($use_tax ? $product['price_wt'] : $product['price']);
+                        $reduction_value += Tools::ps_round($use_tax ? $product['price_wt'] : $product['price'], Context::getContext()->getComputingPrecision());
                         if ($use_cache && (!isset(CartRule::$only_one_gift[$this->id . '-' . $this->gift_product]) || CartRule::$only_one_gift[$this->id . '-' . $this->gift_product] == 0)) {
                             CartRule::$only_one_gift[$this->id . '-' . $this->gift_product] = $id_address;
                         }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -35,6 +35,54 @@ Feature: Cart calculation with cart rules giving gift
     # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 60.4924 tax included
 
+  Scenario: 1 product in my cart, one cart rule offering the same product and a global 50% discount
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product_1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product_2" with a price of 35.567 and 1000 items in stock
+    Given there is a cart rule named "cartrule14" that applies a percent discount of 50.0% with priority 1, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule14" has a discount code "foo14"
+    Given there is a cart rule named "cartrule15" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule15" offers a gift product "product_1"
+    Given cart rule "cartrule15" has a discount code "foo15"
+    When I add 1 items of product "product_1" in my cart
+    And I use the discount "cartrule14"
+    Then I should have 1 products in my cart
+    And the current cart should have the following contextual reductions:
+      | cartrule14        | 9.905 |
+    And my cart total should be precisely 16.9 tax included
+    When I use the discount "cartrule15"
+    Then I should have 2 products in my cart
+    And the current cart should have the following contextual reductions:
+      | cartrule14        | 9.905  |
+      | cartrule15        | 19.81 |
+    And my cart total should be precisely 16.9 tax included
+
+  Scenario: 1 product in my cart, 2 same cart rules offering the same product as gift
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product_1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product_2" with a price of 35.567 and 1000 items in stock
+    Given there is a cart rule named "cartrule16" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule16" offers a gift product "product_1"
+    Given cart rule "cartrule16" has a discount code "foo16"
+    Given there is a cart rule named "cartrule17" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule17" offers a gift product "product_1"
+    Given cart rule "cartrule17" has a discount code "foo17"
+    When I add 1 items of product "product_1" in my cart
+    And I use the discount "cartrule16"
+    Then I should have 2 products in my cart
+    And the current cart should have the following contextual reductions:
+      | cartrule16        | 19.81 |
+    And my cart total should be precisely 26.81 tax included
+    When I use the discount "cartrule17"
+    Then I should have 3 products in my cart
+    And the current cart should have the following contextual reductions:
+      | cartrule16        | 19.81 |
+      | cartrule17        | 19.81 |
+    And my cart total should be precisely 26.82 tax included
+    # 3*19.812 = 59.436 rounded to 59.44 - 19.81*2 = 19.82 + 7 (shipping) = 26.82
+
   Scenario: 2 products in cart, one cart rule offering a gift (in stock) and a global 10% discount
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When a free gift and a percentage discount were added to a cart, if the percentage discount was created before the free gift cart rule (both with same priority), the percentage discount was applied without taking free gifts into account. This PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20690
| How to test?  | See #20690, also see that #11722 is still fixed too even though I added a test for that case.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20741)
<!-- Reviewable:end -->
