### PR TITLE
Fix tab modules list

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -682,40 +682,12 @@ class TabCore extends ObjectModel
         return Db::getInstance()->getValue('SELECT class_name FROM ' . _DB_PREFIX_ . 'tab WHERE id_tab = ' . (int) $idTab);
     }
 
-    /**
-     * @param string $file_to_refresh
-     * @param string $external_file
-     *
-     * @return bool
-     */
-    private static function refresh($file_to_refresh, $external_file)
-    {
-        $content = Tools::file_get_contents($external_file);
-
-        return $content ? (bool) file_put_contents(_PS_ROOT_DIR_ . $file_to_refresh, $content) : false;
-    }
-
-    /**
-     * @param string $file
-     * @param int $timeout
-     *
-     * @return bool
-     */
-    private static function isFresh($file, $timeout = 604800)
-    {
-        if (($time = @filemtime(_PS_ROOT_DIR_ . $file)) && filesize(_PS_ROOT_DIR_ . $file) > 0) {
-            return (time() - $time) < $timeout;
-        }
-
-        return false;
-    }
-
     public static function getTabModulesList($idTab)
     {
         $modulesList = ['default_list' => [], 'slider_list' => []];
 
-        if (!self::isFresh(Module::CACHE_FILE_TAB_MODULES_LIST, 604800)) {
-            self::refresh(Module::CACHE_FILE_TAB_MODULES_LIST, _PS_TAB_MODULE_LIST_URL_);
+        if (!Tools::isFileFresh(Module::CACHE_FILE_TAB_MODULES_LIST, 604800)) {
+            Tools::refreshFile(Module::CACHE_FILE_TAB_MODULES_LIST, _PS_TAB_MODULE_LIST_URL_);
         }
 
         $xmlTabModulesList = @simplexml_load_file(_PS_ROOT_DIR_ . Module::CACHE_FILE_TAB_MODULES_LIST);

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -682,14 +682,43 @@ class TabCore extends ObjectModel
         return Db::getInstance()->getValue('SELECT class_name FROM ' . _DB_PREFIX_ . 'tab WHERE id_tab = ' . (int) $idTab);
     }
 
+    /**
+     * @param string $file_to_refresh
+     * @param string $external_file
+     *
+     * @return bool
+     */
+    private static function refresh($file_to_refresh, $external_file)
+    {
+        $content = Tools::file_get_contents($external_file);
+
+        return $content ? (bool) file_put_contents(_PS_ROOT_DIR_ . $file_to_refresh, $content) : false;
+    }
+
+    /**
+     * @param string $file
+     * @param int $timeout
+     *
+     * @return bool
+     */
+    private static function isFresh($file, $timeout = 604800)
+    {
+        if (($time = @filemtime(_PS_ROOT_DIR_ . $file)) && filesize(_PS_ROOT_DIR_ . $file) > 0) {
+            return (time() - $time) < $timeout;
+        }
+
+        return false;
+    }
+
     public static function getTabModulesList($idTab)
     {
         $modulesList = ['default_list' => [], 'slider_list' => []];
-        $xmlTabModulesList = false;
 
-        if (file_exists(_PS_ROOT_DIR_ . Module::CACHE_FILE_TAB_MODULES_LIST)) {
-            $xmlTabModulesList = @simplexml_load_file(_PS_ROOT_DIR_ . Module::CACHE_FILE_TAB_MODULES_LIST);
+        if (!self::isFresh(Module::CACHE_FILE_TAB_MODULES_LIST, 604800)) {
+            self::refresh(Module::CACHE_FILE_TAB_MODULES_LIST, _PS_TAB_MODULE_LIST_URL_);
         }
+
+        $xmlTabModulesList = @simplexml_load_file(_PS_ROOT_DIR_ . Module::CACHE_FILE_TAB_MODULES_LIST);
 
         $className = null;
         $displayType = 'default_list';

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -686,7 +686,7 @@ class TabCore extends ObjectModel
     {
         $modulesList = ['default_list' => [], 'slider_list' => []];
 
-        if (!Tools::isFileFresh(Module::CACHE_FILE_TAB_MODULES_LIST, 604800)) {
+        if (!Tools::isFileFresh(Module::CACHE_FILE_TAB_MODULES_LIST, Tools::CACHE_LIFETIME_SECONDS)) {
             Tools::refreshFile(Module::CACHE_FILE_TAB_MODULES_LIST, _PS_TAB_MODULE_LIST_URL_);
         }
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4352,6 +4352,32 @@ exit;
     {
         static::$fallbackParameters = $fallbackParameters;
     }
+
+    /**
+     * @param string $file_to_refresh
+     * @param string $external_file
+     *
+     * @return bool
+     */
+    public static function refreshFile($file_to_refresh, $external_file)
+    {
+        return (bool) static::copy($external_file, _PS_ROOT_DIR_ . $file_to_refresh);
+    }
+
+    /**
+     * @param string $file
+     * @param int $timeout
+     *
+     * @return bool
+     */
+    public static function isFileFresh($file, $timeout = 604800)
+    {
+        if (($time = @filemtime(_PS_ROOT_DIR_ . $file)) && filesize(_PS_ROOT_DIR_ . $file) > 0) {
+            return (time() - $time) < $timeout;
+        }
+
+        return false;
+    }
 }
 
 /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -40,6 +40,7 @@ class ToolsCore
 {
     const CACERT_LOCATION = 'https://curl.haxx.se/ca/cacert.pem';
     const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
+    const CACHE_LIFETIME_SECONDS = 604800;
 
     protected static $file_exists_cache = [];
     protected static $_forceCompile;
@@ -4359,7 +4360,7 @@ exit;
      *
      * @return bool
      */
-    public static function refreshFile($file_to_refresh, $external_file)
+    public static function refreshFile(string $file_to_refresh, string $external_file): bool
     {
         return (bool) static::copy($external_file, _PS_ROOT_DIR_ . $file_to_refresh);
     }
@@ -4370,7 +4371,7 @@ exit;
      *
      * @return bool
      */
-    public static function isFileFresh($file, $timeout = 604800)
+    public static function isFileFresh(string $file, int $timeout = self::CACHE_LIFETIME_SECONDS): bool
     {
         if (($time = @filemtime(_PS_ROOT_DIR_ . $file)) && filesize(_PS_ROOT_DIR_ . $file) > 0) {
             return (time() - $time) < $timeout;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -40,7 +40,7 @@ class ToolsCore
 {
     const CACERT_LOCATION = 'https://curl.haxx.se/ca/cacert.pem';
     const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
-    const CACHE_LIFETIME_SECONDS = 604800;
+    public const CACHE_LIFETIME_SECONDS = 604800;
 
     protected static $file_exists_cache = [];
     protected static $_forceCompile;

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1626,8 +1626,6 @@ class AdminControllerCore extends Controller
             $this->page_header_toolbar_title = $this->toolbar_title[count($this->toolbar_title) - 1];
         }
 
-        $this->addPageHeaderToolBarModulesListButton();
-
         $this->context->smarty->assign('help_link', 'https://help.prestashop.com/' . Language::getIsoById($this->context->employee->id_lang) . '/doc/'
             . Tools::getValue('controller') . '?version=' . _PS_VERSION_ . '&country=' . Language::getIsoById($this->context->employee->id_lang));
     }
@@ -1698,7 +1696,6 @@ class AdminControllerCore extends Controller
                     ];
                 }
         }
-        $this->addToolBarModulesListButton();
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4265,6 +4265,8 @@ class AdminControllerCore extends Controller
     }
 
     /**
+     * @deprecated Since 1.7.7 Use Tools::isFileFresh instead
+     *
      * @param string $file
      * @param int $timeout
      *
@@ -4272,17 +4274,12 @@ class AdminControllerCore extends Controller
      */
     public function isFresh($file, $timeout = 604800)
     {
-        if (($time = @filemtime(_PS_ROOT_DIR_ . $file)) && filesize(_PS_ROOT_DIR_ . $file) > 0) {
-            return (time() - $time) < $timeout;
-        }
-
-        return false;
+        return Tools::isFileFresh($file, $timeout);
     }
 
-    /** @var bool */
-    protected static $is_prestashop_up = true;
-
     /**
+     * @deprecated Since 1.7.7 Use Tools::refreshFile instead
+     *
      * @param string $file_to_refresh
      * @param string $external_file
      *
@@ -4290,12 +4287,7 @@ class AdminControllerCore extends Controller
      */
     public function refresh($file_to_refresh, $external_file)
     {
-        if (self::$is_prestashop_up && $content = Tools::file_get_contents($external_file)) {
-            return (bool) file_put_contents(_PS_ROOT_DIR_ . $file_to_refresh, $content);
-        }
-        self::$is_prestashop_up = false;
-
-        return false;
+        return Tools::refreshFile($file_to_refresh, $external_file);
     }
 
     /**

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -734,10 +734,4 @@ class AdminCarriersControllerCore extends AdminController
             return;
         }
     }
-
-    protected function initTabModuleList()
-    {
-        parent::initTabModuleList();
-        $this->filter_modules_list = $this->tab_modules_list['default_list'] = $this->tab_modules_list['slider_list'];
-    }
 }

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -170,10 +170,10 @@ class AdminModulesControllerCore extends AdminController
     public function ajaxProcessRefreshModuleList($force_reload_cache = false)
     {
         // Refresh modules_list.xml every week
-        if (!$this->isFresh(Module::CACHE_FILE_MODULES_LIST, 86400) || $force_reload_cache) {
-            if ($this->refresh(Module::CACHE_FILE_MODULES_LIST, 'https://' . $this->xml_modules_list)) {
+        if (!Tools::isFileFresh(Module::CACHE_FILE_MODULES_LIST, 86400) || $force_reload_cache) {
+            if (Tools::refreshFile(Module::CACHE_FILE_MODULES_LIST, 'https://' . $this->xml_modules_list)) {
                 $this->status = 'refresh';
-            } elseif ($this->refresh(Module::CACHE_FILE_MODULES_LIST, 'http://' . $this->xml_modules_list)) {
+            } elseif (Tools::refreshFile(Module::CACHE_FILE_MODULES_LIST, 'http://' . $this->xml_modules_list)) {
                 $this->status = 'refresh';
             } else {
                 $this->status = 'error';
@@ -184,7 +184,7 @@ class AdminModulesControllerCore extends AdminController
 
         // If logged to Addons Webservices, refresh default country native modules list every day
         if ($this->status != 'error') {
-            if (!$this->isFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 86400) || $force_reload_cache) {
+            if (!Tools::isFileFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 86400) || $force_reload_cache) {
                 if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'))) {
                     $this->status = 'refresh';
                 } else {
@@ -194,7 +194,7 @@ class AdminModulesControllerCore extends AdminController
                 $this->status = 'cache';
             }
 
-            if (!$this->isFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, 86400) || $force_reload_cache) {
+            if (!Tools::isFileFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, 86400) || $force_reload_cache) {
                 if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'))) {
                     $this->status = 'refresh';
                 } else {
@@ -207,7 +207,7 @@ class AdminModulesControllerCore extends AdminController
 
         // If logged to Addons Webservices, refresh customer modules list every 5 minutes
         if ($this->logged_on_addons && $this->status != 'error') {
-            if (!$this->isFresh(Module::CACHE_FILE_CUSTOMER_MODULES_LIST, 300) || $force_reload_cache) {
+            if (!Tools::isFileFresh(Module::CACHE_FILE_CUSTOMER_MODULES_LIST, 300) || $force_reload_cache) {
                 if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_CUSTOMER_MODULES_LIST, Tools::addonsRequest('customer'))) {
                     $this->status = 'refresh';
                 } else {

--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -39,7 +39,6 @@ abstract class AdminStatsTabControllerCore extends AdminController
             return;
         }
 
-        $this->addToolBarModulesListButton();
         $this->toolbar_title = $this->trans('Stats', [], 'Admin.Stats.Feature');
 
         if ($this->display == 'view') {

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -351,7 +351,6 @@ class AdminSuppliersControllerCore extends AdminController
     public function initToolbar()
     {
         parent::initToolbar();
-        $this->addPageHeaderToolBarModulesListButton();
 
         if (empty($this->display) && $this->can_import) {
             $this->toolbar_btn['import'] = [
@@ -363,7 +362,6 @@ class AdminSuppliersControllerCore extends AdminController
 
     public function renderView()
     {
-        $this->initTabModuleList();
         $this->toolbar_title = $this->object->name;
         $products = $this->object->getProductsLite($this->context->language->id);
         $total_product = count($products);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix method which get the list of modules that belong to a tab
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21220
| How to test?  | With Module MBO installed and activated, Go to BO > Payment > Payment methods. The list of Active payment modules must not be empty

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21232)
<!-- Reviewable:end -->
