### PR TITLE
Changed PHPDoc of Tax's getProductTaxRate to more accurate.

### DIFF
--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -250,13 +250,13 @@ class TaxCore extends ObjectModel
     }
 
     /**
-     * Returns the product tax.
+     * Returns the product tax rate.
      *
      * @param int $id_product
      * @param int $id_address
      * @param Context $context
      *
-     * @return Tax
+     * @return float $tax_rate
      */
     public static function getProductTaxRate($id_product, $id_address = null, Context $context = null)
     {

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -256,7 +256,7 @@ class TaxCore extends ObjectModel
      * @param int $id_address
      * @param Context $context
      *
-     * @return float $tax_rate
+     * @return float
      */
     public static function getProductTaxRate($id_product, $id_address = null, Context $context = null)
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the current version of the `Tax` class the method `getProductTaxRate` returns a `Tax` object according to the PHPDoc. I have changed this PHPDoc to return the type `float`.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | It does not really need testing because this only affects a PHPDoc.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21042)
<!-- Reviewable:end -->
