### PR TITLE
Cleaner way to have highlighted text on invalid address

### DIFF
--- a/themes/_core/js/checkout-address.js
+++ b/themes/_core/js/checkout-address.js
@@ -95,6 +95,10 @@ const switchEditAddressButtonColor = function switchEditAddressButtonColor(enabl
   const addressBtn = $('#id-address-' + type + '-address-' + id + ' a.edit-address');
   const classesToToggle = ['text-info', ' address-item-invalid'];
 
+  if (enabled) {
+    $('#' + type + '-addresses a.edit-address').removeClass(classesToToggle);
+  }
+
   addressBtn.toggleClass(classesToToggle, enabled);
 };
 

--- a/themes/_core/js/checkout-address.js
+++ b/themes/_core/js/checkout-address.js
@@ -93,11 +93,9 @@ $(window).on('load', () => {
  */
 const switchEditAddressButtonColor = function switchEditAddressButtonColor(enabled, id, type) {
   const addressBtn = $('#id-address-' + type + '-address-' + id + ' a.edit-address');
-  const classesToToggle = ['text-info', ' address-item-invalid'];
+  const classesToToggle = ['text-info', 'address-item-invalid'];
 
-  if (enabled) {
-    $('#' + type + '-addresses a.edit-address').removeClass(classesToToggle);
-  }
+  $('#' + type + '-addresses a.edit-address').removeClass(classesToToggle);
 
   addressBtn.toggleClass(classesToToggle, enabled);
 };

--- a/themes/_core/js/checkout-address.js
+++ b/themes/_core/js/checkout-address.js
@@ -95,11 +95,7 @@ const switchEditAddressButtonColor = function switchEditAddressButtonColor(enabl
   const addressBtn = $('#id-address-' + type + '-address-' + id + ' a.edit-address');
   const classesToToggle = ['text-info', ' address-item-invalid'];
 
-  if (enabled) {
-    addressBtn.addClass(classesToToggle);
-  } else {
-    addressBtn.removeClass(classesToToggle);
-  }
+  addressBtn.toggleClass(classesToToggle, enabled);
 };
 
 /**

--- a/themes/_core/js/checkout-address.js
+++ b/themes/_core/js/checkout-address.js
@@ -92,14 +92,14 @@ $(window).on('load', () => {
  * @param {String} type
  */
 const switchEditAddressButtonColor = function switchEditAddressButtonColor(enabled, id, type) {
-  let color = '#7a7a7a';
+  const addressBtn = $('#id-address-' + type + '-address-' + id + ' a.edit-address');
+  const classesToToggle = ['text-info', ' address-item-invalid'];
 
   if (enabled) {
-    $('#' + type + '-addresses a.edit-address').prop('style', 'color: #7a7a7a !important');
-    color = '#2fb5d2';
+    addressBtn.addClass(classesToToggle);
+  } else {
+    addressBtn.removeClass(classesToToggle);
   }
-
-  $('#id-address-' + type + '-address-' + id + ' a.edit-address').prop('style', 'color: ' + color + ' !important');
 };
 
 /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Details #20833 
| Type?         | improvement
| Category?     | FO
| BC breaks?    | visually - no, code? yes, but this shouldn't be an issue tbh
| Deprecations? | no
| Fixed ticket? | Fixes #20833 
| How to test?  | 1. add new address, make sure to have at least 2 or 3 addresses<br>2. go to your db, `PREFIX_address`, delete firstname, lastname or any other required field from one of addresses you have<br>3. go to checkout, you should see "Address is incomplete" message after selecting invalid address<br>4. before and after my change "Edit" link should be highlighted with blue color
| Sponsor company  | impSolutions



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20909)
<!-- Reviewable:end -->
