### PR TITLE
install-dev - bugfix: $this->trans() should be $this->translator->trans()

### DIFF
--- a/install-dev/theme/views/system.php
+++ b/install-dev/theme/views/system.php
@@ -32,7 +32,7 @@
 <?php if ($this->tests['required']['success']): ?>
 	<h3 class="okBlock"><?php echo $this->translator->trans('PrestaShop compatibility with your system environment has been verified!', array(), 'Install'); ?></h3>
 <?php else: ?>
-	<h3 class="errorBlock"><?php echo $this->translator->trans('Oops! Please correct the item(s) below, and then click "%refresh_label%" to test the compatibility of your new system.', array('%refresh_label%' => $this->trans('Refresh information', array(), 'Install')), 'Install'); ?></h3>
+	<h3 class="errorBlock"><?php echo $this->translator->trans('Oops! Please correct the item(s) below, and then click "%refresh_label%" to test the compatibility of your new system.', array('%refresh_label%' => $this->translator->trans('Refresh information', array(), 'Install')), 'Install'); ?></h3>
 <?php endif; ?>
 <!-- Display tests results -->
 <?php foreach ($this->tests_render as $type => $categories): ?>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop / 1.7.7.x
| Description?  | install-dev is currently broken because of an invalid call.
| Type?         | bug fix 
| Category?     | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?    | yes / no
| Deprecations? | no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Run install-dev - no crash :)

![install-dev-bug](https://user-images.githubusercontent.com/29786965/93658560-01bad200-fa80-11ea-959c-28f35d199a09.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21070)
<!-- Reviewable:end -->
