### PR TITLE
Grid bulk delete confirmation modal - Shop Parameters > Traffic SEO URLs

### DIFF
--- a/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/MetaGridDefinitionFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
-use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
@@ -47,6 +46,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class MetaGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
+    use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
     /**
@@ -211,12 +211,7 @@ final class MetaGridDefinitionFactory extends AbstractGridDefinitionFactory
     {
         return (new BulkActionCollection())
             ->add(
-                (new SubmitBulkAction('delete_seo_urls'))
-                    ->setName($this->trans('Delete selected', [], 'Admin.Actions'))
-                    ->setOptions([
-                        'submit_route' => 'admin_metas_delete_bulk',
-                        'confirm_message' => $this->trans('Delete selected items?', [], 'Admin.Notifications.Warning'),
-                    ])
+                $this->buildBulkDeleteAction('admin_metas_delete_bulk')
             );
     }
 }

--- a/tests/UI/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
+++ b/tests/UI/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.js
@@ -24,7 +24,7 @@ class SeoAndUrls extends BOBasePage {
     // Bulk Actions
     this.selectAllRowsLabel = `${this.gridPanel} tr.column-filters .md-checkbox i`;
     this.bulkActionsToggleButton = `${this.gridPanel} button.js-bulk-actions-btn`;
-    this.bulkActionsDeleteButton = `${this.gridPanel} #meta_grid_bulk_action_delete_seo_urls`;
+    this.bulkActionsDeleteButton = `${this.gridPanel} #meta_grid_bulk_action_delete_selection`;
 
     // Filters
     this.filterColumn = filterBy => `${this.gridTable} #meta_${filterBy}`;
@@ -78,9 +78,6 @@ class SeoAndUrls extends BOBasePage {
    * @returns {Promise<string>}
    */
   async bulkDeleteSeoUrlPage(page) {
-    // Confirm delete in js modal
-    this.dialogListener(page, true);
-
     // Click on Select All
     await Promise.all([
       page.$eval(this.selectAllRowsLabel, el => el.click()),
@@ -93,7 +90,13 @@ class SeoAndUrls extends BOBasePage {
       this.waitForVisibleSelector(page, `${this.bulkActionsToggleButton}[aria-expanded='true']`),
     ]);
 
-    await this.clickAndWaitForNavigation(page, this.bulkActionsDeleteButton);
+    // Click on delete and wait for modal
+    await Promise.all([
+      page.click(this.bulkActionsDeleteButton),
+      this.waitForVisibleSelector(page, `${this.confirmDeleteModal}.show`),
+    ]);
+
+    await this.confirmDeleteSeoUrlPage(page);
     return this.getTextContent(page, this.alertSuccessBlockParagraph);
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting multiple rows from Shop parameters > Traffic & SEO > SEO URLs
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes #17845 
| How to test?  | Go to Shop parameters > Traffic & SEO > SEO URLs in the BO, Select multiple rows, try to delete a row, you will have a bootstrap modal to confirm deletion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21086)
<!-- Reviewable:end -->
