### PR TITLE
Wrap language into cdata for blank pattern

### DIFF
--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -111,9 +111,11 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
                     }
                 }
                 $node_content .= '<language id="' . $language . '"' . $more_attr . '>';
-                if (isset($field['value']) && is_array($field['value']) && isset($field['value'][$language])) {
-                    $node_content .= '<![CDATA[' . $field['value'][$language] . ']]>';
+                $node_content .= '<![CDATA[';
+                if (isset($field['value'][$language])) {
+                    $node_content .= $field['value'][$language];
                 }
+                $node_content .= ']]>';
                 $node_content .= '</language>';
             }
         } else {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | For language fields, the CDATA appears only when there is a value inside.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Not sure QA is needed here, or can be done by a dev.


With the fix in blank pattern: 
![image](https://user-images.githubusercontent.com/1462701/93178447-8e8a2680-f734-11ea-875d-f520a894ca29.png)

With the fix fetching an entity:
![image](https://user-images.githubusercontent.com/1462701/93178487-9ba71580-f734-11ea-99c4-c4f3d11dab9f.png)

Without the fix in blank pattern:
![image](https://user-images.githubusercontent.com/1462701/93178530-a8c40480-f734-11ea-91d0-0dbf255e7202.png)

Without the fix fetching an entity:
![image](https://user-images.githubusercontent.com/1462701/93178559-b37e9980-f734-11ea-8d7e-1f8b2e127527.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20987)
<!-- Reviewable:end -->
