### PR TITLE
Keep order detail from being updated in BO > Order detail page, when product doesn't exist anymore

### DIFF
--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotUpdateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\UpdateProductInOrderHandlerInterface;
@@ -151,6 +152,12 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         Order $order,
         OrderInvoice $orderInvoice = null
     ) {
+        // assert product exists
+        $product = new Product($orderDetail->product_id);
+        if ($product->id !== (int) $orderDetail->product_id) {
+            throw new CannotUpdateProductInOrderException('You cannot edit the price of a product that no longer exists in your catalog.');
+        }
+
         if (!Validate::isLoadedObject($orderDetail)) {
             throw new OrderException('The Order Detail object could not be loaded.');
         }

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -38,8 +38,8 @@ use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotUpdateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\UpdateProductInOrderHandlerInterface;
@@ -155,7 +155,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderHandler implements 
         // assert product exists
         $product = new Product($orderDetail->product_id);
         if ($product->id !== (int) $orderDetail->product_id) {
-            throw new CannotUpdateProductInOrderException('You cannot edit the price of a product that no longer exists in your catalog.');
+            throw new CannotFindProductInOrderException('You cannot edit the price of a product that no longer exists in your catalog.');
         }
 
         if (!Validate::isLoadedObject($orderDetail)) {

--- a/src/Core/Domain/Order/Exception/CannotFindProductInOrderException.php
+++ b/src/Core/Domain/Order/Exception/CannotFindProductInOrderException.php
@@ -30,6 +30,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
 /**
  * Thrown on failure to update product in an order
  */
-class CannotUpdateProductInOrderException extends OrderException
+class CannotFindProductInOrderException extends OrderException
 {
 }

--- a/src/Core/Domain/Order/Exception/CannotUpdateProductInOrder.php
+++ b/src/Core/Domain/Order/Exception/CannotUpdateProductInOrder.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
+
+/**
+ * Thrown on failure to update order
+ */
+class CannotUpdateProductInOrderException extends OrderException
+{
+}

--- a/src/Core/Domain/Order/Exception/CannotUpdateProductInOrder.php
+++ b/src/Core/Domain/Order/Exception/CannotUpdateProductInOrder.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Order\Exception;
 
 /**
- * Thrown on failure to update order
+ * Thrown on failure to update product in an order
  */
 class CannotUpdateProductInOrderException extends OrderException
 {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -47,7 +47,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendProcessOrderEmailCommand
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotUpdateProductInOrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
@@ -1728,7 +1728,8 @@ class OrderController extends FrameworkBundleAdminController
                 'This product is already in the invoice [1], please edit the quantity instead.',
                 'Admin.Notifications.Error',
                 ['[1]' => $orderInvoiceNumber]
-            CannotUpdateProductInOrderException::class => $this->trans(
+            ),
+            CannotFindProductInOrderException::class => $this->trans(
                 'You cannot edit the price of a product that no longer exists in your catalog.',
                 'Admin.Notifications.Error'
             ),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -47,6 +47,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendProcessOrderEmailCommand
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotEditDeliveredOrderProductException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotUpdateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
@@ -1727,6 +1728,9 @@ class OrderController extends FrameworkBundleAdminController
                 'This product is already in the invoice [1], please edit the quantity instead.',
                 'Admin.Notifications.Error',
                 ['[1]' => $orderInvoiceNumber]
+            CannotUpdateProductInOrderException::class => $this->trans(
+                'You cannot edit the price of a product that no longer exists in your catalog.',
+                'Admin.Notifications.Error'
             ),
         ];
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -45,9 +45,9 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\BulkChangeOrderStatusCommand
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteCartRuleFromOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DuplicateOrderCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateProductInOrderInvoiceException;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotFindProductInOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidProductQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -562,6 +562,8 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             $this->lastException = $e;
         } catch (DuplicateProductInOrderInvoiceException $e) {
             $this->lastException = $e;
+        } catch (CannotFindProductInOrderException $e) {
+            $this->lastException = $e;
         }
     }
 
@@ -1533,20 +1535,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         }
 
         // update product price/quantity in order
-        try {
-            // prices and quantities are not important here
-            $updateProductCommand = new UpdateProductInOrderCommand(
-                (int) $orderId,
-                (int) $productOrderDetail['id_order_detail'],
-                '12',
-                '10',
-                3
-            );
-            $this->getCommandBus()->handle($updateProductCommand);
-        } catch (CannotFindProductInOrderException $e) {
-            // updating a product that was deleted from catalogue should trigger this exception
-            $this->lastException = $e;
-        }
+        $this->updateProductInOrder($orderId, $productOrderDetail, ['price' => '10', 'amount' => '3']);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1540,7 +1540,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 (int) $productOrderDetail['id_order_detail'],
                 '12',
                 '10',
-                (int) 3
+                3
             );
             $this->getCommandBus()->handle($updateProductCommand);
         } catch (CannotFindProductInOrderException $e) {

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -324,3 +324,12 @@ Feature: Order from Back Office (BO)
       | Postal code      | 12345                              |
     When I change order "bo_order1" shipping address to "test-address"
     Then order "bo_order1" shipping address should be "test-address"
+
+  Scenario: Edit a product that doesn't exist in catalogue anymore
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Mug Today is a good day |
+      | amount        | 1                       |
+      | price         | 10                      |
+    And I delete product "Mug Today is a good day" from catalogue
+    And I update deleted product "Mug Today is a good day" in order "bo_order1"
+    Then I should get error that the product being edited was not found


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In BO > Order detail, when updating the price of a deleted product, we would have a bad error message and the order detail would still be updated. This PR improves the error message and do not update the price.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20818
| How to test?  | See steps described in #20818

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20902)
<!-- Reviewable:end -->
