### PR TITLE
Use php FILTER_VALIDATE_DOMAIN filter in MediaServerConfiguration's validateConfiguration method

### DIFF
--- a/src/Adapter/Media/MediaServerConfiguration.php
+++ b/src/Adapter/Media/MediaServerConfiguration.php
@@ -86,8 +86,6 @@ class MediaServerConfiguration implements DataConfigurationInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @todo: when PHP minimum version will be 7.1, use "FILTER_VALIDATE_DOMAIN" constraint.
      */
     public function validateConfiguration(array $configuration)
     {
@@ -128,16 +126,16 @@ class MediaServerConfiguration implements DataConfigurationInterface
     }
 
     /**
-     * To be removed once the minimum version is PHP 7.1.
-     *
      * @param $domainName
      *
      * @return bool
      */
     private function isValidDomain($domainName)
     {
-        $ip = gethostbyname($domainName);
+        if (false !== filter_var($domainName, FILTER_VALIDATE_DOMAIN)) {
+            return false !== filter_var(gethostbyname($domainName), FILTER_VALIDATE_IP);
+        }
 
-        return false !== filter_var($ip, FILTER_VALIDATE_IP);
+        return false;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PHP 7.1 introduces a new domain validation filter, this PR uses it for media server configuration validation.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17280
| How to test?  | 1/  In BO > Advanced Parameters > Performances, check that the server media configuration part still works well. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20998)
<!-- Reviewable:end -->
