### PR TITLE
Fix bug related to cache_default_attribute

### DIFF
--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -67,25 +67,30 @@ class ProductAssemblerCore
 
         $sql = "SELECT
                     p.*,
+                    ps.*,
                     pl.*,
                     sa.out_of_stock,
                     IFNULL(sa.quantity, 0) as quantity,
                     (DATEDIFF(
-				p.`date_add`,
-				DATE_SUB(
-					'$now',
-					INTERVAL $nbDaysNewProduct DAY
-				)
-			) > 0) as new
+                        p.`date_add`,
+                        DATE_SUB(
+                            '$now',
+                            INTERVAL $nbDaysNewProduct DAY
+                        )
+                    ) > 0) as new
                 FROM {$prefix}product p
                 LEFT JOIN {$prefix}product_lang pl
                     ON pl.id_product = p.id_product
                     AND pl.id_shop = $idShop
                     AND pl.id_lang = $idLang
                 LEFT JOIN {$prefix}stock_available sa
-			        ON sa.id_product = p.id_product 
+			        ON sa.id_product = p.id_product
 			        AND sa.id_shop = $idShop
-			    WHERE p.id_product = $idProduct LIMIT 1";
+                LEFT JOIN {$prefix}product_shop ps
+			        ON ps.id_product = p.id_product
+			        AND ps.id_shop = $idShop
+			    WHERE p.id_product = $idProduct
+			    LIMIT 1";
 
         $rows = Db::getInstance()->executeS($sql);
         if ($rows === false) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This solves a bug where 0 is displayed as the product price in the category
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20975
| How to test?  | - Enable multishop and add a new shop<br>- Switch to the new shop<br>- Pick a product with attributes and make it a "Simple product", thus deleting all its attributes for the new shop<br>- Open the product category page, the price is 0 and the image is wrong

More details:
The query is returning `cache_default_attribute` from `product` not from `product_shop`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20964)
<!-- Reviewable:end -->
