### PR TITLE
Bug searching for alias table into no_quotes array

### DIFF
--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -294,7 +294,7 @@ class RequestSqlCore extends ObjectModel
     {
         if ($alias) {
             foreach ($tables as $table) {
-                if (isset($table['alias'], $table['table']) && $table['alias']['no_quotes'] == $alias) {
+                if (isset($table['alias'], $table['table']) && $table['alias']['no_quotes']['parts'][0] == $alias) {
                     return [$table['table']];
                 }
             }


### PR DESCRIPTION
The no_quotes array contains the execution of the AbstractProcessor::revokeQuotation function from the PHPSQLParser composer package. This function returns an array where it is included all the parts, not a string, this is why it is required to navigate also to the parts array and get the first index.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The no_quotes array contains the execution of the AbstractProcessor::revokeQuotation function from the PHPSQLParser composer package. This function returns an array where it is included all the parts, not a string, this is why it is required to navigate also to the parts array and get the first index.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | maybe
| Deprecations? | no
| Fixed ticket? | Fixes #20750
| How to test?  | 
    Go to Backend - Advanced settings - Data Base
    Add any query with joins


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20751)
<!-- Reviewable:end -->
