### PR TITLE
Enable add css and js for migrated pages

### DIFF
--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -404,8 +404,6 @@ abstract class ControllerCore
      * @param string $css_media_type
      * @param int|null $offset
      * @param bool $check_path
-     *
-     * @return true
      */
     public function addCSS($css_uri, $css_media_type = 'all', $offset = null, $check_path = true)
     {

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -244,7 +244,7 @@ class LegacyContext
         );
 
         if (null !== $previousContextController) {
-            $this->preserveCssAndJSAssets($previousContextController, $originCtrl);
+            $this->transferCssAndJSAssets($previousContextController, $originCtrl);
         }
 
         $originCtrl->run();
@@ -362,7 +362,7 @@ class LegacyContext
      * @param Controller $previousContextController
      * @param AdminLegacyLayoutControllerCore $originCtrl
      */
-    private function preserveCssAndJSAssets($previousContextController, AdminLegacyLayoutControllerCore $originCtrl): void
+    private function transferCssAndJSAssets($previousContextController, AdminLegacyLayoutControllerCore $originCtrl): void
     {
         if (!empty($previousContextController->js_files)) {
             array_map(function ($jsAsset) use ($originCtrl) {

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -224,6 +224,11 @@ class LegacyContext
         $metaTitle = '',
         $useRegularH1Structure = true
     ) {
+        $previousContextController = null;
+        if (null !== $this->getContext()->controller) {
+            $previousContextController = $this->getContext()->controller;
+        }
+
         $originCtrl = new AdminLegacyLayoutControllerCore(
             $controllerName,
             $title,
@@ -237,6 +242,11 @@ class LegacyContext
             $metaTitle,
             $useRegularH1Structure
         );
+
+        if (null !== $previousContextController) {
+            $this->preserveCssAndJSAssets($previousContextController, $originCtrl);
+        }
+
         $originCtrl->run();
 
         return $originCtrl->outPutHtml;
@@ -342,5 +352,28 @@ class LegacyContext
     public function getAvailableLanguages()
     {
         return $this->getLanguages(false);
+    }
+
+    /**
+     * This will transfer registered CSS and JS assets
+     * from previous context controller instance
+     * to AdminLegacyLayoutController
+     *
+     * @param Controller $previousContextController
+     * @param AdminLegacyLayoutControllerCore $originCtrl
+     */
+    private function preserveCssAndJSAssets($previousContextController, AdminLegacyLayoutControllerCore $originCtrl): void
+    {
+        if (!empty($previousContextController->js_files)) {
+            array_map(function ($jsAsset) use ($originCtrl) {
+                $originCtrl->addJS($jsAsset);
+            }, $previousContextController->js_files);
+        }
+
+        if (!empty($previousContextController->css_files)) {
+            array_map(function ($cssAsset) use ($originCtrl) {
+                $originCtrl->addCss($cssAsset);
+            }, $previousContextController->css_files);
+        }
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
 use PrestaShopBundle\Security\Voter\PageVoter;
+use RuntimeException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
@@ -136,10 +137,11 @@ class FrameworkBundleAdminController extends Controller
     /**
      * Creates a HookEvent, sets its parameters, and dispatches it.
      *
-     * Wrapper to: @see HookDispatcher::dispatchWithParameters()
+     * Wrapper to: @param string $hookName The hook name
      *
-     * @param string $hookName The hook name
      * @param array $parameters The hook parameters
+     *
+     * @see HookDispatcher::dispatchWithParameters()
      */
     protected function dispatchHook($hookName, array $parameters)
     {
@@ -149,14 +151,15 @@ class FrameworkBundleAdminController extends Controller
     /**
      * Creates a RenderingHookEvent, sets its parameters, and dispatches it. Returns the event with the response(s).
      *
-     * Wrapper to: @see HookDispatcher::renderForParameters()
+     * Wrapper to: @param string $hookName The hook name
      *
-     * @param string $hookName The hook name
      * @param array $parameters The hook parameters
      *
      * @return array The responses of hooks
      *
      * @throws Exception
+     *
+     * @see HookDispatcher::renderForParameters()
      */
     protected function renderHook($hookName, array $parameters)
     {
@@ -530,17 +533,25 @@ class FrameworkBundleAdminController extends Controller
     /**
      * Adds a new stylesheet(s) to the page header.
      *
+     * Warning: this implementation will be broken when layout is migrated
+     * from legacy to Symfony as it relies on the layout being managed
+     * by a legacy controller
+     *
      * @param string|array $cssUri Path to CSS file, or list of css files like this : array(array(uri => media_type), ...)
      * @param string $cssMediaType
      * @param int|null $offset
      * @param bool $checkPath
      */
-    protected function addCSS(
+    public function addCSS(
         $cssUri,
         $cssMediaType = 'all',
         $offset = null,
         $checkPath = true): void
     {
+        if (null === $this->getContext()->controller) {
+            throw new RuntimeException('No context controller available');
+        }
+
         $this->getContext()->controller->addCSS(
             $cssUri, $cssMediaType, $offset, $checkPath
         );
@@ -549,11 +560,19 @@ class FrameworkBundleAdminController extends Controller
     /**
      * Adds a new JavaScript file(s) to the page header.
      *
+     * Warning: this implementation will be broken when layout is migrated
+     * from legacy to Symfony as it relies on the layout being managed
+     * by a legacy controller
+     *
      * @param string|array $jsUri Path to JS file or an array like: array(uri, ...)
      * @param bool $checkPath
      */
-    protected function addJS($jsUri, $checkPath = true): void
+    public function addJS($jsUri, $checkPath = true): void
     {
+        if (null === $this->getContext()->controller) {
+            throw new RuntimeException('No context controller available');
+        }
+
         $this->getContext()->controller->addJS(
             $jsUri, $checkPath
         );
@@ -562,12 +581,20 @@ class FrameworkBundleAdminController extends Controller
     /**
      * Removes CSS stylesheet(s) from the queued stylesheet list.
      *
+     * Warning: this implementation will be broken when layout is migrated
+     * from legacy to Symfony as it relies on the layout being managed
+     * by a legacy controller
+     *
      * @param string|array $cssUri Path to CSS file or an array like: array(array(uri => media_type), ...)
      * @param string $cssMediaType
      * @param bool $checkPath
      */
-    protected function removeCSS($cssUri, $cssMediaType = 'all', bool $checkPath = true): void
+    public function removeCSS($cssUri, $cssMediaType = 'all', bool $checkPath = true): void
     {
+        if (null === $this->getContext()->controller) {
+            throw new \RuntimeException('No context controller available');
+        }
+
         $this->getContext()->controller->removeCSS(
             $cssUri, $cssMediaType, $checkPath
         );
@@ -576,11 +603,19 @@ class FrameworkBundleAdminController extends Controller
     /**
      * Removes JS file(s) from the queued JS file list.
      *
+     * Warning: this implementation will be broken when layout is migrated
+     * from legacy to Symfony as it relies on the layout being managed
+     * by a legacy controller
+     *
      * @param string|array $jsUri Path to JS file or an array like: array(uri, ...)
      * @param bool $checkPath
      */
-    protected function removeJS($jsUri, $checkPath = true): void
+    public function removeJS($jsUri, $checkPath = true): void
     {
+        if (null === $this->getContext()->controller) {
+            throw new \RuntimeException('No context controller available');
+        }
+
         $this->getContext()->controller->removeJS($jsUri, $checkPath);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -526,4 +526,61 @@ class FrameworkBundleAdminController extends Controller
             $e->getMessage()
         );
     }
+
+    /**
+     * Adds a new stylesheet(s) to the page header.
+     *
+     * @param string|array $cssUri Path to CSS file, or list of css files like this : array(array(uri => media_type), ...)
+     * @param string $cssMediaType
+     * @param int|null $offset
+     * @param bool $checkPath
+     */
+    protected function addCSS(
+        $cssUri,
+        $cssMediaType = 'all',
+        $offset = null,
+        $checkPath = true): void
+    {
+        $this->getContext()->controller->addCSS(
+            $cssUri, $cssMediaType, $offset, $checkPath
+        );
+    }
+
+    /**
+     * Adds a new JavaScript file(s) to the page header.
+     *
+     * @param string|array $jsUri Path to JS file or an array like: array(uri, ...)
+     * @param bool $checkPath
+     */
+    protected function addJS($jsUri, $checkPath = true): void
+    {
+        $this->getContext()->controller->addJS(
+            $jsUri, $checkPath
+        );
+    }
+
+    /**
+     * Removes CSS stylesheet(s) from the queued stylesheet list.
+     *
+     * @param string|array $cssUri Path to CSS file or an array like: array(array(uri => media_type), ...)
+     * @param string $cssMediaType
+     * @param bool $checkPath
+     */
+    protected function removeCSS($cssUri, $cssMediaType = 'all', bool $checkPath = true): void
+    {
+        $this->getContext()->controller->removeCSS(
+            $cssUri, $cssMediaType, $checkPath
+        );
+    }
+
+    /**
+     * Removes JS file(s) from the queued JS file list.
+     *
+     * @param string|array $jsUri Path to JS file or an array like: array(uri, ...)
+     * @param bool $checkPath
+     */
+    protected function removeJS($jsUri, $checkPath = true): void
+    {
+        $this->getContext()->controller->removeJS($jsUri, $checkPath);
+    }
 }

--- a/src/PrestaShopBundle/Controller/Api/ApiController.php
+++ b/src/PrestaShopBundle/Controller/Api/ApiController.php
@@ -29,13 +29,14 @@ namespace PrestaShopBundle\Controller\Api;
 use Exception;
 use PrestaShopBundle\Api\QueryParamsCollection;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-abstract class ApiController
+abstract class ApiController extends Controller
 {
     /**
      * @var LoggerInterface
@@ -55,7 +56,7 @@ abstract class ApiController
      */
     protected $container;
 
-    public function setContainer(ContainerInterface $container)
+    public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
     }
@@ -197,16 +198,16 @@ abstract class ApiController
     /**
      * Checks if access is granted.
      *
-     * @param array $accessLevel
-     * @param string $controller name of the controller
+     * @param array $attributes
+     * @param string $subject name of the controller
      *
      * @return bool
      */
-    protected function isGranted(array $accessLevel, $controller)
+    protected function isGranted($attributes, $subject = null)
     {
         return $this->container->get('security.authorization_checker')->isGranted(
-            $accessLevel,
-            $controller . '_'
+            $attributes,
+            $subject . '_'
         );
     }
 }

--- a/src/PrestaShopBundle/EventListener/ControllerListener.php
+++ b/src/PrestaShopBundle/EventListener/ControllerListener.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventListener;
+
+use PrestaShopBundle\Routing\ControllerStack;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+
+/**
+ * This class listens to Symfony kernel
+ * and register what controller is being matched with incoming requests
+ */
+class ControllerListener
+{
+    /**
+     * @var ControllerStack
+     */
+    private $controllerStack;
+
+    /**
+     * @param ControllerStack $controllerStack
+     */
+    public function __construct(ControllerStack $controllerStack)
+    {
+        $this->controllerStack = $controllerStack;
+    }
+
+    /**
+     * @param FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        if ($event->getController()[0] instanceof Controller) {
+            $this->controllerStack->push($event->getController()[0]);
+        }
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -101,3 +101,10 @@ services:
           - '@logger'
         tags:
           - { name: kernel.event_subscriber }
+
+    prestashop.bundle.controller_stack:
+        class: PrestaShopBundle\EventListener\ControllerListener
+        arguments:
+          - '@prestashop.bundle.routing.controller_stack'
+        tags:
+          - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -53,3 +53,9 @@ services:
         class: 'PrestaShopBundle\Routing\Linter\AdminRouteProvider'
         arguments:
             - '@router'
+
+    prestashop.bundle.routing.controller_stack:
+        class: 'PrestaShopBundle\Routing\ControllerStack'
+
+    controller_stack:
+        alias: 'prestashop.bundle.routing.controller_stack'

--- a/src/PrestaShopBundle/Routing/ControllerStack.php
+++ b/src/PrestaShopBundle/Routing/ControllerStack.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Routing;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * Inspired by \Symfony\Component\HttpFoundation\RequestStack
+ */
+class ControllerStack
+{
+    /**
+     * @var Controller[]
+     */
+    private $controllers = [];
+
+    /**
+     * @param Controller $controller
+     */
+    public function push(Controller $controller)
+    {
+        $this->controllers[] = $controller;
+    }
+
+    /**
+     * @return Controller|null
+     */
+    public function pop()
+    {
+        if (!$this->controllers) {
+            return null;
+        }
+
+        return array_pop($this->controllers);
+    }
+
+    /**
+     * @return Controller|null
+     */
+    public function getCurrentController()
+    {
+        return end($this->controllers) ?: null;
+    }
+
+    /**
+     * Gets the master Controller.
+     *
+     * @return Controller|null
+     */
+    public function getRootController()
+    {
+        if (!$this->controllers) {
+            return null;
+        }
+
+        return $this->controllers[0];
+    }
+
+    /**
+     * Returns the parent request of the current.
+     *
+     * If current Controller is the master controller, it returns null.
+     *
+     * @return Controller|null
+     */
+    public function getParentController()
+    {
+        $pos = \count($this->controllers) - 2;
+
+        if (!isset($this->controllers[$pos])) {
+            return null;
+        }
+
+        return $this->controllers[$pos];
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Enable the use of `addCSS()` and `addJS()` in migrated pages, introduces ControllerStack
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes partially https://github.com/PrestaShop/PrestaShop/issues/13943
| How to test?  | See below

# How to test

Install module 
[demotestaddcss.zip](https://github.com/PrestaShop/PrestaShop/files/5232476/demotestaddcss.zip)

Open "customer" listing BO page, a "It works!" alert appears because the module successfully injected `myscript.css` inside the page.

# PR content

## addCss & friends

This PR enables the use of `addCSS()`, `addJS()`, `removeCSS()` and `removeJS()` in Symfony controllers. It was a very useful function available for legacy controllers.

So now you can do `$customerController->addJS($myJavascriptFile);` to inject a JS file into Customer BO page. That is great! 🎉 

## Usage inside hooks

If you are using a Core controller, it's very easy to use `addCSS()` or `addJS()`. Same if you are using a module Symfony controller.

**But a second issues comes:** it is actually hard to use `addCss` or `addJs` **in a hook** ⛵ !

See the following example (from the sample module)
```php
    public function hookActionCustomerGridDefinitionModifier(array $params)
    {
        
    }
```
You are inside this hook, which goal is to modify the "Customer Grid". Let's say you want to add a new column AND the JS file in charge of managing this column (for example the new column uses a specific ColorPicker). How do you inject the JS file using `addJS()`

What you need to do is:
- explore the code to find out that this hook is fired when user browses "Customer Grid BO page", which is powered by CustomerController
- retrieve the `$customerController` instance

Now that you know the Controller that you want to target is CustomerController, you can retrieve is because it is a service! So you can do this
```php
    public function hookActionCustomerGridDefinitionModifier(array $params)
    {
        $controller = $this->get('PrestaShopBundle\Controller\Admin\Sell\Customer\CustomerController');
        $controller->addJS('myscript.js');
    }
```

## Hooks fired from multiple places

On this hook we are lucky, the hook will be triggered only on Customer Grid page. So we know 100% "the controller that we need to retrieve is CustomerController". **However there are hooks that can be fired from multiple BO pages.**

➡️  _So we need a way to know "I am plugged on hook Foo, what is the Controller that handled the HTTP request ?"_

In a hook function, the hook params contain PS version, route name, request, but not controller. From request it is possible to find the controller name but it's very dirty.

**Second issue**: even you can find the controller name, but to retrieve the controller _instance_ is even more complex.

➡️ So I did this

### Use controller stack

I introduced a ControllerStack whose behavior is similar to Symfony RequestStack. It listens to Symfony kernel and registers the controllers being matched to HTTP requests.

This allows you to retrieve the "current controller".

Example:
```php
    public function hookActionCustomerGridDefinitionModifier(array $params)
    {
        $controller = $this->get('controller_stack')->getCurrentController();
        $controller->addJS('myscript.js');
    }
```

So this allows module developer to inject his JS from hook without knowing which controller handled the HTTP request.

## Documentation

As this is for module developers, I will need to write a documentation about it when it's merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21016)
<!-- Reviewable:end -->
