### PR TITLE
Use make assets before installing prestashop in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,10 @@ before_install:
 
 install:
   - composer install --ansi --prefer-dist --no-interaction --no-progress --quiet;
+  - if [ "$PRESTASHOP_TEST_TYPE" = "integration" ] || [ "$PRESTASHOP_TEST_TYPE" = "sanity" ]; then
+        make assets;
+    fi
+
   - if [ "$PRESTASHOP_TEST_TYPE" != "sanity" ]; then
       bash travis-scripts/install-prestashop;
     fi
@@ -101,12 +105,10 @@ script:
     fi
 
   - if [ "$PRESTASHOP_TEST_TYPE" = "integration" ]; then
-        make assets;
         bash tests/check_integration.sh;
     fi
 
   - if [ "$PRESTASHOP_TEST_TYPE" = "sanity" ]; then
-        make assets;
         bash tests/check_sanity.sh;
     fi
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The make assets must be executed before installing prestashop during tests in travis context..
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Tests must be green, no need QA.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20938)
<!-- Reviewable:end -->
