### PR TITLE
Fix OrderReturnState should not use soft delete

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -571,6 +571,7 @@ class AdminStatusesControllerCore extends AdminController
             $this->className = 'OrderReturnState';
             $this->table = 'order_return_state';
             $this->boxes = Tools::getValue('order_return_stateBox');
+            $this->deleted = false;
             parent::processBulkDelete();
         }
 

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -66,6 +66,12 @@ class AdminStatusesControllerCore extends AdminController
      */
     protected function initOrderStatutsList()
     {
+        $this->table = 'order_state';
+        $this->className = 'OrderState';
+        $this->_defaultOrderBy = $this->identifier = 'id_order_state';
+        $this->list_id = 'order_state';
+        $this->deleted = true;
+        $this->_orderBy = null;
         $this->fields_list = [
             'id_order_state' => [
                 'title' => $this->trans('ID', [], 'Admin.Global'),
@@ -630,7 +636,7 @@ class AdminStatusesControllerCore extends AdminController
                 return;
             }
 
-            foreach (Tools::getValue($this->table . 'Box') as $selection) {
+            foreach (Tools::getValue($this->table . 'Box', []) as $selection) {
                 $order_state = new OrderState((int) $selection, $this->context->language->id);
                 if (!$order_state->isRemovable()) {
                     $this->errors[] = $this->trans('For security reasons, you cannot delete default order statuses.', [], 'Admin.Shopparameters.Notification');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because `OrderReturnState` was handled the same way as `OrderState`, it was impossible to bulk delete order return states. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20743
| How to test?  | See #20743

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20796)
<!-- Reviewable:end -->
