### PR TITLE
Simplified customer preferences

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
@@ -29,9 +29,8 @@ namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller responsible of "Configure > Shop Parameters > Customer Settings" page.
@@ -41,12 +40,11 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
     /**
      * Show customer preferences page.
      *
-     * @Template("@PrestaShop/Admin/Configure/ShopParameters/customer_preferences.html.twig")
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
-     * @return array Template parameters
+     * @return Response
      */
     public function indexAction(Request $request)
     {
@@ -54,13 +52,13 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
 
         $form = $this->get('prestashop.admin.customer_preferences.form_handler')->getForm();
 
-        return [
+        return $this->render('@PrestaShop/Admin/Configure/ShopParameters/customer_preferences.html.twig', [
             'layoutTitle' => $this->trans('Customers', 'Admin.Navigation.Menu'),
             'requireAddonsSearch' => true,
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
             'generalForm' => $form->createView(),
-        ];
+        ]);
     }
 
     /**
@@ -71,7 +69,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return Response
      */
     public function processAction(Request $request)
     {
@@ -80,7 +78,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
         $form = $formHandler->getForm();
         $form->handleRequest($request);
 
-        if ($form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             if ($errors = $formHandler->save($data)) {
@@ -92,6 +90,14 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
             $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
         }
 
-        return $this->redirectToRoute('admin_customer_preferences');
+        $legacyController = $request->attributes->get('_legacy_controller');
+
+        return $this->render('@PrestaShop/Admin/Configure/ShopParameters/customer_preferences.html.twig', [
+            'layoutTitle' => $this->trans('Customers', 'Admin.Navigation.Menu'),
+            'requireAddonsSearch' => true,
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink($legacyController),
+            'generalForm' => $form->createView(),
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/CustomerPreferencesDataProvider.php
@@ -67,35 +67,6 @@ final class CustomerPreferencesDataProvider implements FormDataProviderInterface
      */
     public function setData(array $data)
     {
-        if ($errors = $this->validate($data)) {
-            return $errors;
-        }
-
         return $this->generalDataConfiguration->updateConfiguration($data);
-    }
-
-    /**
-     * Perform validations on form data.
-     *
-     * @param array $data
-     *
-     * @return array Array of errors if any
-     */
-    private function validate(array $data)
-    {
-        $errors = [];
-
-        $passwordResetDelay = $data['password_reset_delay'];
-        if (!is_numeric($passwordResetDelay) || $passwordResetDelay < 0) {
-            $fieldName = $this->translator->trans('Password reset delay', [], 'Admin.Shopparameters.Feature');
-
-            $errors[] = [
-                'key' => 'The %s field is invalid.',
-                'domain' => 'Admin.Notifications.Error',
-                'parameters' => [$fieldName],
-            ];
-        }
-
-        return $errors;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -72,13 +72,13 @@ class GeneralType extends TranslatorAwareType
                     new GreaterThanOrEqual(
                         [
                             'value' => 0,
-                            'message' => $this->trans('The field is invalid.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
                         ]
                     ),
                     new Type(
                         [
                             'value' => 'numeric',
-                            'message' => $this->trans('The field is invalid.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
                         ]
                     ),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -31,6 +31,8 @@ use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class generates "General" form
@@ -66,6 +68,20 @@ class GeneralType extends TranslatorAwareType
                     'Password reset delay',
                     'Admin.Shopparameters.Feature'
                 ),
+                'constraints' => [
+                    new GreaterThanOrEqual(
+                        [
+                            'value' => 0,
+                            'message' => $this->trans('The field is invalid.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                    new Type(
+                        [
+                            'value' => 'numeric',
+                            'message' => $this->trans('The field is invalid.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                ],
                 'help' => $this->trans(
                     'Minimum time required between two requests for a password reset.',
                     'Admin.Shopparameters.Help'

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -41,14 +41,73 @@ class GeneralType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('redisplay_cart_at_login', SwitchType::class)
-            ->add('send_email_after_registration', SwitchType::class)
+            ->add('redisplay_cart_at_login', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Re-display cart at login',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'After a customer logs in, you can recall and display the content of his/her last shopping cart.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ])
+            ->add('send_email_after_registration', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Send an email after registration',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Send an email with summary of the account information after registration.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ])
             ->add('password_reset_delay', TextWithUnitType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Password reset delay',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Minimum time required between two requests for a password reset.',
+                    'Admin.Shopparameters.Help'
+                ),
                 'unit' => $this->trans('minutes', 'Admin.Shopparameters.Feature'),
             ])
-            ->add('enable_b2b_mode', SwitchType::class)
-            ->add('ask_for_birthday', SwitchType::class)
-            ->add('enable_offers', SwitchType::class);
+            ->add('enable_b2b_mode', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Enable B2B mode',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ])
+            ->add('ask_for_birthday', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Ask for birth date',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Display or not the birth date field.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ])
+            ->add('enable_offers', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Enable partner offers',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Display or not the partner offers tick box, to receive offers from the store\'s partners.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -42,7 +42,6 @@ class GeneralType extends TranslatorAwareType
     {
         $builder
             ->add('redisplay_cart_at_login', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Re-display cart at login',
                     'Admin.Shopparameters.Feature'
@@ -53,7 +52,6 @@ class GeneralType extends TranslatorAwareType
                 ),
             ])
             ->add('send_email_after_registration', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Send an email after registration',
                     'Admin.Shopparameters.Feature'
@@ -64,7 +62,6 @@ class GeneralType extends TranslatorAwareType
                 ),
             ])
             ->add('password_reset_delay', TextWithUnitType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Password reset delay',
                     'Admin.Shopparameters.Feature'
@@ -76,7 +73,6 @@ class GeneralType extends TranslatorAwareType
                 'unit' => $this->trans('minutes', 'Admin.Shopparameters.Feature'),
             ])
             ->add('enable_b2b_mode', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Enable B2B mode',
                     'Admin.Shopparameters.Feature'
@@ -87,7 +83,6 @@ class GeneralType extends TranslatorAwareType
                 ),
             ])
             ->add('ask_for_birthday', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Ask for birth date',
                     'Admin.Shopparameters.Feature'
@@ -98,7 +93,6 @@ class GeneralType extends TranslatorAwareType
                 ),
             ])
             ->add('enable_offers', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Enable partner offers',
                     'Admin.Shopparameters.Feature'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme generalForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block customer_preferences_general %}
 <div class="col-xl-10">
@@ -34,52 +34,7 @@
         </h3>
         <div class="card-block row">
             <div class="card-text">
-                <div class="form-group row">
-                    {{ ps.label_with_help(('Re-display cart at login'|trans), ('After a customer logs in, you can recall and display the content of his/her last shopping cart.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                    <div class="col-sm">
-                      {{ form_errors(generalForm.redisplay_cart_at_login) }}
-                      {{ form_widget(generalForm.redisplay_cart_at_login) }}
-                    </div>
-                </div>
-                <div class="form-group row">
-                    {{ ps.label_with_help(('Send an email after registration'|trans), ('Send an email with summary of the account information after registration.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                    <div class="col-sm">
-                      {{ form_errors(generalForm.send_email_after_registration) }}
-                      {{ form_widget(generalForm.send_email_after_registration) }}
-                    </div>
-                </div>
-                <div class="form-group row">
-                    {{ ps.label_with_help(('Password reset delay'|trans), ('Minimum time required between two requests for a password reset.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                    <div class="col-sm">
-                      {{ form_errors(generalForm.password_reset_delay) }}
-                      {{ form_widget(generalForm.password_reset_delay) }}
-                    </div>
-                </div>
-                <div class="form-group row">
-                    {{ ps.label_with_help(('Enable B2B mode'|trans), ('Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                    <div class="col-sm">
-                      {{ form_errors(generalForm.enable_b2b_mode) }}
-                      {{ form_widget(generalForm.enable_b2b_mode) }}
-                    </div>
-                </div>
-                <div class="form-group row">
-                    {{ ps.label_with_help(('Ask for birth date'|trans), ('Display or not the birth date field.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                    <div class="col-sm">
-                      {{ form_errors(generalForm.ask_for_birthday) }}
-                      {{ form_widget(generalForm.ask_for_birthday) }}
-                    </div>
-                </div>
-                <div class="form-group row">
-                    {{ ps.label_with_help(('Enable partner offers'|trans), ('Display or not the partner offers tick box, to receive offers from the store\'s partners.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-                    <div class="col-sm">
-                      {{ form_errors(generalForm.enable_offers) }}
-                      {{ form_widget(generalForm.enable_offers) }}
-                    </div>
-                </div>
-
-                {% block customer_general_preferences_form_rest %}
-                  {{ form_rest(generalForm) }}
-                {% endblock %}
+              {{ form_widget(generalForm) }}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -82,6 +82,7 @@
       </div>
     {% endif %}
   </div>
+  {{ block('form_help') }}
 {% endblock text_with_unit_widget %}
 
 {% block ip_address_text_widget %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify customer preferences form
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Shop Parameters -> Customer settings form. Everything must look the and work the same with following exceptions: 1. blue help box replaced with help text under input. 2. Password reset delay is now required(it was always required but now is shown as such 3. Error message for password reset delay appears next to the input instead of at the top of the page. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21234)
<!-- Reviewable:end -->
