### PR TITLE
Properly handle malformed controllers in routes configuration

### DIFF
--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -73,7 +73,7 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
         $controllerAndMethod = $this->extractControllerAndMethodNamesFromRoute($route);
 
         if ($controllerAndMethod === null) {
-            throw new LinterException(sprintf('"%s" does not cannot be parsed', $route->getDefault('_controller')));
+            throw new LinterException(sprintf('"%s" cannot be parsed', $route->getDefault('_controller')));
         }
 
         $reflection = new ReflectionMethod(

--- a/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
+++ b/src/PrestaShopBundle/Routing/Linter/SecurityAnnotationLinter.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Routing\Linter;
 
 use Doctrine\Common\Annotations\Reader;
+use InvalidArgumentException;
 use PrestaShopBundle\Routing\Linter\Exception\LinterException;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use ReflectionMethod;
@@ -71,6 +72,10 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
     {
         $controllerAndMethod = $this->extractControllerAndMethodNamesFromRoute($route);
 
+        if ($controllerAndMethod === null) {
+            throw new LinterException(sprintf('"%s" does not cannot be parsed', $route->getDefault('_controller')));
+        }
+
         $reflection = new ReflectionMethod(
             $controllerAndMethod['controller'],
             $controllerAndMethod['method']
@@ -96,7 +101,7 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
     /**
      * @param Route $route
      *
-     * @return array
+     * @return array|null
      */
     private function extractControllerAndMethodNamesFromRoute(Route $route)
     {
@@ -104,7 +109,11 @@ final class SecurityAnnotationLinter implements RouteLinterInterface
 
         if (strpos($controller, '::') === false) {
             // we need to support controllers defined as services & defined using short notation
-            $controller = $this->controllerNameParser->parse($controller);
+            try {
+                $controller = $this->controllerNameParser->parse($controller);
+            } catch (InvalidArgumentException $e) {
+                return null;
+            }
         }
 
         list($controller, $method) = explode('::', $controller, 2);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If a controller is malformed, an InvalidArgumentException is raised by Symfony. We must catch this one and make sure it goes to the errors list.
| Type?         | bug fix
| Category?     |  CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Run `php bin/console prestashop:linter:security-annotation find-missing` everything is ok after using this patch :).

Before this patch:
![image](https://user-images.githubusercontent.com/1462701/94452906-5b25ae00-01b0-11eb-8263-537ff608a9a7.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21187)
<!-- Reviewable:end -->
