### PR TITLE
Use assembler to present products in cart

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -95,6 +95,9 @@ class CartPresenter implements PresenterInterface
      */
     private function presentProduct(array $rawProduct)
     {
+	    $assembler = new \ProductAssembler( Context::getContext() );
+	    $rawProduct = $assembler->assembleProduct( $rawProduct );
+
         $settings = new ProductPresentationSettings();
 
         $settings->catalog_mode = Configuration::isCatalogMode();

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -95,8 +95,9 @@ class CartPresenter implements PresenterInterface
      */
     private function presentProduct(array $rawProduct)
     {
-        $assembler = new \ProductAssembler( Context::getContext() );
-        $rawProduct = $assembler->assembleProduct( $rawProduct );
+        $assembler = new \ProductAssembler(Context::getContext());
+        $assembledProduct = $assembler->assembleProduct($rawProduct);
+        $rawProduct = array_merge($assembledProduct, $rawProduct);
 
         $settings = new ProductPresentationSettings();
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Product;
+use ProductAssembler;
 use Symfony\Component\Translation\TranslatorInterface;
 use TaxConfiguration;
 use Tools;
@@ -95,7 +96,7 @@ class CartPresenter implements PresenterInterface
      */
     private function presentProduct(array $rawProduct)
     {
-        $assembler = new \ProductAssembler(Context::getContext());
+        $assembler = new ProductAssembler(Context::getContext());
         $assembledProduct = $assembler->assembleProduct($rawProduct);
         $rawProduct = array_merge($assembledProduct, $rawProduct);
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -95,8 +95,8 @@ class CartPresenter implements PresenterInterface
      */
     private function presentProduct(array $rawProduct)
     {
-	    $assembler = new \ProductAssembler( Context::getContext() );
-	    $rawProduct = $assembler->assembleProduct( $rawProduct );
+        $assembler = new \ProductAssembler( Context::getContext() );
+        $rawProduct = $assembler->assembleProduct( $rawProduct );
 
         $settings = new ProductPresentationSettings();
 


### PR DESCRIPTION
This allows other modules to use the `actionGetProductPropertiesAfter` hook in the cart as well.


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Support product property hooks for the cart presenter.
| Type?         | bug fix
| Category?     | FO
| Deprecations? | no
| Fixed ticket? | Fixes #20989 
| How to test?  | Add custom product properties using the `actionGetProductPropertiesAfter` hook. They are currently not available in the cart templates. With this PR they are.


Example hook function:
```php
    public function hookactionGetProductPropertiesAfter( $params )
    {
        $params['product']['test20989'] = 'Test property issue 20989';
    }
```
Next, go to your theme's cart template: `templates/checkout/_partials/cart-detailed-product-line.tpl`.
Add `{$product.test20989}` anywhere you want and with the PR applied it will output `Test property` issue #20989.
(Without the PR it will result in an error.)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20980)
<!-- Reviewable:end -->
