### PR TITLE
Update Order amount when its addresses are modified

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -333,6 +333,36 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Update the Delivery Address ID of the Cart.
+     *
+     * @param int $id_address Current Address ID to change
+     * @param int $id_address_new New Address ID
+     */
+    public function updateDeliveryAddressId($id_address, $id_address_new)
+    {
+        $to_update = false;
+        if (!isset($this->id_address_delivery) || $this->id_address_delivery == $id_address) {
+            $to_update = true;
+            $this->id_address_delivery = $id_address_new;
+        }
+        if ($to_update) {
+            $this->update();
+        }
+
+        $sql = 'UPDATE `' . _DB_PREFIX_ . 'cart_product`
+        SET `id_address_delivery` = ' . (int) $id_address_new . '
+        WHERE  `id_cart` = ' . (int) $this->id . '
+            AND `id_address_delivery` = ' . (int) $id_address;
+        Db::getInstance()->execute($sql);
+
+        $sql = 'UPDATE `' . _DB_PREFIX_ . 'customization`
+            SET `id_address_delivery` = ' . (int) $id_address_new . '
+            WHERE  `id_cart` = ' . (int) $this->id . '
+                AND `id_address_delivery` = ' . (int) $id_address;
+        Db::getInstance()->execute($sql);
+    }
+
+    /**
      * Deletes current Cart from the database.
      *
      * @return bool True if delete was successful

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -340,12 +340,8 @@ class CartCore extends ObjectModel
      */
     public function updateDeliveryAddressId(int $currentAddressId, int $newAddressId)
     {
-        $needsUpdate = false;
         if (!isset($this->id_address_delivery) || (int) $this->id_address_delivery === $currentAddressId) {
-            $needsUpdate = true;
             $this->id_address_delivery = $newAddressId;
-        }
-        if ($needsUpdate) {
             $this->update();
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -335,30 +335,30 @@ class CartCore extends ObjectModel
     /**
      * Update the Delivery Address ID of the Cart.
      *
-     * @param int $id_address Current Address ID to change
-     * @param int $id_address_new New Address ID
+     * @param int $currentAddressId Current Address ID to change
+     * @param int $newAddressId New Address ID
      */
-    public function updateDeliveryAddressId($id_address, $id_address_new)
+    public function updateDeliveryAddressId(int $currentAddressId, int $newAddressId)
     {
-        $to_update = false;
-        if (!isset($this->id_address_delivery) || $this->id_address_delivery == $id_address) {
-            $to_update = true;
-            $this->id_address_delivery = $id_address_new;
+        $needsUpdate = false;
+        if (!isset($this->id_address_delivery) || (int) $this->id_address_delivery === $currentAddressId) {
+            $needsUpdate = true;
+            $this->id_address_delivery = $newAddressId;
         }
-        if ($to_update) {
+        if ($needsUpdate) {
             $this->update();
         }
 
         $sql = 'UPDATE `' . _DB_PREFIX_ . 'cart_product`
-        SET `id_address_delivery` = ' . (int) $id_address_new . '
+        SET `id_address_delivery` = ' . $newAddressId . '
         WHERE  `id_cart` = ' . (int) $this->id . '
-            AND `id_address_delivery` = ' . (int) $id_address;
+            AND `id_address_delivery` = ' . $currentAddressId;
         Db::getInstance()->execute($sql);
 
         $sql = 'UPDATE `' . _DB_PREFIX_ . 'customization`
-            SET `id_address_delivery` = ' . (int) $id_address_new . '
+            SET `id_address_delivery` = ' . $newAddressId . '
             WHERE  `id_cart` = ' . (int) $this->id . '
-                AND `id_address_delivery` = ' . (int) $id_address;
+                AND `id_address_delivery` = ' . $currentAddressId;
         Db::getInstance()->execute($sql);
     }
 

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -456,12 +456,29 @@ class OrderDetailCore extends ObjectModel
         return $this->saveTaxCalculator($order, true);
     }
 
+    /**
+     * Get a TaxCalculator adapted for the OrderDetail's product and the specified address
+     *
+     * @param Address $address
+     *
+     * @return TaxCalculator
+     */
     public function getTaxCalculatorByAddress(Address $address)
     {
         $this->setContext((int) $this->id_shop);
-        $tax_manager = TaxManagerFactory::getManager($address, (int) Product::getIdTaxRulesGroupByIdProduct((int) $this->product_id, $this->context));
+        $tax_manager = TaxManagerFactory::getManager($address, $this->getTaxRulesGroupId());
 
         return $tax_manager->getTaxCalculator();
+    }
+
+    /**
+     * Dynamically get the taxRulesGroupId instead of relying one the one saved in database
+     *
+     * @return int
+     */
+    public function getTaxRulesGroupId(): int
+    {
+        return (int) Product::getIdTaxRulesGroupByIdProduct((int) $this->product_id, $this->context);
     }
 
     /**

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -392,10 +392,6 @@ class OrderDetailCore extends ObjectModel
             return false;
         }
 
-        if (count($this->tax_calculator->taxes) == 0) {
-            return true;
-        }
-
         if ($order->total_products <= 0) {
             return true;
         }
@@ -441,11 +437,15 @@ class OrderDetailCore extends ObjectModel
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'order_detail_tax` WHERE id_order_detail=' . (int) $this->id);
         }
 
-        $values = rtrim($values, ',');
-        $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'order_detail_tax` (id_order_detail, id_tax, unit_amount, total_amount)
+        if (!empty($values)) {
+            $values = rtrim($values, ',');
+            $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'order_detail_tax` (id_order_detail, id_tax, unit_amount, total_amount)
                 VALUES ' . $values;
 
-        return Db::getInstance()->execute($sql);
+            return Db::getInstance()->execute($sql);
+        }
+
+        return true;
     }
 
     public function updateTaxAmount($order)

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -463,7 +463,7 @@ class OrderDetailCore extends ObjectModel
      *
      * @return TaxCalculator
      */
-    public function getTaxCalculatorByAddress(Address $address)
+    public function getTaxCalculatorByAddress(Address $address): TaxCalculator
     {
         $this->setContext((int) $this->id_shop);
         $tax_manager = TaxManagerFactory::getManager($address, $this->getTaxRulesGroupId());

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -139,10 +139,14 @@ class OrderDetailCore extends ObjectModel
     /** @var datetime */
     public $download_deadline;
 
-    /** @var string $tax_name * */
+    /**
+     * @var string @deprecated Order Detail Tax is saved in order_detail_tax table now
+     */
     public $tax_name;
 
-    /** @var float $tax_rate * */
+    /**
+     * @var float @deprecated Order Detail Tax is saved in order_detail_tax table now
+     */
     public $tax_rate;
 
     /** @var float $tax_computation_method * */
@@ -357,9 +361,8 @@ class OrderDetailCore extends ObjectModel
         if ($results = Db::getInstance()->executeS($sql)) {
             foreach ($results as $result) {
                 $taxes[] = new Tax((int) $result['id_tax']);
+                $computation_method = $result['tax_computation_method'];
             }
-
-            $computation_method = $result['tax_computation_method'];
         }
 
         return new TaxCalculator($taxes, $computation_method);
@@ -372,6 +375,9 @@ class OrderDetailCore extends ObjectModel
      * @deprecated Functionality moved to Order::updateOrderDetailTax
      *             because we need the full order object to do a good job here.
      *             Will no longer be supported after 1.6.1
+     *             (Note: this one is not that deprecated because Order::updateOrderDetailTax
+     *             performs no update unless order_detail_tax is filled. So we rely on updateTaxAmount
+     *             which correctly builds the TaxCalculator with up to date taxes unlike getTaxCalculatorStatic)
      *
      * @return bool
      */
@@ -444,12 +450,18 @@ class OrderDetailCore extends ObjectModel
 
     public function updateTaxAmount($order)
     {
-        $this->setContext((int) $this->id_shop);
         $address = new Address((int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $tax_manager = TaxManagerFactory::getManager($address, (int) Product::getIdTaxRulesGroupByIdProduct((int) $this->product_id, $this->context));
-        $this->tax_calculator = $tax_manager->getTaxCalculator();
+        $this->tax_calculator = $this->getTaxCalculatorByAddress($address);
 
         return $this->saveTaxCalculator($order, true);
+    }
+
+    public function getTaxCalculatorByAddress(Address $address)
+    {
+        $this->setContext((int) $this->id_shop);
+        $tax_manager = TaxManagerFactory::getManager($address, (int) Product::getIdTaxRulesGroupByIdProduct((int) $this->product_id, $this->context));
+
+        return $tax_manager->getTaxCalculator();
     }
 
     /**

--- a/classes/tax/TaxManagerFactory.php
+++ b/classes/tax/TaxManagerFactory.php
@@ -85,6 +85,14 @@ class TaxManagerFactoryCore
     }
 
     /**
+     * Reset static cache (mainly for test environment)
+     */
+    public static function resetStaticCache()
+    {
+        TaxManagerFactory::$cache_tax_manager = null;
+    }
+
+    /**
      * Create a unique identifier for the address.
      *
      * @param Address

--- a/classes/tax/TaxRulesTaxManager.php
+++ b/classes/tax/TaxRulesTaxManager.php
@@ -51,7 +51,8 @@ class TaxRulesTaxManagerCore implements TaxManagerInterface
             $this->configurationManager = $configurationManager;
         }
 
-        $this->address = $address;
+        // We clone the address so that the information use by this TaxManager never change (address can be modified somewhere else)
+        $this->address = clone $address;
         $this->type = $type;
     }
 

--- a/install-dev/fixtures/fashion/data/delivery.xml
+++ b/install-dev/fixtures/fashion/data/delivery.xml
@@ -14,17 +14,17 @@
     <delivery id="delivery_2" id_shop="" id_shop_group="" id_carrier="My_carrier" id_range_price="" id_range_weight="range_weight_1" id_zone="North_America" price="5.000000"/>
     <delivery id="delivery_4" id_shop="" id_shop_group="" id_carrier="My_carrier" id_range_price="range_price_1" id_range_weight="" id_zone="Europe" price="5.000000"/>
     <delivery id="delivery_5" id_shop="" id_shop_group="" id_carrier="My_carrier" id_range_price="range_price_1" id_range_weight="" id_zone="North_America" price="5.000000"/>
-    <delivery id="delivery_6" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_2" id_range_weight="" id_zone="Europe" price="4.000000"/>
+    <delivery id="delivery_6" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_2" id_range_weight="" id_zone="Europe" price="3.000000"/>
     <delivery id="delivery_7" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_2" id_range_weight="" id_zone="North_America" price="4.000000"/>
-    <delivery id="delivery_8" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_3" id_range_weight="" id_zone="Europe" price="2.000000"/>
+    <delivery id="delivery_8" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_3" id_range_weight="" id_zone="Europe" price="1.000000"/>
     <delivery id="delivery_9" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_3" id_range_weight="" id_zone="North_America" price="2.000000"/>
     <delivery id="delivery_10" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_4" id_range_weight="" id_zone="Europe" price="0.000000"/>
     <delivery id="delivery_11" id_shop="" id_shop_group="" id_carrier="My_cheap_carrier" id_range_price="range_price_4" id_range_weight="" id_zone="North_America" price="0.000000"/>
     <delivery id="delivery_12" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_2" id_zone="Europe" price="0.000000"/>
     <delivery id="delivery_13" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_2" id_zone="North_America" price="0.000000"/>
-    <delivery id="delivery_14" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_3" id_zone="Europe" price="3.000000"/>
+    <delivery id="delivery_14" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_3" id_zone="Europe" price="2.000000"/>
     <delivery id="delivery_15" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_3" id_zone="North_America" price="3.000000"/>
-    <delivery id="delivery_16" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_4" id_zone="Europe" price="6.000000"/>
+    <delivery id="delivery_16" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_4" id_zone="Europe" price="5.000000"/>
     <delivery id="delivery_17" id_shop="" id_shop_group="" id_carrier="My_light_carrier" id_range_price="" id_range_weight="range_weight_4" id_zone="North_America" price="6.000000"/>
   </entities>
 </entity_delivery>

--- a/src/Adapter/Cart/CommandHandler/UpdateCartAddressesHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartAddressesHandler.php
@@ -76,9 +76,9 @@ final class UpdateCartAddressesHandler extends AbstractCartHandler implements Up
     private function fillCartWithCommandData(Cart $cart, UpdateCartAddressesCommand $command): void
     {
         if ($command->getNewDeliveryAddressId()) {
-            // updateAddressId() will actually allow the address change to be impacted on all
-            // other data linked to the cart delivery address
-            $cart->updateAddressId($cart->id_address_delivery, $command->getNewDeliveryAddressId()->getValue());
+            // updateDeliveryAddressId() will actually allow the address change to be impacted on all
+            // other data linked to the cart delivery address (and it doesn't modify the invoice address)
+            $cart->updateDeliveryAddressId($cart->id_address_delivery, $command->getNewDeliveryAddressId()->getValue());
         }
 
         if ($command->getNewInvoiceAddressId()) {

--- a/src/Adapter/Cart/CommandHandler/UpdateCartAddressesHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartAddressesHandler.php
@@ -78,7 +78,7 @@ final class UpdateCartAddressesHandler extends AbstractCartHandler implements Up
         if ($command->getNewDeliveryAddressId()) {
             // updateDeliveryAddressId() will actually allow the address change to be impacted on all
             // other data linked to the cart delivery address (and it doesn't modify the invoice address)
-            $cart->updateDeliveryAddressId($cart->id_address_delivery, $command->getNewDeliveryAddressId()->getValue());
+            $cart->updateDeliveryAddressId((int) $cart->id_address_delivery, $command->getNewDeliveryAddressId()->getValue());
         }
 
         if ($command->getNewInvoiceAddressId()) {

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -114,6 +114,6 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
      */
     private function formatLegacyDeliveryOptionFromCarrierId(int $carrierId): string
     {
-        return sprintf('%s,', $carrierId);
+        return sprintf('%d,', $carrierId);
     }
 }

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -71,7 +71,7 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
         ;
 
         $cart->setDeliveryOption([
-            $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($command->getNewCarrierId()),
+            (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($command->getNewCarrierId()),
         ]);
 
         $cart->update();

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -139,8 +139,17 @@ class Configuration extends ParameterBag implements ConfigurationInterface, Shop
             return $this->getLocalized($key, $shopId, $shopGroupId);
         }
 
-        if (ConfigurationLegacy::hasKey($key, null, $shopGroupId, $shopId)) {
-            return ConfigurationLegacy::get($key, null, $shopGroupId, $shopId);
+        // Since has key doesn't check manage the fallback shop > shop group > global, we handle it manually
+        if (ConfigurationLegacy::hasKey($key, null, null, $shopId)) {
+            return ConfigurationLegacy::get($key, null, null, $shopId);
+        }
+
+        if (ConfigurationLegacy::hasKey($key, null, $shopGroupId)) {
+            return ConfigurationLegacy::get($key, null, $shopGroupId);
+        }
+
+        if (ConfigurationLegacy::hasKey($key)) {
+            return ConfigurationLegacy::get($key);
         }
 
         return $default;

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -139,7 +139,7 @@ class Configuration extends ParameterBag implements ConfigurationInterface, Shop
             return $this->getLocalized($key, $shopId, $shopGroupId);
         }
 
-        // Since has key doesn't check manage the fallback shop > shop group > global, we handle it manually
+        // Since hasKey doesn't check manage the fallback shop > shop group > global, we handle it manually
         if (ConfigurationLegacy::hasKey($key, null, null, $shopId)) {
             return ConfigurationLegacy::get($key, null, null, $shopId);
         }
@@ -231,7 +231,11 @@ class Configuration extends ParameterBag implements ConfigurationInterface, Shop
         $shopId = null !== $shopConstraint->getShopId() ? $shopConstraint->getShopId()->getValue() : null;
         $shopGroupId = null !== $shopConstraint->getShopGroupId() ? $shopConstraint->getShopGroupId()->getValue() : null;
 
-        return ConfigurationLegacy::hasKey($key, null, $shopGroupId, $shopId);
+        return
+            ConfigurationLegacy::hasKey($key, null, null, $shopId)
+            || ConfigurationLegacy::hasKey($key, null, $shopGroupId)
+            || ConfigurationLegacy::hasKey($key)
+        ;
     }
 
     /**

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -106,6 +106,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
 
         $shopId = $this->getShopId($shopConstraint);
         $shopGroupId = $this->getShopGroupId($shopConstraint);
+        $isStrict = $this->isStrict($shopConstraint);
 
         //If configuration has never been accessed it is still empty and hasKey/isLangKey will always return false
         if (!ConfigurationLegacy::configurationIsLoaded()) {
@@ -119,16 +120,16 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
 
         // Since hasKey doesn't check manage the fallback shop > shop group > global, we handle it manually
         $hasKey = ConfigurationLegacy::hasKey($key, null, null, $shopId);
-        if ($hasKey || $shopConstraint->isStrict()) {
+        if ($hasKey || $isStrict) {
             return $hasKey ? ConfigurationLegacy::get($key, null, null, $shopId) : null;
         }
 
         $hasKey = ConfigurationLegacy::hasKey($key, null, $shopGroupId);
-        if ($hasKey || $shopConstraint->isStrict()) {
+        if ($hasKey || $isStrict) {
             return $hasKey ? ConfigurationLegacy::get($key, null, $shopGroupId) : null;
         }
 
-        if ($hasKey = ConfigurationLegacy::hasKey($key) || $shopConstraint->isStrict()) {
+        if ($hasKey = ConfigurationLegacy::hasKey($key) || $isStrict) {
             return $hasKey ? ConfigurationLegacy::get($key) : null;
         }
 
@@ -185,14 +186,15 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     {
         $shopId = $this->getShopId($shopConstraint);
         $shopGroupId = $this->getShopGroupId($shopConstraint);
+        $isStrict = $this->isStrict($shopConstraint);
 
         $hasKey = ConfigurationLegacy::hasKey($key, null, null, $shopId);
-        if ($hasKey || $shopConstraint->isStrict()) {
+        if ($hasKey || $isStrict) {
             return $hasKey;
         }
 
         $hasKey = ConfigurationLegacy::hasKey($key, null, $shopGroupId);
-        if ($hasKey || $shopConstraint->isStrict()) {
+        if ($hasKey || $isStrict) {
             return $hasKey;
         }
 
@@ -325,5 +327,15 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
             ? $shopConstraint->getShopGroupId()->getValue()
             : null
         ;
+    }
+
+    /**
+     * @param ShopConstraint|null $shopConstraint
+     *
+     * @return int|null
+     */
+    private function isStrict(?ShopConstraint $shopConstraint): ?int
+    {
+        return null !== $shopConstraint ? $shopConstraint->isStrict() : false;
     }
 }

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -142,7 +142,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
      * @param string $key
      * @param mixed $value
      * @param ShopConstraint|null $shopConstraint
-     * @param array $options Options
+     * @param array $options Options @deprecated Will be removed in next major
      *
      * @return $this
      *

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -206,7 +206,6 @@ class Configuration extends ParameterBag implements ConfigurationInterface, Shop
         }
     }
 
-
     /**
      * {@inheritdoc}
      */
@@ -225,7 +224,6 @@ class Configuration extends ParameterBag implements ConfigurationInterface, Shop
 
         return ConfigurationLegacy::hasKey($key, null, $shopGroupId, $shopId);
     }
-
 
     /**
      * Removes a configuration key.

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -64,6 +64,14 @@ final class ContextStateManager
     }
 
     /**
+     * @return Context
+     */
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    /**
      * Sets context cart and saves previous value
      *
      * @param Cart|null $cart

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -347,4 +347,22 @@ abstract class AbstractOrderHandler
     {
         return RoundModeConverter::getNumberRoundMode((int) Configuration::get('PS_PRICE_ROUND_MODE'));
     }
+
+    /**
+     * Delivery option consists of deliveryAddress and carrierId.
+     *
+     * Legacy multishipping feature used comma separated carriers in delivery option (e.g. {'1':'6,7'}
+     * Now that multishipping is gone - delivery option should consist of one carrier and one address.
+     *
+     * However the structure of deliveryOptions is still used with comma in legacy, so
+     * this method provides assurance for deliveryOption structure until major refactoring
+     *
+     * @param int $carrierId
+     *
+     * @return string
+     */
+    protected function formatLegacyDeliveryOptionFromCarrierId(int $carrierId): string
+    {
+        return sprintf('%d,', $carrierId);
+    }
 }

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -358,13 +358,10 @@ abstract class AbstractOrderHandler
      */
     protected function getOrderShopConstraint(Order $order): ShopConstraint
     {
-        $constraint = new ShopConstraint();
-        $constraint
-            ->setShopId($order->id_shop)
-            ->setShopGroupId($order->id_shop_group)
-        ;
-
-        return $constraint;
+        return new ShopConstraint(
+            (int) $order->id_shop,
+            (int) $order->id_shop_group
+        );
     }
 
     /**

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -370,9 +370,10 @@ abstract class AbstractOrderHandler
         $taxAddress = new Address($taxAddressId);
         $computingPrecision = $this->getPrecisionFromCart($cart);
 
+        $context = Context::getContext();
         foreach ($order->getOrderDetailList() as $row) {
             $orderDetail = new OrderDetail($row['id_order_detail']);
-            $orderDetail->id_tax_rules_group = (int) Product::getIdTaxRulesGroupByIdProduct($orderDetail->product_id, Context::getContext());
+            $orderDetail->id_tax_rules_group = (int) Product::getIdTaxRulesGroupByIdProduct($orderDetail->product_id, $context);
             $taxManager = TaxManagerFactory::getManager($taxAddress, $orderDetail->id_tax_rules_group);
             $taxCalculator = $taxManager->getTaxCalculator();
 

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -49,6 +49,7 @@ use PrestaShopException;
 use Product;
 use SpecificPrice;
 use Tools;
+use TaxManagerFactory;
 use Validate;
 
 /**

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -30,7 +30,6 @@ use Address;
 use Cart;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
-use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\ChangeOrderDeliveryAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -47,20 +46,11 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
     private $orderAmountUpdater;
 
     /**
-     * @var ShopConfigurationInterface
-     */
-    private $shopConfiguration;
-
-    /**
      * @param OrderAmountUpdater $orderAmountUpdater
-     * @param ShopConfigurationInterface $shopConfiguration
      */
-    public function __construct(
-        OrderAmountUpdater $orderAmountUpdater,
-        ShopConfigurationInterface $shopConfiguration
-    ) {
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
         $this->orderAmountUpdater = $orderAmountUpdater;
-        $this->shopConfiguration = $shopConfiguration;
     }
 
     /**
@@ -85,11 +75,6 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
 
         $order->id_address_delivery = $address->id;
         $this->orderAmountUpdater->update($order, $cart);
-
-        // Update OrderDetails tax if the address is the delivery address
-        if ($this->shopConfiguration->get('PS_TAX_ADDRESS_TYPE', null, $this->getOrderShopConstraint($order)) === 'id_address_delivery') {
-            $this->updateOrderDetailsTax($order, $cart, new Address($order->id_address_delivery));
-        }
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -55,7 +55,7 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
 
         $cart->updateDeliveryAddressId((int) $cart->id_address_delivery, (int) $address->id);
         $cart->setDeliveryOption([
-            $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($order->id_carrier),
+            (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($order->id_carrier),
         ]);
         $cart->update();
 

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -28,9 +28,9 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Address;
 use Cart;
-use Configuration;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\ChangeOrderDeliveryAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -47,11 +47,20 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
     private $orderAmountUpdater;
 
     /**
-     * @param OrderAmountUpdater $orderAmountUpdater
+     * @var ShopConfigurationInterface
      */
-    public function __construct(OrderAmountUpdater $orderAmountUpdater)
-    {
+    private $shopConfiguration;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     * @param ShopConfigurationInterface $shopConfiguration
+     */
+    public function __construct(
+        OrderAmountUpdater $orderAmountUpdater,
+        ShopConfigurationInterface $shopConfiguration
+    ) {
         $this->orderAmountUpdater = $orderAmountUpdater;
+        $this->shopConfiguration = $shopConfiguration;
     }
 
     /**
@@ -78,8 +87,8 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
         $this->orderAmountUpdater->update($order, $cart);
 
         // Update OrderDetails tax if the address is the delivery address
-        if (Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop) === 'id_address_delivery') {
-            $this->updateOrderDetailsTax($order, $cart);
+        if ($this->shopConfiguration->getForShop('PS_TAX_ADDRESS_TYPE', $this->getOrderShopConstraint($order)) === 'id_address_delivery') {
+            $this->updateOrderDetailsTax($order, $cart, new Address($order->id_address_delivery));
         }
     }
 

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -53,7 +53,7 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
             throw new OrderException('New delivery address is not valid');
         }
 
-        $cart->updateDeliveryAddressId($cart->id_address_delivery, $address->id);
+        $cart->updateDeliveryAddressId((int) $cart->id_address_delivery, (int) $address->id);
         $cart->setDeliveryOption([
             $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($order->id_carrier),
         ]);

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 use Address;
 use Cart;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
+use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\ChangeOrderDeliveryAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -39,6 +40,19 @@ use Validate;
  */
 final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler implements ChangeOrderDeliveryAddressHandlerInterface
 {
+    /**
+     * @var OrderAmountUpdater
+     */
+    private $orderAmountUpdater;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     */
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
+        $this->orderAmountUpdater = $orderAmountUpdater;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -60,9 +74,7 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
         $cart->update();
 
         $order->id_address_delivery = $address->id;
-        $order->update();
-
-        $order->refreshShippingCost();
+        $this->orderAmountUpdater->update($order, $cart);
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -87,7 +87,7 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
         $this->orderAmountUpdater->update($order, $cart);
 
         // Update OrderDetails tax if the address is the delivery address
-        if ($this->shopConfiguration->getForShop('PS_TAX_ADDRESS_TYPE', $this->getOrderShopConstraint($order)) === 'id_address_delivery') {
+        if ($this->shopConfiguration->get('PS_TAX_ADDRESS_TYPE', null, $this->getOrderShopConstraint($order)) === 'id_address_delivery') {
             $this->updateOrderDetailsTax($order, $cart, new Address($order->id_address_delivery));
         }
     }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Address;
 use Cart;
+use Configuration;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand;
@@ -75,6 +76,11 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
 
         $order->id_address_delivery = $address->id;
         $this->orderAmountUpdater->update($order, $cart);
+
+        // Update OrderDetails tax if the address is the delivery address
+        if (Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop) === 'id_address_delivery') {
+            $this->updateOrderDetailsTax($order, $cart);
+        }
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderDeliveryAddressHandler.php
@@ -76,22 +76,4 @@ final class ChangeOrderDeliveryAddressHandler extends AbstractOrderHandler imple
         $order->id_address_delivery = $address->id;
         $this->orderAmountUpdater->update($order, $cart);
     }
-
-    /**
-     * Delivery option consists of deliveryAddress and carrierId.
-     *
-     * Legacy multishipping feature used comma separated carriers in delivery option (e.g. {'1':'6,7'}
-     * Now that multishipping is gone - delivery option should consist of one carrier and one address.
-     *
-     * However the structure of deliveryOptions is still used with comma in legacy, so
-     * this method provides assurance for deliveryOption structure until major refactoring
-     *
-     * @param int $carrierId
-     *
-     * @return string
-     */
-    private function formatLegacyDeliveryOptionFromCarrierId(int $carrierId): string
-    {
-        return sprintf('%s,', $carrierId);
-    }
 }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -28,9 +28,9 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Address;
 use Cart;
-use Configuration;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\ChangeOrderInvoiceAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -47,11 +47,20 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
     private $orderAmountUpdater;
 
     /**
-     * @param OrderAmountUpdater $orderAmountUpdater
+     * @var ShopConfigurationInterface
      */
-    public function __construct(OrderAmountUpdater $orderAmountUpdater)
-    {
+    private $shopConfiguration;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     * @param ShopConfigurationInterface $shopConfiguration
+     */
+    public function __construct(
+        OrderAmountUpdater $orderAmountUpdater,
+        ShopConfigurationInterface $shopConfiguration
+    ) {
         $this->orderAmountUpdater = $orderAmountUpdater;
+        $this->shopConfiguration = $shopConfiguration;
     }
 
     /**
@@ -75,8 +84,8 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
         $this->orderAmountUpdater->update($order, $cart);
 
         // Update OrderDetails tax if the address is the delivery address
-        if (Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop) === 'id_address_invoice') {
-            $this->updateOrderDetailsTax($order, $cart);
+        if ($this->shopConfiguration->getForShop('PS_TAX_ADDRESS_TYPE', $this->getOrderShopConstraint($order)) === 'id_address_invoice') {
+            $this->updateOrderDetailsTax($order, $cart, new Address($order->id_address_invoice));
         }
     }
 }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -53,11 +53,12 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
             throw new OrderException('New invoice address is not valid');
         }
 
-        $order->id_address_invoice = $address->id;
         $cart->id_address_invoice = $address->id;
-
-        $order->update();
-        $order->refreshShippingCost();
         $cart->update();
+
+        $order->id_address_invoice = $address->id;
+        $order->update();
+
+        $order->refreshShippingCost();
     }
 }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 
 use Address;
 use Cart;
+use Configuration;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand;
@@ -72,5 +73,10 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
 
         $order->id_address_invoice = $address->id;
         $this->orderAmountUpdater->update($order, $cart);
+
+        // Update OrderDetails tax if the address is the delivery address
+        if (Configuration::get('PS_TAX_ADDRESS_TYPE', null, null, $order->id_shop) === 'id_address_invoice') {
+            $this->updateOrderDetailsTax($order, $cart);
+        }
     }
 }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -84,7 +84,7 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
         $this->orderAmountUpdater->update($order, $cart);
 
         // Update OrderDetails tax if the address is the delivery address
-        if ($this->shopConfiguration->getForShop('PS_TAX_ADDRESS_TYPE', $this->getOrderShopConstraint($order)) === 'id_address_invoice') {
+        if ($this->shopConfiguration->get('PS_TAX_ADDRESS_TYPE', null, $this->getOrderShopConstraint($order)) === 'id_address_invoice') {
             $this->updateOrderDetailsTax($order, $cart, new Address($order->id_address_invoice));
         }
     }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -30,7 +30,6 @@ use Address;
 use Cart;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
-use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\ChangeOrderInvoiceAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -47,20 +46,11 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
     private $orderAmountUpdater;
 
     /**
-     * @var ShopConfigurationInterface
-     */
-    private $shopConfiguration;
-
-    /**
      * @param OrderAmountUpdater $orderAmountUpdater
-     * @param ShopConfigurationInterface $shopConfiguration
      */
-    public function __construct(
-        OrderAmountUpdater $orderAmountUpdater,
-        ShopConfigurationInterface $shopConfiguration
-    ) {
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
         $this->orderAmountUpdater = $orderAmountUpdater;
-        $this->shopConfiguration = $shopConfiguration;
     }
 
     /**
@@ -82,10 +72,5 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
 
         $order->id_address_invoice = $address->id;
         $this->orderAmountUpdater->update($order, $cart);
-
-        // Update OrderDetails tax if the address is the delivery address
-        if ($this->shopConfiguration->get('PS_TAX_ADDRESS_TYPE', null, $this->getOrderShopConstraint($order)) === 'id_address_invoice') {
-            $this->updateOrderDetailsTax($order, $cart, new Address($order->id_address_invoice));
-        }
     }
 }

--- a/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
+++ b/src/Adapter/Order/CommandHandler/ChangeOrderInvoiceAddressHandler.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 use Address;
 use Cart;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
+use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\ChangeOrderInvoiceAddressHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -39,6 +40,19 @@ use Validate;
  */
 final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implements ChangeOrderInvoiceAddressHandlerInterface
 {
+    /**
+     * @var OrderAmountUpdater
+     */
+    private $orderAmountUpdater;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     */
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
+        $this->orderAmountUpdater = $orderAmountUpdater;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -57,8 +71,6 @@ final class ChangeOrderInvoiceAddressHandler extends AbstractOrderHandler implem
         $cart->update();
 
         $order->id_address_invoice = $address->id;
-        $order->update();
-
-        $order->refreshShippingCost();
+        $this->orderAmountUpdater->update($order, $cart);
     }
 }

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -32,6 +32,7 @@ use Customer;
 use Hook;
 use OrderCarrier;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
+use PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\UpdateOrderShippingDetailsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
@@ -43,6 +44,19 @@ use Validate;
  */
 final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler implements UpdateOrderShippingDetailsHandlerInterface
 {
+    /**
+     * @var OrderAmountUpdater
+     */
+    private $orderAmountUpdater;
+
+    /**
+     * @param OrderAmountUpdater $orderAmountUpdater
+     */
+    public function __construct(OrderAmountUpdater $orderAmountUpdater)
+    {
+        $this->orderAmountUpdater = $orderAmountUpdater;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -76,7 +90,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
             $orderCarrier->update();
 
             $order->id_carrier = $carrierId;
-            $order->refreshShippingCost();
+            $this->orderAmountUpdater->update($order, $cart);
         }
 
         //load fresh order carrier because updated just before

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -123,22 +123,4 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
             ], null, false, true, false, $order->id_shop);
         }
     }
-
-    /**
-     * Delivery option consists of deliveryAddress and carrierId.
-     *
-     * Legacy multishipping feature used comma separated carriers in delivery option (e.g. {'1':'6,7'}
-     * Now that multishipping is gone - delivery option should consist of one carrier and one address.
-     *
-     * However the structure of deliveryOptions is still used with comma in legacy, so
-     * this method provides assurance for deliveryOption structure until major refactoring
-     *
-     * @param int $carrierId
-     *
-     * @return string
-     */
-    private function formatLegacyDeliveryOptionFromCarrierId(int $carrierId): string
-    {
-        return sprintf('%s,', $carrierId);
-    }
 }

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -68,7 +68,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
         if ($oldCarrierId !== $carrierId) {
             $cart = Cart::getCartByOrderId($order->id);
             $cart->setDeliveryOption([
-                $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($carrierId),
+                (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($carrierId),
             ]);
             $cart->save();
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -75,7 +75,7 @@ class OrderAmountUpdater
     public function update(
         Order $order,
         Cart $cart,
-        ?int $orderInvoiceId
+        ?int $orderInvoiceId = null
     ): void {
         $this->cleanCaches();
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -259,7 +259,11 @@ class OrderAmountUpdater
                     break;
             }
 
-            // Finally update taxes (order_detail_tax table)
+            // Finally update taxes (order_detail_tax table) We don't use Order::updateOrderDetailTax because there
+            // it rely too much on order_detail_tax and there are two things it's not able to do
+            // - insert new order_detail_tax when no one was present
+            // - clean all order_detail_tax when they are not needed any more
+            // This should be fixed and refactored so that OrderDetail::saveTaxCalculator can really be depreciated
             $orderDetail->updateTaxAmount($order);
 
             if (!$orderDetail->update()) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -298,6 +298,7 @@ class OrderAmountUpdater
                     $orderCartRule = new OrderCartRule($orderCartRuleData['id_order_cart_rule']);
                     $orderCartRule->id_order = $order->id;
                     $orderCartRule->name = $cartRule->name;
+                    $orderCartRule->free_shipping = $cartRule->free_shipping;
                     $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
                     $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
                     $orderCartRule->save();
@@ -330,6 +331,7 @@ class OrderAmountUpdater
             $orderCartRule->id_cart_rule = $cartRule->id;
             $orderCartRule->id_order_invoice = $orderInvoiceId ?? 0;
             $orderCartRule->name = $cartRule->name;
+            $orderCartRule->free_shipping = $cartRule->free_shipping;
             $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
             $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
             $orderCartRule->save();

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -99,10 +99,7 @@ class CartRuleCalculator
 
         // Free shipping on selected carriers
         if ($cartRule->free_shipping && $withFreeShipping) {
-            $initialShippingFees = new AmountImmutable(
-                $cart->getOrderTotal(true, Cart::ONLY_SHIPPING),
-                $cart->getOrderTotal(false, Cart::ONLY_SHIPPING)
-            );
+            $initialShippingFees = $this->calculator->getFees()->getInitialShippingFees();
             $this->calculator->getFees()->subDiscountValueShipping($initialShippingFees);
             $cartRuleData->addDiscountApplied($initialShippingFees);
         }

--- a/src/Core/Domain/Configuration/ShopConfigurationInterface.php
+++ b/src/Core/Domain/Configuration/ShopConfigurationInterface.php
@@ -28,13 +28,34 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Configuration;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
-interface ShopConfigurationInterface
+interface ShopConfigurationInterface extends ConfigurationInterface
 {
-    public function getForShop(string $key, ShopConstraint $shopConstraint);
+    /**
+     * @param string $key
+     * @param mixed|null $default
+     * @param ShopConstraint|null $shopConstraint
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null, ShopConstraint $shopConstraint = null);
 
-    public function setForShop(string $key, $value, ShopConstraint $shopConstraint): void;
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @param ShopConstraint|null $shopConstraint
+     *
+     * @return mixed
+     */
+    public function set($key, $value, ShopConstraint $shopConstraint = null);
 
-    public function hasForShop(string $key, ShopConstraint $shopConstraint): bool;
+    /**
+     * @param string $key
+     * @param ShopConstraint|null $shopConstraint
+     *
+     * @return mixed
+     */
+    public function has($key, ShopConstraint $shopConstraint = null);
 }

--- a/src/Core/Domain/Configuration/ShopConfigurationInterface.php
+++ b/src/Core/Domain/Configuration/ShopConfigurationInterface.php
@@ -24,49 +24,17 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject;
+declare(strict_types=1);
 
-use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
+namespace PrestaShop\PrestaShop\Core\Domain\Configuration;
 
-/**
- * Shop identity
- */
-class ShopId
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+interface ShopConfigurationInterface
 {
-    /**
-     * @var int
-     */
-    private $shopId;
+    public function getForShop(string $key, ShopConstraint $shopConstraint);
 
-    /**
-     * @param int $shopId
-     *
-     * @throws ShopException
-     */
-    public function __construct(int $shopId)
-    {
-        $this->assertIsGreaterThanZero($shopId);
+    public function setForShop(string $key, $value, ShopConstraint $shopConstraint): void;
 
-        $this->shopId = $shopId;
-    }
-
-    /**
-     * @return int
-     */
-    public function getValue()
-    {
-        return $this->shopId;
-    }
-
-    /**
-     * @param int $shopId
-     *
-     * @throws ShopException
-     */
-    private function assertIsGreaterThanZero(int $shopId)
-    {
-        if (0 >= $shopId) {
-            throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopId, true)));
-        }
-    }
+    public function hasForShop(string $key, ShopConstraint $shopConstraint): bool;
 }

--- a/src/Core/Domain/Configuration/ShopConfigurationInterface.php
+++ b/src/Core/Domain/Configuration/ShopConfigurationInterface.php
@@ -47,7 +47,7 @@ interface ShopConfigurationInterface extends ConfigurationInterface
      * @param mixed $value
      * @param ShopConstraint|null $shopConstraint
      *
-     * @return mixed
+     * @return ShopConfigurationInterface
      */
     public function set($key, $value, ShopConstraint $shopConstraint = null);
 
@@ -55,7 +55,7 @@ interface ShopConfigurationInterface extends ConfigurationInterface
      * @param string $key
      * @param ShopConstraint|null $shopConstraint
      *
-     * @return mixed
+     * @return bool
      */
     public function has($key, ShopConstraint $shopConstraint = null);
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
@@ -52,15 +52,16 @@ class ShopConstraint
 
     /**
      * @param int $shopId
-     */
-    /**
-     * @param int $shopId
+     *
+     * @return $this
      *
      * @throws ShopException
      */
-    public function setShopId(int $shopId): void
+    public function setShopId(int $shopId): self
     {
         $this->shopId = new ShopId($shopId);
+
+        return $this;
     }
 
     /**
@@ -74,10 +75,14 @@ class ShopConstraint
     /**
      * @param int $shopGroupId
      *
+     * @return $this
+     *
      * @throws ShopException
      */
-    public function setShopGroupId(int $shopGroupId): void
+    public function setShopGroupId(int $shopGroupId): self
     {
         $this->shopGroupId = new ShopGroupId($shopGroupId);
+
+        return $this;
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
@@ -24,49 +24,60 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject;
 
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 
-/**
- * Shop identity
- */
-class ShopId
+class ShopConstraint
 {
     /**
-     * @var int
+     * @var ShopId|null
      */
     private $shopId;
 
     /**
-     * @param int $shopId
-     *
-     * @throws ShopException
+     * @var ShopGroupId|null
      */
-    public function __construct(int $shopId)
-    {
-        $this->assertIsGreaterThanZero($shopId);
-
-        $this->shopId = $shopId;
-    }
+    private $shopGroupId;
 
     /**
-     * @return int
+     * @return ShopId|null
      */
-    public function getValue()
+    public function getShopId(): ?ShopId
     {
         return $this->shopId;
     }
 
     /**
      * @param int $shopId
+     */
+    /**
+     * @param int $shopId
      *
      * @throws ShopException
      */
-    private function assertIsGreaterThanZero(int $shopId)
+    public function setShopId(int $shopId): void
     {
-        if (0 >= $shopId) {
-            throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopId, true)));
-        }
+        $this->shopId = new ShopId($shopId);
+    }
+
+    /**
+     * @return ShopGroupId|null
+     */
+    public function getShopGroupId(): ?ShopGroupId
+    {
+        return $this->shopGroupId;
+    }
+
+    /**
+     * @param int $shopGroupId
+     *
+     * @throws ShopException
+     */
+    public function setShopGroupId(int $shopGroupId): void
+    {
+        $this->shopGroupId = new ShopGroupId($shopGroupId);
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
@@ -43,6 +43,18 @@ class ShopConstraint
     private $shopGroupId;
 
     /**
+     * @param int|null $shopId
+     * @param int|null $shopGroupId
+     *
+     * @throws ShopException
+     */
+    public function __construct(?int $shopId, ?int $shopGroupId)
+    {
+        $this->shopId = null !== $shopId ? new ShopId($shopId) : null;
+        $this->shopGroupId = null !== $shopGroupId ? new ShopGroupId($shopGroupId) : null;
+    }
+
+    /**
      * @return ShopId|null
      */
     public function getShopId(): ?ShopId
@@ -51,38 +63,10 @@ class ShopConstraint
     }
 
     /**
-     * @param int $shopId
-     *
-     * @return $this
-     *
-     * @throws ShopException
-     */
-    public function setShopId(int $shopId): self
-    {
-        $this->shopId = new ShopId($shopId);
-
-        return $this;
-    }
-
-    /**
      * @return ShopGroupId|null
      */
     public function getShopGroupId(): ?ShopGroupId
     {
         return $this->shopGroupId;
-    }
-
-    /**
-     * @param int $shopGroupId
-     *
-     * @return $this
-     *
-     * @throws ShopException
-     */
-    public function setShopGroupId(int $shopGroupId): self
-    {
-        $this->shopGroupId = new ShopGroupId($shopGroupId);
-
-        return $this;
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
@@ -60,7 +60,7 @@ class ShopConstraint
      */
     public static function shop(int $shopId): self
     {
-        return new self($shopId, null, false);
+        return new static($shopId, null, false);
     }
 
     /**
@@ -74,7 +74,7 @@ class ShopConstraint
      */
     public static function shopGroup(int $shopGroupId): self
     {
-        return new self(null, $shopGroupId, false);
+        return new static(null, $shopGroupId, false);
     }
 
     /**
@@ -84,7 +84,7 @@ class ShopConstraint
      */
     public static function allShops(): self
     {
-        return new self(null, null, false);
+        return new static(null, null, false);
     }
 
     /**

--- a/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
@@ -43,15 +43,62 @@ class ShopConstraint
     private $shopGroupId;
 
     /**
-     * @param int|null $shopId
-     * @param int|null $shopGroupId
+     * Indicate if the value returned matches the constraints strictly, else it fallbacks to Shop > Group > Global value
+     *
+     * @var bool
+     */
+    private $strict;
+
+    /**
+     * Constraint to get configuration for a specific shop
+     *
+     * @param int $shopId
+     *
+     * @return static
      *
      * @throws ShopException
      */
-    public function __construct(?int $shopId, ?int $shopGroupId)
+    public static function shop(int $shopId): self
+    {
+        return new self($shopId, null, false);
+    }
+
+    /**
+     * Constraint to get configuration for a specific shop group
+     *
+     * @param int $shopGroupId
+     *
+     * @return static
+     *
+     * @throws ShopException
+     */
+    public static function shopGroup(int $shopGroupId): self
+    {
+        return new self(null, $shopGroupId, false);
+    }
+
+    /**
+     * Constraint to get configuration for all shops (the global value)
+     *
+     * @return static
+     */
+    public static function allShops(): self
+    {
+        return new self(null, null, false);
+    }
+
+    /**
+     * @param int|null $shopId
+     * @param int|null $shopGroupId
+     * @param bool $strict
+     *
+     * @throws ShopException
+     */
+    public function __construct(?int $shopId, ?int $shopGroupId, bool $strict = false)
     {
         $this->shopId = null !== $shopId ? new ShopId($shopId) : null;
         $this->shopGroupId = null !== $shopGroupId ? new ShopGroupId($shopGroupId) : null;
+        $this->strict = $strict;
     }
 
     /**
@@ -68,5 +115,13 @@ class ShopConstraint
     public function getShopGroupId(): ?ShopGroupId
     {
         return $this->shopGroupId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStrict(): bool
+    {
+        return $this->strict;
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
@@ -65,7 +65,13 @@ class ShopGroupId
     private function assertIsGreaterThanZero(int $shopGroupId): void
     {
         if (0 >= $shopGroupId) {
-            throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopGroupId, true)));
+            throw new ShopException(
+                sprintf(
+                    'Shop id %s is invalid. Shop id must be number that is greater than zero.',
+                    var_export($shopGroupId, true
+                    )
+                )
+            );
         }
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
@@ -68,8 +68,7 @@ class ShopGroupId
             throw new ShopException(
                 sprintf(
                     'Shop id %s is invalid. Shop id must be number that is greater than zero.',
-                    var_export($shopGroupId, true
-                    )
+                    var_export($shopGroupId, true)
                 )
             );
         }

--- a/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
@@ -24,30 +24,29 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject;
 
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 
-/**
- * Shop identity
- */
-class ShopId
+class ShopGroupId
 {
     /**
      * @var int
      */
-    private $shopId;
+    private $shopGroupId;
 
     /**
-     * @param int $shopId
+     * @param int $shopGroupId
      *
      * @throws ShopException
      */
-    public function __construct(int $shopId)
+    public function __construct(int $shopGroupId)
     {
-        $this->assertIsGreaterThanZero($shopId);
+        $this->assertIsGreaterThanZero($shopGroupId);
 
-        $this->shopId = $shopId;
+        $this->shopGroupId = $shopGroupId;
     }
 
     /**
@@ -55,18 +54,18 @@ class ShopId
      */
     public function getValue()
     {
-        return $this->shopId;
+        return $this->shopGroupId;
     }
 
     /**
-     * @param int $shopId
+     * @param int $shopGroupId
      *
      * @throws ShopException
      */
-    private function assertIsGreaterThanZero(int $shopId)
+    private function assertIsGreaterThanZero(int $shopGroupId)
     {
-        if (0 >= $shopId) {
-            throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopId, true)));
+        if (0 >= $shopGroupId) {
+            throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopGroupId, true)));
         }
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopGroupId.php
@@ -52,7 +52,7 @@ class ShopGroupId
     /**
      * @return int
      */
-    public function getValue()
+    public function getValue(): int
     {
         return $this->shopGroupId;
     }
@@ -62,7 +62,7 @@ class ShopGroupId
      *
      * @throws ShopException
      */
-    private function assertIsGreaterThanZero(int $shopGroupId)
+    private function assertIsGreaterThanZero(int $shopGroupId): void
     {
         if (0 >= $shopGroupId) {
             throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopGroupId, true)));

--- a/src/Core/Domain/Shop/ValueObject/ShopId.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopId.php
@@ -66,7 +66,12 @@ class ShopId
     private function assertIsGreaterThanZero(int $shopId): void
     {
         if (0 >= $shopId) {
-            throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopId, true)));
+            throw new ShopException(
+                sprintf(
+                    'Shop id %s is invalid. Shop id must be number that is greater than zero.',
+                    var_export($shopId, true)
+                )
+            );
         }
     }
 }

--- a/src/Core/Domain/Shop/ValueObject/ShopId.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopId.php
@@ -53,7 +53,7 @@ class ShopId
     /**
      * @return int
      */
-    public function getValue()
+    public function getValue(): int
     {
         return $this->shopId;
     }
@@ -63,7 +63,7 @@ class ShopId
      *
      * @throws ShopException
      */
-    private function assertIsGreaterThanZero(int $shopId)
+    private function assertIsGreaterThanZero(int $shopId): void
     {
         if (0 >= $shopId) {
             throw new ShopException(sprintf('Shop id %s is invalid. Shop id must be number that is greater than zero.', var_export($shopId, true)));

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -46,7 +46,6 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ChangeOrderDeliveryAddressHandler
     arguments:
         - '@prestashop.adapter.order.amount.updater'
-        - '@prestashop.adapter.legacy.configuration'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand
@@ -55,7 +54,6 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ChangeOrderInvoiceAddressHandler
     arguments:
         - '@prestashop.adapter.order.amount.updater'
-        - '@prestashop.adapter.legacy.configuration'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand
@@ -254,6 +252,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderAmountUpdater
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.context_state_manager'
 
   prestashop.adapter.order.product_quantity.updater:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -46,6 +46,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ChangeOrderDeliveryAddressHandler
     arguments:
         - '@prestashop.adapter.order.amount.updater'
+        - '@prestashop.adapter.legacy.configuration'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand
@@ -54,6 +55,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ChangeOrderInvoiceAddressHandler
     arguments:
         - '@prestashop.adapter.order.amount.updater'
+        - '@prestashop.adapter.legacy.configuration'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -44,12 +44,16 @@ services:
 
   prestashop.adapter.order.command_handler.change_order_delivery_address_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ChangeOrderDeliveryAddressHandler
+    arguments:
+        - '@prestashop.adapter.order.amount.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand
 
   prestashop.adapter.order.command_handler.change_order_invoice_address_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\ChangeOrderInvoiceAddressHandler
+    arguments:
+        - '@prestashop.adapter.order.amount.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand
@@ -74,6 +78,8 @@ services:
 
   prestashop.adapter.order.command_handler.update_order_shipping_details_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\UpdateOrderShippingDetailsHandler
+    arguments:
+        - '@prestashop.adapter.order.amount.updater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand

--- a/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
+++ b/tests-legacy/Integration/PrestaShopBundle/Test/LightWebTestCase.php
@@ -245,8 +245,8 @@ class LightWebTestCase extends TestCase
             ->getMock();
 
         $values = array(
-            array('_PS_MODE_DEMO_', null, true),
-            array('_PS_MODULE_DIR_', null, __DIR__ . '/../../../resources/modules/'),
+            array('_PS_MODE_DEMO_', null, null, true),
+            array('_PS_MODULE_DIR_', null, null, __DIR__ . '/../../../resources/modules/'),
         );
 
         $configurationMock->method('get')

--- a/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
+++ b/tests-legacy/Unit/Adapter/Module/Configuration/ModuleSelfConfiguratorTest.php
@@ -33,6 +33,7 @@ use LegacyTests\TestCase\UnitTestCase;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\Filesystem\Filesystem;
 
 class ModuleSelfConfiguratorTest extends UnitTestCase
@@ -308,14 +309,14 @@ class ConfigurationMock extends Configuration
 {
     private $configurationData = array();
 
-    public function set($key, $value, array $options = [])
+    public function set($key, $value, ShopConstraint $shopConstraint = null, array $options = [])
     {
         $this->configurationData[$key] = $value;
 
         return $this;
     }
 
-    public function get($key, $default = null)
+    public function get($key, $default = null, ShopConstraint $shopConstraint = null)
     {
         return isset($this->configurationData[$key])?$this->configurationData[$key]:$default;
     }

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -40,6 +40,7 @@ use LegacyTests\PrestaShopBundle\Utils\DatabaseCreator;
 use Pack;
 use Product;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use TaxManagerFactory;
 
 class CommonFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -121,6 +122,14 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @BeforeScenario @clear-cache-before-scenario
+     */
+    public static function clearCacheBeforeScenario()
+    {
+        self::clearCache();
+    }
+
+    /**
      * This hook can be used to flag a scenario for database hard reset
      *
      * @BeforeScenario @database-scenario
@@ -155,5 +164,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
         Pack::resetStaticCache();
         Product::resetStaticCache();
         Language::resetCache();
+        TaxManagerFactory::resetStaticCache();
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -26,8 +26,12 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Address;
 use AppKernel;
 use Cache;
+use Carrier;
+use Cart;
+use CartRule;
 use Category;
 use Context;
 use Employee;
@@ -142,9 +146,13 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
      */
     private static function clearCache(): void
     {
+        Address::resetStaticCache();
         Cache::clear();
-        Pack::resetStaticCache();
+        Carrier::resetStaticCache();
+        Cart::resetStaticCache();
+        CartRule::resetStaticCache();
         Category::resetStaticCache();
+        Pack::resetStaticCache();
         Product::resetStaticCache();
         Language::resetCache();
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AddressFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AddressFeatureContext.php
@@ -290,6 +290,8 @@ class AddressFeatureContext extends AbstractDomainFeatureContext
         $order->id_currency = 1;
         $order->id_customer = $customerId;
         $order->id_carrier = 1;
+        $order->id_shop = 1;
+        $order->id_shop_group = 1;
         $order->payment = 'Payment by check';
         $order->module = 'ps_checkpayment';
         $order->total_paid = $order->total_paid_real = $order->total_paid_tax_incl = $order->total_paid_tax_excl = 42;

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -106,6 +106,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
                 (int) $customerId
             )
         );
+        // Reset context's cart to avoid one from former tests to be used with invalid values (like non existent addresses)
+        Context::getContext()->cart = new Cart($cartIdObject->getValue());
 
         SharedStorage::getStorage()->set($cartReference, $cartIdObject->getValue());
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -98,13 +98,12 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     {
         // Clear static cache each time you create a cart
         Cart::resetStaticCache();
-        /** @var Customer $customer */
-        $customer = SharedStorage::getStorage()->get($customerReference);
+        $customerId = SharedStorage::getStorage()->get($customerReference);
 
         /** @var CartId $cartIdObject */
         $cartIdObject = $this->getCommandBus()->handle(
             new CreateEmptyCustomerCartCommand(
-                (int) $customer->id
+                (int) $customerId
             )
         );
 
@@ -204,7 +203,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
      */
     public function selectAddressAsDeliveryAndInvoiceAddress(string $countryIsoCode, string $customerReference, string $cartReference)
     {
-        $customer = SharedStorage::getStorage()->get($customerReference);
+        $customerId = SharedStorage::getStorage()->get($customerReference);
+        $customer = new Customer($customerId);
 
         $getAddressByCountryIsoCode = static function ($isoCode) use ($customer) {
             $customerAddresses = $customer->getAddresses((int) Configuration::get('PS_LANG_DEFAULT'));
@@ -245,7 +245,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
         string $countryIsoCode,
         string $stateName
     ) {
-        $customer = SharedStorage::getStorage()->get($customerReference);
+        $customerId = SharedStorage::getStorage()->get($customerReference);
+        $customer = new Customer($customerId);
 
         $getAddressByCountryIsoCode = static function ($isoCode) use ($customer, $stateName) {
             $customerAddresses = $customer->getAddresses((int) Configuration::get('PS_LANG_DEFAULT'));

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -27,7 +27,6 @@
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
-use Customer;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetPrivateNoteAboutCustomerCommand;
@@ -89,12 +88,9 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
      */
     public function setPrivateNoteAboutCustomer($privateNote, $reference)
     {
-        /** @var Customer $customer */
-        $customer = $this->getSharedStorage()->get($reference);
+        $customerId = $this->getSharedStorage()->get($reference);
 
-        $this->getCommandBus()->handle(new SetPrivateNoteAboutCustomerCommand((int) $customer->id, $privateNote));
-
-        $this->getSharedStorage()->set($reference, new Customer($customer->id));
+        $this->getCommandBus()->handle(new SetPrivateNoteAboutCustomerCommand((int) $customerId, $privateNote));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -367,30 +367,18 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         foreach ($invoiceShippingData as $invoiceShippingIndex => $invoiceShippingDetails) {
             $shippingTaxDetails = $invoiceShippingTaxDetails[$invoiceShippingIndex];
             foreach ($invoiceShippingDetails as $shippingField => $shippingValue) {
-                if (empty($shippingValue)) {
-                    Assert::assertNull(
-                        $shippingTaxDetails[$shippingField],
-                        sprintf(
-                            'Expected field %s to be null instead of %s',
-                            $shippingField,
-                            $shippingTaxDetails[$shippingField]
-                        )
-                    );
-                } else {
-                    Assert::assertEquals(
-                        (float) $shippingValue,
-                        (float) $shippingTaxDetails[$shippingField],
-                        sprintf(
-                            'Invalid order tax field %s, expected %s instead of %s',
-                            $shippingField,
-                            $shippingValue,
-                            (float) $shippingTaxDetails[$shippingField]
-                        )
-                    );
-                }
+                Assert::assertEquals(
+                    (float) $shippingValue,
+                    (float) $shippingTaxDetails[$shippingField],
+                    sprintf(
+                        'Invalid order tax field %s, expected %s instead of %s',
+                        $shippingField,
+                        $shippingValue,
+                        (float) $shippingTaxDetails[$shippingField]
+                    )
+                );
             }
         }
-
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderShippingFeatureContext.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 use Order;
 use PHPUnit\Framework\Assert as Assert;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderCarrierForViewing;
@@ -166,6 +167,19 @@ class OrderShippingFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @When I change order :orderReference invoice address to :orderInvoiceAddress
+     *
+     * @param string $orderReference
+     * @param string $orderInvoiceAddress
+     */
+    public function changeOrderInvoiceAddressTo(string $orderReference, string $orderInvoiceAddress)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $newInvoiceAddressId = (int) SharedStorage::getStorage()->get($orderInvoiceAddress);
+        $this->getCommandBus()->handle(new ChangeOrderInvoiceAddressCommand($orderId, $newInvoiceAddressId));
+    }
+
+    /**
      * @Then order :orderReference shipping address should be :orderShippingAddress
      *
      * @param string $orderReference
@@ -180,5 +194,22 @@ class OrderShippingFeatureContext extends AbstractDomainFeatureContext
         $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
         $orderShippingAddressId = $orderForViewing->getShippingAddress()->getAddressId();
         Assert::assertSame($expectedShippingAddressId, $orderShippingAddressId);
+    }
+
+    /**
+     * @Then order :orderReference invoice address should be :orderInvoiceAddress
+     *
+     * @param string $orderReference
+     * @param string $orderInvoiceAddress
+     */
+    public function orderInvoiceAddressShouldBe(string $orderReference, string $orderInvoiceAddress)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $expectedInvoiceAddressId = (int) SharedStorage::getStorage()->get($orderInvoiceAddress);
+
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        $orderInvoiceAddressId = $orderForViewing->getInvoiceAddress()->getAddressId();
+        Assert::assertSame($expectedInvoiceAddressId, $orderInvoiceAddressId);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -226,7 +226,7 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
 
         $order = new Order($orderId);
         $orderProductsTaxDetails = $order->getProductTaxesDetails();
-        Assert::isEmpty($orderProductsTaxDetails);
+        Assert::assertEmpty($orderProductsTaxDetails, 'The order should have no tax details');
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderFeatureContext.php
@@ -180,6 +180,56 @@ class OrderFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Then order :reference should have following tax details:
+     */
+    public function checkOrderTaxDetails(string $orderReference, TableNode $table)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $taxDetailsData = $table->getColumnsHash();
+
+        $order = new Order($orderId);
+        $orderProductsTaxDetails = $order->getProductTaxesDetails();
+        // Check that the number of rows match
+        Assert::assertLessThanOrEqual(
+            count($orderProductsTaxDetails),
+            count($taxDetailsData),
+            sprintf(
+                'Invalid number of tax details, expected at least %d instead of %d',
+                count($taxDetailsData),
+                count($orderProductsTaxDetails)
+            )
+        );
+
+        foreach ($taxDetailsData as $taxDetailsIndex => $expectedTaxDetails) {
+            $productsTaxDetails = $orderProductsTaxDetails[$taxDetailsIndex];
+            foreach ($expectedTaxDetails as $taxField => $taxValue) {
+                Assert::assertEquals(
+                    (float) $taxValue,
+                    (float) $productsTaxDetails[$taxField],
+                    sprintf(
+                        'Invalid order tax field %s, expected %s instead of %s',
+                        $taxField,
+                        $taxValue,
+                        (float) $productsTaxDetails[$taxField]
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * @Then order :reference should have no tax details
+     */
+    public function checkOrderHasNoTaxDetails(string $orderReference)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+
+        $order = new Order($orderId);
+        $orderProductsTaxDetails = $order->getProductTaxesDetails();
+        Assert::isEmpty($orderProductsTaxDetails);
+    }
+
+    /**
      * @Then order :reference carrier should have following details:
      */
     public function checkOrderCarrierDetails(string $orderReference, TableNode $table)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -49,6 +49,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -71,6 +72,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 4.0    |
       | total_shipping_tax_incl  | 4.24   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 1.860 |
       | shipping_cost_tax_excl | 4.00  |
@@ -90,6 +92,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_incl      | 122.75 |
       | total_paid               | 122.75 |
       | total_paid_real          | 0.0    |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 2.00  |
@@ -109,6 +112,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_incl      | 61.27  |
       | total_paid               | 61.27  |
       | total_paid_real          | 0.0    |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 4.00  |
@@ -140,6 +144,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 2.00  |
@@ -162,6 +167,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.30   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 1.860 |
       | shipping_cost_tax_excl | 5.00  |
@@ -181,6 +187,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_incl      | 129.11 |
       | total_paid               | 129.11 |
       | total_paid_real          | 0.0    |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 8.00  |
@@ -200,6 +207,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_incl      | 65.51  |
       | total_paid               | 65.51  |
       | total_paid_real          | 0.0    |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 8.00  |
@@ -227,6 +235,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 2.00  |
@@ -249,6 +258,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.30   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 1.860 |
       | shipping_cost_tax_excl | 5.00  |
@@ -267,6 +277,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 1.860 |
       | shipping_cost_tax_excl | 7.00  |
@@ -285,6 +296,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 4.0    |
       | total_shipping_tax_incl  | 4.24   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 1.860 |
       | shipping_cost_tax_excl | 4.00  |
@@ -313,6 +325,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 2.00  |
@@ -335,6 +348,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 1.860 |
       | shipping_cost_tax_excl | 2.00  |
@@ -354,6 +368,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 2.00  |
@@ -371,6 +386,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 2.00  |
@@ -388,6 +404,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 4.380 |
       | shipping_cost_tax_excl | 2.00  |
@@ -422,6 +439,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -455,6 +473,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.30   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
@@ -482,6 +501,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.00   |
+      | carrier_tax_rate         | 0.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
@@ -524,6 +544,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -557,6 +578,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -584,6 +606,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.00   |
+      | carrier_tax_rate         | 0.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
@@ -619,6 +642,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 7.00  |
@@ -644,6 +668,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -673,6 +698,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -718,6 +744,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.0    |
+      | carrier_tax_rate         | 0.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
@@ -753,6 +780,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
@@ -781,6 +809,7 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.0    |
+      | carrier_tax_rate         | 0.0    |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-shipping
 @reset-database-before-feature
 @order-shipping
+@clear-cache-before-feature
 Feature: Order from Back Office (BO)
   In order to manage orders for FO customers
   As a BO user
@@ -10,6 +11,7 @@ Feature: Order from Back Office (BO)
     Given email sending is disabled
     And the current currency is "USD"
     And country "US" is enabled
+    And country "FR" is enabled
     And the module "dummy_payment" is installed
     And I am logged in as "test@prestashop.com" employee
     And there is customer "testCustomer" with email "pub@prestashop.com"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -403,18 +403,22 @@ Feature: Order from Back Office (BO)
       | message             | test                       |
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
+    And I add discount to order "bo_order1" with following details:
+      | name      | FreeShippingDiscount |
+      | type      | free_shipping        |
     And order "bo_order1" should have 2 products in total
     And order "bo_order1" should have 0 invoices
-    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$6.00"
     And order "bo_order1" should have "price_carrier" as a carrier
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 29.800 |
-      | total_paid_tax_incl      | 31.590 |
-      | total_paid               | 31.590 |
+      | total_discounts_tax_excl | 6.0    |
+      | total_discounts_tax_incl | 6.36   |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 25.230 |
+      | total_paid               | 25.230 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
@@ -436,11 +440,11 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 28.800 |
-      | total_paid_tax_incl      | 30.530 |
-      | total_paid               | 30.530 |
+      | total_discounts_tax_excl | 5.0    |
+      | total_discounts_tax_incl | 5.30   |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 25.230 |
+      | total_paid               | 25.230 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.30   |
@@ -448,18 +452,19 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
       | shipping_cost_tax_incl | 5.30  |
+    And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"
     When I change order "bo_order1" invoice address to "test-customer-france-address"
     Then order "bo_order1" invoice address should be "test-customer-france-address"
     # Shipping fees use invoice address so the shipping fees should be reduced now
     # (no tax applied because France tax rules are not installed)
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
-      | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 28.800 |
-      | total_paid_tax_incl      | 30.230 |
-      | total_paid               | 30.230 |
+      | total_products_wt        | 23.800 |
+      | total_discounts_tax_excl | 5.0    |
+      | total_discounts_tax_incl | 5.0    |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 23.800 |
+      | total_paid               | 23.800 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.00   |
@@ -467,6 +472,7 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
       | shipping_cost_tax_incl | 5.00  |
+    And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"
 
   Scenario: I change the customer delivery address to another zone and check that shipping fees have been updated
     Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
@@ -478,18 +484,22 @@ Feature: Order from Back Office (BO)
       | message             | test                       |
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
+    And I add discount to order "bo_order1" with following details:
+      | name      | FreeShippingDiscount |
+      | type      | free_shipping        |
     And order "bo_order1" should have 2 products in total
     And order "bo_order1" should have 0 invoices
-    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have 1 cart rule
+    And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$6.00"
     And order "bo_order1" should have "price_carrier" as a carrier
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 29.800 |
-      | total_paid_tax_incl      | 31.590 |
-      | total_paid               | 31.590 |
+      | total_discounts_tax_excl | 6.0    |
+      | total_discounts_tax_incl | 6.36   |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 25.230 |
+      | total_paid               | 25.230 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
@@ -507,15 +517,15 @@ Feature: Order from Back Office (BO)
       | Postal code      | 75008                        |
     And I change order "bo_order1" invoice address to "test-customer-france-address"
     Then order "bo_order1" invoice address should be "test-customer-france-address"
-    # Shipping fees use delivery address so changing the invoice address should not modify them
+    # Shipping fees use delivery address so changing the invoice address should not modify them nor the taxes
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 29.800 |
-      | total_paid_tax_incl      | 31.590 |
-      | total_paid               | 31.590 |
+      | total_discounts_tax_excl | 6.0    |
+      | total_discounts_tax_incl | 6.36   |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 25.230 |
+      | total_paid               | 25.230 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
@@ -523,18 +533,19 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
       | shipping_cost_tax_incl | 6.36  |
+    And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$6.00"
     When I change order "bo_order1" shipping address to "test-customer-france-address"
     Then order "bo_order1" shipping address should be "test-customer-france-address"
     # Shipping fees use delivery address so the shipping fees should be reduced now, the fee and tax changes
     # (no tax applied because France tax rules are not installed)
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
-      | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 28.800 |
-      | total_paid_tax_incl      | 30.230 |
-      | total_paid               | 30.230 |
+      | total_products_wt        | 23.800 |
+      | total_discounts_tax_excl | 5.0    |
+      | total_discounts_tax_incl | 5.0    |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 23.800 |
+      | total_paid               | 23.800 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.00   |
@@ -542,3 +553,4 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
       | shipping_cost_tax_incl | 5.00  |
+    And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -426,6 +426,13 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
       | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
     When I add new address to customer "testCustomer" with following details:
       | Address alias    | test-customer-france-address |
       | First name       | testFirstName                |
@@ -452,6 +459,13 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
       | shipping_cost_tax_incl | 5.30  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
     And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"
     When I change order "bo_order1" invoice address to "test-customer-france-address"
     Then order "bo_order1" invoice address should be "test-customer-france-address"
@@ -473,6 +487,13 @@ Feature: Order from Back Office (BO)
       | shipping_cost_tax_excl | 5.00  |
       | shipping_cost_tax_incl | 5.00  |
     And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 11.900 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 23.800 |
+      | total_price_tax_excl        | 23.800 |
 
   Scenario: I change the customer delivery address to another zone and check that shipping fees have been updated
     Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
@@ -507,6 +528,13 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
       | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
     When I add new address to customer "testCustomer" with following details:
       | Address alias    | test-customer-france-address |
       | First name       | testFirstName                |
@@ -533,6 +561,13 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 6.00  |
       | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
     And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$6.00"
     When I change order "bo_order1" shipping address to "test-customer-france-address"
     Then order "bo_order1" shipping address should be "test-customer-france-address"
@@ -553,4 +588,11 @@ Feature: Order from Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 5.00  |
       | shipping_cost_tax_incl | 5.00  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 11.900 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 23.800 |
+      | total_price_tax_excl        | 23.800 |
     And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -711,6 +711,7 @@ Feature: Order from Back Office (BO)
       | total_price_tax_incl        | 25.230 |
       | total_price_tax_excl        | 23.800 |
 
+  @order-detail-tax
   Scenario: I use and address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
     Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
     Given I enable carrier "price_carrier"
@@ -730,8 +731,9 @@ Feature: Order from Back Office (BO)
       | message             | test                       |
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
+    And I update order "bo_order1" status to "Payment accepted"
+    Then order "bo_order1" should have 1 invoice
     And order "bo_order1" should have 2 products in total
-    And order "bo_order1" should have 0 invoices
     And order "bo_order1" should have "price_carrier" as a carrier
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
@@ -741,7 +743,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_excl      | 28.800 |
       | total_paid_tax_incl      | 28.800 |
       | total_paid               | 28.800 |
-      | total_paid_real          | 0.0    |
+      | total_paid_real          | 28.800 |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.0    |
       | carrier_tax_rate         | 0.0    |
@@ -756,8 +758,20 @@ Feature: Order from Back Office (BO)
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
       | total_price_tax_excl        | 23.800 |
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 23.800 |
+      | total_products_wt       | 23.800 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 28.800 |
+      | total_paid_tax_incl     | 28.800 |
+      | total_shipping_tax_excl | 5.0    |
+      | total_shipping_tax_incl | 5.00   |
     And order "bo_order1" should have no tax details
-    Then I add new address to customer "testCustomer" with following details:
+    And the first invoice from order "bo_order1" should have following shipping tax details:
+      | total_tax_excl | rate | total_amount | id_tax |
+      | 5.0            | 0.00 | 0.0          |        |
+    Given I add new address to customer "testCustomer" with following details:
       | Address alias    | test-customer-states-address |
       | First name       | testFirstName                |
       | Last name        | testLastName                 |
@@ -777,7 +791,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_excl      | 29.800 |
       | total_paid_tax_incl      | 31.590 |
       | total_paid               | 31.590 |
-      | total_paid_real          | 0.0    |
+      | total_paid_real          | 28.800 |
       | total_shipping_tax_excl  | 6.0    |
       | total_shipping_tax_incl  | 6.36   |
       | carrier_tax_rate         | 6.0    |
@@ -792,9 +806,21 @@ Feature: Order from Back Office (BO)
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
       | total_price_tax_excl        | 23.800 |
-    Then order "bo_order1" should have following tax details:
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 23.800 |
+      | total_products_wt       | 25.230 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 29.800 |
+      | total_paid_tax_incl     | 31.590 |
+      | total_shipping_tax_excl | 6.0    |
+      | total_shipping_tax_incl | 6.36   |
+    And order "bo_order1" should have following tax details:
       | unit_tax_base | total_tax_base | unit_amount | total_amount |
       | 11.900        | 23.800         | 0.714       | 1.430        |
+    And the first invoice from order "bo_order1" should have following shipping tax details:
+      | total_tax_excl | rate | total_amount | id_tax |
+      | 6.0            | 6.00 | 0.0          |        |
     # If I switch back the order_detail_tax are cleaned
     And I change order "bo_order1" shipping address to "test-customer-france-address"
     Then order "bo_order1" shipping address should be "test-customer-france-address"
@@ -806,7 +832,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_excl      | 28.800 |
       | total_paid_tax_incl      | 28.800 |
       | total_paid               | 28.800 |
-      | total_paid_real          | 0.0    |
+      | total_paid_real          | 28.800 |
       | total_shipping_tax_excl  | 5.0    |
       | total_shipping_tax_incl  | 5.0    |
       | carrier_tax_rate         | 0.0    |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -596,3 +596,91 @@ Feature: Order from Back Office (BO)
       | total_price_tax_incl        | 23.800 |
       | total_price_tax_excl        | 23.800 |
     And order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$5.00"
+
+  Scenario: I apply free discount shipping after it has been changed the discount should be correct
+    Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_invoice
+    Given I enable carrier "price_carrier"
+    And I select carrier "default_carrier" for cart "dummy_cart"
+    Then cart "dummy_cart" should have "default_carrier" as a carrier
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And order "bo_order1" should have "default_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 7.00  |
+      | shipping_cost_tax_incl | 7.42  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
+    When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "price_carrier"
+    Then cart "dummy_cart" should have "price_carrier" as a carrier
+    And order "bo_order1" should have "price_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 29.800 |
+      | total_paid_tax_incl      | 31.590 |
+      | total_paid               | 31.590 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 6.0    |
+      | total_shipping_tax_incl  | 6.36   |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 6.00  |
+      | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
+    And I add discount to order "bo_order1" with following details:
+      | name      | FreeShippingDiscount |
+      | type      | free_shipping        |
+    And order "bo_order1" should have 2 products in total
+    And order "bo_order1" should have 0 invoices
+    And order "bo_order1" should have 1 cart rule
+    Then order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$6.00"
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 6.0    |
+      | total_discounts_tax_incl | 6.36   |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 25.230 |
+      | total_paid               | 25.230 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 6.0    |
+      | total_shipping_tax_incl  | 6.36   |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 6.00  |
+      | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -711,7 +711,6 @@ Feature: Order from Back Office (BO)
       | total_price_tax_incl        | 25.230 |
       | total_price_tax_excl        | 23.800 |
 
-  @order-detail-tax
   Scenario: I use and address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
     Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
     Given I enable carrier "price_carrier"
@@ -769,8 +768,8 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_incl | 5.00   |
     And order "bo_order1" should have no tax details
     And the first invoice from order "bo_order1" should have following shipping tax details:
-      | total_tax_excl | rate | total_amount | id_tax |
-      | 5.0            | 0.00 | 0.0          |        |
+      | total_tax_excl | rate | total_amount |
+      | 5.0            | 0.00 | 0.0          |
     Given I add new address to customer "testCustomer" with following details:
       | Address alias    | test-customer-states-address |
       | First name       | testFirstName                |
@@ -819,8 +818,8 @@ Feature: Order from Back Office (BO)
       | unit_tax_base | total_tax_base | unit_amount | total_amount |
       | 11.900        | 23.800         | 0.714       | 1.430        |
     And the first invoice from order "bo_order1" should have following shipping tax details:
-      | total_tax_excl | rate | total_amount | id_tax |
-      | 6.0            | 6.00 | 0.0          |        |
+      | total_tax_excl | rate | total_amount |
+      | 6.0            | 6.00 | 0.36         |
     # If I switch back the order_detail_tax are cleaned
     And I change order "bo_order1" shipping address to "test-customer-france-address"
     Then order "bo_order1" shipping address should be "test-customer-france-address"
@@ -848,3 +847,6 @@ Feature: Order from Back Office (BO)
       | total_price_tax_incl        | 23.800 |
       | total_price_tax_excl        | 23.800 |
     And order "bo_order1" should have no tax details
+    And the first invoice from order "bo_order1" should have following shipping tax details:
+      | total_tax_excl | rate | total_amount |
+      | 5.0            | 0.00 | 0.00         |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -407,7 +407,6 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have 0 invoices
     And order "bo_order1" should have 0 cart rule
     And order "bo_order1" should have "price_carrier" as a carrier
-    And order "bo_order1" should have 2 products in total
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
@@ -483,7 +482,6 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have 0 invoices
     And order "bo_order1" should have 0 cart rule
     And order "bo_order1" should have "price_carrier" as a carrier
-    And order "bo_order1" should have 2 products in total
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -684,3 +684,112 @@ Feature: Order from Back Office (BO)
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
       | total_price_tax_excl        | 23.800 |
+
+  Scenario: I use and address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
+    Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
+    Given I enable carrier "price_carrier"
+    And I select carrier "price_carrier" for cart "dummy_cart"
+    Then cart "dummy_cart" should have "price_carrier" as a carrier
+    Then I add new address to customer "testCustomer" with following details:
+      | Address alias    | test-customer-france-address |
+      | First name       | testFirstName                |
+      | Last name        | testLastName                 |
+      | Address          | 36 Avenue des Champs Elysees |
+      | City             | Paris                        |
+      | Country          | France                       |
+      | Postal code      | 75008                        |
+    And I select "FR" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And order "bo_order1" should have 2 products in total
+    And order "bo_order1" should have 0 invoices
+    And order "bo_order1" should have "price_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 23.800 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 28.800 |
+      | total_paid_tax_incl      | 28.800 |
+      | total_paid               | 28.800 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.0    |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 5.00  |
+      | shipping_cost_tax_incl | 5.00  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 11.900 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 23.800 |
+      | total_price_tax_excl        | 23.800 |
+    And order "bo_order1" should have no tax details
+    Then I add new address to customer "testCustomer" with following details:
+      | Address alias    | test-customer-states-address |
+      | First name       | testFirstName                |
+      | Last name        | testLastName                 |
+      | Address          | 36 Avenue des Champs Elysees |
+      | City             | Miami                        |
+      | Country          | United States                |
+      | State            | Florida                      |
+      | Postal code      | 33133                        |
+    And I change order "bo_order1" shipping address to "test-customer-states-address"
+    Then order "bo_order1" shipping address should be "test-customer-states-address"
+    # Shipping cost changes because we are not in the same zone but the tax is still the one from invoice address
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 29.800 |
+      | total_paid_tax_incl      | 31.590 |
+      | total_paid               | 31.590 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 6.0    |
+      | total_shipping_tax_incl  | 6.36   |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 6.00  |
+      | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.230 |
+      | total_price_tax_excl        | 23.800 |
+    Then order "bo_order1" should have following tax details:
+      | unit_tax_base | total_tax_base | unit_amount | total_amount |
+      | 11.900        | 23.800         | 0.714       | 1.430        |
+    # If I switch back the order_detail_tax are cleaned
+    And I change order "bo_order1" shipping address to "test-customer-france-address"
+    Then order "bo_order1" shipping address should be "test-customer-france-address"
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 23.800 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 28.800 |
+      | total_paid_tax_incl      | 28.800 |
+      | total_paid               | 28.800 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.0    |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 5.00  |
+      | shipping_cost_tax_incl | 5.00  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 11.900 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 23.800 |
+      | total_price_tax_excl        | 23.800 |
+    And order "bo_order1" should have no tax details


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Add behat tests regarding the order's addresses modification Updated a few handler related to order/cart addresses and carrier along the way to make sure modifications are consistent The automated tests did highlight that the cart was not correctly updated however I'm not sure if it had consequences of shipping calculations
| Type?         | improvement
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? |  Fixes #21099 and #21254
| How to test?  | Travis tests green, not sure how QA can test it except by modifying addresses in order creation and edition and checking that shipping fees are correctly updated (this can be done thanks to the new carriers pre installed in the fixtures)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20903)
<!-- Reviewable:end -->

## :notebook: BC break

* A new parameter was introduced in this method: `PrestaShop\PrestaShop\Adapter::set($key, $value, ShopConstraint $shopConstraint = null, array $options = [])`
  * Thus the `$options` becomes the fourth parameter, we didn't find any use in the core code, but some modules might use it.
* Some other public methods have new (optional) parameters:
  * `PrestaShop\PrestaShop\Adapter::get($key, $default = null, ShopConstraint $shopConstraint = null)`
  * `PrestaShop\PrestaShop\Adapter::has($key, ShopConstraint $shopConstraint = null)`

## Deprecation

Nothing really changed but I reallized some fields in OrderDetail are not used any more, they are probably here for backward compatibility but the tax info is now stored in `order_detail_tax`