### PR TITLE
Change default 'Erase previous images' button state to no

### DIFF
--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -108,11 +108,11 @@
 				</label>
 				<div class="col-lg-9">
 					<span class="switch prestashop-switch fixed-width-lg">
-						<input type="radio" name="erase" id="erase_on" value="1" checked="checked">
+						<input type="radio" name="erase" id="erase_on" value="1">
 						<label for="erase_on" class="radioCheck">
 							{l s='Yes' d='Admin.Global'}
 						</label>
-						<input type="radio" name="erase" id="erase_off" value="0">
+						<input type="radio" name="erase" id="erase_off" value="0" checked="checked">
 						<label for="erase_off" class="radioCheck">
 							{l s='No' d='Admin.Global'}
 						</label>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | By default, turn off the 'Erase previous images' button when regenerating thumbnails specific module/theme.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20962.
| How to test?  | Go to "BO -> Design -> Image Settings", "Erase previous images" setting should be "No" by default

:notebook: 
* Validated by PM @LouiseBonnard : https://github.com/PrestaShop/PrestaShop/issues/20962#issuecomment-692632521

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21166)
<!-- Reviewable:end -->
