### PR TITLE
Simplify computeMappingBetweenOldAndNewPositions()

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.js
@@ -188,55 +188,14 @@ export default class PositionExtension {
    */
   computeMappingBetweenOldAndNewPositions(rowsData) {
     const regex = /^row_(\d+)_(\d+)$/;
+    const mapping = Array(rowsData.length).fill().map(Object);
 
-    const rowsNb = rowsData.length;
-    const positionsBeforeDragAndDrop = {};
-    const positionsAfterDragAndDrop = {};
-    const mapping = [];
-
-    let rowDataMarker;
-    let rowDataParsedData;
-    let i;
-    let rowID;
-    let rowOldPosition;
-    let rowOldOffset;
-    let rowNewOffset;
-
-    // first, compute for each position,
-    // where they were before the drag-and-drop
-    // and where they are after the drag-and-drop
-    for (i = 0; i < rowsNb; i += 1) {
-      rowDataMarker = rowsData[i].rowMarker;
-      rowDataParsedData = regex.exec(rowDataMarker);
-
-      rowID = rowDataParsedData[1];
-      rowOldPosition = parseInt(rowDataParsedData[2], 10);
-      rowOldOffset = rowsData[i].offset;
-      rowNewOffset = i;
-
-      positionsBeforeDragAndDrop[rowOldOffset] = rowOldPosition;
-      positionsAfterDragAndDrop[rowNewOffset] = rowOldPosition;
-    }
-
-    let previousRowPositionWithThisOffset;
-
-    // for each row in table, we look at before the drag-and-drop
-    // and find what other row was there, this is the new position
-    // of current row
-    for (i = 0; i < rowsNb; i += 1) {
-      rowDataMarker = rowsData[i].rowMarker;
-      rowDataParsedData = regex.exec(rowDataMarker);
-      rowID = rowDataParsedData[1];
-      rowOldPosition = parseInt(rowDataParsedData[2], 10);
-
-      rowNewOffset = i;
-      previousRowPositionWithThisOffset = positionsBeforeDragAndDrop[rowNewOffset];
-
-      mapping.push({
-        rowId: rowID,
-        oldPosition: rowOldPosition,
-        newPosition: previousRowPositionWithThisOffset,
-      });
+    for (let i = 0; i < rowsData.length; i += 1) {
+      const [, rowId, oldPosition] = regex.exec(rowsData[i].rowMarker);
+      mapping[i].rowId = rowId;
+      mapping[i].oldPosition = parseInt(oldPosition, 10);
+      // This row will have as a new position the old position of the current one
+      mapping[rowsData[i].offset].newPosition = mapping[i].oldPosition;
     }
 
     return mapping;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improve readability and performance<br>
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Go to pages(cms) and check that the positions are changed, even on the second page.<br><br>My tests to guarantee that the function does the same as before was to add `console.log (mapping, this.computeMappingBetweenOldAndNewPositions_old (rowsData))` before return to verify that the returned object was the same as the one generated with the previous function. It is also helpfull to abort the form submission with `updatePosition(){return; ...`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21072)
<!-- Reviewable:end -->
