### PR TITLE
Make locale errors from translatable type work with locale

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -26,21 +26,22 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class TranslatableType adds translatable inputs with custom inner type to forms.
  * Language selection uses a dropdown.
  */
-class TranslatableType extends AbstractType
+class TranslatableType extends TranslatorAwareType
 {
     /**
      * @var array List of enabled locales
@@ -73,6 +74,8 @@ class TranslatableType extends AbstractType
     private $defaultShopLanguageId;
 
     /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
      * @param array $availableLocales
      * @param UrlGeneratorInterface $urlGenerator
      * @param bool $saveFormLocaleChoice
@@ -80,12 +83,15 @@ class TranslatableType extends AbstractType
      * @param int $defaultShopLanguageId
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         array $availableLocales,
         UrlGeneratorInterface $urlGenerator,
         $saveFormLocaleChoice,
         $defaultFormLanguageId,
         $defaultShopLanguageId
     ) {
+        parent::__construct($translator, $locales);
         $this->enabledLocales = $this->filterEnableLocales($availableLocales);
         $this->availableLocales = $availableLocales;
         $this->urlGenerator = $urlGenerator;
@@ -116,6 +122,32 @@ class TranslatableType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        $errors = [];
+
+        foreach ($view->vars['errors'] as $existingError) {
+            $errors[] = $existingError;
+        }
+
+        $errorsByLocale = $this->getErrorsByLocale($view, $form, $options['locales']);
+
+        if (!empty($errorsByLocale)) {
+            foreach ($errorsByLocale as $errorByLocale) {
+                /** Needs to be translated */
+                $modifiedErrorMessage = $this->trans(
+                    '%error_message% - Language: %language_name%',
+                    'Admin.Notifications.Error',
+                    [
+                        '%error_message%' => $errorByLocale['error_message'],
+                        '%language_name%' => $errorByLocale['locale_name'],
+                    ]
+                );
+                $errors[] = new FormError($modifiedErrorMessage);
+            }
+        }
+
+        $varsForm = $view->vars['errors']->getForm();
+        $view->vars['formatted_text_area'] = ($options['type'] === FormattedTextareaType::class);
+        $view->vars['errors'] = new FormErrorIterator($varsForm, $errors);
         $view->vars['locales'] = $options['locales'];
         $view->vars['default_locale'] = $this->getDefaultLocale($options['locales']);
         $view->vars['hide_locales'] = 1 >= count($options['locales']);
@@ -125,8 +157,6 @@ class TranslatableType extends AbstractType
                 'admin_employees_change_form_language'
             );
         }
-
-        $this->setErrorsByLocale($view, $form, $options['locales']);
     }
 
     /**
@@ -168,8 +198,10 @@ class TranslatableType extends AbstractType
      * @param FormView $view
      * @param FormInterface $form
      * @param array $locales
+     *
+     * @return array|null
      */
-    private function setErrorsByLocale(FormView $view, FormInterface $form, array $locales)
+    private function getErrorsByLocale(FormView $view, FormInterface $form, array $locales)
     {
         if (count($locales) <= 1) {
             return;
@@ -178,7 +210,7 @@ class TranslatableType extends AbstractType
         $formErrors = $form->getErrors(true);
 
         if (empty($formErrors)) {
-            return;
+            return null;
         }
 
         if (1 === count($formErrors)) {
@@ -188,11 +220,11 @@ class TranslatableType extends AbstractType
                 $locales
             );
 
-            if (null !== $errorByLocale) {
-                $view->vars['error_by_locale'] = $errorByLocale;
+            if (!$errorByLocale) {
+                return null;
             }
 
-            return;
+            return [$errorByLocale];
         }
 
         $errorsByLocale = $this->getTranslatableErrors(
@@ -201,9 +233,7 @@ class TranslatableType extends AbstractType
             $locales
         );
 
-        if (null !== $errorsByLocale) {
-            $view->vars['errors_by_locale'] = $errorsByLocale;
-        }
+        return $errorsByLocale;
     }
 
     /**
@@ -274,7 +304,7 @@ class TranslatableType extends AbstractType
             if ($doesLocaleExistForInvalidForm) {
                 foreach ($formErrors as $formError) {
                     if ($this->doesErrorFormAndCurrentFormMatches($formError->getOrigin(), $formItem)) {
-                        $errorsByLocale[$locales[$iteration]['iso_code']] = [
+                        $errorsByLocale[] = [
                             'locale_name' => $locales[$iteration]['name'],
                             'error_message' => $formError->getMessage(),
                         ];

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -122,11 +122,7 @@ class TranslatableType extends TranslatorAwareType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $errors = [];
-
-        foreach ($view->vars['errors'] as $existingError) {
-            $errors[] = $existingError;
-        }
+        $errors = iterator_to_array($view->vars['errors']);
 
         $errorsByLocale = $this->getErrorsByLocale($view, $form, $options['locales']);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -130,7 +130,7 @@ class TranslatableType extends TranslatorAwareType
 
         $errorsByLocale = $this->getErrorsByLocale($view, $form, $options['locales']);
 
-        if (!empty($errorsByLocale)) {
+        if ($errorsByLocale !== null) {
             foreach ($errorsByLocale as $errorByLocale) {
                 /** Needs to be translated */
                 $modifiedErrorMessage = $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -257,12 +257,6 @@ class TranslatableType extends TranslatorAwareType
         $iteration = 0;
 
         foreach ($form as $formItem) {
-            if (0 === $iteration) {
-                ++$iteration;
-
-                continue;
-            }
-
             if ($this->doesErrorFormAndCurrentFormMatches($formError->getOrigin(), $formItem)) {
                 $nonDefaultLanguageFormKey = $iteration;
 

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -146,7 +146,6 @@ class TranslatableType extends TranslatorAwareType
         }
 
         $varsForm = $view->vars['errors']->getForm();
-        $view->vars['formatted_text_area'] = ($options['type'] === FormattedTextareaType::class);
         $view->vars['errors'] = new FormErrorIterator($varsForm, $errors);
         $view->vars['locales'] = $options['locales'];
         $view->vars['default_locale'] = $this->getDefaultLocale($options['locales']);

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -674,6 +674,8 @@ services:
 
     form.type.common.translatable:
         class: 'PrestaShopBundle\Form\Admin\Type\TranslatableType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - "@=service('prestashop.adapter.legacy.context').getAvailableLanguages()"
             - '@router.default'

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -702,8 +702,6 @@
   {% endspaceless %}
 {% endblock material_multiple_choice_table_widget %}
 
-
-
 {% block translatable_widget -%}
   <div class="input-group locale-input-group js-locale-input-group d-flex">
     {% for translateField in form %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -702,36 +702,9 @@
   {% endspaceless %}
 {% endblock material_multiple_choice_table_widget %}
 
-{# Copied translatablefields_widget made to be compatible with TranslatableType.php and to be used in translatable widget#}
-{% block translatable_formatted_fields %}
-  <div class="translations tabbable" id="{{ form.vars.id }}">
-    {% if hide_locales == false and form|length > 1 %}
-      <ul class="translationsLocales nav nav-pills">
-        {% for translationsFields in form %}
-          <li class="nav-item">
-            <a href="#" data-locale="{{ translationsFields.vars.label }}" class="{% if default_locale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
-              {{ translationsFields.vars.label|capitalize }}
-            </a>
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-
-    <div class="translationsFields tab-content">
-      {% for translationsFields in form %}
-        <div data-locale="{{ translationsFields.vars.label }}" class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hide_locales == false and form|length > 1 %}panel panel-default{% endif %} {% if default_locale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
-          {{ form_widget(translationsFields) }}
-        </div>
-      {% endfor %}
-    </div>
-  </div>
-{% endblock %}
 
 
 {% block translatable_widget -%}
-  {% if formatted_text_area %}
-    {{ block('translatable_formatted_fields') }}
-  {% else %}
   <div class="input-group locale-input-group js-locale-input-group d-flex">
     {% for translateField in form %}
       {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
@@ -765,7 +738,6 @@
       </div>
     {% endif %}
   </div>
-  {% endif %}
   {{ block('form_help') }}
 {%- endblock translatable_widget %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -95,7 +95,6 @@
 
 {#--deleted {%- block form_row -%}
   {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
-
   {{- ps.form_group_row(form, { attr: form.vars.attr }, {
     'label': form.vars.label
   }) -}}
@@ -552,36 +551,68 @@
 
 {% block form_errors -%}
   {% if errors|length > 0 -%}
-    <div class="invalid-feedback-container">
+    {# If we got more then one error then we need to display popover instead of errors list #}
+    {%- if errors|length > 1 -%}
+
+      {% set popoverContainer = 'popover-error-container-'~form.vars.id %}
+      <div class="{{ popoverContainer }}"></div>
+
+      {% set popoverErrorContent %}
+        <div class="popover-error-list">
+          <ul>
+            {%- for error in errors -%}
+              <li class="text-danger"> {{
+                error.messagePluralization is null
+                ? error.messageTemplate|trans(error.messageParameters, 'form_error')
+                : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
+                }}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endset %}
+
+      <template class="js-popover-error-content" data-id="{{ form.vars.id }}">
+        {{ popoverErrorContent }}
+      </template>
+
+      {% set errorPopover %}
+        <span
+          data-toggle="form-popover-error"
+          data-id="{{ form.vars.id }}"
+          data-placement="bottom"
+          data-template='<div class="popover form-popover-error" role="tooltip"><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+          data-trigger="hover"
+          data-container=".{{ popoverContainer }}"
+        >
+          <i class="material-icons form-error-icon">error_outline</i> <u> {{ '%count% errors'|transchoice(errors|length, {}, 'Admin.Global') }}</u>
+        </span>
+      {% endset %}
+
+      <div class="invalid-feedback-container">
+        <div class="text-danger">
+          {{ errorPopover }}
+        </div>
+      </div>
+
+      {# If there is only one error then display it without popover #}
+    {%- else -%}
       <div class="d-inline-block text-danger align-top">
         <i class="material-icons form-error-icon">error_outline</i>
       </div>
       <div class="d-inline-block">
-      {%- if errors|length > 1 -%}
-        <ul class="text-danger">
-          {%- for error in errors -%}
-            <li> {{
-              error.messagePluralization is null
-              ? error.messageTemplate|trans(error.messageParameters, 'form_error')
-              : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
-              }}
-            </li>
-          {%- endfor -%}
-        </ul>
-      {%- else -%}
-        <div class="text-danger">
-          {%- for error in errors -%}
+        {% for error in errors %}
+          <div class="text-danger">
             <p> {{
               error.messagePluralization is null
               ? error.messageTemplate|trans(error.messageParameters, 'form_error')
               : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'form_error')
               }}
             </p>
-          {%- endfor -%}
-        </div>
-      {%- endif -%}
+          </div>
+        {%- endfor -%}
       </div>
-    </div>
+    {%- endif -%}
   {%- endif %}
 {%- endblock form_errors %}
 
@@ -671,7 +702,36 @@
   {% endspaceless %}
 {% endblock material_multiple_choice_table_widget %}
 
+{# Copied translatablefields_widget made to be compatible with TranslatableType.php and to be used in translatable widget#}
+{% block translatable_formatted_fields %}
+  <div class="translations tabbable" id="{{ form.vars.id }}">
+    {% if hide_locales == false and form|length > 1 %}
+      <ul class="translationsLocales nav nav-pills">
+        {% for translationsFields in form %}
+          <li class="nav-item">
+            <a href="#" data-locale="{{ translationsFields.vars.label }}" class="{% if default_locale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
+              {{ translationsFields.vars.label|capitalize }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    <div class="translationsFields tab-content">
+      {% for translationsFields in form %}
+        <div data-locale="{{ translationsFields.vars.label }}" class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hide_locales == false and form|length > 1 %}panel panel-default{% endif %} {% if default_locale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
+          {{ form_widget(translationsFields) }}
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+{% endblock %}
+
+
 {% block translatable_widget -%}
+  {% if formatted_text_area %}
+    {{ block('translatable_formatted_fields') }}
+  {% else %}
   <div class="input-group locale-input-group js-locale-input-group d-flex">
     {% for translateField in form %}
       {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
@@ -705,6 +765,7 @@
       </div>
     {% endif %}
   </div>
+  {% endif %}
   {{ block('form_help') }}
 {%- endblock translatable_widget %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -95,6 +95,7 @@
 
 {#--deleted {%- block form_row -%}
   {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+
   {{- ps.form_group_row(form, { attr: form.vars.attr }, {
     'label': form.vars.label
   }) -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -215,7 +215,7 @@
 
     {% elseif form.vars.error_by_locale is defined %}
       {% set errorByLocale = '%error_message% - Language: %language_name%'|trans({'%error_message%': form.vars.error_by_locale.error_message, '%language_name%': form.vars.error_by_locale.locale_name}, 'Admin.Notifications.Error') %}
-{#      {% set errors = [errorByLocale] %}#}
+      {% set errors = [errorByLocale] %}
     {% endif %}
 
     <div class="invalid-feedback-container">

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -142,11 +142,6 @@
     {% endfor %}
 
     {#iterating over child errors because errors can be nested#}
-    {% for child in form.children %}
-      {% for error in child.vars.errors %}
-        {% set errors = errors|merge([error.message]) %}
-      {% endfor %}
-    {% endfor %}
   {% endif %}
 
   {% if errors|length > 0 %}
@@ -220,7 +215,7 @@
 
     {% elseif form.vars.error_by_locale is defined %}
       {% set errorByLocale = '%error_message% - Language: %language_name%'|trans({'%error_message%': form.vars.error_by_locale.error_message, '%language_name%': form.vars.error_by_locale.locale_name}, 'Admin.Notifications.Error') %}
-      {% set errors = [errorByLocale] %}
+{#      {% set errors = [errorByLocale] %}#}
     {% endif %}
 
     <div class="invalid-feedback-container">


### PR DESCRIPTION
…e FormattableTextArea compatible with translatableType

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR is meant to make locale errors from translatable type work with simplified forms as well as make FormattedTextareaType work with TranslatableType
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | This PR best to be tested with pr to example-modules(https://github.com/PrestaShop/example-modules/pull/28/).That PR contains simplified form with translatable fields and errors. Please test the form behaves in a relevant way.<br/><br/>Also some of the already existing translatable fields need to be tested to make sure they were not affected. Please test 1 or 2 BO page with fields that can be translated to check the form errors are working as expected.

BC break because TranslatableType now extends TranslatorAwareType so any module that extended TranslatableType before might run into problems. 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21062)
<!-- Reviewable:end -->
