### PR TITLE
Reduce conditions complexity

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2915,23 +2915,14 @@ class CartCore extends ObjectModel
             $order_by_price = !Configuration::get('PS_CARRIER_DEFAULT_SORT');
         }
         if (null === $order_way) {
-            $order_way = Configuration::get('PS_CARRIER_DEFAULT_ORDER');
+            $order_way = Configuration::get('PS_CARRIER_DEFAULT_ORDER') ? 1 : -1;
         }
 
         if ($order_by_price) {
-            if ($order_way) {
-                return ($option1['total_price_with_tax'] < $option2['total_price_with_tax']) * 2 - 1;
-            } else {
-                // return -1 or 1
-                return ($option1['total_price_with_tax'] >= $option2['total_price_with_tax']) * 2 - 1;
-            }
-        } elseif ($order_way) {
-            // return -1 or 1
-            return ($option1['position'] < $option2['position']) * 2 - 1;
-        } else {
-            // return -1 or 1
-            return ($option1['position'] >= $option2['position']) * 2 - 1;
+            return $option1['total_price_with_tax'] < $option2['total_price_with_tax'] ? $order_way : -$order_way;
         }
+
+        return $option1['position'] < $option2['position'] ? $order_way : -$order_way;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I think `$a < $b ? 1 : -1` is better than `($a < $b) * 2 - 1`<br> More readable, more permformant (twice as fast but insignificant).<br>I have also reduced the complexity of all `if` branches and applied the return early pattern 
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Regression tests, we need to check that Carrier order still works as expected during checkout process Also test by switching configuration of `PS_CARRIER_DEFAULT_SORT` (`Sort by`) and `PS_CARRIER_DEFAULT_ORDER` (`Order by`) in Shipping > Preferences (By the way the naming of these labels could use some improvement 😅    - from @jolelievre)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21057)
<!-- Reviewable:end -->
