### PR TITLE
Grid bulk delete confirmation modal - Advanced Parameters > Webservice keys

### DIFF
--- a/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
@@ -49,6 +49,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
     /**
@@ -257,12 +258,7 @@ final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
-                (new SubmitBulkAction('delete_webservice'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_webservice_keys_bulk_delete',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
+                $this->buildBulkDeleteAction('admin_webservice_keys_bulk_delete')
             );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting multiple rows from Advanced parameters > Webservice
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes #17845 
| How to test?  | Go to Advanced parameters > Webservice in the BO, Select multiple rows, try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21084)
<!-- Reviewable:end -->
