### PR TITLE
Grid bulk delete confirmation modal - Advanced Parameters > Emails

### DIFF
--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
@@ -50,6 +49,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
     /**
@@ -272,12 +272,7 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
     {
         return (new BulkActionCollection())
             ->add(
-                (new SubmitBulkAction('delete_email_logs'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_emails_delete_bulk',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
+                $this->buildBulkDeleteAction('admin_emails_delete_bulk')
             );
     }
 }

--- a/tests/UI/pages/BO/advancedParameters/email/index.js
+++ b/tests/UI/pages/BO/advancedParameters/email/index.js
@@ -29,7 +29,7 @@ class Email extends BOBasePage {
     // Bulk Actions
     this.selectAllRowsLabel = `${this.emailGridPanel} tr.column-filters .grid_bulk_action_select_all`;
     this.bulkActionsToggleButton = `${this.emailGridPanel} button.js-bulk-actions-btn`;
-    this.bulkActionsDeleteButton = '#email_logs_grid_bulk_action_delete_email_logs';
+    this.bulkActionsDeleteButton = '#email_logs_grid_bulk_action_delete_selection';
     // Email form
     this.logEmailsLabel = toggle => `label[for='form_log_emails_${toggle}']`;
     this.saveEmailFormButton = '#form-log-email-save-button';
@@ -155,7 +155,6 @@ class Email extends BOBasePage {
    * @returns {Promise<string>}
    */
   async deleteEmailLogsBulkActions(page) {
-    this.dialogListener(page, true);
     // Click on Select All
     await Promise.all([
       page.$eval(this.selectAllRowsLabel, el => el.click()),
@@ -166,8 +165,13 @@ class Email extends BOBasePage {
       page.click(this.bulkActionsToggleButton),
       this.waitForVisibleSelector(page, `${this.bulkActionsToggleButton}[aria-expanded='true']`),
     ]);
-    // Click on delete
-    await this.clickAndWaitForNavigation(page, this.bulkActionsDeleteButton);
+
+    // Bulk delete email logs
+    await Promise.all([
+      this.waitForSelectorAndClick(page, this.bulkActionsDeleteButton),
+      this.waitForVisibleSelector(page, `${this.confirmDeleteModal}.show`),
+    ]);
+    await this.clickAndWaitForNavigation(page, this.confirmDeleteButton);
     return this.getTextContent(page, this.alertSuccessBlockParagraph);
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting multiple rows from Advanced parameters > Emails
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes #17845 
| How to test?  | Go to Advanced parameters > Emails in the BO, Select multiple rows, try to delete a row, you will have a bootstrap modal to confirm deletion


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21079)
<!-- Reviewable:end -->
