### PR TITLE
Improve refresh checkout page js

### DIFF
--- a/themes/_core/js/common.js
+++ b/themes/_core/js/common.js
@@ -67,11 +67,7 @@ export function refreshCheckoutPage() {
   
   // not set : add it to the url
   queryParams['updatedTransaction'] = 1;
-  const joined = [];
-  for (let key in queryParams) {
-    let val = queryParams[key]; // gets the value by looking for the key in the object
-    joined.push(key + "=" + val);
-  }
 
-  window.location.href = window.location.pathname + "?" + joined.join("&");
+  const joined = Object.entries(queryParams).map(v => v.join('=')).join('&');
+  window.location.href = window.location.pathname + "?" + joined;
 }

--- a/themes/_core/js/common.js
+++ b/themes/_core/js/common.js
@@ -55,7 +55,7 @@ export function psGetRequestParameter(paramName) {
  * amount is correctly updated on payment modules
  */
 export function refreshCheckoutPage() {
-  let queryParams = psGetRequestParameter();
+  const queryParams = psGetRequestParameter();
   // we get the refresh flag : on payment step we need to refresh page to be sure
   // amount is correctly updated on payemnt modules
   if (queryParams['updatedTransaction']) {

--- a/themes/_core/js/common.js
+++ b/themes/_core/js/common.js
@@ -55,21 +55,23 @@ export function psGetRequestParameter(paramName) {
  * amount is correctly updated on payment modules
  */
 export function refreshCheckoutPage() {
+  let queryParams = psGetRequestParameter();
   // we get the refresh flag : on payment step we need to refresh page to be sure
   // amount is correctly updated on payemnt modules
-  if (psGetRequestParameter('updatedTransaction') !== null) {
+  if (queryParams['updatedTransaction']) {
     // this parameter is used to display some info message
     // already set : just refresh page
     window.location.reload();
-  } else {
-    // not set : add it to the url
-    let queryParams = psGetRequestParameter();
-    queryParams['updatedTransaction'] = 1;
-    const joined = [];
-    for (let key in queryParams) {
-      let val = queryParams[key]; // gets the value by looking for the key in the object
-      joined.push(key + "=" + val);
-    }
-    window.location.href = window.location.pathname + "?" + joined.join("&");
+    return;
   }
+  
+  // not set : add it to the url
+  queryParams['updatedTransaction'] = 1;
+  const joined = [];
+  for (let key in queryParams) {
+    let val = queryParams[key]; // gets the value by looking for the key in the object
+    joined.push(key + "=" + val);
+  }
+
+  window.location.href = window.location.pathname + "?" + joined.join("&");
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | - Improve readability: Return early pattern<br>- Improves performance: avoid calling 2 times the psGetRequestParameter() function that parses the url<br>- Simplify the code: change 5 lines loop to an easy to understand and concise single functional line.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | It should work as before, as expected, on `updateCart` event when there is `$('.js-cart').data('refresh-url')` and, on change/select delivery option when there is `.js-cart-payment-step-refresh` element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20967)
<!-- Reviewable:end -->
