### PR TITLE
Make Module manager error notifications fixed

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -351,7 +351,7 @@ export default class ModuleCard {
         return;
       }
 
-      $.growl.notice({message: result[moduleTechName].msg, duration: 15000});
+      $.growl.notice({message: result[moduleTechName].msg, duration: 6000});
 
       const alteredSelector = self.getModuleItemSelector().replace('.', '');
       let mainElement = null;

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -331,12 +331,12 @@ export default class ModuleCard {
       },
     }).done((result) => {
       if (result === undefined) {
-        $.growl.error({message: 'No answer received from server'});
+        $.growl.error({message: 'No answer received from server', fixed: true});
         return;
       }
 
       if (typeof result.status !== 'undefined' && result.status === false) {
-        $.growl.error({message: result.msg});
+        $.growl.error({message: result.msg, fixed: true});
         return;
       }
 
@@ -351,7 +351,7 @@ export default class ModuleCard {
         return;
       }
 
-      $.growl.notice({message: result[moduleTechName].msg});
+      $.growl.notice({message: result[moduleTechName].msg, duration: 15000});
 
       const alteredSelector = self.getModuleItemSelector().replace('.', '');
       let mainElement = null;
@@ -379,7 +379,7 @@ export default class ModuleCard {
     }).fail(() => {
       const moduleItem = jqElementObj.closest('module-item-list');
       const techName = moduleItem.data('techName');
-      $.growl.error({message: `Could not perform action ${action} for module ${techName}`});
+      $.growl.error({message: `Could not perform action ${action} for module ${techName}`, fixed: true});
     }).always(() => {
       jqElementObj.fadeIn();
       spinnerObj.remove();

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -347,7 +347,7 @@ export default class ModuleCard {
           self.confirmPrestaTrust(result[moduleTechName]);
         }
 
-        $.growl.error({message: result[moduleTechName].msg});
+        $.growl.error({message: result[moduleTechName].msg, fixed: true});
         return;
       }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix the error notification when an error occured on install / uninstall / enable / disable module
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20700 
| How to test?  | Generate a module with a false return on installation and try to install it. You should have the red error notification which remains fixed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21121)
<!-- Reviewable:end -->
