### PR TITLE
Use SF cache pool prune after module action

### DIFF
--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -59,8 +59,7 @@ final class SymfonyCacheClearer implements CacheClearerInterface
         $application->setAutoExit(false);
 
         $input = new ArrayInput([
-            'command' => 'cache:clear',
-            '--no-warmup',
+            'command' => 'cache:pool:prune',
         ]);
 
         $output = new NullOutput();

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -383,10 +383,6 @@ class ModuleController extends ModuleAbstractController
         $moduleManager->setActionParams($request->request->get('actionParams', []));
         $moduleRepository = $this->container->get('prestashop.core.admin.module.repository');
         $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
-        // Get accessed module object
-        $moduleAccessed = $moduleRepository->getModule($module);
-        // Get accessed module DB Id
-        $moduleAccessedId = (int) $moduleAccessed->database->get('id');
         $response = [$module => []];
 
         if (!method_exists($moduleManager, $action)) {
@@ -476,6 +472,10 @@ class ModuleController extends ModuleAbstractController
                 ]
             );
 
+            // Get accessed module object
+            $moduleAccessed = $moduleRepository->getModule($module);
+            // Get accessed module DB Id
+            $moduleAccessedId = (int) $moduleAccessed->database->get('id');
             $logger = $this->container->get('logger');
             $logger->error($response[$module]['msg'], ['object_type' => 'Module', 'object_id' => $moduleAccessedId]);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since PR https://github.com/PrestaShop/PrestaShop/pull/20689/, issues arise after module action (install, upgrade, uninstall) because Symfony Cache Clear timeouts. Using `cache:pool:prune` instead of `cache:clear` seems to solve the issue.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20852
| How to test?  | Please see ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20942)
<!-- Reviewable:end -->
