### PR TITLE
Modify partial update in AbstractObjectModelRepository to simplify argument & implement it in UpdateProductBasicInformationHandler

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2196,18 +2196,4 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         return self::$htmlFields[$this->def['table']];
     }
-
-    /**
-     * @param array $fields
-     */
-    public function addFieldsToUpdate(array $fields): void
-    {
-        if (null === $this->update_fields) {
-            $this->update_fields = [];
-        }
-
-        foreach ($fields as $fieldName => $value) {
-            $this->update_fields[$fieldName] = $value;
-        }
-    }
 }

--- a/src/Adapter/AbstractObjectModelRepository.php
+++ b/src/Adapter/AbstractObjectModelRepository.php
@@ -157,7 +157,7 @@ abstract class AbstractObjectModelRepository
         string $exceptionClass,
         int $errorCode = 0
     ): void {
-        $objectModel->addFieldsToUpdate($propertiesToUpdate);
+        $objectModel->setFieldsToUpdate($this->formatPropertiesToUpdate($propertiesToUpdate));
         $this->updateObjectModel($objectModel, $exceptionClass, $errorCode);
     }
 
@@ -209,5 +209,28 @@ abstract class AbstractObjectModelRepository
                 $e
             );
         }
+    }
+
+    /**
+     * @param array $propertiesToUpdate
+     *
+     * @return array<string, mixed>
+     */
+    private function formatPropertiesToUpdate(array $propertiesToUpdate): array
+    {
+        $formattedPropertiesToUpdate = [];
+        foreach ($propertiesToUpdate as $property) {
+            if (!is_array($property)) {
+                $formattedPropertiesToUpdate[$property] = true;
+
+                continue;
+            }
+
+            foreach ($property as $propertyName => $langId) {
+                $formattedPropertiesToUpdate[$propertyName][$langId] = true;
+            }
+        }
+
+        return $formattedPropertiesToUpdate;
     }
 }

--- a/src/Adapter/AbstractObjectModelRepository.php
+++ b/src/Adapter/AbstractObjectModelRepository.php
@@ -219,14 +219,14 @@ abstract class AbstractObjectModelRepository
     private function formatPropertiesToUpdate(array $propertiesToUpdate): array
     {
         $formattedPropertiesToUpdate = [];
-        foreach ($propertiesToUpdate as $property) {
+        foreach ($propertiesToUpdate as $propertyName => $property) {
             if (!is_array($property)) {
                 $formattedPropertiesToUpdate[$property] = true;
 
                 continue;
             }
 
-            foreach ($property as $propertyName => $langId) {
+            foreach ($property as $langId) {
                 $formattedPropertiesToUpdate[$propertyName][$langId] = true;
             }
         }

--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductBasicInformationHandlerInterface;
@@ -38,7 +37,7 @@ use Product;
 /**
  * Handles command for product basic information update using legacy object model
  */
-final class UpdateProductBasicInformationHandler extends AbstractProductHandler implements UpdateProductBasicInformationHandlerInterface
+final class UpdateProductBasicInformationHandler implements UpdateProductBasicInformationHandlerInterface
 {
     /**
      * @var ProductRepository
@@ -61,7 +60,7 @@ final class UpdateProductBasicInformationHandler extends AbstractProductHandler 
      */
     public function handle(UpdateProductBasicInformationCommand $command): void
     {
-        $product = $this->getProduct($command->getProductId());
+        $product = $this->productRepository->get($command->getProductId());
         $updatableProperties = $this->fillUpdatableProperties($product, $command);
 
         if (empty($updatableProperties)) {

--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -90,39 +90,21 @@ final class UpdateProductBasicInformationHandler implements UpdateProductBasicIn
         $localizedNames = $command->getLocalizedNames();
         if (null !== $localizedNames) {
             $product->name = $localizedNames;
-            $updatableProperties['name'] = $this->getUpdatableLangs($localizedNames);
+            $updatableProperties['name'] = array_keys($localizedNames);
         }
 
         $localizedDescriptions = $command->getLocalizedDescriptions();
         if (null !== $localizedDescriptions) {
             $product->description = $localizedDescriptions;
-            $updatableProperties['description'] = $this->getUpdatableLangs($localizedDescriptions);
+            $updatableProperties['description'] = array_keys($localizedDescriptions);
         }
 
         $localizedShortDescriptions = $command->getLocalizedShortDescriptions();
         if (null !== $localizedShortDescriptions) {
             $product->description_short = $localizedShortDescriptions;
-            $updatableProperties['description_short'] = $this->getUpdatableLangs($localizedShortDescriptions);
+            $updatableProperties['description_short'] = array_keys($localizedShortDescriptions);
         }
 
         return $updatableProperties;
-    }
-
-    /**
-     * @param array $property
-     *
-     * @return int[]
-     */
-    private function getUpdatableLangs(array $property): array
-    {
-        $updatableLangs = [];
-        foreach ($property as $langId => $value) {
-            if (null === $value) {
-                continue;
-            }
-            $updatableLangs[] = $langId;
-        }
-
-        return $updatableLangs;
     }
 }

--- a/src/Adapter/Product/Update/ProductCustomizationFieldUpdater.php
+++ b/src/Adapter/Product/Update/ProductCustomizationFieldUpdater.php
@@ -112,7 +112,7 @@ class ProductCustomizationFieldUpdater
 
         $this->productRepository->partialUpdate(
             $product,
-            ['customizable' => true, 'text_fields' => true, 'uploadable_files' => true],
+            ['customizable', 'text_fields', 'uploadable_files'],
             CannotUpdateProductException::FAILED_UPDATE_CUSTOMIZATION_FIELDS
         );
     }

--- a/src/Adapter/Product/Update/ProductSupplierUpdater.php
+++ b/src/Adapter/Product/Update/ProductSupplierUpdater.php
@@ -112,7 +112,7 @@ class ProductSupplierUpdater
 
         $this->productRepository->partialUpdate(
             $product,
-            ['supplier_reference' => true, 'wholesale_price' => true, 'id_supplier' => true],
+            ['supplier_reference', 'wholesale_price', 'id_supplier'],
             CannotUpdateProductException::FAILED_UPDATE_DEFAULT_SUPPLIER
         );
     }
@@ -152,7 +152,7 @@ class ProductSupplierUpdater
 
         $this->productRepository->partialUpdate(
             $product,
-            ['supplier_reference' => true, 'wholesale_price' => true, 'id_supplier' => true],
+            ['supplier_reference', 'wholesale_price', 'id_supplier'],
             CannotUpdateProductException::FAILED_UPDATE_DEFAULT_SUPPLIER
         );
     }

--- a/src/Adapter/Product/Validate/ProductValidator.php
+++ b/src/Adapter/Product/Validate/ProductValidator.php
@@ -54,11 +54,11 @@ class ProductValidator extends AbstractObjectModelValidator
     }
 
     /**
-     * @param $product
+     * @param Product $product
      *
      * @throws ProductConstraintException
      */
-    private function validateCustomizability($product): void
+    private function validateCustomizability(Product $product): void
     {
         $this->validateObjectModelProperty($product, 'customizable', ProductConstraintException::class);
         $this->validateObjectModelProperty($product, 'text_fields', ProductConstraintException::class);

--- a/src/Adapter/Product/Validate/ProductValidator.php
+++ b/src/Adapter/Product/Validate/ProductValidator.php
@@ -48,9 +48,48 @@ class ProductValidator extends AbstractObjectModelValidator
      */
     public function validate(Product $product): void
     {
+        $this->validateCustomizability($product);
+        $this->validateBasicInfo($product);
+        //@todo; more properties when refactoring other handlers to use updater/validator
+    }
+
+    /**
+     * @param $product
+     *
+     * @throws ProductConstraintException
+     */
+    private function validateCustomizability($product): void
+    {
         $this->validateObjectModelProperty($product, 'customizable', ProductConstraintException::class);
         $this->validateObjectModelProperty($product, 'text_fields', ProductConstraintException::class);
         $this->validateObjectModelProperty($product, 'uploadable_files', ProductConstraintException::class);
-        //@todo; more properties when refactoring other handlers to use updater/validator
+    }
+
+    /**
+     * @param Product $product
+     *
+     * @throws ProductConstraintException
+     */
+    private function validateBasicInfo(Product $product): void
+    {
+        $this->validateObjectModelLocalizedProperty(
+            $product,
+            'name',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_NAME
+        );
+        $this->validateObjectModelLocalizedProperty(
+            $product,
+            'description',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_DESCRIPTION
+        );
+
+        $this->validateObjectModelLocalizedProperty(
+            $product,
+            'description_short',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_SHORT_DESCRIPTION
+        );
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -93,6 +93,8 @@ services:
 
     prestashop.adapter.product.command_handler.update_product_basic_information_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductBasicInformationHandler
+        arguments:
+            - '@prestashop.adapter.product.product_repository'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Formats $propertiesToUpdate inside AbstractObjectModelRepository and allows removing redundant booleans in $propertiesToUpdate argument. None of modified classes are yet released. All of them related to product page migration. Also remove addFieldsToUpdate() from ObjectModel (which was also added during the product migration recently and is not a BC)
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | related https://github.com/PrestaShop/PrestaShop/pull/20544#discussion_r497331953
| How to test?  | CI :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21226)
<!-- Reviewable:end -->
