### PR TITLE
Fix product.yml ident to 4 spaces

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -135,7 +135,7 @@ services:
             - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_HOME_CATEGORY")'
         tags:
             - name: tactician.handler
-                command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand
 
     prestashop.adapter.product.command_handler.add_customization_field_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddCustomizationFieldHandler
@@ -189,7 +189,7 @@ services:
             - '@prestashop.adapter.product.query_handler.get_product_suppliers_for_editing_handler'
         tags:
             - name: tactician.handler
-                command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions
 
     prestashop.adapter.product.command_handler.add_product_supplier_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductSupplierHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -45,8 +45,8 @@ services:
     prestashop.adapter.product.command_handler.update_product_status_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductStatusCommandHandler
         tags:
-          - name: tactician.handler
-            command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductStatusCommand
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductStatusCommand
 
     prestashop.adapter.product.query_handler.search_products:
         class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\SearchProductsHandler
@@ -67,67 +67,67 @@ services:
               command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled
 
     prestashop.adapter.product.command_handler.get_product_for_editing_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductForEditingHandler
-      arguments:
-        - '@prestashop.core.util.number.number_extractor'
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing
+        class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductForEditingHandler
+        arguments:
+            - '@prestashop.core.util.number.number_extractor'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing
 
     prestashop.adapter.product.command_handler.get_packed_products_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetPackedProductsHandler
-      arguments:
-        - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetPackedProducts
+        class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetPackedProductsHandler
+        arguments:
+            - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetPackedProducts
 
     prestashop.adapter.product.command_handler.add_product_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductHandler
-      arguments:
-        - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
-        - '@=service("prestashop.adapter.legacy.context").getContext().shop.id_category'
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductHandler
+        arguments:
+            - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
+            - '@=service("prestashop.adapter.legacy.context").getContext().shop.id_category'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand
 
     prestashop.adapter.product.command_handler.update_product_basic_information_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductBasicInformationHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductBasicInformationHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand
 
     prestashop.adapter.product.command_handler.update_product_prices_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductPricesHandler
-      arguments:
-        - '@prestashop.core.util.number.number_extractor'
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductPricesHandler
+        arguments:
+            - '@prestashop.core.util.number.number_extractor'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand
 
     prestashop.adapter.product.command_handler.update_product_tags_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductTagsHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductTagsHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTagsCommand
 
     prestashop.adapter.product.command_handler.update_product_options_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductOptionsHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductOptionsHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand
 
     prestashop.adapter.product.command_handler.update_product_pack_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductPackHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPackCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductPackHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPackCommand
 
     prestashop.adapter.product.command_handler.set_associated_product_categories_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetAssociatedProductCategoriesHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductCategoriesCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetAssociatedProductCategoriesHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductCategoriesCommand
 
     prestashop.adapter.product.command_handler.remove_all_associated_product_categories_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\RemoveAllAssociatedProductCategoriesHandler
@@ -135,86 +135,86 @@ services:
             - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_HOME_CATEGORY")'
         tags:
             - name: tactician.handler
-              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand
+                command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand
 
     prestashop.adapter.product.command_handler.add_customization_field_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddCustomizationFieldHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\AddCustomizationFieldCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddCustomizationFieldHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\AddCustomizationFieldCommand
 
     prestashop.adapter.product.command_handler.update_customization_field_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateCustomizationFieldHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateCustomizationFieldCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateCustomizationFieldHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateCustomizationFieldCommand
 
     prestashop.adapter.product.command_handler.delete_customization_field_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DeleteCustomizationFieldHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\DeleteCustomizationFieldCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DeleteCustomizationFieldHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\DeleteCustomizationFieldCommand
 
     prestashop.adapter.product.query_handler.get_product_customization_fields_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductCustomizationFieldsHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields
+        class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductCustomizationFieldsHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields
 
     prestashop.adapter.product.command_handler.update_product_customization_fields_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductCustomizationFieldsHandler
-      arguments:
-        - '@prestashop.adapter.product.command_handler.add_customization_field_handler'
-        - '@prestashop.adapter.product.command_handler.update_customization_field_handler'
-        - '@prestashop.adapter.product.command_handler.delete_customization_field_handler'
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductCustomizationFieldsHandler
+        arguments:
+            - '@prestashop.adapter.product.command_handler.add_customization_field_handler'
+            - '@prestashop.adapter.product.command_handler.update_customization_field_handler'
+            - '@prestashop.adapter.product.command_handler.delete_customization_field_handler'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\UpdateProductCustomizationFieldsCommand
 
     prestashop.adapter.product.command_handler.update_product_shipping_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductShippingHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductShippingHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand
 
     prestashop.adapter.product.query_handler.get_product_suppliers_for_editing_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductSuppliersForEditingHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSuppliersForEditing
+        class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductSuppliersForEditingHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSuppliersForEditing
 
     prestashop.adapter.product.query_handler.get_product_supplier_options_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductSupplierOptionsHandler
         arguments:
             - '@prestashop.adapter.product.query_handler.get_product_suppliers_for_editing_handler'
         tags:
-            -   name: tactician.handler
+            - name: tactician.handler
                 command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions
 
     prestashop.adapter.product.command_handler.add_product_supplier_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductSupplierHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\AddProductSupplierCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductSupplierHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\AddProductSupplierCommand
 
     prestashop.adapter.product.command_handler.update_product_supplier_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductSupplierHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\UpdateProductSupplierCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductSupplierHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\UpdateProductSupplierCommand
 
     prestashop.adapter.product.command_handler.delete_product_supplier_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DeleteProductSupplierHandler
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\DeleteProductSupplierCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DeleteProductSupplierHandler
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\DeleteProductSupplierCommand
 
     prestashop.adapter.product.command_handler.update_product_suppliers_handler:
-      class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductSuppliersHandler
-      arguments:
-        - '@prestashop.adapter.product.command_handler.add_product_supplier_handler'
-        - '@prestashop.adapter.product.command_handler.update_product_supplier_handler'
-        - '@prestashop.adapter.product.command_handler.delete_product_supplier_handler'
-      tags:
-        - name: tactician.handler
-          command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\UpdateProductSuppliersCommand
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductSuppliersHandler
+        arguments:
+            - '@prestashop.adapter.product.command_handler.add_product_supplier_handler'
+            - '@prestashop.adapter.product.command_handler.update_product_supplier_handler'
+            - '@prestashop.adapter.product.command_handler.delete_product_supplier_handler'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\UpdateProductSuppliersCommand


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modify product.yml indent to use 4 spaces. See https://github.com/PrestaShop/PrestaShop/issues/15977#issuecomment-685453660
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | related to #20324
| How to test?  | No need manual testing. Automatic tests must pass and should be enough.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20815)
<!-- Reviewable:end -->
