### PR TITLE
Avoid loading all combinations in memory when only one is needed

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4385,7 +4385,7 @@ class ProductCore extends ObjectModel
                 ';
 
         if ($id_product_attribute !== null) {
-            $sql .= ' AND `product_attribute_shop.id_product_attribute` = ' . (int) $id_product_attribute . ' ';
+            $sql .= ' AND product_attribute_shop.`id_product_attribute` = ' . (int) $id_product_attribute . ' ';
         }
 
         $sql .= 'GROUP BY id_attribute_group, id_product_attribute

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4356,10 +4356,11 @@ class ProductCore extends ObjectModel
      * Get all available attribute groups.
      *
      * @param int $id_lang Language identifier
+     * @param int $id_product_attribute Combination id to get the groups for
      *
      * @return array Attribute groups
      */
-    public function getAttributesGroups($id_lang)
+    public function getAttributesGroups($id_lang, $id_product_attribute = null)
     {
         if (!Combination::isFeatureActive()) {
             return [];
@@ -4381,7 +4382,13 @@ class ProductCore extends ObjectModel
                 WHERE pa.`id_product` = ' . (int) $this->id . '
                     AND al.`id_lang` = ' . (int) $id_lang . '
                     AND agl.`id_lang` = ' . (int) $id_lang . '
-                GROUP BY id_attribute_group, id_product_attribute
+                ';
+
+        if ($id_product_attribute !== null) {
+            $sql .= ' AND `product_attribute_shop.id_product_attribute` = ' . (int)$id_product_attribute . ' ';
+        }
+
+        $sql .= 'GROUP BY id_attribute_group, id_product_attribute
                 ORDER BY ag.`position` ASC, a.`position` ASC, agl.`name` ASC';
 
         return Db::getInstance()->executeS($sql);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4385,7 +4385,7 @@ class ProductCore extends ObjectModel
                 ';
 
         if ($id_product_attribute !== null) {
-            $sql .= ' AND `product_attribute_shop.id_product_attribute` = ' . (int)$id_product_attribute . ' ';
+            $sql .= ' AND `product_attribute_shop.id_product_attribute` = ' . (int) $id_product_attribute . ' ';
         }
 
         $sql .= 'GROUP BY id_attribute_group, id_product_attribute

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1120,7 +1120,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $combinations = $this->product->getAttributesGroups($this->context->language->id, $combinationId);
 
-        if (empty($combinations)) {
+        if ($combinations === false || !is_array($combinations) || empty($combinations)) {
             return null;
         }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1124,7 +1124,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             return null;
         }
 
-        return $combinations[0];
+        return reset($combinations);
     }
 
     /**

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1119,7 +1119,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function findProductCombinationById($combinationId)
     {
         $combinations = $this->product->getAttributesGroups($this->context->language->id, $combinationId);
-        
+
         if (empty($combinations)) {
             return null;
         }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1118,17 +1118,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function findProductCombinationById($combinationId)
     {
-        $foundCombination = null;
-        $combinations = $this->product->getAttributesGroups($this->context->language->id);
-        foreach ($combinations as $combination) {
-            if ((int) ($combination['id_product_attribute']) === $combinationId) {
-                $foundCombination = $combination;
-
-                break;
-            }
+        $combinations = $this->product->getAttributesGroups($this->context->language->id, $combinationId);
+        
+        if (empty($combinations)) {
+            return null;
         }
 
-        return $foundCombination;
+        return $combinations[0];
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes slow loading of product page when the product has a lot of combination. Filters the desired combination in SQL instead of in-memory
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20928
| How to test?  | composer run phpunit-legacy

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20929)
<!-- Reviewable:end -->
