### PR TITLE
Grid bulk delete confirmation modal - Shop Parameters > Contacts

### DIFF
--- a/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
@@ -47,6 +46,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
     /**
@@ -211,12 +211,7 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
     {
         return (new BulkActionCollection())
             ->add(
-                (new SubmitBulkAction('delete_all'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_contacts_delete_bulk',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
+                $this->buildBulkDeleteAction('admin_contacts_delete_bulk')
             );
     }
 

--- a/tests/UI/pages/BO/shopParameters/contact/index.js
+++ b/tests/UI/pages/BO/shopParameters/contact/index.js
@@ -29,7 +29,7 @@ class Contacts extends BOBasePage {
     // Bulk Actions
     this.selectAllRowsLabel = `${this.contactsGridPanel} tr.column-filters .grid_bulk_action_select_all`;
     this.bulkActionsToggleButton = `${this.contactsGridPanel} button.js-bulk-actions-btn`;
-    this.bulkActionsDeleteButton = '#contact_grid_bulk_action_delete_all';
+    this.bulkActionsDeleteButton = '#contact_grid_bulk_action_delete_selection';
     // Sort Selectors
     this.tableHead = `${this.contactsGridPanel} thead`;
     this.sortColumnDiv = column => `${this.tableHead} div.ps-sortable-column[data-sort-col-name='${column}']`;
@@ -156,8 +156,8 @@ class Contacts extends BOBasePage {
         `${this.listTableToggleDropDown(row)}[aria-expanded='true']`,
       ),
     ]);
-    // Click on delete
 
+    // Click on delete
     await Promise.all([
       page.click(this.deleteRowLink(row)),
       this.waitForVisibleSelector(page, `${this.confirmDeleteModal}.show`),
@@ -181,8 +181,6 @@ class Contacts extends BOBasePage {
    * @return {Promise<string>}
    */
   async deleteContactsBulkActions(page) {
-    // Add listener to dialog to accept deletion
-    this.dialogListener(page);
     // Click on Select All
     await Promise.all([
       page.$eval(this.selectAllRowsLabel, el => el.click()),
@@ -193,8 +191,14 @@ class Contacts extends BOBasePage {
       page.click(this.bulkActionsToggleButton),
       this.waitForVisibleSelector(page, this.bulkActionsToggleButton),
     ]);
+
     // Click on delete and wait for modal
-    await this.clickAndWaitForNavigation(page, this.bulkActionsDeleteButton);
+    await Promise.all([
+      page.click(this.bulkActionsDeleteButton),
+      this.waitForVisibleSelector(page, `${this.confirmDeleteModal}.show`),
+    ]);
+
+    await this.confirmDeleteContact(page);
     return this.getTextContent(page, this.alertSuccessBlockParagraph);
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting multiple rows from Shop parameters > Contacts
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes #17845 
| How to test?  | Go to Shop parameters > Contacts in the BO, Select multiple rows, try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21085)
<!-- Reviewable:end -->
