### PR TITLE
Remove $response variable re-declaration

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttributeController.php
@@ -142,7 +142,6 @@ class AttributeController extends FrameworkBundleAdminController
         $attributes = $product->sortCombinationByAttributePosition($newCombinationIds, $locales[0]['id_lang']);
         $this->ensureProductHasDefaultCombination($product, $attributes);
 
-        $response = new JsonResponse();
         $combinationDataProvider = $this->get('prestashop.adapter.data_provider.combination');
         $result = [
             'ids_product_attribute' => [],


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | `$response = new JsonResponse();`<br>and some lines after, without having been modified:<br>`$response = new JsonResponse();`
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20866)
<!-- Reviewable:end -->
