### PR TITLE
Add '-' to checkout's summary subtotal if it is discount type

### DIFF
--- a/themes/classic/templates/checkout/_partials/cart-summary-subtotals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-subtotals.tpl
@@ -34,7 +34,7 @@
         </span>
 
         <span class="value">
-          {$subtotal.value}
+          {if 'discount' == $subtotal.type}-&nbsp;{/if}{$subtotal.value}
         </span>
       </div>
     {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Minus symbol is missed for discount type subtotals at checkout's cart summary in Classic theme.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21161
| How to test?  | At the BO enable a discount and make sure Classic theme is also enabled. Add any product that fits the discount conditions to your cart and go to the checkout page. There, confirm that the minus symbol is showed before the amount discounted.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21065)
<!-- Reviewable:end -->
