### PR TITLE
Make FO product delivery time bold

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -182,6 +182,7 @@
 
     .delivery-information {
       padding: 0 0 0 2px;
+      font-weight: bold;
 
       &::before {
         padding: 0 2px 0 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Display FO Product page delivery time in bold
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21039.
| How to test?  | 1. Go to BO, Shop param>product settings 2. Set a Delivery time of in-stock products and save 3. Check the result in FO on a product page, delivery time must be displayed in bold

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21217)
<!-- Reviewable:end -->
