### PR TITLE
Add check for visitor's country

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -1502,6 +1502,11 @@ class CarrierCore extends ObjectModel
             if (!Address::isCountryActiveById($id_address)) {
                 return [];
             }
+        } else if (isset(Context::getContext()->cookie->iso_code_country)){
+            // Use visitor's country. Needed for when Geolocation is on.
+            $country_id = Country::getByIso(Context::getContext()->cookie->iso_code_country);
+            $country = new Country($country_id);
+            $id_zone = $country->id_zone;
         } else {
             $country = new Country($ps_country_default);
             $id_zone = $country->id_zone;


### PR DESCRIPTION
The visitor's country needs to be checked before the default country is used in the event that Geolocation is on. This then selects the proper carriers for the visitors country and properly displays them in the shopping according to the options set in Shipping->preferences.

iso_code_country is used to create the country_id for the visitor because the visitor's cookie does not contain id_country.

This is related to https://github.com/PrestaShop/PrestaShop/pull/13517.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The visitor's country needs to be checked before the default country is used in the event that Geolocation is on. Related to #13517.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20789)
<!-- Reviewable:end -->
