### PR TITLE
Fix availability messages quickview also updating product page

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -246,7 +246,7 @@ function replaceAddToCartSections(data) {
   if ($productAddToCart === null) {
     showErrorNextToAddtoCartButton();
   }
-  const $addProductToCart = $('.product-add-to-cart');
+  const $addProductToCart = $(prestashop.selectors.product.addToCart);
   const productAvailabilitySelector = '.add';
   const productAvailabilityMessageSelector = '#product-availability';
   const productMinimalQuantitySelector = '.product-minimal-quantity';

--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -36,7 +36,7 @@ prestashop.selectors = {
     refresh: '.product-refresh',
     miniature: '.js-product-miniature',
     minimalQuantity: '.product-minimal-quantity',
-    addToCart: '.product-add-to-cart',
+    addToCart: '.quickview .product-add-to-cart, .page-product:not(.modal-open) .row .product-add-to-cart, .page-product:not(.modal-open) .product-container .product-add-to-cart',
     prices:
       '.quickview .product-prices, .page-product:not(.modal-open) .row .product-prices, .page-product:not(.modal-open) .product-container .product-prices',
     customization:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See below
| Type?         | bug fix 
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21167.
| How to test?  | See below

Hello guys, here is a bug :

When we are in an X product page, and if there is another Y product in that same page (like related products, same category products ..), if we open the quickview modal of the Y product (we are always in the X product page), and make some ajax by changing some attributes, the two availability blocks ( `.product-add-to-cart #product-availability` ) are changing together simultaneously (shown by the red arrow). 

![ajax_bug](https://user-images.githubusercontent.com/39015823/94323859-ac0e8a00-ff97-11ea-8723-f64df603df4d.jpg)

and this is because of the   `.product-add-to-cart #product-availability` selector, which is a result of this code :

```js
  const $addProductToCart = $('.product-add-to-cart');
  const productAvailabilitySelector = '.add';
  const productAvailabilityMessageSelector = '#product-availability';
  const productMinimalQuantitySelector = '.product-minimal-quantity';

...(some skipped lines)

  replaceAddToCartSection({
    $addToCartSnippet: $productAddToCart,
    $targetParent: $addProductToCart,
    targetSelector: productAvailabilityMessageSelector,
  });

...(some skipped lines)

function replaceAddToCartSection(replacement) {
  const destinationObject = $(replacement.$targetParent.find(replacement.targetSelector));
  ...(some skipped lines)
}
```

So the responsible here is this line :
https://github.com/PrestaShop/PrestaShop/blob/08119ad4c1c5b88d2afe088951ae44c19df77440/themes/_core/js/product.js#L249

it should be more selective (inside/outside) the quickview modal, so like many other selectors, it must be some thing like :
```js
const $addProductToCart = $('.quickview .product-add-to-cart, .page-product:not(.modal-open) .row .product-add-to-cart'); 
```

But since Prestashop is progressing in these selectors, the best solution is to make two changes :
1- Replacing this line :
https://github.com/PrestaShop/PrestaShop/blob/08119ad4c1c5b88d2afe088951ae44c19df77440/themes/_core/js/selectors.js#L39
to become :
```js
addToCart: '.quickview .product-add-to-cart, .page-product:not(.modal-open) .row .product-add-to-cart, .page-product:not(.modal-open) .product-container .product-add-to-cart',
```
2- Replacing this line :
https://github.com/PrestaShop/PrestaShop/blob/08119ad4c1c5b88d2afe088951ae44c19df77440/themes/_core/js/product.js#L249
to become :
```js
const $addProductToCart = $(prestashop.selectors.product.addToCart); 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21169)
<!-- Reviewable:end -->
