### PR TITLE
Make FormattedTextAreaType works with TranslatableType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -122,6 +122,7 @@ class TranslatableType extends TranslatorAwareType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        $view->vars['formatted_text_area'] = ($options['type'] === FormattedTextareaType::class);
         $errors = iterator_to_array($view->vars['errors']);
 
         $errorsByLocale = $this->getErrorsByLocale($view, $form, $options['locales']);

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -764,9 +764,7 @@
         </div>
       {% endif %}
     </div>
-  {% endif %}
-  {{ block('form_help') }}
-{%- endblock translatable_widget %}
+{%- endblock translatable_default %}
 
 {% block translatable_widget -%}
   {% if formatted_text_area %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -705,40 +705,75 @@
   {% endspaceless %}
 {% endblock material_multiple_choice_table_widget %}
 
-{% block translatable_widget -%}
-  <div class="input-group locale-input-group js-locale-input-group d-flex">
-    {% for translateField in form %}
-      {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
-      {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
-      {% if default_locale.id_lang != translateField.vars.name %}
-        {% set classes = classes ~ ' d-none' %}
-      {% endif %}
-      <div class="{{ classes }}" style="flex-grow: 1;">
-        {{ form_widget(translateField) }}
-      </div>
-    {% endfor %}
-    {% if not hide_locales %}
-      <div class="dropdown">
-        <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
-                type="button"
-                data-toggle="dropdown"
-          {% if change_form_language_url is defined %}
-            data-change-language-url="{{ form.vars.change_form_language_url }}"
-          {% endif %}
-                aria-haspopup="true"
-                aria-expanded="false"
-                id="{{ form.vars.id }}"
-        >
-          {{ form.vars.default_locale.iso_code }}
-        </button>
-        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
-          {% for locale in locales %}
-            <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
-          {% endfor %}
-        </div>
-      </div>
+{# Copied translatablefields_widget made to be compatible with TranslatableType.php and to be used in translatable widget#}
+{% block translatable_formatted_fields %}
+  <div class="translations tabbable" id="{{ form.vars.id }}">
+    {% if hide_locales == false and form|length > 1 %}
+      <ul class="translationsLocales nav nav-pills">
+        {% for translationsFields in form %}
+          <li class="nav-item">
+            <a href="#" data-locale="{{ translationsFields.vars.label }}" class="{% if default_locale.id_lang == translationsFields.vars.name %}active{% endif %} nav-link" data-toggle="tab" data-target=".translationsFields-{{ translationsFields.vars.id }}">
+              {{ translationsFields.vars.label|capitalize }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
     {% endif %}
+
+    <div class="translationsFields tab-content">
+      {% for translationsFields in form %}
+        <div data-locale="{{ translationsFields.vars.label }}" class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hide_locales == false and form|length > 1 %}panel panel-default{% endif %} {% if default_locale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
+          {{ form_widget(translationsFields) }}
+        </div>
+      {% endfor %}
+    </div>
   </div>
+{% endblock %}
+
+{% block translatable_default -%}
+    <div class="input-group locale-input-group js-locale-input-group d-flex">
+      {% for translateField in form %}
+        {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
+        {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
+        {% if default_locale.id_lang != translateField.vars.name %}
+          {% set classes = classes ~ ' d-none' %}
+        {% endif %}
+        <div class="{{ classes }}" style="flex-grow: 1;">
+          {{ form_widget(translateField) }}
+        </div>
+      {% endfor %}
+      {% if not hide_locales %}
+        <div class="dropdown">
+          <button class="btn btn-outline-secondary dropdown-toggle js-locale-btn"
+                  type="button"
+                  data-toggle="dropdown"
+            {% if change_form_language_url is defined %}
+              data-change-language-url="{{ form.vars.change_form_language_url }}"
+            {% endif %}
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  id="{{ form.vars.id }}"
+          >
+            {{ form.vars.default_locale.iso_code }}
+          </button>
+          <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+            {% for locale in locales %}
+              <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+  {{ block('form_help') }}
+{%- endblock translatable_widget %}
+
+{% block translatable_widget -%}
+  {% if formatted_text_area %}
+    {{ block('translatable_formatted_fields') }}
+  {% else %}
+    {{ block('translatable_default') }}
+  {% endif %}
   {{ block('form_help') }}
 {%- endblock translatable_widget %}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make FormattedTextAreaType works with TranslatableType. The reason being so we have only one type for translatbleTypes instead of multiple like we have now
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 1) Make sure that translatable fields didn't get affected in non-simplified-pages(Categories page). 2) Test that Translatable formatted text area type fully works in module Demo Symfony Form   in https://github.com/PrestaShop/example-modules repository. But only with this PR https://github.com/PrestaShop/example-modules/pull/29 PR is merged.  

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21115)
<!-- Reviewable:end -->
