### PR TITLE
Changed the naming for attributes in product list

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1092,7 +1092,7 @@ class CartCore extends ObjectModel
             ORDER BY ag.`position` ASC, a.`position` ASC'
         );
 
-        $colon = Context::getContext()->getTranslator()->trans(':', [], 'Admin.Global');
+        $colon = Context::getContext()->getTranslator()->trans(': ', [], 'Admin.Global');
         foreach ($result as $row) {
             $key = $row['id_product_attribute'] . '-' . $id_lang;
             self::$_attributesLists[$key]['attributes'] .= $row['public_group_name'] . $colon . $row['attribute_name'] . $separator . ' ';

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1092,7 +1092,7 @@ class CartCore extends ObjectModel
             ORDER BY ag.`position` ASC, a.`position` ASC'
         );
 
-        $colon = Context::getContext()->getTranslator()->trans(': ', [], 'Shop.Theme.Catalog);
+        $colon = Context::getContext()->getTranslator()->trans(': ', [], 'Shop.Pdf');
         foreach ($result as $row) {
             $key = $row['id_product_attribute'] . '-' . $id_lang;
             self::$_attributesLists[$key]['attributes'] .= $row['public_group_name'] . $colon . $row['attribute_name'] . $separator . ' ';

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1092,9 +1092,11 @@ class CartCore extends ObjectModel
             ORDER BY ag.`position` ASC, a.`position` ASC'
         );
 
+        $colon = Context::getContext()->getTranslator()->trans(':', [], 'Admin.Global');
         foreach ($result as $row) {
-            self::$_attributesLists[$row['id_product_attribute'] . '-' . $id_lang]['attributes'] .= $row['public_group_name'] . ' : ' . $row['attribute_name'] . $separator . ' ';
-            self::$_attributesLists[$row['id_product_attribute'] . '-' . $id_lang]['attributes_small'] .= $row['attribute_name'] . $separator . ' ';
+            $key = $row['id_product_attribute'] . '-' . $id_lang;
+            self::$_attributesLists[$key]['attributes'] .= $row['public_group_name'] . $colon . $row['attribute_name'] . $separator . ' ';
+            self::$_attributesLists[$key]['attributes_small'] .= $row['attribute_name'] . $separator . ' ';
         }
 
         foreach ($pa_implode as $id_product_attribute) {
@@ -4033,7 +4035,7 @@ class CartCore extends ObjectModel
                 WHERE NOT EXISTS (SELECT 1 FROM ' . _DB_PREFIX_ . 'orders o WHERE o.`id_cart` = c.`id_cart`
                                     AND o.`id_customer` = ' . (int) $id_customer . ')
                 AND c.`id_customer` = ' . (int) $id_customer . '
-                AND c.`id_cart` = (SELECT `id_cart` FROM `' . _DB_PREFIX_ . 'cart` c2 WHERE c2.`id_customer` = ' . (int) $id_customer . ' ORDER BY `id_cart` DESC LIMIT 1) 
+                AND c.`id_cart` = (SELECT `id_cart` FROM `' . _DB_PREFIX_ . 'cart` c2 WHERE c2.`id_customer` = ' . (int) $id_customer . ' ORDER BY `id_cart` DESC LIMIT 1)
                 AND c.`id_guest` != 0
                     ' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'c') . '
                 ORDER BY c.`date_upd` DESC';

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1092,7 +1092,7 @@ class CartCore extends ObjectModel
             ORDER BY ag.`position` ASC, a.`position` ASC'
         );
 
-        $colon = Context::getContext()->getTranslator()->trans(': ', [], 'Admin.Global');
+        $colon = Context::getContext()->getTranslator()->trans(': ', [], 'Shop.Theme.Catalog);
         foreach ($result as $row) {
             $key = $row['id_product_attribute'] . '-' . $id_lang;
             self::$_attributesLists[$key]['attributes'] .= $row['public_group_name'] . $colon . $row['attribute_name'] . $separator . ' ';

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -723,7 +723,7 @@ class OrderDetailCore extends ObjectModel
         $this->id_customization = $product['id_customization'] ? (int) $product['id_customization'] : 0;
         $this->product_name = $product['name'] .
             ((isset($product['attributes']) && $product['attributes'] != null) ?
-                ' - ' . $product['attributes'] : '');
+                ' (' . $product['attributes'] . ')' : '');
 
         $this->product_quantity = (int) $product['cart_quantity'];
         $this->product_ean13 = empty($product['ean13']) ? null : pSQL($product['ean13']);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Changed the naming for attributes in product list
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19636
| How to test?  | * Build assets<br>* Go in BO<br>* Set the configuration in Menu `Configure > Shop > Product Preferences` : `Fieldset Product Page` : `Configuration Separator of attribute anchor on the product links` to `,` (comma)<br>* Create an order with product(s) with multiples attributes<br>* Check product list and invoice<br>* **BEFORE:**<br>![image](https://user-images.githubusercontent.com/1533248/94164668-9c088480-fe89-11ea-974c-42b88259c006.png)<br>* **AFTER:**<br>![image](https://user-images.githubusercontent.com/1533248/94164709-a88cdd00-fe89-11ea-8849-df5e56799869.png)<br>![image](https://user-images.githubusercontent.com/1533248/94164732-b3e00880-fe89-11ea-8020-3932c697469c.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21141)
<!-- Reviewable:end -->
