### PR TITLE
Fix Features page throwing an exception after specific steps are made

### DIFF
--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -460,7 +460,7 @@ class AdminFeaturesControllerCore extends AdminController
     public function initProcess()
     {
         // Are we working on feature values?
-        if (Tools::getValue('id_feature_value')
+        if (Tools::getValue('id_feature_value') && !Tools::getValue('id_feature')
             || Tools::isSubmit('deletefeature_value')
             || Tools::isSubmit('submitAddfeature_value')
             || Tools::isSubmit('addfeature_value')

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -460,7 +460,7 @@ class AdminFeaturesControllerCore extends AdminController
     public function initProcess()
     {
         // Are we working on feature values?
-        if (Tools::getValue('id_feature_value') && !Tools::getValue('id_feature')
+        if ((Tools::getValue('id_feature_value') && !Tools::getValue('id_feature'))
             || Tools::isSubmit('deletefeature_value')
             || Tools::isSubmit('submitAddfeature_value')
             || Tools::isSubmit('addfeature_value')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because `AdminFeaturesControllerCore` handles both feature & feature_value forms and a bad `if` statement, when you saved a feature value you were redirected to the list of features. Also, the page could throw an exception if you played with name/value sort buttons in both feature & feature_value pages. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20777
| How to test?  | Please check #20777

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21045)
<!-- Reviewable:end -->
