### PR TITLE
Grid bulk delete confirmation modal - Advanced Parameters > DB > SQL Requests

### DIFF
--- a/src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/RequestSqlGridDefinitionFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
@@ -48,6 +47,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class RequestSqlGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
     /**
@@ -217,13 +217,7 @@ final class RequestSqlGridDefinitionFactory extends AbstractGridDefinitionFactor
     {
         return (new BulkActionCollection())
             ->add(
-                (new SubmitBulkAction('delete_all'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_sql_requests_delete_bulk',
-                        'submit_method' => 'POST',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
+                $this->buildBulkDeleteAction('admin_sql_requests_delete_bulk')
             );
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting multiple rows from Advanced parameters > Database > SQL Requests
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes #17845 
| How to test?  | Go to Advanced parameters > Database > SQL Requests in the BO, Select multiple rows, try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21082)
<!-- Reviewable:end -->
