### PR TITLE
Make legacy parameters from routing accessible in migrated pages

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -49,6 +49,7 @@ class ToolsCore
     protected static $request;
     protected static $cldr_cache = [];
     protected static $colorBrightnessCalculator;
+    protected static $fallbackParameters = [];
 
     public static $round_mode = null;
 
@@ -512,8 +513,14 @@ class ToolsCore
 
         if (getenv('kernel.environment') === 'test' && self::$request instanceof Request) {
             $value = self::$request->request->get($key, self::$request->query->get($key, $default_value));
-        } else {
-            $value = (isset($_POST[$key]) ? $_POST[$key] : (isset($_GET[$key]) ? $_GET[$key] : $default_value));
+        } elseif (isset($_POST[$key]) || isset($_GET[$key])) {
+            $value = isset($_POST[$key]) ? $_POST[$key] : $_GET[$key];
+        } elseif (isset(static::$fallbackParameters[$key])) {
+            $value = static::$fallbackParameters[$key];
+        }
+
+        if (!isset($value)) {
+            $value = $default_value;
         }
 
         if (is_string($value)) {
@@ -4331,6 +4338,14 @@ exit;
             die('Error: "install" directory is missing');
         }
         exit;
+    }
+
+    /**
+     * @param array $fallbackParameters
+     */
+    public static function setFallbackParameters(array $fallbackParameters): void
+    {
+        static::$fallbackParameters = $fallbackParameters;
     }
 }
 

--- a/src/PrestaShopBundle/EventListener/LegacyParametersListener.php
+++ b/src/PrestaShopBundle/EventListener/LegacyParametersListener.php
@@ -32,6 +32,13 @@ use PrestaShopBundle\Routing\Converter\LegacyParametersConverter;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Tools;
 
+/**
+ * This listener converts the request routing information (if present) into an array
+ * of legacy parameters which is then injected into the Tools class allowing to access
+ * former legacy parameters using the same Tools::getValue and the same parameter name.
+ *
+ * Note: this is limited to parameters defined in the routing via _legacy_link and _legacy_parameters
+ */
 class LegacyParametersListener
 {
     /**
@@ -56,7 +63,8 @@ class LegacyParametersListener
             return;
         }
 
-        $legacyParameters = $this->converter->getParametersByRequest($event->getRequest());
+        $request = $event->getRequest();
+        $legacyParameters = $this->converter->getParameters($request->attributes->all(), $request->query->all());
         if (null === $legacyParameters) {
             return;
         }

--- a/src/PrestaShopBundle/EventListener/LegacyParametersListener.php
+++ b/src/PrestaShopBundle/EventListener/LegacyParametersListener.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\EventListener;
+
+use PrestaShopBundle\Routing\Converter\LegacyParametersConverter;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Tools;
+
+class LegacyParametersListener
+{
+    /**
+     * @var LegacyParametersConverter
+     */
+    private $converter;
+
+    /**
+     * @param LegacyParametersConverter $converter
+     */
+    public function __construct(LegacyParametersConverter $converter)
+    {
+        $this->converter = $converter;
+    }
+
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $legacyParameters = $this->converter->getParametersByRequest($event->getRequest());
+        if (null === $legacyParameters) {
+            return;
+        }
+
+        Tools::setFallbackParameters($legacyParameters);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -25,12 +25,21 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
+    # Priority 40 to be called before the RouterListener
     prestashop.legacy_url_listener:
         class: PrestaShopBundle\EventListener\LegacyUrlListener
         arguments:
         - "@prestashop.bundle.routing.converter.legacy_url_converter"
         tags:
         - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 40 }
+
+    # Priority 30 to be called after the RouterListener
+    prestashop.legacy_parameters_listener:
+        class: PrestaShopBundle\EventListener\LegacyParametersListener
+        arguments:
+            - "@prestashop.bundle.routing.converter.legacy_parameters_converter"
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 30 }
 
     prestashop.multishop_command_listener:
         class: PrestaShopBundle\EventListener\MultishopCommandListener

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -12,6 +12,10 @@ services:
             - '@router'
             - '@prestashop.bundle.routing.converter.cache_provider'
 
+    prestashop.bundle.routing.converter.legacy_parameters_converter:
+        class: 'PrestaShopBundle\Routing\Converter\LegacyParametersConverter'
+        public: true
+
     prestashop.bundle.routing.converter.router_provider:
         class: 'PrestaShopBundle\Routing\Converter\RouterProvider'
         arguments:

--- a/src/PrestaShopBundle/Routing/Converter/LegacyParametersConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyParametersConverter.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Routing\Converter;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class LegacyParametersConverter
+{
+    /**
+     * @param Request $request
+     *
+     * @return array|null
+     */
+    public function getParametersByRequest(Request $request): ?array
+    {
+        return $this->getParameters($request->attributes->all(), $request->query->all());
+    }
+
+    /**
+     * @param array $requestAttributes
+     * @param array $queryParameters
+     *
+     * @return array|null
+     */
+    public function getParameters(array $requestAttributes, array $queryParameters): ?array
+    {
+        if (!isset($requestAttributes['_legacy_parameters']) && !isset($requestAttributes['_legacy_link'])) {
+            return null;
+        }
+
+        $legacyParameters = [];
+
+        // Convert new parameters into legacy ones (search in attributes and query parameters)
+        $parametersMatching = $requestAttributes['_legacy_parameters'] ?? [];
+        foreach ($parametersMatching as $legacyParameter => $routingParameter) {
+            if (isset($requestAttributes[$routingParameter])) {
+                $legacyParameters[$legacyParameter] = $requestAttributes[$routingParameter];
+            } elseif (isset($queryParameters[$routingParameter])) {
+                $legacyParameters[$legacyParameter] = $queryParameters[$routingParameter];
+            }
+        }
+
+        // Set controller and action based on _legacy_link
+        if (isset($requestAttributes['_legacy_link'])) {
+            $legacyLinks = $requestAttributes['_legacy_link'];
+            if (!is_array($legacyLinks)) {
+                $legacyLinks = [$legacyLinks];
+            }
+
+            // Loop through the _legacy_link until a controller and action is found
+            foreach ($legacyLinks as $legacyLink) {
+                $linkParts = explode(':', $legacyLink);
+                if (!isset($legacyParameters['controller'])) {
+                    $legacyParameters['controller'] = $linkParts[0];
+                }
+                if (!isset($legacyParameters['action']) && count($linkParts) > 1) {
+                    $legacyParameters['action'] = $linkParts[1];
+                }
+                if (isset($legacyParameters['controller'], $legacyParameters['action'])) {
+                    break;
+                }
+            }
+        }
+
+        return $legacyParameters;
+    }
+}

--- a/src/PrestaShopBundle/Routing/Converter/LegacyParametersConverter.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyParametersConverter.php
@@ -28,21 +28,21 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Routing\Converter;
 
-use Symfony\Component\HttpFoundation\Request;
-
+/**
+ * This class converts the request information (attributes and query parameters)
+ * and returns an array of parameters adapted with their legacy names (based on
+ * the configuration from the routing).
+ */
 class LegacyParametersConverter
 {
     /**
-     * @param Request $request
+     * Use the request attributes which contain the routing configuration along with query
+     * parameters to return an array containing the equivalent with legacy parameters names.
      *
-     * @return array|null
-     */
-    public function getParametersByRequest(Request $request): ?array
-    {
-        return $this->getParameters($request->attributes->all(), $request->query->all());
-    }
-
-    /**
+     * Example with $request being a Symfony Request:
+     *
+     * $legacyParameters = $converter->getParameters($request->attributes->all(), $request->query->all());
+     *
      * @param array $requestAttributes
      * @param array $queryParameters
      *

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\PrestaShopBundle\Routing\Converter;
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyParametersConverterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyParametersConverterTest.php
@@ -30,8 +30,6 @@ namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\LegacyParametersConverter;
-use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\HttpFoundation\Request;
 
 class LegacyParametersConverterTest extends TestCase
 {
@@ -46,21 +44,6 @@ class LegacyParametersConverterTest extends TestCase
     {
         $converter = new LegacyParametersConverter();
         $legacyParameters = $converter->getParameters($requestAttributes, $queryParameters);
-        $this->assertEquals($expectedLegacyParameters, $legacyParameters);
-    }
-
-    /**
-     * @dataProvider getExpectedLegacyParameters
-     *
-     * @param array $requestAttributes
-     * @param array $queryParameters
-     * @param array|null $expectedLegacyParameters
-     */
-    public function testGetParametersByRequest(array $requestAttributes, array $queryParameters, ?array $expectedLegacyParameters)
-    {
-        $converter = new LegacyParametersConverter();
-        $request = $this->buildRequestMock($requestAttributes, $queryParameters);
-        $legacyParameters = $converter->getParametersByRequest($request);
         $this->assertEquals($expectedLegacyParameters, $legacyParameters);
     }
 
@@ -115,24 +98,5 @@ class LegacyParametersConverterTest extends TestCase
                 ['controller' => 'AdminOrders', 'action' => 'vieworder', 'id_order' => 51],
             ],
         ];
-    }
-
-    /**
-     * @param array $requestAttributes
-     * @param array $queryParameters
-     *
-     * @return \PHPUnit\Framework\MockObject\MockObject|Request
-     */
-    private function buildRequestMock(array $requestAttributes, array $queryParameters)
-    {
-        $mockRequest = $this
-            ->getMockBuilder(Request::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mockRequest->attributes = new ParameterBag($requestAttributes);
-        $mockRequest->query = new ParameterBag($queryParameters);
-
-        return $mockRequest;
     }
 }

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyParametersConverterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyParametersConverterTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Routing\Converter\LegacyParametersConverter;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class LegacyParametersConverterTest extends TestCase
+{
+    /**
+     * @dataProvider getExpectedLegacyParameters
+     *
+     * @param array $requestAttributes
+     * @param array $queryParameters
+     * @param array|null $expectedLegacyParameters
+     */
+    public function testGetParameters(array $requestAttributes, array $queryParameters, ?array $expectedLegacyParameters)
+    {
+        $converter = new LegacyParametersConverter();
+        $legacyParameters = $converter->getParameters($requestAttributes, $queryParameters);
+        $this->assertEquals($expectedLegacyParameters, $legacyParameters);
+    }
+
+    /**
+     * @dataProvider getExpectedLegacyParameters
+     *
+     * @param array $requestAttributes
+     * @param array $queryParameters
+     * @param array|null $expectedLegacyParameters
+     */
+    public function testGetParametersByRequest(array $requestAttributes, array $queryParameters, ?array $expectedLegacyParameters)
+    {
+        $converter = new LegacyParametersConverter();
+        $request = $this->buildRequestMock($requestAttributes, $queryParameters);
+        $legacyParameters = $converter->getParametersByRequest($request);
+        $this->assertEquals($expectedLegacyParameters, $legacyParameters);
+    }
+
+    public function getExpectedLegacyParameters()
+    {
+        return [
+            [
+                [],
+                [],
+                null,
+            ],
+            // Simple controller without action
+            [
+                ['_legacy_link' => 'AdminOrders'],
+                [],
+                ['controller' => 'AdminOrders'],
+            ],
+            // Controller and action
+            [
+                ['_legacy_link' => 'AdminOrders:vieworder'],
+                [],
+                ['controller' => 'AdminOrders', 'action' => 'vieworder'],
+            ],
+            // Multiple legacy links, the first one is used
+            [
+                ['_legacy_link' => ['AdminOrders', 'AdminUnknown:list', 'AdminOrders:index']],
+                [],
+                ['controller' => 'AdminOrders', 'action' => 'list'],
+            ],
+            // Multiple legacy links, the first one is used
+            [
+                ['_legacy_link' => ['AdminOrders', 'AdminUnknown:index', 'AdminOrders:list']],
+                [],
+                ['controller' => 'AdminOrders', 'action' => 'index'],
+            ],
+            // Legacy parameters defined and matches attribute
+            [
+                ['_legacy_link' => 'AdminOrders:vieworder', '_legacy_parameters' => ['id_order' => 'orderId'], 'orderId' => 42],
+                [],
+                ['controller' => 'AdminOrders', 'action' => 'vieworder', 'id_order' => 42],
+            ],
+            // Legacy parameters defined, attributes has priority over query parameter
+            [
+                ['_legacy_link' => 'AdminOrders:vieworder', '_legacy_parameters' => ['id_order' => 'orderId'], 'orderId' => 42],
+                ['orderId' => 51],
+                ['controller' => 'AdminOrders', 'action' => 'vieworder', 'id_order' => 42],
+            ],
+            [
+                // Legacy parameters defined, query parameter is used as a fallback
+                ['_legacy_link' => 'AdminOrders:vieworder', '_legacy_parameters' => ['id_order' => 'orderId']],
+                ['orderId' => 51],
+                ['controller' => 'AdminOrders', 'action' => 'vieworder', 'id_order' => 51],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $requestAttributes
+     * @param array $queryParameters
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject|Request
+     */
+    private function buildRequestMock(array $requestAttributes, array $queryParameters)
+    {
+        $mockRequest = $this
+            ->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockRequest->attributes = new ParameterBag($requestAttributes);
+        $mockRequest->query = new ParameterBag($queryParameters);
+
+        return $mockRequest;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyRouteTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyRouteTest.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\PrestaShopBundle\Routing\Converter;
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\LegacyRoute;

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\PrestaShopBundle\Routing\Converter;
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\PrestaShopBundle\Routing\Converter;
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/RoutingCacheKeyGeneratorTest.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\PrestaShopBundle\Routing\Converter;
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShopBundle\Routing\Converter\RoutingCacheKeyGenerator;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In migrated pages the previous query parameters were not accessible any more due to parameters renaming and sometimes the url includes them directly This PR doesn't not solve every problem but at least it allows to access the parameters defined in the routing via `_legacy_parameters` and `_legacy_link` It won't solve every issue for module developers who still need to update their module to be compatible with migrated pages but at least it will help them a little
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20934
| How to test?  | Use the ps_qualityassurance module and register this hook:<br><br>Hook name: `displayAdminOrderTop`<br>Content: `return '<h3>Order id: ' . Tools::getValue('id_order') . '</h3>';`<br><br>Then go to an Order view page, without the PR you should see at the top of the page `Order id:` but no ID, and with the PR you will see `Order id: 5` (if order id is 5 of course)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21025)
<!-- Reviewable:end -->
