### PR TITLE
Removed mention tax in invoice when Tax is disabled

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -56,6 +56,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         $this->order_invoice = $order_invoice;
         $this->order = new Order((int) $this->order_invoice->id_order);
         $this->smarty = $smarty;
+        $this->smarty->assign('isTaxEnabled', (bool) Configuration::get('PS_TAX'));
 
         // If shop_address is null, then update it with current one.
         // But no DB save required here to avoid massive updates for bulk PDF generation case.

--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -24,149 +24,161 @@
  *}
 <table class="product" width="100%" cellpadding="4" cellspacing="0">
 
-	<thead>
-	<tr>
-		<th class="product header small" width="{$layout.reference.width}%">{l s='Reference' d='Shop.Pdf' pdf='true'}</th>
-		<th class="product header small" width="{$layout.product.width}%">{l s='Product' d='Shop.Pdf' pdf='true'}</th>
-		<th class="product header small" width="{$layout.tax_code.width}%">{l s='Tax Rate' d='Shop.Pdf' pdf='true'}</th>
+  {assign var='widthColProduct' value=$layout.product.width}
+  {if !$isTaxEnabled}
+    {assign var='widthColProduct' value=$widthColProduct+$layout.tax_code.width}
+  {/if}
+  <thead>
+    <tr>
+      <th class="product header small" width="{$layout.reference.width}%">{l s='Reference' d='Shop.Pdf' pdf='true'}</th>
+      <th class="product header small" width="{$widthColProduct}%">{l s='Product' d='Shop.Pdf' pdf='true'}</th>
+      {if $isTaxEnabled}
+        <th class="product header small" width="{$layout.tax_code.width}%">{l s='Tax Rate' d='Shop.Pdf' pdf='true'}</th>
+      {/if}
+      {if isset($layout.before_discount)}
+        <th class="product header small" width="{$layout.unit_price_tax_excl.width}%">
+          {l s='Base price' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}
+        </th>
+      {/if}
 
-		{if isset($layout.before_discount)}
-			<th class="product header small" width="{$layout.unit_price_tax_excl.width}%">{l s='Base price' d='Shop.Pdf' pdf='true'} <br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}</th>
-		{/if}
+      <th class="product header-right small" width="{$layout.unit_price_tax_excl.width}%">
+        {l s='Unit Price' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}
+      </th>
+      <th class="product header small" width="{$layout.quantity.width}%">{l s='Qty' d='Shop.Pdf' pdf='true'}</th>
+      <th class="product header-right small" width="{$layout.total_tax_excl.width}%">
+        {l s='Total' d='Shop.Pdf' pdf='true'}{if $isTaxEnabled}<br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}{/if}
+      </th>
+    </tr>
+  </thead>
 
-		<th class="product header-right small" width="{$layout.unit_price_tax_excl.width}%">{l s='Unit Price' d='Shop.Pdf' pdf='true'} <br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}</th>
-		<th class="product header small" width="{$layout.quantity.width}%">{l s='Qty' d='Shop.Pdf' pdf='true'}</th>
-		<th class="product header-right small" width="{$layout.total_tax_excl.width}%">{l s='Total' d='Shop.Pdf' pdf='true'} <br /> {l s='(Tax excl.)' d='Shop.Pdf' pdf='true'}</th>
-	</tr>
-	</thead>
+  <tbody>
 
-	<tbody>
+  <!-- PRODUCTS -->
+  {foreach $order_details as $order_detail}
+    {cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
+    <tr class="product {$bgcolor_class}">
 
-	<!-- PRODUCTS -->
-	{foreach $order_details as $order_detail}
-		{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
-		<tr class="product {$bgcolor_class}">
+      <td class="product center">
+        {$order_detail.product_reference}
+      </td>
+      <td class="product left">
+        {if $display_product_images}
+          <table width="100%">
+            <tr>
+              <td width="15%">
+                {if isset($order_detail.image) && $order_detail.image->id}
+                  {$order_detail.image_tag}
+                {/if}
+              </td>
+              <td width="5%">&nbsp;</td>
+              <td width="80%">
+                {$order_detail.product_name}
+              </td>
+            </tr>
+          </table>
+        {else}
+          {$order_detail.product_name}
+        {/if}
 
-			<td class="product center">
-				{$order_detail.product_reference}
-			</td>
-			<td class="product left">
-				{if $display_product_images}
-					<table width="100%">
-						<tr>
-							<td width="15%">
-								{if isset($order_detail.image) && $order_detail.image->id}
-									{$order_detail.image_tag}
-								{/if}
-							</td>
-							<td width="5%">&nbsp;</td>
-							<td width="80%">
-								{$order_detail.product_name}
-							</td>
-						</tr>
-					</table>
-				{else}
-					{$order_detail.product_name}
-				{/if}
+      </td>
+      {if $isTaxEnabled}
+        <td class="product center">
+          {$order_detail.order_detail_tax_label}
+        </td>
+      {/if}
 
-			</td>
-			<td class="product center">
-				{$order_detail.order_detail_tax_label}
-			</td>
+      {if isset($layout.before_discount)}
+        <td class="product center">
+          {if isset($order_detail.unit_price_tax_excl_before_specific_price)}
+            {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_before_specific_price}
+          {else}
+            --
+          {/if}
+        </td>
+      {/if}
 
-			{if isset($layout.before_discount)}
-				<td class="product center">
-					{if isset($order_detail.unit_price_tax_excl_before_specific_price)}
-						{displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_before_specific_price}
-					{else}
-						--
-					{/if}
-				</td>
-			{/if}
+      <td class="product right">
+        {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_including_ecotax}
+        {if $order_detail.ecotax_tax_excl > 0}
+          <br>
+          <small>{{displayPrice currency=$order->id_currency price=$order_detail.ecotax_tax_excl}|string_format:{l s='ecotax: %s' d='Shop.Pdf' pdf='true'}}</small>
+        {/if}
+      </td>
+      <td class="product center">
+        {$order_detail.product_quantity}
+      </td>
+      <td  class="product right">
+        {displayPrice currency=$order->id_currency price=$order_detail.total_price_tax_excl_including_ecotax}
+      </td>
+    </tr>
 
-			<td class="product right">
-				{displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_including_ecotax}
-				{if $order_detail.ecotax_tax_excl > 0}
-					<br>
-					<small>{{displayPrice currency=$order->id_currency price=$order_detail.ecotax_tax_excl}|string_format:{l s='ecotax: %s' d='Shop.Pdf' pdf='true'}}</small>
-				{/if}
-			</td>
-			<td class="product center">
-				{$order_detail.product_quantity}
-			</td>
-			<td  class="product right">
-				{displayPrice currency=$order->id_currency price=$order_detail.total_price_tax_excl_including_ecotax}
-			</td>
-		</tr>
+    {foreach $order_detail.customizedDatas as $customizationPerAddress}
+      {foreach $customizationPerAddress as $customizationId => $customization}
+        <tr class="customization_data {$bgcolor_class}">
+          <td class="center"> &nbsp;</td>
 
-		{foreach $order_detail.customizedDatas as $customizationPerAddress}
-			{foreach $customizationPerAddress as $customizationId => $customization}
-				<tr class="customization_data {$bgcolor_class}">
-					<td class="center"> &nbsp;</td>
+          <td>
+            {if isset($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) && count($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) > 0}
+              <table style="width: 100%;">
+                {foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
+                  <tr>
+                    <td style="width: 30%;">
+                      {$customization_infos.name|string_format:{l s='%s:' d='Shop.Pdf' pdf='true'}}
+                    </td>
+                    <td>{if (int)$customization_infos.id_module}{$customization_infos.value nofilter}{else}{$customization_infos.value}{/if}</td>
+                  </tr>
+                {/foreach}
+              </table>
+            {/if}
 
-					<td>
-						{if isset($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) && count($customization.datas[Product::CUSTOMIZE_TEXTFIELD]) > 0}
-							<table style="width: 100%;">
-								{foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
-									<tr>
-										<td style="width: 30%;">
-											{$customization_infos.name|string_format:{l s='%s:' d='Shop.Pdf' pdf='true'}}
-										</td>
-										<td>{if (int)$customization_infos.id_module}{$customization_infos.value nofilter}{else}{$customization_infos.value}{/if}</td>
-									</tr>
-								{/foreach}
-							</table>
-						{/if}
+            {if isset($customization.datas[Product::CUSTOMIZE_FILE]) && count($customization.datas[Product::CUSTOMIZE_FILE]) > 0}
+              <table style="width: 100%;">
+                <tr>
+                  <td style="width: 70%;">{l s='image(s):' d='Shop.Pdf' pdf='true'}</td>
+                  <td>{count($customization.datas[Product::CUSTOMIZE_FILE])}</td>
+                </tr>
+              </table>
+            {/if}
+          </td>
 
-						{if isset($customization.datas[Product::CUSTOMIZE_FILE]) && count($customization.datas[Product::CUSTOMIZE_FILE]) > 0}
-							<table style="width: 100%;">
-								<tr>
-									<td style="width: 70%;">{l s='image(s):' d='Shop.Pdf' pdf='true'}</td>
-									<td>{count($customization.datas[Product::CUSTOMIZE_FILE])}</td>
-								</tr>
-							</table>
-						{/if}
-					</td>
+          <td class="center">
+            ({if $customization.quantity == 0}1{else}{$customization.quantity}{/if})
+          </td>
 
-					<td class="center">
-						({if $customization.quantity == 0}1{else}{$customization.quantity}{/if})
-					</td>
+          {assign var=end value=($layout._colCount-3)}
+          {for $var=0 to $end}
+            <td class="center">
+              --
+            </td>
+          {/for}
 
-					{assign var=end value=($layout._colCount-3)}
-					{for $var=0 to $end}
-						<td class="center">
-							--
-						</td>
-					{/for}
+        </tr>
+      {/foreach}
+    {/foreach}
+  {/foreach}
+  <!-- END PRODUCTS -->
 
-				</tr>
-				<!--if !$smarty.foreach.custo_foreach.last-->
-			{/foreach}
-		{/foreach}
-	{/foreach}
-	<!-- END PRODUCTS -->
+  <!-- CART RULES -->
 
-	<!-- CART RULES -->
+  {assign var="shipping_discount_tax_incl" value="0"}
+  {foreach from=$cart_rules item=cart_rule name="cart_rules_loop"}
+    {if $smarty.foreach.cart_rules_loop.first}
+    <tr class="discount">
+      <th class="header" colspan="{$layout._colCount}">
+        {l s='Discounts' d='Shop.Pdf' pdf='true'}
+      </th>
+    </tr>
+    {/if}
+    <tr class="discount">
+      <td class="white right" colspan="{$layout._colCount - 1}">
+        {$cart_rule.name}
+      </td>
+      <td class="right white">
+        - {displayPrice currency=$order->id_currency price=$cart_rule.value_tax_excl}
+      </td>
+    </tr>
+  {/foreach}
 
-	{assign var="shipping_discount_tax_incl" value="0"}
-	{foreach from=$cart_rules item=cart_rule name="cart_rules_loop"}
-		{if $smarty.foreach.cart_rules_loop.first}
-		<tr class="discount">
-			<th class="header" colspan="{$layout._colCount}">
-				{l s='Discounts' d='Shop.Pdf' pdf='true'}
-			</th>
-		</tr>
-		{/if}
-		<tr class="discount">
-			<td class="white right" colspan="{$layout._colCount - 1}">
-				{$cart_rule.name}
-			</td>
-			<td class="right white">
-				- {displayPrice currency=$order->id_currency price=$cart_rule.value_tax_excl}
-			</td>
-		</tr>
-	{/foreach}
-
-	</tbody>
+  </tbody>
 
 </table>

--- a/pdf/invoice.tax-tab.tpl
+++ b/pdf/invoice.tax-tab.tpl
@@ -24,78 +24,79 @@
  *}
 
 <!--  TAX DETAILS -->
-{if $tax_exempt}
+{if $isTaxEnabled}
+  {if $tax_exempt}
 
-	{l s='Exempt of VAT according to section 259B of the General Tax Code.' d='Shop.Pdf' pdf='true'}
+    {l s='Exempt of VAT according to section 259B of the General Tax Code.' d='Shop.Pdf' pdf='true'}
 
-{elseif (isset($tax_breakdowns) && $tax_breakdowns)}
-	<table id="tax-tab" width="100%">
-		<thead>
-			<tr>
-				<th class="header small">{l s='Tax Detail' d='Shop.Pdf' pdf='true'}</th>
-				<th class="header small">{l s='Tax Rate' d='Shop.Pdf' pdf='true'}</th>
-				{if $display_tax_bases_in_breakdowns}
-					<th class="header small">{l s='Base price' d='Shop.Pdf' pdf='true'}</th>
-				{/if}
-				<th class="header-right small">{l s='Total Tax' d='Shop.Pdf' pdf='true'}</th>
-			</tr>
-		</thead>
-		<tbody>
-		{assign var=has_line value=false}
+  {elseif (isset($tax_breakdowns) && $tax_breakdowns)}
+    <table id="tax-tab" width="100%">
+      <thead>
+        <tr>
+          <th class="header small">{l s='Tax Detail' d='Shop.Pdf' pdf='true'}</th>
+          <th class="header small">{l s='Tax Rate' d='Shop.Pdf' pdf='true'}</th>
+          {if $display_tax_bases_in_breakdowns}
+            <th class="header small">{l s='Base price' d='Shop.Pdf' pdf='true'}</th>
+          {/if}
+          <th class="header-right small">{l s='Total Tax' d='Shop.Pdf' pdf='true'}</th>
+        </tr>
+      </thead>
+      <tbody>
+      {assign var=has_line value=false}
 
-		{foreach $tax_breakdowns as $label => $bd}
-			{assign var=label_printed value=false}
+      {foreach $tax_breakdowns as $label => $bd}
+        {assign var=label_printed value=false}
 
-			{foreach $bd as $line}
-				{if $line.rate == 0}
-					{continue}
-				{/if}
-				{assign var=has_line value=true}
-				<tr>
-					<td class="white">
-						{if !$label_printed}
-							{if $label == 'product_tax'}
-								{l s='Products' d='Shop.Pdf' pdf='true'}
-							{elseif $label == 'shipping_tax'}
-								{l s='Shipping' d='Shop.Pdf' pdf='true'}
-							{elseif $label == 'ecotax_tax'}
-								{l s='Ecotax' d='Shop.Pdf' pdf='true'}
-							{elseif $label == 'wrapping_tax'}
-								{l s='Wrapping' d='Shop.Pdf' pdf='true'}
-							{/if}
-							{assign var=label_printed value=true}
-						{/if}
-					</td>
+        {foreach $bd as $line}
+          {if $line.rate == 0}
+            {continue}
+          {/if}
+          {assign var=has_line value=true}
+          <tr>
+            <td class="white">
+              {if !$label_printed}
+                {if $label == 'product_tax'}
+                  {l s='Products' d='Shop.Pdf' pdf='true'}
+                {elseif $label == 'shipping_tax'}
+                  {l s='Shipping' d='Shop.Pdf' pdf='true'}
+                {elseif $label == 'ecotax_tax'}
+                  {l s='Ecotax' d='Shop.Pdf' pdf='true'}
+                {elseif $label == 'wrapping_tax'}
+                  {l s='Wrapping' d='Shop.Pdf' pdf='true'}
+                {/if}
+                {assign var=label_printed value=true}
+              {/if}
+            </td>
 
-					<td class="center white">
-						{$line.rate} %
-					</td>
+            <td class="center white">
+              {$line.rate} %
+            </td>
 
-					{if $display_tax_bases_in_breakdowns}
-						<td class="right white">
-							{if isset($is_order_slip) && $is_order_slip}- {/if}
-							{displayPrice currency=$order->id_currency price=$line.total_tax_excl}
-						</td>
-					{/if}
+            {if $display_tax_bases_in_breakdowns}
+              <td class="right white">
+                {if isset($is_order_slip) && $is_order_slip}- {/if}
+                {displayPrice currency=$order->id_currency price=$line.total_tax_excl}
+              </td>
+            {/if}
 
-					<td class="right white">
-						{if isset($is_order_slip) && $is_order_slip}- {/if}
-						{displayPrice currency=$order->id_currency price=$line.total_amount}
-					</td>
-				</tr>
-			{/foreach}
-		{/foreach}
+            <td class="right white">
+              {if isset($is_order_slip) && $is_order_slip}- {/if}
+              {displayPrice currency=$order->id_currency price=$line.total_amount}
+            </td>
+          </tr>
+        {/foreach}
+      {/foreach}
 
-		{if !$has_line}
-		<tr>
-			<td class="white center" colspan="{if $display_tax_bases_in_breakdowns}4{else}3{/if}">
-				{l s='No taxes' d='Shop.Pdf' pdf='true'}
-			</td>
-		</tr>
-		{/if}
+      {if !$has_line}
+        <tr>
+          <td class="white center" colspan="{if $display_tax_bases_in_breakdowns}4{else}3{/if}">
+            {l s='No taxes' d='Shop.Pdf' pdf='true'}
+          </td>
+        </tr>
+      {/if}
 
-		</tbody>
-	</table>
-
+      </tbody>
+    </table>
+  {/if}
 {/if}
 <!--  / TAX DETAILS -->

--- a/pdf/invoice.total-tab.tpl
+++ b/pdf/invoice.total-tab.tpl
@@ -24,75 +24,81 @@
  *}
 <table id="total-tab" width="100%">
 
-	<tr>
-		<td class="grey" width="50%">
-			{l s='Total Products' d='Shop.Pdf' pdf='true'}
-		</td>
-		<td class="white" width="50%">
-			{displayPrice currency=$order->id_currency price=$footer.products_before_discounts_tax_excl}
-		</td>
-	</tr>
+  <tr>
+    <td class="grey" width="50%">
+      {l s='Total Products' d='Shop.Pdf' pdf='true'}
+    </td>
+    <td class="white" width="50%">
+      {displayPrice currency=$order->id_currency price=$footer.products_before_discounts_tax_excl}
+    </td>
+  </tr>
 
-	{if $footer.product_discounts_tax_excl > 0}
+  {if $footer.product_discounts_tax_excl > 0}
 
-		<tr>
-			<td class="grey" width="50%">
-				{l s='Total Discounts' d='Shop.Pdf' pdf='true'}
-			</td>
-			<td class="white" width="50%">
-				- {displayPrice currency=$order->id_currency price=$footer.product_discounts_tax_excl}
-			</td>
-		</tr>
+    <tr>
+      <td class="grey" width="50%">
+        {l s='Total Discounts' d='Shop.Pdf' pdf='true'}
+      </td>
+      <td class="white" width="50%">
+        - {displayPrice currency=$order->id_currency price=$footer.product_discounts_tax_excl}
+      </td>
+    </tr>
 
-	{/if}
-	{if !$order->isVirtual()}
-	<tr>
-		<td class="grey" width="50%">
-			{l s='Shipping Costs' d='Shop.Pdf' pdf='true'}
-		</td>
-		<td class="white" width="50%">
-			{if $footer.shipping_tax_excl > 0}
-				{displayPrice currency=$order->id_currency price=$footer.shipping_tax_excl}
-			{else}
-				{l s='Free Shipping' d='Shop.Pdf' pdf='true'}
-			{/if}
-		</td>
-	</tr>
-	{/if}
+  {/if}
+  {if !$order->isVirtual()}
+  <tr>
+    <td class="grey" width="50%">
+      {l s='Shipping Costs' d='Shop.Pdf' pdf='true'}
+    </td>
+    <td class="white" width="50%">
+      {if $footer.shipping_tax_excl > 0}
+        {displayPrice currency=$order->id_currency price=$footer.shipping_tax_excl}
+      {else}
+        {l s='Free Shipping' d='Shop.Pdf' pdf='true'}
+      {/if}
+    </td>
+  </tr>
+  {/if}
 
-	{if $footer.wrapping_tax_excl > 0}
-		<tr>
-			<td class="grey">
-				{l s='Wrapping Costs' d='Shop.Pdf' pdf='true'}
-			</td>
-			<td class="white">{displayPrice currency=$order->id_currency price=$footer.wrapping_tax_excl}</td>
-		</tr>
-	{/if}
+  {if $footer.wrapping_tax_excl > 0}
+    <tr>
+      <td class="grey">
+        {l s='Wrapping Costs' d='Shop.Pdf' pdf='true'}
+      </td>
+      <td class="white">{displayPrice currency=$order->id_currency price=$footer.wrapping_tax_excl}</td>
+    </tr>
+  {/if}
 
-	<tr class="bold">
-		<td class="grey">
-			{l s='Total (Tax excl.)' d='Shop.Pdf' pdf='true'}
-		</td>
-		<td class="white">
-			{displayPrice currency=$order->id_currency price=$footer.total_paid_tax_excl}
-		</td>
-	</tr>
-	{if $footer.total_taxes > 0}
-	<tr class="bold">
-		<td class="grey">
-			{l s='Total Tax' d='Shop.Pdf' pdf='true'}
-		</td>
-		<td class="white">
-			{displayPrice currency=$order->id_currency price=$footer.total_taxes}
-		</td>
-	</tr>
-	{/if}
-	<tr class="bold big">
-		<td class="grey">
-			{l s='Total' d='Shop.Pdf' pdf='true'}
-		</td>
-		<td class="white">
-			{displayPrice currency=$order->id_currency price=$footer.total_paid_tax_incl}
-		</td>
-	</tr>
+  <tr class="bold">
+    <td class="grey">
+      {if $isTaxEnabled}
+        {l s='Total (Tax excl.)' d='Shop.Pdf' pdf='true'}
+      {else}
+        {l s='Total' d='Shop.Pdf' pdf='true'}
+      {/if}
+    </td>
+    <td class="white">
+      {displayPrice currency=$order->id_currency price=$footer.total_paid_tax_excl}
+    </td>
+  </tr>
+  {if $isTaxEnabled}
+    {if $footer.total_taxes > 0}
+      <tr class="bold">
+        <td class="grey">
+          {l s='Total Tax' d='Shop.Pdf' pdf='true'}
+        </td>
+        <td class="white">
+          {displayPrice currency=$order->id_currency price=$footer.total_taxes}
+        </td>
+      </tr>
+    {/if}
+    <tr class="bold big">
+      <td class="grey">
+        {l s='Total' d='Shop.Pdf' pdf='true'}
+      </td>
+      <td class="white">
+        {displayPrice currency=$order->id_currency price=$footer.total_paid_tax_incl}
+      </td>
+    </tr>
+  {/if}
 </table>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed mention tax in invoice when Tax is disabled
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19558
| How to test?  | * Go in BO<br>* Check the configuration "Tax" is enabled<br>* Generate a new invoice : Tax must be mentioned in invoice PDF<br>* Example : [With Tax](https://github.com/PrestaShop/PrestaShop/files/5277479/FA000004-1.pdf)<br>* Set configuration "Tax" to disabled<br>* Generate a new invoice : Tax must not be mentioned in invoice PDF<br>* Example : [Without Tax](https://github.com/PrestaShop/PrestaShop/files/5277477/FA000004-6.pdf)<br>

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21153)
<!-- Reviewable:end -->
