### PR TITLE
Grid bulk delete confirmation modal - Advanced Parameters > Team > Profiles

### DIFF
--- a/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
@@ -48,6 +47,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
     /**
@@ -212,12 +212,8 @@ final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
     protected function getBulkActions()
     {
         return (new BulkActionCollection())
-            ->add((new SubmitBulkAction('bulk_delete_profiles'))
-            ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-            ->setOptions([
-                'submit_route' => 'admin_profiles_bulk_delete',
-                'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-            ])
+            ->add(
+                $this->buildBulkDeleteAction('admin_profiles_bulk_delete')
             )
         ;
     }

--- a/tests/UI/pages/BO/advancedParameters/team/profiles/index.js
+++ b/tests/UI/pages/BO/advancedParameters/team/profiles/index.js
@@ -28,7 +28,7 @@ class Profiles extends BOBasePage {
     // Bulk Actions
     this.selectAllRowsLabel = `${this.profilesListForm} tr.column-filters .grid_bulk_action_select_all`;
     this.bulkActionsToggleButton = `${this.profilesListForm} button.dropdown-toggle`;
-    this.bulkActionsDeleteButton = `${this.profilesListForm} #profile_grid_bulk_action_bulk_delete_profiles`;
+    this.bulkActionsDeleteButton = `${this.profilesListForm} #profile_grid_bulk_action_delete_selection`;
     // Delete modal
     this.confirmDeleteModal = '#profile-grid-confirm-modal';
     this.confirmDeleteButton = `${this.confirmDeleteModal} button.btn-confirm-submit`;
@@ -161,7 +161,6 @@ class Profiles extends BOBasePage {
    * @returns {Promise<string>}
    */
   async deleteBulkActions(page) {
-    this.dialogListener(page);
     // Click on Select All
     await Promise.all([
       page.$eval(this.selectAllRowsLabel, el => el.click()),
@@ -170,10 +169,16 @@ class Profiles extends BOBasePage {
     // Click on Button Bulk actions
     await Promise.all([
       page.click(this.bulkActionsToggleButton),
-      this.waitForVisibleSelector(page, this.bulkActionsToggleButton),
+      this.waitForVisibleSelector(page, this.bulkActionsDeleteButton),
     ]);
+
     // Click on delete and wait for modal
-    await this.clickAndWaitForNavigation(page, this.bulkActionsDeleteButton);
+    await Promise.all([
+      page.click(this.bulkActionsDeleteButton),
+      this.waitForVisibleSelector(page, `${this.confirmDeleteModal}.show`),
+    ]);
+
+    await this.confirmDeleteProfiles(page);
     return this.getTextContent(page, this.alertSuccessBlockParagraph);
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting multiple rows from Advanced parameters > Team > Profiles
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes #17845 
| How to test?  | Go to Advanced parameters > Team > Profiles in the BO, Select multiple rows, try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21081)
<!-- Reviewable:end -->
