### PR TITLE
Directory "/build/" was defined twice in .gitignore root file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,7 +303,6 @@ crashlytics-build.properties
 
 ### NetBeans ###
 nbproject/
-/build/
 nbbuild/
 dist/
 nbdist/


### PR DESCRIPTION
"/build/" defined twice twice on line 181 and 306

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | "/build/" defined twice
| Type?         | improvement
| Category?     | CO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | ?
| How to test?  | Nothing to test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21211)
<!-- Reviewable:end -->
