### PR TITLE
Update Mobiledetect library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "league/tactician-bundle": "^1.0",
         "martinlindhe/php-mb-helpers": "^0.1.6",
         "matthiasmullie/minify": "~1.3.0",
-        "mobiledetect/mobiledetectlib": "~2.8.22",
+        "mobiledetect/mobiledetectlib": "~2.8.34",
         "mrclay/minify": "~2.3.0",
         "nikic/php-parser": "^4.0",
         "paragonie/random_compat": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c735286f77ae2ec651d0b33b00908d48",
+    "content-hash": "2d0711586c3802f62f87182f1e3ca756",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Missing some devices Example : [`Android SM-T510`](https://www.samsung.com/be_fr/tablets/galaxy-tab-a-10-1-t510/SM-T510NZKDLUX/)  .
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fix https://github.com/PrestaShop/PrestaShop/issues/20937.
| How to test?  | See 👇🏾.


The following code must display `2` in [`Android SM-T510`](https://www.samsung.com/be_fr/tablets/galaxy-tab-a-10-1-t510/SM-T510NZKDLUX/) devices  [See](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Context.php#L123)
```php
echo Context::getContext()->getDevice();
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20891)
<!-- Reviewable:end -->
