### PR TITLE
Fix get scalar value from VO in recently merged deleter services

### DIFF
--- a/src/Adapter/Product/CustomizationFieldDeleter.php
+++ b/src/Adapter/Product/CustomizationFieldDeleter.php
@@ -97,7 +97,7 @@ final class CustomizationFieldDeleter implements CustomizationFieldDeleterInterf
             $customizationField = $this->customizationFieldProvider->get($customizationFieldId);
 
             if (!$this->performDeletion($customizationField)) {
-                $failedIds[] = $customizationFieldId;
+                $failedIds[] = $customizationFieldId->getValue();
             }
         }
 

--- a/src/Adapter/Product/ProductDeleter.php
+++ b/src/Adapter/Product/ProductDeleter.php
@@ -75,7 +75,7 @@ final class ProductDeleter implements ProductDeleterInterface
         $failedIds = [];
         foreach ($productIds as $productId) {
             if (!$this->deleteProduct($this->productProvider->get($productId))) {
-                $failedIds[] = $productId;
+                $failedIds[] = $productId->getValue();
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | in recently merged pr (#20805 and #21053) I've introduced couple deleter services, but left little mistakes. In bulkDelete uses getValue() method on ProductId and CustomizationFieldId objects.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | related #20830
| How to test?  | travis :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21060)
<!-- Reviewable:end -->
