### PR TITLE
Introduce CannotBulkDeleteCustomizationFieldException

### DIFF
--- a/src/Adapter/Product/CustomizationFieldDeleter.php
+++ b/src/Adapter/Product/CustomizationFieldDeleter.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product;
 
 use CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationFieldDeleterInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CannotBulkDeleteCustomizationFieldException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CannotDeleteCustomizationFieldException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
@@ -77,7 +78,13 @@ final class CustomizationFieldDeleter implements CustomizationFieldDeleterInterf
     public function delete(CustomizationFieldId $customizationFieldId): void
     {
         $customizationField = $this->customizationFieldProvider->get($customizationFieldId);
-        $this->performDeletion($customizationField, CannotDeleteCustomizationFieldException::FAILED_DELETE);
+
+        if (!$this->performDeletion($customizationField)) {
+            throw new CannotDeleteCustomizationFieldException(sprintf(
+                'Failed deleting customization field #%d',
+                $customizationField->id
+            ));
+        }
     }
 
     /**
@@ -85,10 +92,23 @@ final class CustomizationFieldDeleter implements CustomizationFieldDeleterInterf
      */
     public function bulkDelete(array $customizationFieldIds): void
     {
+        $failedIds = [];
         foreach ($customizationFieldIds as $customizationFieldId) {
             $customizationField = $this->customizationFieldProvider->get($customizationFieldId);
-            $this->performDeletion($customizationField, CannotDeleteCustomizationFieldException::FAILED_BULK_DELETE);
+
+            if (!$this->performDeletion($customizationField)) {
+                $failedIds[] = $customizationFieldId;
+            }
         }
+
+        if (empty($failedIds)) {
+            return;
+        }
+
+        throw new CannotBulkDeleteCustomizationFieldException(
+            $failedIds,
+            sprintf('Failed deleting following customization fields: "%s"', implode(', ', $failedIds))
+        );
     }
 
     /**
@@ -102,7 +122,7 @@ final class CustomizationFieldDeleter implements CustomizationFieldDeleterInterf
      * @throws ProductException
      * @throws ProductNotFoundException
      */
-    private function performDeletion(CustomizationField $customizationField, int $errorCode): void
+    private function performDeletion(CustomizationField $customizationField): bool
     {
         $product = $this->getProduct((int) $customizationField->id_product);
         $usedFieldIds = array_map('intval', $product->getUsedCustomizationFieldsIds());
@@ -115,12 +135,7 @@ final class CustomizationFieldDeleter implements CustomizationFieldDeleterInterf
                 $successfullyDeleted = $customizationField->delete();
             }
 
-            if (!$successfullyDeleted) {
-                throw new CannotDeleteCustomizationFieldException(
-                    sprintf('Failed deleting customization field #%d', $customizationField->id),
-                    $errorCode
-                );
-            }
+            return (bool) $successfullyDeleted;
         } catch (PrestaShopException $e) {
             throw new CustomizationFieldException(
                 sprintf(

--- a/src/Adapter/Product/CustomizationFieldDeleter.php
+++ b/src/Adapter/Product/CustomizationFieldDeleter.php
@@ -113,11 +113,9 @@ final class CustomizationFieldDeleter implements CustomizationFieldDeleterInterf
 
     /**
      * @param CustomizationField $customizationField
-     * @param int $errorCode
      *
-     * @return void
+     * @return bool
      *
-     * @throws CannotDeleteCustomizationFieldException
      * @throws CustomizationFieldException
      * @throws ProductException
      * @throws ProductNotFoundException

--- a/src/Core/Domain/Product/Customization/Exception/CannotBulkDeleteCustomizationFieldException.php
+++ b/src/Core/Domain/Product/Customization/Exception/CannotBulkDeleteCustomizationFieldException.php
@@ -28,9 +28,36 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use Throwable;
+
 /**
- * Is thrown when customization field deletion fails
+ * Thrown when customization field deletion fails in bulk action
  */
-class CannotDeleteCustomizationFieldException extends CustomizationFieldException
+class CannotBulkDeleteCustomizationFieldException extends ProductException
 {
+    /**
+     * @var int[]
+     */
+    private $customizationFieldIds;
+
+    /**
+     * @param array $customizationFieldIds
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(array $customizationFieldIds, $message = '', $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->customizationFieldIds = $customizationFieldIds;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getCustomizationFieldIds(): array
+    {
+        return $this->customizationFieldIds;
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | use separate Exception for bulk delete action of CustomizationField. Exception constructor requires failedIds, so it is more clearer which fields failed. (and can be used to format better messages for user). Also, bulk action is not stopped on first exception, rather it continues looping and stores failed ids inside exception which is thrown after the loop ends.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | improvement of #19964 part of #19681
| How to test?  | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21053)
<!-- Reviewable:end -->
