### PR TITLE
Validate password only if not empty, fixing Guest Checkout

### DIFF
--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -140,7 +140,7 @@ class CustomerFormCore extends AbstractForm
         }
 
         $passwordField = $this->getField('password');
-        if (!empty($passwordField->getValue())
+        if ((!empty($passwordField->getValue()) || $this->passwordRequired)
             && Validate::isPasswd($passwordField->getValue()) === false) {
             $passwordField->AddError($this->translator->trans(
                 'Password must be between 5 and 72 characters long',

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -140,7 +140,8 @@ class CustomerFormCore extends AbstractForm
         }
 
         $passwordField = $this->getField('password');
-        if (Validate::isPasswd($passwordField->getValue()) === false) {
+        if (!empty($passwordField->getValue())
+            && Validate::isPasswd($passwordField->getValue()) === false) {
             $passwordField->AddError($this->translator->trans(
                 'Password must be between 5 and 72 characters long',
                 [],

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -65,6 +65,7 @@ class CustomerFormCore extends AbstractForm
     public function setGuestAllowed($guest_allowed = true)
     {
         $this->formatter->setPasswordRequired(!$guest_allowed);
+        $this->setPasswordRequired(!$guest_allowed);
         $this->guest_allowed = $guest_allowed;
 
         return $this;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PR https://github.com/PrestaShop/PrestaShop/pull/19534/ introduced a better validation of the Customer Form in Checkout, but it removed the ability to have guest checkout (= no password). So I fix it by triggering the validation only if not empty.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20517
| How to test?  | Please see ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20941)
<!-- Reviewable:end -->
