### PR TITLE
Do not recalculate shipping if PS_ORDER_RECALCULATE_SHIPPING is false

### DIFF
--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -31,7 +31,6 @@ namespace PrestaShop\PrestaShop\Adapter\Order;
 use Cache;
 use Cart;
 use CartRule;
-use Configuration;
 use Context;
 use Currency;
 use Order;
@@ -119,7 +118,7 @@ class OrderAmountUpdater
         $order->total_shipping_tax_excl = $cart->getOrderTotal(false, Cart::ONLY_SHIPPING, $orderProducts, $carrierId);
         $order->total_shipping_tax_incl = $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $orderProducts, $carrierId);
 
-        if (!Configuration::get('PS_ORDER_RECALCULATE_SHIPPING')) {
+        if (!$this->configuration->get('PS_ORDER_RECALCULATE_SHIPPING')) {
             $shippingDiffTaxIncluded = $order->total_shipping_tax_incl - $totalShippingTaxIncluded;
             $shippingDiffTaxExcluded = $order->total_shipping_tax_excl - $totalShippingTaxExcluded;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | When an order was modified in the BO, shipping fees where recalculated whether or not `PS_ORDER_RECALCULATE_SHIPPING` was set to false.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20744
| How to test?  | See #20744

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20798)
<!-- Reviewable:end -->
