### PR TITLE
Restore initial Behat values for order_specific_prices.feature

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_specific_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_specific_prices.feature
@@ -57,7 +57,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
     Then product "Test Product With Specific Price" in order "bo_order1" should have no specific price
-    Given I generate invoice for "bo_order1" order
+    Given I update order "bo_order1" status to "Payment accepted"
     And order "bo_order1" should have 1 invoices
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product With Specific Price  |
@@ -73,7 +73,7 @@ Feature: Order from Back Office (BO)
       | total_paid_tax_excl      | 54.800 |
       | total_paid_tax_incl      | 58.090 |
       | total_paid               | 58.090 |
-      | total_paid_real          | 0.0000 |
+      | total_paid_real          | 48.550 |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In PR https://github.com/PrestaShop/PrestaShop/pull/20939 we had to modify some Behat statements in order for CI to pass. Without them, we had a very exotic error only for php7.2.<br/>Because we need to merge https://github.com/PrestaShop/PrestaShop/pull/20939 (it was a merge of 1.7.7.x into develop) we had to validate it, however as mentioned by @PierreRambaud this was a dirty fix. We need to explore deeper the root cause of the issue to provide a good fix.<br/><br/>This PR is expected to fail when run by Travis, and we need to find what must be adapted to make it pass.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20954
| How to test?  | Travis should be green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20953)
<!-- Reviewable:end -->
