### PR TITLE
Fix ecotax value and label displayed in Admin Product form

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -740,6 +740,7 @@
 		$.each(products, function() {
 			var id_product = Number(this.id_product);
 			var id_product_attribute = Number(this.id_product_attribute);
+			var id_customization = Number(this.id_customization);
 			cart_quantity[Number(this.id_product)+'_'+Number(this.id_product_attribute)+'_'+Number(this.id_customization)] = this.cart_quantity;
 			cart_content += '<tr><td><img src="'+this.image_link+'" title="'+this.name+'" /></td><td>'+this.name+'<br />'+this.attributes_small+'</td><td>'+this.reference+'</td><td><input type="text" rel="'+this.id_product+'_'+this.id_product_attribute+'" class="product_unit_price" value="' + this.numeric_price + '" /></td><td>';
 			cart_content += (!this.id_customization ? '<div class="input-group fixed-width-md"><div class="input-group-btn"><a href="#" class="btn btn-default increaseqty_product" rel="'+this.id_product+'_'+this.id_product_attribute+'_'+(this.id_customization ? this.id_customization : 0)+'" ><i class="icon-caret-up"></i></a><a href="#" class="btn btn-default decreaseqty_product" rel="'+this.id_product+'_'+this.id_product_attribute+'_'+(this.id_customization ? this.id_customization : 0)+'"><i class="icon-caret-down"></i></a></div>' : '');
@@ -747,7 +748,7 @@
 			cart_content += (!this.id_customization ? '<div class="input-group-btn"><a href="#" class="delete_product btn btn-default" rel="delete_'+this.id_product+'_'+this.id_product_attribute+'_'+(this.id_customization ? this.id_customization : 0)+'" ><i class="icon-remove text-danger"></i></a></div></div>' : '');
 			cart_content += '</td><td>' + formatCurrency(this.numeric_total, currency_format, currency_sign, currency_blank) + '</td></tr>';
 
-			if (this.id_customization && this.id_customization != 0)
+			if (id_customization && id_customization != 0)
 			{
 				$.each(this.customized_datas[this.id_product][this.id_product_attribute][id_address_delivery], function() {
 					var customized_desc = '';

--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -738,6 +738,7 @@
 		$.each(products, function() {
 			var id_product = Number(this.id_product);
 			var id_product_attribute = Number(this.id_product_attribute);
+			var id_customization = Number(this.id_customization);
 			cart_quantity[Number(this.id_product)+'_'+Number(this.id_product_attribute)+'_'+Number(this.id_customization)] = this.cart_quantity;
 			cart_content += '<tr><td><img src="'+this.image_link+'" title="'+this.name+'" /></td><td>'+this.name+'<br />'+this.attributes_small+'</td><td>'+this.reference+'</td><td><input type="text" rel="'+this.id_product+'_'+this.id_product_attribute+'" class="product_unit_price" value="' + this.numeric_price + '" /></td><td>';
 			cart_content += (!this.id_customization ? '<div class="input-group fixed-width-md"><div class="input-group-btn"><a href="#" class="btn btn-default increaseqty_product" rel="'+this.id_product+'_'+this.id_product_attribute+'_'+(this.id_customization ? this.id_customization : 0)+'" ><i class="icon-caret-up"></i></a><a href="#" class="btn btn-default decreaseqty_product" rel="'+this.id_product+'_'+this.id_product_attribute+'_'+(this.id_customization ? this.id_customization : 0)+'"><i class="icon-caret-down"></i></a></div>' : '');
@@ -745,7 +746,7 @@
 			cart_content += (!this.id_customization ? '<div class="input-group-btn"><a href="#" class="delete_product btn btn-default" rel="delete_'+this.id_product+'_'+this.id_product_attribute+'_'+(this.id_customization ? this.id_customization : 0)+'" ><i class="icon-remove text-danger"></i></a></div></div>' : '');
 			cart_content += '</td><td>' + formatCurrency(this.numeric_total, currency_format, currency_sign, currency_blank) + '</td></tr>';
 
-			if (this.id_customization && this.id_customization != 0)
+			if (id_customization && id_customization != 0)
 			{
 				$.each(this.customized_datas[this.id_product][this.id_product_attribute][id_address_delivery], function() {
 					var customized_desc = '';

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -411,8 +411,6 @@ class ContextCore
         // In case we have at least 1 translated message, we return the current translator.
         // If some translations are missing, clear cache
         if ($locale === '' || count($translator->getCatalogue($locale)->all())) {
-            $this->translator = $translator;
-
             return $translator;
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1446,9 +1446,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                 throw new PrestaShopException('Validation function not found. ' . $data['validate']);
             }
 
-            $value = Tools::getValue($field);
+            $value = Tools::getValue($field, null);
 
-            if (empty($value)) {
+            if ($value === null) {
                 $errors[$field] = $this->trans('The field %s is required.', array(self::displayFieldName($field, get_class($this), $htmlentities)), 'Admin.Notifications.Error');
             }
         }

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -82,7 +82,7 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         // to check if required fields are set
         if ($command->isPartnerOffersSubscribed() !== null) {
             $_POST[RequiredField::PARTNER_OFFERS] = $command->isPartnerOffersSubscribed();
-        } else if ($command->isNewsletterSubscribed() !== null) {
+        } elseif ($command->isNewsletterSubscribed() !== null) {
             $_POST[RequiredField::NEWSLETTER] = $command->isNewsletterSubscribed();
         }
 

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -80,7 +80,20 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
 
         // validateFieldsRequiredDatabase() below is using $_POST
         // to check if required fields are set
-        $_POST[RequiredField::PARTNER_OFFERS] = $command->isPartnerOffersSubscribed();
+        if ($command->isPartnerOffersSubscribed() !== null) {
+            $_POST[RequiredField::PARTNER_OFFERS] = $command->isPartnerOffersSubscribed();
+        } else if ($command->isNewsletterSubscribed() !== null) {
+            $_POST[RequiredField::NEWSLETTER] = $command->isNewsletterSubscribed();
+        }
+
+        // before validation, we need to get the list of customer mandatory fields from the database
+        // and set their current values (only if it is not being modified: if it is not in $_POST)
+        $requiredFields = $customer->getFieldsRequiredDatabase();
+        foreach ($requiredFields as $field) {
+            if (!array_key_exists($field['field_name'], $_POST)) {
+                $_POST[$field['field_name']] = $customer->{$field['field_name']};
+            }
+        }
 
         $this->assertRequiredFieldsAreNotMissing($customer);
 

--- a/src/Core/Domain/Customer/ValueObject/RequiredField.php
+++ b/src/Core/Domain/Customer/ValueObject/RequiredField.php
@@ -48,5 +48,4 @@ class RequiredField
         self::PARTNER_OFFERS,
         self::NEWSLETTER,
     ];
-
 }

--- a/src/Core/Domain/Customer/ValueObject/RequiredField.php
+++ b/src/Core/Domain/Customer/ValueObject/RequiredField.php
@@ -37,9 +37,16 @@ class RequiredField
     const PARTNER_OFFERS = 'optin';
 
     /**
+     * Newsletter field name
+     */
+    const NEWSLETTER = 'newsletter';
+
+    /**
      * All allowed required fields for customer
      */
     const ALLOWED_REQUIRED_FIELDS = [
         self::PARTNER_OFFERS,
+        self::NEWSLETTER,
     ];
+
 }

--- a/src/Core/Domain/Customer/ValueObject/RequiredField.php
+++ b/src/Core/Domain/Customer/ValueObject/RequiredField.php
@@ -48,4 +48,5 @@ class RequiredField
         self::PARTNER_OFFERS,
         self::NEWSLETTER,
     ];
+
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -482,6 +482,8 @@ class CustomerController extends AbstractAdminController
             $editableCustomer = $this->getQueryBus()->handle(new GetCustomerForEditing((int) $customerId));
 
             $editCustomerCommand = new EditCustomerCommand((int) $customerId);
+
+            // toggle newsletter subscription
             $editCustomerCommand->setNewsletterSubscribed(!$editableCustomer->isNewsletterSubscribed());
 
             $this->getCommandBus()->handle($editCustomerCommand);

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -117,7 +117,7 @@ class ProductPrice extends CommonAbstractType
                 FormType\MoneyType::class,
                 [
                     'required' => false,
-                    'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Ecotax' . !$this->eco_tax_rate ?: '(tax incl.)', [], 'Admin.Catalog.Feature'),
                     'currency' => $this->currency->iso_code,
                     'constraints' => [
                         new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -119,7 +119,7 @@ class ProductPrice extends CommonAbstractType
                 FormType\MoneyType::class,
                 [
                     'required' => false,
-                    'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Ecotax' . !$this->eco_tax_rate ?: '(tax incl.)', [], 'Admin.Catalog.Feature'),
                     'currency' => $this->currency->iso_code,
                     'constraints' => [
                         new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -526,9 +526,11 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
      */
     private function mapStep2FormData(Product $product)
     {
+        $ecotaxRate = $this->taxRuleDataProvider->getProductEcotaxRate();
+
         return array(
             'price' => $product->price,
-            'ecotax' => $product->ecotax,
+            'ecotax' => $ecotaxRate ? ($product->ecotax * (1 + $ecotaxRate / 100)) : $product->ecotax,
             'id_tax_rules_group' => isset($product->id_tax_rules_group)
                 ? (int) $product->id_tax_rules_group
                 : $this->taxRuleDataProvider->getIdTaxRulesGroupMostUsed(),


### PR DESCRIPTION
| Questions | Answers
| -- | --
| Branch? | 1.7.6.x
| Description? | Fix ecotax displaying in admin product.
| Type? | bug fix
| Category? | BO
| BC breaks? | no (I think)
| Deprecations? | no
| Fixed ticket? | Partially, #9855
| How to test? | Save a product after editing ecotax and refresh the page. The ecotax value should be displayed tax included and the product price tax included should be correctly computed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21015)
<!-- Reviewable:end -->
