### PR TITLE
Simplified logs form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs;
 
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * This form class generates the "Logs by email" form in Logs page.
  */
-final class LogsByEmailType extends CommonAbstractType
+final class LogsByEmailType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -43,8 +43,15 @@ final class LogsByEmailType extends CommonAbstractType
     {
         $builder
             ->add('logs_by_email', TextType::class, [
-                'required' => true,
-                'label' => false,
+                'required' => false,
+                'label' => $this->trans(
+                    'Minimum severity level',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Enter "5" if you do not want to receive any emails.',
+                    'Admin.Shopparameters.Help'
+                ),
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -43,7 +43,7 @@ final class LogsByEmailType extends TranslatorAwareType
     {
         $builder
             ->add('logs_by_email', TextType::class, [
-                'required' => false,
+                'required' => true,
                 'label' => $this->trans(
                     'Minimum severity level',
                     'Admin.Shopparameters.Feature'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -291,6 +291,13 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.logs_by_email:
+        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs\LogsByEmailType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.performance.smarty:
         class: 'PrestaShopBundle\Form\Admin\AdvancedParameters\Performance\SmartyType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
@@ -24,7 +24,7 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme logsByEmailForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block content %}
   {% block logs_severity_level_meaning %}
@@ -51,18 +51,7 @@
           </h3>
           <div class="card-block row">
             <div class="card-text">
-              <div class="form-group row">
-                {% set helptip = 'Enter "5" if you do not want to receive any emails.'|trans({}, 'Admin.Advparameters.Help') ~ ' ' ~ 'Emails will be sent to the shop owner.'|trans({}, 'Admin.Advparameters.Help') %}
-                {{ ps.label_with_help(('Minimum severity level'|trans), helptip, 'col-sm-2') }}
-                <div class="col-sm">
-                  {{ form_errors(logsByEmailForm) }}
-                  {{ form_widget(logsByEmailForm) }}
-                </div>
-              </div>
-
-              {% block logs_by_email_form_rest %}
-                {{ form_rest(logsByEmailForm) }}
-              {% endblock %}
+              {{ form_widget(logsByEmailForm) }}
             </div>
           </div>
           <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify logs settings form
| Type?         | improvement
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Advanced Parameters -> Logs. Everything must look the same with one exception: blue help box replaced with help text under input.


:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType instead of using TranslatorAwareTrait. This means if any module extends LogsByEmailType file they will get an exception.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21234)
<!-- Reviewable:end -->
