### PR TITLE
Save customer message on order creation from BO

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -144,7 +144,7 @@ final class AddOrderFromBackOfficeHandler implements AddOrderFromBackOfficeHandl
     private function addOrderMessage(Cart $cart, string $orderMessage): void
     {
         if (!Validate::isMessage($orderMessage)) {
-            throw new OrderConstraintException('', OrderConstraintException::INVALID_CUSTOMER_MESSAGE);
+            throw new OrderConstraintException('The order message is invalid', OrderConstraintException::INVALID_CUSTOMER_MESSAGE);
         }
 
         $messageId = null;

--- a/src/Core/Domain/Order/Exception/OrderConstraintException.php
+++ b/src/Core/Domain/Order/Exception/OrderConstraintException.php
@@ -31,4 +31,8 @@ namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
  */
 class OrderConstraintException extends OrderException
 {
+    /**
+     * Used in create order from BO when the customer message is invalid.
+     */
+    const INVALID_CUSTOMER_MESSAGE = 1;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -53,6 +53,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductExcept
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidOrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidProductQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailSendException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
@@ -1658,6 +1659,13 @@ class OrderController extends FrameworkBundleAdminController
                 ),
                 InvalidOrderStateException::INVALID_ID => $this->trans(
                     'You must choose an order status to create the order.',
+                    'Admin.Orderscustomers.Notification'
+                ),
+            ],
+
+            OrderConstraintException::class => [
+                OrderConstraintException::INVALID_CUSTOMER_MESSAGE => $this->trans(
+                    'The order message given is invalid',
                     'Admin.Orderscustomers.Notification'
                 ),
             ],

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -35,6 +35,28 @@ Feature: Order from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
 
+  Scenario: Check customer message can be null
+    When I create an empty cart "dummy_cart2" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart2"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart2"
+    And I add order "bo_order2" with the following details:
+      | cart                | dummy_cart2                 |
+      | message             |                             |
+      | payment module name | dummy_payment               |
+      | status              | Awaiting bank wire payment  |
+    Then order "bo_order2" must have no customer message
+
+  Scenario: Check customer message is saved when creating an order
+    When I create an empty cart "dummy_cart2" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart2"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart2"
+    And I add order "bo_order2" with the following details:
+      | cart                | dummy_cart2                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    Then order "bo_order2" must have customer message with content "test"
+
   Scenario: Update order status
     When I update order "bo_order1" status to "Awaiting Cash On Delivery validation"
     Then order "bo_order1" has status "Awaiting Cash On Delivery validation"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -78,6 +78,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderCartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AddressFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\OrderMessageContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderRefundFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Save customer message when creating an order from the Backoffice
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20686
| How to test?  | 1. Go to BO => Orders => Add new Order page<br>2. Add some products to the cart<br>3. IN the Summary section => add an order message<br>4. Create the Order<br>5. The message given is displayed in the order messages list

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20757)
<!-- Reviewable:end -->
