### PR TITLE
Remove undefined 2nd argument passed to scrollToPreviousPaginationBar()

### DIFF
--- a/admin-dev/themes/new-theme/js/translation-page/messages-pagination.js
+++ b/admin-dev/themes/new-theme/js/translation-page/messages-pagination.js
@@ -71,7 +71,7 @@ export default function () {
 
   $('.translation-domain .go-to-pagination-bar').click((event) => {
     const paginationBar = $(event.target).parents('.translation-domain').find('.pagination')[0];
-    scrollToPreviousPaginationBar(paginationBar, event.target);
+    scrollToPreviousPaginationBar(paginationBar);
 
     return false;
   });
@@ -93,7 +93,7 @@ export default function () {
 
     $(nav).find('.page-link').click((event) => {
       const paginationBar = $(event.target).parents('.pagination')[0];
-      scrollToPreviousPaginationBar(paginationBar, event.target);
+      scrollToPreviousPaginationBar(paginationBar);
     });
 
     $(nav).find('.page-item').click((event) => {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove undefined 2nd argument passed to function scrollToPreviousPaginationBar<br>`const scrollToPreviousPaginationBar = (paginationBar) => { ...  };`
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | not needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20965)
<!-- Reviewable:end -->
