### PR TITLE
Add github action to check eslint and step identifier doubles for UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
       types: [opened,edited,reopened,synchronize,labeled]
 
+defaults:
+  run:
+      working-directory: ./tests/UI/
+
 jobs:
 
   linter:
     runs-on: ubuntu-latest
-    name: UI tests - Linter
+    name: Linter
     if: contains(github.event.pull_request.labels.*.name, 'TE')
 
     steps:
@@ -16,14 +20,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies in UI tests directory
-        run: cd tests/UI/ && npm install
+        run: npm install
 
       - name: Check eslint errors
         run: npm run lint-no-fix
 
   Steps-identifiers:
     runs-on: ubuntu-latest
-    name: UI tests - Checking doubles in steps identifiers
+    name: Checking doubles in steps identifiers
     if: contains(github.event.pull_request.labels.*.name, 'TE')
 
     steps:
@@ -31,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies in UI tests directory
-        run: cd tests/UI/ && npm install
+        run: npm install
 
       - name: Generate mocha reports with failed steps
         run: GENERATE_FAILED_STEPS=true npm run functional-tests

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,40 @@
+name: UI tests
+
+on:
+  pull_request:
+      types: [opened,edited,reopened,synchronize,labeled]
+
+jobs:
+
+  linter:
+    runs-on: ubuntu-latest
+    name: UI tests - Linter
+    if: contains(github.event.pull_request.labels.*.name, 'TE')
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies in UI tests directory
+        run: cd tests && npm install
+
+      - name: Check eslint errors
+        run: npm run lint-no-fix
+
+  Steps-identifiers:
+    runs-on: ubuntu-latest
+    name: UI tests - Checking doubles in steps identifiers
+    if: contains(github.event.pull_request.labels.*.name, 'TE')
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies in UI tests directory
+        run: cd tests && npm install
+
+      - name: Generate mocha reports with failed steps
+        run: GENERATE_FAILED_STEPS=true npm run functional-tests
+
+      - name: Checking doubles in steps identifiers
+        run: npm run step-idenfiers-checker

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -37,8 +37,10 @@ jobs:
       - name: Install dependencies in UI tests directory
         run: npm install
 
-      - name: Generate mocha reports with failed steps
+      - name: Checking doubles in steps identifiers
         run: GENERATE_FAILED_STEPS=true npm run functional-tests
 
       - name: Checking doubles in steps identifiers
-        run: npm run step-idenfiers-checker
+        - run: GENERATE_FAILED_STEPS=true npm run functional-tests
+        if: succeeded() || failed()
+        - run: npm run step-idenfiers-checker

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Checking doubles in steps identifiers
         - run: GENERATE_FAILED_STEPS=true npm run functional-tests
-        if: succeeded() || failed()
+        if: ${{ failure() || success() }}
         - run: npm run step-idenfiers-checker

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install
 
       - name: Check eslint errors
-        run: npm run lint-dry-run
+        run: npm run lint
 
   Steps-identifiers:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -37,10 +37,9 @@ jobs:
       - name: Install dependencies in UI tests directory
         run: npm install
 
-      - name: Checking doubles in steps identifiers
+      - name: Generate mocha reports with failed steps
         run: GENERATE_FAILED_STEPS=true npm run functional-tests
+        continue-on-error: true
 
       - name: Checking doubles in steps identifiers
-        - run: GENERATE_FAILED_STEPS=true npm run functional-tests
-        if: ${{ failure() || success() }}
-        - run: npm run step-idenfiers-checker
+        run: npm run step-idenfiers-checker

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies in UI tests directory
-        run: cd tests && npm install
+        run: cd tests/UI/ && npm install
 
       - name: Check eslint errors
         run: npm run lint-no-fix
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies in UI tests directory
-        run: cd tests && npm install
+        run: cd tests/UI/ && npm install
 
       - name: Generate mocha reports with failed steps
         run: GENERATE_FAILED_STEPS=true npm run functional-tests

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install
 
       - name: Check eslint errors
-        run: npm run lint-no-fix
+        run: npm run lint-dry-run
 
   Steps-identifiers:
     runs-on: ubuntu-latest

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/06_trafficAndSeo/01_seoAndUrls/helperCard.js
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/06_trafficAndSeo/01_seoAndUrls/helperCard.js
@@ -50,7 +50,7 @@ describe('Helper card', async () => {
   });
 
   it('should open the help side bar and check the document language', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
+    await testContext.addContextItem(this, 'testIdentifier', 'goToSeoPage', baseContext);
 
     const isHelpSidebarVisible = await seoAndUrlsPage.openHelpSideBar(page);
     await expect(isHelpSidebarVisible).to.be.true;

--- a/tests/UI/campaigns/functional/BO/13_shopParameters/06_trafficAndSeo/01_seoAndUrls/helperCard.js
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/06_trafficAndSeo/01_seoAndUrls/helperCard.js
@@ -50,7 +50,7 @@ describe('Helper card', async () => {
   });
 
   it('should open the help side bar and check the document language', async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'goToSeoPage', baseContext);
+    await testContext.addContextItem(this, 'testIdentifier', 'openHelpSidebar', baseContext);
 
     const isHelpSidebarVisible = await seoAndUrlsPage.openHelpSideBar(page);
     await expect(isHelpSidebarVisible).to.be.true;

--- a/tests/UI/campaigns/tools/stepIdentifiersChecker.js
+++ b/tests/UI/campaigns/tools/stepIdentifiersChecker.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+// Get mochawesome report
+const jsonFile = fs.readFileSync('./mochawesome-report/mochawesome.json');
+
+/**
+ * Count doubles for each context
+ * @param contexts
+ * @return {*}, key = context, value =
+ */
+const count = contexts => contexts.reduce(
+  (a, b) => ({
+    ...a,
+    [b]: (a[b] || 0) + 1,
+  }),
+  {},
+);
+
+/**
+ * Get only doubles and delete common tests (loginBO and logoutBO)
+ * @param dict
+ * @return {string[]}
+ */
+const duplicates = dict => Object.keys(dict)
+  .filter(
+    key => dict[key] > 1 && key !== 'loginBO' && key !== 'logoutBO',
+  );
+
+/**
+ * Check for doubles in mochawesome report
+ * @param jsonFile
+ */
+const checkDoubles = (jsonFile) => {
+  // Parse json report
+  const jsonReport = JSON.parse(jsonFile);
+
+  // Map all tests contexts
+  const reportContexts = Object.values(jsonReport.allTests).map(test => JSON.parse(test.context).value);
+
+  const contextDoubles = duplicates(count(reportContexts));
+
+  if (contextDoubles.length !== 0) {
+    console.error('Some test identifiers must be fixed:\n', contextDoubles);
+  } else {
+    console.log('All good, no changes are required');
+  }
+};
+
+// Run file
+checkDoubles(jsonFile);

--- a/tests/UI/campaigns/tools/stepIdentifiersChecker.js
+++ b/tests/UI/campaigns/tools/stepIdentifiersChecker.js
@@ -40,8 +40,7 @@ const checkDoubles = (jsonFile) => {
   const contextDoubles = duplicates(count(reportContexts));
 
   if (contextDoubles.length !== 0) {
-    console.error('Some test identifiers must be fixed:\n', contextDoubles);
-    throw new Error();
+    throw new Error('Some test identifiers must be fixed:\n' + contextDoubles);
   } else {
     console.log('All good, no changes are required');
   }

--- a/tests/UI/campaigns/tools/stepIdentifiersChecker.js
+++ b/tests/UI/campaigns/tools/stepIdentifiersChecker.js
@@ -40,7 +40,7 @@ const checkDoubles = (jsonFile) => {
   const contextDoubles = duplicates(count(reportContexts));
 
   if (contextDoubles.length !== 0) {
-    throw new Error('Some test identifiers must be fixed:\n' + contextDoubles);
+    throw new Error(`Some test identifiers must be fixed:\n${contextDoubles}`);
   } else {
     console.log('All good, no changes are required');
   }

--- a/tests/UI/campaigns/tools/stepIdentifiersChecker.js
+++ b/tests/UI/campaigns/tools/stepIdentifiersChecker.js
@@ -41,6 +41,7 @@ const checkDoubles = (jsonFile) => {
 
   if (contextDoubles.length !== 0) {
     console.error('Some test identifiers must be fixed:\n', contextDoubles);
+    throw new Error();
   } else {
     console.log('All good, no changes are required');
   }

--- a/tests/UI/campaigns/utils/globals.js
+++ b/tests/UI/campaigns/utils/globals.js
@@ -38,3 +38,5 @@ global.BROWSER = {
   },
   interceptErrors: JSON.parse(process.env.INTERCEPT_ERRORS || false),
 };
+
+global.GENERATE_FAILED_STEPS = process.env.GENERATE_FAILED_STEPS || false;

--- a/tests/UI/campaigns/utils/testContext.js
+++ b/tests/UI/campaigns/utils/testContext.js
@@ -17,5 +17,10 @@ module.exports = {
         value: baseContext === undefined ? value : `${baseContext}_${value}`,
       },
     );
+
+    // Throw an error in step to not execute the rest of it
+    if (global.GENERATE_FAILED_STEPS) {
+      throw Error('This error is thrown to just generate a report with failed steps');
+    }
   },
 };

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -7,11 +7,13 @@
   },
   "scripts": {
     "linkchecker": "./node_modules/mocha/bin/mocha campaigns/tools/linkchecker.js",
-    "lint": "eslint  --fix --ignore-path .gitignore .",
+    "lint": "eslint --fix --ignore-path .gitignore .",
+    "lint-no-fix": "eslint --ignore-path .gitignore .",
     "specific-test": "./node_modules/mocha/bin/mocha --recursive --file campaigns/utils/setup.js campaigns/$TEST_PATH",
     "sanity-tests": "./node_modules/mocha/bin/mocha --file campaigns/utils/setup.js campaigns/sanity/*",
     "sanity-travis": "./node_modules/mocha/bin/mocha --bail --file campaigns/utils/setup.js campaigns/sanity/*",
-    "functional-tests": "./node_modules/mocha/bin/mocha --recursive --file campaigns/utils/setup.js campaigns/functional/*"
+    "functional-tests": "./node_modules/mocha/bin/mocha --recursive --file campaigns/utils/setup.js campaigns/functional/*",
+    "step-idenfiers-checker": "node campaigns/tools/stepIdentifiersChecker.js "
   },
   "_moduleAliases": {
     "@pages": "pages",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "linkchecker": "./node_modules/mocha/bin/mocha campaigns/tools/linkchecker.js",
-    "lint": "eslint --fix --ignore-path .gitignore .",
-    "lint-dry-run": "eslint --ignore-path .gitignore .",
+    "lint-fix": "eslint --fix --ignore-path .gitignore .",
+    "lint": "eslint --ignore-path .gitignore .",
     "specific-test": "./node_modules/mocha/bin/mocha --recursive --file campaigns/utils/setup.js campaigns/$TEST_PATH",
     "sanity-tests": "./node_modules/mocha/bin/mocha --file campaigns/utils/setup.js campaigns/sanity/*",
     "sanity-travis": "./node_modules/mocha/bin/mocha --bail --file campaigns/utils/setup.js campaigns/sanity/*",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "linkchecker": "./node_modules/mocha/bin/mocha campaigns/tools/linkchecker.js",
     "lint": "eslint --fix --ignore-path .gitignore .",
-    "lint-no-fix": "eslint --ignore-path .gitignore .",
+    "lint-dry-run": "eslint --ignore-path .gitignore .",
     "specific-test": "./node_modules/mocha/bin/mocha --recursive --file campaigns/utils/setup.js campaigns/$TEST_PATH",
     "sanity-tests": "./node_modules/mocha/bin/mocha --file campaigns/utils/setup.js campaigns/sanity/*",
     "sanity-travis": "./node_modules/mocha/bin/mocha --bail --file campaigns/utils/setup.js campaigns/sanity/*",


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | Add github action to check eslint and step identifier doubles for UI tests (this jobs only runs if Label TE is set on PR)
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Should a new github workflow in checks sub tab 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21122)
<!-- Reviewable:end -->
