### PR TITLE
Replaced SQL query to fetch modules hooked on stat hook by Hook function to have a singl Source of Truth

### DIFF
--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -175,16 +175,10 @@ abstract class AdminStatsTabControllerCore extends AdminController
 
     protected function getModules()
     {
-        $sql = 'SELECT h.`name` AS hook, m.`name`
-				FROM `' . _DB_PREFIX_ . 'module` m
-				LEFT JOIN `' . _DB_PREFIX_ . 'hook_module` hm ON hm.`id_module` = m.`id_module`
-				LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON hm.`id_hook` = h.`id_hook`
-				WHERE h.`name` = \'displayAdminStatsModules\'
-					AND m.`active` = 1
-				GROUP BY hm.id_module
-				ORDER BY hm.`position`';
-
-        return Db::getInstance()->executeS($sql);
+        return array_map(
+            function ($moduleArray) {return ['name' => $moduleArray['module']]; },
+            Hook::getHookModuleExecList('displayAdminStatsModules')
+        );
     }
 
     public function displayStats()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In previous implementation, `AdminStatTabsController::getModules()` would fetch modules hooked on `displayAdminStatsModules` using a SQL query. This does not support the use of aliases. I used `Hook::getHookModuleExecList()` instead, which support aliases, to fetch the "modules hooked on stat display area". 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21186
| How to test?  | Please see ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21195)
<!-- Reviewable:end -->
