### PR TITLE
We improved the code readability and added a hook

### DIFF
--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -106,10 +106,14 @@ class ModuleDataUpdater
             if (LegacyModule::initUpgradeModule($module)) {
                 $legacy_instance = LegacyModule::getInstanceByName($name);
                 $legacy_instance->runUpgradeModule();
+                
+                if (empty($legacy_instance->getErrors()){
+                    LegacyModule::upgradeModuleVersion($name, $module->version);
+                    Hook::exec('actionModuleUpgradeAfter', array('object' => $module));
+                    return true;
+                }
 
-                LegacyModule::upgradeModuleVersion($name, $module->version);
-
-                return !count($legacy_instance->getErrors());
+                return false;
             } elseif (LegacyModule::getUpgradeStatus($name)) {
                 return true;
             }

--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -109,7 +109,7 @@ class ModuleDataUpdater
                 
                 if (empty($legacy_instance->getErrors()){
                     LegacyModule::upgradeModuleVersion($name, $module->version);
-                    Hook::exec('actionModuleUpgradeAfter', array('object' => $module));
+                    Hook::exec('actionModuleUpgradeAfter', array('module' => $module));
                     return true;
                 }
 


### PR DESCRIPTION
1. The version has to be updated only if the upgrade procedure has been completed without errors.
2. It is useful for a hook to exist after a module has been upgraded. Maybe another module needs this kind of information in order to execute some query.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.7.x
| Type?         | improvement / new feature / refacto
| Category?     | FO / BO
| BC breaks?    | no
| Deprecations? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20943)
<!-- Reviewable:end -->
