### PR TITLE
Grid row delete confirmation modal - Customer service > Order messages

### DIFF
--- a/src/Core/Grid/Definition/Factory/OrderMessageGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderMessageGridDefinitionFactory.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -47,6 +46,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 final class OrderMessageGridDefinitionFactory extends AbstractFilterableGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     public const GRID_ID = 'order_message';
 
@@ -110,19 +110,12 @@ final class OrderMessageGridDefinitionFactory extends AbstractFilterableGridDefi
                                 'route_param_field' => 'id_order_message',
                             ])
                     )
-                    ->add((new SubmitRowAction('delete'))
-                    ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                    ->setIcon('delete')
-                    ->setOptions([
-                        'route' => 'admin_order_messages_delete',
-                        'route_param_name' => 'orderMessageId',
-                        'route_param_field' => 'id_order_message',
-                        'confirm_message' => $this->trans(
-                            'Delete selected item?',
-                            [],
-                            'Admin.Notifications.Warning'
-                        ),
-                    ])
+                    ->add(
+                        $this->buildDeleteAction(
+                            'admin_order_messages_delete',
+                            'orderMessageId',
+                            'id_order_message'
+                        )
                     ),
             ])
             )

--- a/tests/UI/pages/BO/customerService/orderMessages/index.js
+++ b/tests/UI/pages/BO/customerService/orderMessages/index.js
@@ -120,7 +120,6 @@ class OrderMessages extends BOBasePage {
    * @returns {Promise<string>}
    */
   async deleteOrderMessage(page, row = 1) {
-    this.dialogListener(page, true);
     await Promise.all([
       page.click(this.dropdownToggleButton(row)),
       this.waitForVisibleSelector(
@@ -128,7 +127,15 @@ class OrderMessages extends BOBasePage {
         `${this.dropdownToggleButton(row)}[aria-expanded='true']`,
       ),
     ]);
-    await this.clickAndWaitForNavigation(page, this.deleteRowLink(row));
+
+    // Click on delete and wait for modal
+    await Promise.all([
+      page.click(this.deleteRowLink(row)),
+      this.waitForVisibleSelector(page, `${this.confirmDeleteModal}.show`),
+    ]);
+
+    // Confirm delete in modal
+    await this.confirmDeleteOrderMessages(page);
     return this.getTextContent(page, this.alertSuccessBlockParagraph);
   }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Customer services > Order messages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17847
| How to test?  | Go to Customer services > Order messages in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21033)
<!-- Reviewable:end -->
