### PR TITLE
Improvement/emphasize irreversibly of thumbs regeneration

### DIFF
--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -63,10 +63,9 @@
                 {l s='Regenerate thumbnails' d='Admin.Design.Feature'}
             </h3>
 
-			<div class="alert alert-info">
-				{l s='Regenerates thumbnails for all existing images' d='Admin.Design.Help'}<br />
-				{l s='Please be patient. This can take several minutes.' d='Admin.Design.Help'}<br />
-				{l s='Be careful! Manually uploaded thumbnails will be erased and replaced by automatically generated thumbnails.' d='Admin.Design.Help'}
+			<div class="alert alert-warning">
+				{l s='Be careful! Depending on the options selected, former manually uploaded thumbnails might be erased and replaced by automatically generated thumbnails.' d='Admin.Design.Notification'}<br />
+				{l s='Also, regenerating thumbnails for all existing images can take several minutes, please be patient.' d='Admin.Design.Notification'}
 			</div>
 
 			<div class="form-group">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Emphasize irreversibly of thumbs regeneration by adding a warning message instead of info message
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20962
| How to test?  | Go to "BO -> Design -> Image Settings", "Regenerate Thumbnails" block should have replaced the warning instead of the info message

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21215)
<!-- Reviewable:end -->
