### PR TITLE
Fix [BO- Stores page] Sort by post code not working

### DIFF
--- a/install-dev/fixtures/fashion/data/store.xml
+++ b/install-dev/fixtures/fashion/data/store.xml
@@ -18,7 +18,7 @@
     <field name="active"/>
   </fields>
   <entities>
-    <store id="Dade_County" id_country="US" id_state="FL" postcode=" 33135" latitude="25.76500500" longitude="-80.24379700" phone="" fax="" active="1">
+    <store id="Dade_County" id_country="US" id_state="FL" postcode="33135" latitude="25.76500500" longitude="-80.24379700" phone="" fax="" active="1">
       <name>Dade County</name>
       <address1>3030 SW 8th St Miami</address1>
       <address2/>
@@ -27,7 +27,7 @@
       <email/>
       <note/>
     </store>
-    <store id="E_Fort_Lauderdale" id_country="US" id_state="FL" postcode=" 33304" latitude="26.13793600" longitude="-80.13943500" phone="" fax="" active="1">
+    <store id="E_Fort_Lauderdale" id_country="US" id_state="FL" postcode="33304" latitude="26.13793600" longitude="-80.13943500" phone="" fax="" active="1">
       <name>E Fort Lauderdale</name>
       <address1>1000 Northeast 4th Ave Fort Lauderdale</address1>
       <address2/>
@@ -45,7 +45,7 @@
       <email/>
       <note/>
     </store>
-    <store id="Coconut_Grove" id_country="US" id_state="FL" postcode=" 33133" latitude="25.73629600" longitude="-80.24479700" phone="" fax="" active="1">
+    <store id="Coconut_Grove" id_country="US" id_state="FL" postcode="33133" latitude="25.73629600" longitude="-80.24479700" phone="" fax="" active="1">
       <name>Coconut Grove</name>
       <address1>2999 SW 32nd Avenue</address1>
       <address2/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In BO > Stroe page sort by post code not working, when sorting by post code, the result is incorrect.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21038
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/21038

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21048)
<!-- Reviewable:end -->
