### PR TITLE
Fix cumulative percentage behat test

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
@@ -13,9 +13,10 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Given cart rule "cartrule3" has a discount code "foo3"
     Then I should have 0 different products in my cart
     When I use the discount "cartrule2"
-    Then cart rule "cartrule2" has a contextual reduction value of 0.0
     When I use the discount "cartrule3"
-    Then cart rule "cartrule3" has a contextual reduction value of 0.0
+    Then the current cart should have the following contextual reductions:
+      | cartrule2        | 0  |
+      | cartrule3        | 0  |
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
@@ -30,9 +31,10 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Given cart rule "cartrule3" has a discount code "foo3"
     When I add 1 items of product "product1" in my cart
     When I use the discount "cartrule2"
-    Then cart rule "cartrule2" has a contextual reduction value of 9.905
     When I use the discount "cartrule3"
-    Then cart rule "cartrule3" has a contextual reduction value of 1.981
+    Then the current cart should have the following contextual reductions:
+      | cartrule2        | 9.905  |
+      | cartrule3        | 0.9905 |
     Then my cart total should be 15.9154 tax included
     #known to fail on previous
     #Then my cart total using previous calculation method should be 15.9154 tax included
@@ -48,9 +50,10 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Given cart rule "cartrule3" has a discount code "foo3"
     When I add 3 items of product "product1" in my cart
     When I use the discount "cartrule2"
-    Then cart rule "cartrule2" has a contextual reduction value of 29.72
     When I use the discount "cartrule3"
-    Then cart rule "cartrule3" has a contextual reduction value of 5.944
+    Then the current cart should have the following contextual reductions:
+      | cartrule2        | 29.72 |
+      | cartrule3        | 2.972 |
     Then my cart total should be precisely 33.75 tax included
 
   @cumulative-percent-reduction
@@ -68,9 +71,10 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product3" in my cart
     When I use the discount "cartrule2"
-    Then cart rule "cartrule2" has a contextual reduction value of 77.705
     When I use the discount "cartrule3"
-    Then cart rule "cartrule3" has a contextual reduction value of 15.541
+    Then the current cart should have the following contextual reductions:
+      | cartrule2        | 77.705 |
+      | cartrule3        | 7.7705 |
     Then my cart total should be 76.93 tax included
     #known to fail on previous
     #Then my cart total using previous calculation method should be 76.93 tax included


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The test of cumulative percentage reductions's contextual values was badly tested and would pass with wrong values
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No manual test: behat test must be green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20758)
<!-- Reviewable:end -->
