### PR TITLE
Update to check Language association to the current store

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -200,10 +200,12 @@ if (defined('_PS_ADMIN_DIR_')) {
 }
 
 /* if the language stored in the cookie is not available language, use default language */
-if (isset($cookie->id_lang) && $cookie->id_lang)
-	$language = new Language($cookie->id_lang);
-if (!isset($language) || !Validate::isLoadedObject($language) || !$language->isAssociatedToShop())
-	$language = new Language(Configuration::get('PS_LANG_DEFAULT'));
+if (isset($cookie->id_lang) && $cookie->id_lang) {
+    $language = new Language($cookie->id_lang);
+}
+if (!isset($language) || !Validate::isLoadedObject($language) || !$language->isAssociatedToShop()) {
+    $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
+}
 
 $context->language = $language;
 

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -200,12 +200,11 @@ if (defined('_PS_ADMIN_DIR_')) {
 }
 
 /* if the language stored in the cookie is not available language, use default language */
-if (isset($cookie->id_lang) && $cookie->id_lang) {
-    $language = new Language($cookie->id_lang);
-}
-if (!isset($language) || !Validate::isLoadedObject($language)) {
-    $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
-}
+if (isset($cookie->id_lang) && $cookie->id_lang)
+	$language = new Language($cookie->id_lang);
+if (!isset($language) || !Validate::isLoadedObject($language) || !$language->isAssociatedToShop())
+	$language = new Language(Configuration::get('PS_LANG_DEFAULT'));
+
 $context->language = $language;
 
 /* Get smarty */


### PR DESCRIPTION
This change force PrestaShop to check if the id_lang from the Prestashop cookie is available in the current store, if not available and associated then the default language is selected.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR validate the loaded id_lang from the cookie and verify if the loaded language is available in the shop, if not associated then the default language for the store is selected
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20807.
| How to test?  | To verify you need to create two shops under the same group and use the same domain with a virtual url for each one, assign a different language for each store and only associate one language to each one, then switch between stores and you can see the language is set incorrectly, to verify the language you need to dump($context->language) in config.inc.php line 200. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20809)
<!-- Reviewable:end -->
