### PR TITLE
Modify discounts listing in Customer page to use Grid - Delete modal

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/index.js
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.js
@@ -32,6 +32,7 @@ import SortingExtension from '@components/grid/extension/sorting-extension';
 import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
 import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
 import SubmitGridExtension from '@components/grid/extension/submit-grid-action-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 import LinkableItem from '@components/linkable-item';
 import ChoiceTable from '@components/choice-table';
@@ -62,6 +63,9 @@ $(() => {
   customerGrid.addExtension(new DeleteCustomersBulkActionExtension());
   customerGrid.addExtension(new DeleteCustomerRowActionExtension());
   customerGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+
+  const customerDiscountsGrid = new Grid('customer_discount');
+  customerDiscountsGrid.addExtension(new SubmitRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/src/Core/Grid/Action/Row/Type/Customer/DeleteCustomerDiscountRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/Customer/DeleteCustomerDiscountRowAction.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,25 +22,42 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-<div class="card customer-discounts-card">
-  <h3 class="card-header">
-    <i class="material-icons">loyalty</i>
-    {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
-  </h3>
-  <div class="card-body">
-    {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-      </p>
-    {% endif %}
-  </div>
-</div>
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AbstractRowAction;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class DeleteCustomerDiscountRowAction extends AbstractRowAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'delete_customer_discount';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired([
+                'id_cart_rule',
+            ])
+            ->setDefaults([
+                'method' => 'POST',
+                'confirm_message' => '',
+                'modal_options' => null,
+            ])
+            ->setAllowedTypes('id_cart_rule', 'string')
+            ->setAllowedTypes('method', 'string')
+            ->setAllowedTypes('confirm_message', 'string')
+        ;
+    }
+}

--- a/src/Core/Grid/Action/Row/Type/Customer/DeleteCustomerDiscountRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/Customer/DeleteCustomerDiscountRowAction.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\AbstractRowAction;

--- a/src/Core/Grid/Action/Row/Type/Customer/EditCustomerDiscountRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/Customer/EditCustomerDiscountRowAction.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\AbstractRowAction;

--- a/src/Core/Grid/Action/Row/Type/Customer/EditCustomerDiscountRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/Customer/EditCustomerDiscountRowAction.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,25 +22,35 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-<div class="card customer-discounts-card">
-  <h3 class="card-header">
-    <i class="material-icons">loyalty</i>
-    {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
-  </h3>
-  <div class="card-body">
-    {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-      </p>
-    {% endif %}
-  </div>
-</div>
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\AbstractRowAction;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class EditCustomerDiscountRowAction extends AbstractRowAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'edit_customer_discount';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired([
+                'id_cart_rule',
+            ])
+            ->setAllowedTypes('id_cart_rule', 'string')
+        ;
+    }
+}

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
+use CartRule;
 use Customer;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
@@ -64,7 +65,7 @@ final class CustomerDiscountGridDataFactory implements GridDataFactoryInterface
      */
     public function getData(SearchCriteriaInterface $searchCriteria)
     {
-        $discounts = \CartRule::getCustomerCartRules(
+        $discounts = CartRule::getCustomerCartRules(
             $this->contextLangId,
             $this->customer->id,
             false,

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use Customer;

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use Customer;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Class CustomerDiscountGridDataFactory is responsible of returning grid data for customer's discounts.
+ */
+final class CustomerDiscountGridDataFactory implements GridDataFactoryInterface
+{
+    /**
+     * @var int
+     */
+    private $contextLangId;
+    /**
+     * @var Customer
+     */
+    private $customer;
+
+    /**
+     * @param int $contextLangId
+     * @param Customer $customer
+     */
+    public function __construct(
+        int $contextLangId,
+        Customer $customer
+    ) {
+        $this->contextLangId = $contextLangId;
+        $this->customer = $customer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $discounts = \CartRule::getCustomerCartRules(
+            $this->contextLangId,
+            $this->customer->id,
+            false,
+            false
+        );
+
+        $records = new RecordCollection($discounts);
+
+        return new GridData(
+            $records,
+            $records->count()
+        );
+    }
+}

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactoryDecorator.php
@@ -29,8 +29,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
-use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
-use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactoryDecorator.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Class CustomerDiscountGridDataFactoryDecorator decorates data from customer addresses doctrine data factory.
+ */
+final class CustomerDiscountGridDataFactoryDecorator implements GridDataFactoryInterface
+{
+    /**
+     * @var GridDataFactoryInterface
+     */
+    private $customerDiscountDoctrineGridDataFactory;
+
+    /**
+     * @param GridDataFactoryInterface $customerDiscountDoctrineGridDataFactory
+     */
+    public function __construct(
+        GridDataFactoryInterface $customerDiscountDoctrineGridDataFactory
+    ) {
+        $this->customerDiscountDoctrineGridDataFactory = $customerDiscountDoctrineGridDataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $customerData = $this->customerDiscountDoctrineGridDataFactory->getData($searchCriteria);
+
+//        $customerRecords = $this->applyModifications($customerData->getRecords());
+
+        return new GridData(
+            $customerData->getRecords(),
+            $customerData->getRecordsTotal(),
+            $customerData->getQuery()
+        );
+    }
+
+    /**
+     * @param RecordCollectionInterface $addresses
+     *
+     * @return RecordCollection
+     */
+    private function xapplyModifications(RecordCollectionInterface $addresses)
+    {
+        $modifiedDiscountes = [];
+
+        foreach ($addresses as $address) {
+            if (empty($address['company'])) {
+                $address['company'] = '--';
+            }
+
+            $address['full_name'] = sprintf('%s %s', $address['firstname'], $address['lastname']);
+
+            $address['full_address'] = sprintf(
+                '%s %s %s %s',
+                $address['address1'],
+                $address['address2'],
+                $address['postcode'],
+                $address['city']
+            );
+
+            if (!empty($address['phone'])) {
+                $address['phone_number'] = $address['phone'];
+            } elseif (!empty($address['phone_mobile'])) {
+                $address['phone_number'] = $address['phone_mobile'];
+            } else {
+                $address['phone_number'] = '--';
+            }
+
+            $modifiedDiscountes[] = $address;
+        }
+
+        return new RecordCollection($modifiedDiscountes);
+    }
+}

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactoryDecorator.php
@@ -59,50 +59,10 @@ final class CustomerDiscountGridDataFactoryDecorator implements GridDataFactoryI
     {
         $customerData = $this->customerDiscountDoctrineGridDataFactory->getData($searchCriteria);
 
-//        $customerRecords = $this->applyModifications($customerData->getRecords());
-
         return new GridData(
             $customerData->getRecords(),
             $customerData->getRecordsTotal(),
             $customerData->getQuery()
         );
-    }
-
-    /**
-     * @param RecordCollectionInterface $addresses
-     *
-     * @return RecordCollection
-     */
-    private function xapplyModifications(RecordCollectionInterface $addresses)
-    {
-        $modifiedDiscountes = [];
-
-        foreach ($addresses as $address) {
-            if (empty($address['company'])) {
-                $address['company'] = '--';
-            }
-
-            $address['full_name'] = sprintf('%s %s', $address['firstname'], $address['lastname']);
-
-            $address['full_address'] = sprintf(
-                '%s %s %s %s',
-                $address['address1'],
-                $address['address2'],
-                $address['postcode'],
-                $address['city']
-            );
-
-            if (!empty($address['phone'])) {
-                $address['phone_number'] = $address['phone'];
-            } elseif (!empty($address['phone_mobile'])) {
-                $address['phone_number'] = $address['phone_mobile'];
-            } else {
-                $address['phone_number'] = '--';
-            }
-
-            $modifiedDiscountes[] = $address;
-        }
-
-        return new RecordCollection($modifiedDiscountes);
     }
 }

--- a/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer\DeleteCustomerDiscountRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer\EditCustomerDiscountRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+
+/**
+ * Class CustomerDiscountGridDefinitionFactory defines customer's discounts grid structure.
+ */
+final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    const GRID_ID = 'customer_discount';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Vouchers', [], 'Admin.Orderscustomers.Feature');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return (new ColumnCollection())
+            ->add(
+                (new DataColumn('id_cart_rule'))
+                    ->setName($this->trans('ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_cart_rule',
+                    ])
+            )
+            ->add(
+                (new DataColumn('code'))
+                    ->setName($this->trans('Code', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'code',
+                    ])
+            )
+            ->add(
+                (new DataColumn('name'))
+                    ->setName($this->trans('Name', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'name',
+                    ])
+            )
+            ->add(
+                (new DataColumn('active'))
+                    ->setName($this->trans('Status', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'active',
+                    ])
+            )
+            ->add(
+                (new DataColumn('quantity'))
+                    ->setName($this->trans('Qty available', [], 'Admin.Orderscustomers.Feature'))
+                    ->setOptions([
+                        'field' => 'quantity',
+                    ])
+            )
+            ->add((new ActionColumn('actions'))
+            ->setName($this->trans('Actions', [], 'Admin.Global'))
+            ->setOptions([
+                'actions' => (new RowActionCollection())
+                    ->add(
+                        (new EditCustomerDiscountRowAction('edit'))
+                            ->setName($this->trans('Edit', [], 'Admin.Actions'))
+                            ->setIcon('edit')
+                            ->setOptions([
+                                'id_cart_rule' => 'id_cart_rule',
+                            ])
+                    )
+                    ->add(
+                        (new DeleteCustomerDiscountRowAction('delete'))
+                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
+                            ->setIcon('delete')
+                            ->setOptions([
+                                'id_cart_rule' => 'id_cart_rule',
+                                'confirm_message' => $this->trans('Are you sure you want to delete the selected item(s)?', [], 'Admin.Global'),
+                                'method' => 'POST',
+                                'modal_options' => new ModalOptions([
+                                    'title' => $this->trans('Delete selection', [], 'Admin.Actions'),
+                                    'confirm_button_label' => $this->trans('Delete', [], 'Admin.Actions'),
+                                    'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
+                                    'confirm_button_class' => 'btn-danger',
+                                ]),
+                            ])
+                    ),
+            ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewOptions()
+    {
+        return (new ViewOptionsCollection())
+            ->add('display_name', false);
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer\DeleteCustomerDiscountRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer\EditCustomerDiscountRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
@@ -131,14 +130,5 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ),
             ])
             );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getViewOptions()
-    {
-        return (new ViewOptionsCollection())
-            ->add('display_name', false);
     }
 }

--- a/src/Core/Search/Filters/CustomerDiscountFilters.php
+++ b/src/Core/Search/Filters/CustomerDiscountFilters.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,25 +22,34 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-<div class="card customer-discounts-card">
-  <h3 class="card-header">
-    <i class="material-icons">loyalty</i>
-    {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
-  </h3>
-  <div class="card-body">
-    {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-      </p>
-    {% endif %}
-  </div>
-</div>
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Default customer's addresses list filters
+ */
+final class CustomerDiscountFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = CustomerDiscountGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 50,
+            'offset' => 0,
+            'orderBy' => 'id_cart_rule',
+            'sortOrder' => 'asc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -57,6 +57,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters\CustomerDiscountFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
@@ -281,6 +282,14 @@ class CustomerController extends AbstractAdminController
             'note' => $customerInformation->getGeneralInformation()->getPrivateNote(),
         ]);
 
+        $customerDiscountGridFactory = $this->get('prestashop.core.grid.factory.customer.discount');
+        $customerDiscountFilters = new CustomerDiscountFilters([
+            'filters' => [
+                'id_customer' => $customerId,
+            ],
+        ]);
+        $customerDiscountGrid = $customerDiscountGridFactory->getGrid($customerDiscountFilters);
+
         if ($request->query->has('conf')) {
             $this->manageLegacyFlashes($request->query->get('conf'));
         }
@@ -289,6 +298,7 @@ class CustomerController extends AbstractAdminController
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'customerInformation' => $customerInformation,
+            'customerDiscountGrid' => $this->presentGrid($customerDiscountGrid),
             'isMultistoreEnabled' => $this->get('prestashop.adapter.feature.multistore')->isActive(),
             'transferGuestAccountForm' => $transferGuestAccountForm,
             'privateNoteForm' => $privateNoteForm->createView(),

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -86,6 +86,12 @@ services:
             - "@prestashop.core.localization.locale.context_locale"
             - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
 
+    prestashop.core.grid.data_provider.customer_discount:
+        class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerDiscountGridDataFactory'
+        arguments:
+            - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+            - "@=service('prestashop.adapter.legacy.context').getContext().customer"
+
     prestashop.core.grid.data.factory.language:
         class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
@@ -161,7 +167,7 @@ services:
             - '@prestashop.adapter.manufacturer.manufacturer_logo_thumbnail_provider'
 
     prestashop.core.grid.data.factory.manufacturer_address:
-        class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\DoctrineGridDataFactory'
+        class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
         arguments:
             - '@prestashop.core.grid.query_builder.manufacturer_address'
             - '@prestashop.core.hook.dispatcher'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -89,6 +89,11 @@ services:
             - '@=service("prestashop.adapter.form.choice_provider.gender_by_id_choice_provider").getChoices()'
         public: true
 
+    prestashop.core.grid.definition.factory.customer.discount:
+        class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerDiscountGridDefinitionFactory'
+        parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+        public: true
+
     prestashop.core.grid.definition.factory.language:
         class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory'
         parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -88,6 +88,14 @@ services:
             - '@prestashop.core.grid.filter.form_factory'
             - '@prestashop.core.hook.dispatcher'
 
+    prestashop.core.grid.factory.customer.discount:
+        class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+        arguments:
+            - '@prestashop.core.grid.definition.factory.customer.discount'
+            - '@prestashop.core.grid.data_provider.customer_discount'
+            - '@prestashop.core.grid.filter.form_factory'
+            - '@prestashop.core.hook.dispatcher'
+
     prestashop.core.grid.factory.language:
         class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
         arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/delete_customer_discount.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/delete_customer_discount.html.twig
@@ -31,8 +31,8 @@
 
 {% set confirmation_message = action.options.confirm_message %}
 
-<a class="{{ class }} grid-{{ action.name|lower }}-row-link"
-   href="#"
+<button class="{{ class }} grid-{{ action.name|lower }}-row-link"
+   type="button"
    data-confirm-message="{{ confirmation_message }}"
    data-url="{{ getAdminLink('AdminCartRules', true, {'id_cart_rule': record[action.options.id_cart_rule], 'deletecart_rule': 1, 'back': app.request.uri}) }}"
    data-method="{{ action.options.method }}"
@@ -53,4 +53,4 @@
   {% if not attributes.tooltip_name %}
     {{ action.name }}
   {% endif %}
-</a>
+</button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/delete_customer_discount.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/delete_customer_discount.html.twig
@@ -1,0 +1,56 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% set class = 'btn tooltip-link js-submit-row-action' %}
+
+{% if attributes.class is defined %}
+  {% set class = class ~ ' ' ~ attributes.class %}
+{% endif %}
+
+{% set confirmation_message = action.options.confirm_message %}
+
+<a class="{{ class }} grid-{{ action.name|lower }}-row-link"
+   href="#"
+   data-confirm-message="{{ confirmation_message }}"
+   data-url="{{ getAdminLink('AdminCartRules', true, {'id_cart_rule': record[action.options.id_cart_rule], 'deletecart_rule': 1, 'back': app.request.uri}) }}"
+   data-method="{{ action.options.method }}"
+  {% if action.options.modal_options.options is defined %}
+    {% for attribute, value in action.options.modal_options.options %}
+      data-{{ attribute|replace({'_':'-'}) }}="{{ value }}"
+    {% endfor %}
+  {% endif %}
+  {% if attributes.tooltip_name %}
+    data-toggle="pstooltip"
+    data-placement="top"
+    data-original-title="{{ action.name }}"
+  {% endif %}
+>
+  {% if action.icon is not empty %}
+    <i class="material-icons">{{ action.icon }}</i>
+  {% endif %}
+  {% if not attributes.tooltip_name %}
+    {{ action.name }}
+  {% endif %}
+</a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/edit_customer_discount.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/edit_customer_discount.html.twig
@@ -23,23 +23,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div class="card customer-discounts-card">
-  <h3 class="card-header">
-    <i class="material-icons">loyalty</i>
-    {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
-  </h3>
-  <div class="card-body">
-    {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-      </p>
-    {% endif %}
-  </div>
-</div>
+{% set class = 'btn tooltip-link js-link-row-action' %}
+
+{% if attributes.class is defined %}
+  {% set class = class ~ ' ' ~ attributes.class %}
+{% endif %}
+
+<a class="{{ class }} grid-{{ action.name|lower|replace({' ': '-'}) }}-row-link"
+   href="{{ getAdminLink('AdminCartRules', true, {'id_cart_rule': record[action.options.id_cart_rule], 'addcart_rule': 1, 'back': app.request.uri}) }}"
+  {% if attributes.tooltip_name %}
+    data-toggle="pstooltip"
+    data-placement="top"
+    data-original-title="{{ action.name }}"
+  {% endif %}
+>
+  {% if action.icon is not empty %}
+    <i class="material-icons">{{ action.icon }}</i>
+  {% endif %}
+  {% if not attributes.tooltip_name %}
+    {{ action.name }}
+  {% endif %}
+</a>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modify discounts listing in Customer page to use Grid instead of table. This enables use to add a confirmation modal when deleting a row from a grid.
Customers > View > Discounts.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Customers > View > Discounts in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

This may have impact on automated tests @PrestaShop/qa-automation

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20799)
<!-- Reviewable:end -->
