### PR TITLE
Fix the french exotax percentage displayed as an example

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxOptionsType.php
@@ -132,7 +132,7 @@ class TaxOptionsType extends TranslatorAwareType
                     'Ecotax',
                     'Admin.International.Feature'),
                 'help' => $this->trans(
-                    'Define the ecotax (e.g. French ecotax: 19.6%).',
+                    'Define the ecotax (e.g. French ecotax: 20%).',
                     'Admin.International.Help'),
                 'choices' => $this->taxRuleGroupChoiceProvider->getChoices(),
             ]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Fix the french exotax percentage displayed as an example
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20597
| How to test?  | Go in the BO > International > Taxes > Taxes options, Select "use ecotax", save, see the sentence under the ecotax field: 20% should be displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21237)
<!-- Reviewable:end -->
