### PR TITLE
PHPStan (Level 3)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP tests
+name: PHP Code Style
 on: [push, pull_request]
 jobs:
   php-cs-fixer:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: composer install --prefer-dist
+      - run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
 
       - name: Run phpstan
-        run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist --error-format github
+        run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -30,13 +30,13 @@ class CMSCategoryCore extends ObjectModel
     /** @var int CMSCategory ID */
     public $id_cms_category;
 
-    /** @var string Name */
+    /** @var array<string> Name */
     public $name;
 
     /** @var bool Status for display */
     public $active = 1;
 
-    /** @var string Description */
+    /** @var array<string> Description */
     public $description;
 
     /** @var int Parent CMSCategory ID */
@@ -48,16 +48,16 @@ class CMSCategoryCore extends ObjectModel
     /** @var int Parents number */
     public $level_depth;
 
-    /** @var string string used in rewrited URL */
+    /** @var array<string> string used in rewrited URL */
     public $link_rewrite;
 
-    /** @var string Meta title */
+    /** @var array<string> Meta title */
     public $meta_title;
 
-    /** @var string Meta keywords */
+    /** @var array<string> Meta keywords */
     public $meta_keywords;
 
-    /** @var string Meta description */
+    /** @var array<string> Meta description */
     public $meta_description;
 
     /** @var string Object creation date */

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -55,32 +55,73 @@ class CartRuleCore extends ObjectModel
     public $quantity = 1;
     public $quantity_per_user = 1;
     public $priority = 1;
+    /**
+     * @var bool
+     */
     public $partial_use = 1;
     public $code;
     public $minimum_amount;
+    /**
+     * @var bool
+     */
     public $minimum_amount_tax;
     public $minimum_amount_currency;
+    /**
+     * @var bool
+     */
     public $minimum_amount_shipping;
+    /**
+     * @var bool
+     */
     public $country_restriction;
+    /**
+     * @var bool
+     */
     public $carrier_restriction;
+    /**
+     * @var bool
+     */
     public $group_restriction;
+    /**
+     * @var bool
+     */
     public $cart_rule_restriction;
+    /**
+     * @var bool
+     */
     public $product_restriction;
+    /**
+     * @var bool
+     */
     public $shop_restriction;
+    /**
+     * @var bool
+     */
     public $free_shipping;
     public $reduction_percent;
     public $reduction_amount;
-
     /**
      * @var bool is this voucher value tax included (false = tax excluded value)
      */
     public $reduction_tax;
+    /**
+     * @var int
+     */
     public $reduction_currency;
     public $reduction_product;
+    /**
+     * @var bool
+     */
     public $reduction_exclude_special;
     public $gift_product;
     public $gift_product_attribute;
+    /**
+     * @var bool
+     */
     public $highlight;
+    /**
+     * @var bool
+     */
     public $active = 1;
     public $date_add;
     public $date_upd;

--- a/classes/Contact.php
+++ b/classes/Contact.php
@@ -31,15 +31,16 @@ class ContactCore extends ObjectModel
 {
     public $id;
 
-    /** @var string Name */
+    /** @var array<string> Name */
     public $name;
 
-    /** @var string e-mail */
+    /** @var string E-mail */
     public $email;
 
-    /** @var string Detailed description */
+    /** @var array<string> Detailed description */
     public $description;
 
+    /** @var bool */
     public $customer_service;
 
     /**

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -26,6 +26,7 @@
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShopBundle\Install\Language as InstallLanguage;
 use PrestaShopBundle\Translation\TranslatorComponent as Translator;
 use PrestaShopBundle\Translation\TranslatorLanguageLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -66,7 +67,7 @@ class ContextCore
     /** @var string */
     public $override_controller_name_for_translations;
 
-    /** @var Language */
+    /** @var Language|InstallLanguage */
     public $language;
 
     /** @var Currency */
@@ -429,9 +430,9 @@ class ContextCore
         $translator->clearLanguage($locale);
 
         $adminContext = defined('_PS_ADMIN_DIR_');
-        // Do not load DB translations when $this->language is PrestashopBundle\Install\Language
+        // Do not load DB translations when $this->language is InstallLanguage
         // because it means that we're looking for the installer translations, so we're not yet connected to the DB
-        $withDB = !$this->language instanceof PrestashopBundle\Install\Language;
+        $withDB = !$this->language instanceof InstallLanguage;
         $theme = $this->shop !== null ? $this->shop->theme : null;
         (new TranslatorLanguageLoader($adminContext))->loadLanguage($translator, $locale, $withDB, $theme);
 

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -561,6 +561,10 @@ class CurrencyCore extends ObjectModel
             $id_lang = Configuration::get('PS_LANG_DEFAULT');
         }
 
+        if (!isset($this->symbol[$id_lang])) {
+            return '';
+        }
+
         return Tools::ucfirst($this->symbol[$id_lang]);
     }
 

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -478,7 +478,7 @@ class CurrencyCore extends ObjectModel
             Configuration::updateValue('PS_CURRENCY_DEFAULT', $result['id_currency']);
         }
 
-        $this->deleted = 1;
+        $this->deleted = true;
 
         // Remove currency restrictions
         $res = Db::getInstance()->delete('module_currency', 'id_currency = ' . (int) $this->id);

--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -48,7 +48,7 @@ class CustomerMessageCore extends ObjectModel
     /** @var string */
     public $user_agent;
 
-    /** @var int */
+    /** @var bool */
     public $private;
 
     /** @var string */
@@ -73,7 +73,7 @@ class CustomerMessageCore extends ObjectModel
             'message' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'required' => true, 'size' => 16777216],
             'file_name' => ['type' => self::TYPE_STRING],
             'user_agent' => ['type' => self::TYPE_STRING],
-            'private' => ['type' => self::TYPE_INT],
+            'private' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_upd' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'read' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -35,10 +35,10 @@ class EmployeeCore extends ObjectModel
     /** @var int Employee ID */
     public $id;
 
-    /** @var string Determine employee profile */
+    /** @var int Employee profile */
     public $id_profile;
 
-    /** @var string employee language */
+    /** @var int Employee language */
     public $id_lang;
 
     /** @var string Lastname */
@@ -53,7 +53,7 @@ class EmployeeCore extends ObjectModel
     /** @var string Password */
     public $passwd;
 
-    /** @var datetime Password */
+    /** @var string Password */
     public $last_passwd_gen;
 
     public $stats_date_from;
@@ -79,7 +79,7 @@ class EmployeeCore extends ObjectModel
     /** @var int employee desired screen width */
     public $bo_width;
 
-    /** @var bool, false */
+    /** @var bool */
     public $bo_menu = 1;
 
     /* Deprecated */

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -29,7 +29,7 @@
  */
 class FeatureCore extends ObjectModel
 {
-    /** @var string Name */
+    /** @var array<string> Name */
     public $name;
 
     /** @var int */

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -49,7 +49,7 @@ class HookCore extends ObjectModel
     public $position = false;
 
     /**
-     * @var active
+     * @var bool
      */
     public $active = true;
 

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -43,7 +43,7 @@ class ImageCore extends ObjectModel
     /** @var bool Image is cover */
     public $cover;
 
-    /** @var string Legend */
+    /** @var array<int,string> Legend */
     public $legend;
 
     /** @var string image extension */

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -45,6 +45,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      */
     const PACK_DOWNLOAD_TIMEOUT = 20;
 
+    /** @var int */
     public $id;
 
     /** @var string Name */
@@ -646,7 +647,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      * @param int|false $id_shop Shop ID
      * @param bool $ids_only If true, returns an array of language IDs
      *
-     * @return array<int|Language> Language information
+     * @return array<int|array> Language information
      */
     public static function getLanguages($active = true, $id_shop = false, $ids_only = false)
     {

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -34,10 +34,10 @@ class ManufacturerCore extends ObjectModel
     /** @var string Name */
     public $name;
 
-    /** @var string A description */
+    /** @var array<string> Description */
     public $description;
 
-    /** @var string A short description */
+    /** @var array<string> Short description */
     public $short_description;
 
     /** @var int Address */
@@ -52,13 +52,13 @@ class ManufacturerCore extends ObjectModel
     /** @var string Friendly URL */
     public $link_rewrite;
 
-    /** @var string Meta title */
+    /** @var array<string> Meta title */
     public $meta_title;
 
-    /** @var string Meta keywords */
+    /** @var array<string> Meta keywords */
     public $meta_keywords;
 
-    /** @var string Meta description */
+    /** @var array<string> Meta description */
     public $meta_description;
 
     /** @var bool active */

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -52,7 +52,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     const HAS_ONE = 1;
     const HAS_MANY = 2;
 
-    /** @var int Object ID */
+    /** @var int|null Object ID */
     public $id;
 
     /** @var int Language ID */
@@ -907,7 +907,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         if (!array_key_exists('deleted', get_object_vars($this))) {
             throw new PrestaShopException('Property "deleted" is missing in object model ' . get_class($this));
         }
-        $this->deleted = 1;
+        $this->deleted = true;
 
         return $this->update();
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -98,10 +98,10 @@ class ProductCore extends ObjectModel
     /** @var array|int|null Will be filled by reference by priceCalculation() */
     public $specificPrice = 0;
 
-    /** @var float Additional shipping cost */
+    /** @var string Additional shipping cost */
     public $additional_shipping_cost = 0;
 
-    /** @var float Wholesale Price in euros */
+    /** @var string Wholesale Price in euros */
     public $wholesale_price = 0;
 
     /** @var bool on_sale */
@@ -311,7 +311,7 @@ class ProductCore extends ObjectModel
     public $cache_default_attribute;
 
     /**
-     * @var string If product is populated, this property contain the rewrite link of the default category
+     * @var string|string[] If product is populated, this property contain the rewrite link of the default category
      */
     public $category;
 

--- a/classes/ProductDownload.php
+++ b/classes/ProductDownload.php
@@ -44,10 +44,10 @@ class ProductDownloadCore extends ObjectModel
     /** @var string DateExpiration deadline of the file */
     public $date_expiration;
 
-    /** @var string NbDaysAccessible how many days the customer can access to file */
+    /** @var int NbDaysAccessible how many days the customer can access to file */
     public $nb_days_accessible;
 
-    /** @var string NbDownloadable how many time the customer can download the file */
+    /** @var int NbDownloadable how many time the customer can download the file */
     public $nb_downloadable;
 
     /** @var bool Active if file is accessible or not */

--- a/classes/ProductSupplier.php
+++ b/classes/ProductSupplier.php
@@ -143,7 +143,7 @@ class ProductSupplierCore extends ObjectModel
      * @param int $idSupplier Supplier ID
      * @param bool $withCurrency Optional With currency
      *
-     * @return array
+     * @return string
      */
     public static function getProductSupplierPrice($idProduct, $idProductAttribute, $idSupplier, $withCurrency = false)
     {

--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -34,7 +34,7 @@ class ProfileCore extends ObjectModel
         'class_name',
     ];
 
-    /** @var string Name */
+    /** @var array<string> Name */
     public $name;
 
     /**

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -37,7 +37,7 @@ class SupplierCore extends ObjectModel
     /** @var string Name */
     public $name;
 
-    /** @var string A short description for the discount */
+    /** @var array<string> A short description for the discount */
     public $description;
 
     /** @var string Object creation date */
@@ -49,13 +49,13 @@ class SupplierCore extends ObjectModel
     /** @var string Friendly URL */
     public $link_rewrite;
 
-    /** @var string Meta title */
+    /** @var array<string> Meta title */
     public $meta_title;
 
-    /** @var string Meta keywords */
+    /** @var array<string> Meta keywords */
     public $meta_keywords;
 
-    /** @var string Meta description */
+    /** @var array<string> Meta description */
     public $meta_description;
 
     /** @var bool active */

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1123,7 +1123,7 @@ class AdminControllerCore extends Controller
                         $this->errors[] = $this->trans('Unable to delete associated images.', [], 'Admin.Notifications.Error');
                     }
 
-                    $object->deleted = 1;
+                    $object->deleted = true;
                     if ($res = $object->update()) {
                         $this->redirect_after = self::$currentIndex . '&conf=1&token=' . $this->token;
                     }
@@ -1255,7 +1255,7 @@ class AdminControllerCore extends Controller
                         $object_new = $object->duplicateObject();
                         if (Validate::isLoadedObject($object_new)) {
                             // Update old object to deleted
-                            $object->deleted = 1;
+                            $object->deleted = true;
                             $object->update();
 
                             // Update new object with post values
@@ -4061,7 +4061,7 @@ class AdminControllerCore extends Controller
                     $to_delete = new $this->className((int) $id);
                     $delete_ok = true;
                     if ($this->deleted) {
-                        $to_delete->deleted = 1;
+                        $to_delete->deleted = true;
                         if (!$to_delete->update()) {
                             $result = false;
                             $delete_ok = false;

--- a/classes/order/OrderMessage.php
+++ b/classes/order/OrderMessage.php
@@ -25,10 +25,10 @@
  */
 class OrderMessageCore extends ObjectModel
 {
-    /** @var string name name */
+    /** @var array<string> Name */
     public $name;
 
-    /** @var string message content */
+    /** @var array<string> Message content */
     public $message;
 
     /** @var string Object creation date */

--- a/classes/order/OrderReturnState.php
+++ b/classes/order/OrderReturnState.php
@@ -25,7 +25,7 @@
  */
 class OrderReturnStateCore extends ObjectModel
 {
-    /** @var string Name */
+    /** @var array<string> Name */
     public $name;
 
     /** @var string Display state in the specified color */

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -25,10 +25,10 @@
  */
 class OrderStateCore extends ObjectModel
 {
-    /** @var string Name */
+    /** @var array<string> Name */
     public $name;
 
-    /** @var string Template name if there is any e-mail to send */
+    /** @var array<string> Template name if there is any e-mail to send */
     public $template;
 
     /** @var bool Send an e-mail to customer ? */

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -880,7 +880,7 @@ class ShopCore extends ObjectModel
      * @param int $shop_id Shop ID
      * @param bool $as_id
      *
-     * @return int Group ID
+     * @return int|array Group ID
      */
     public static function getGroupFromShop($shop_id, $as_id = true)
     {

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -51,8 +51,15 @@ class StockAvailableCore extends ObjectModel
     /** @var bool determine if the available stock value depends on physical stock */
     public $depends_on_stock = false;
 
-    /** @var bool determine if a product is out of stock - it was previously in Product class */
-    public $out_of_stock = false;
+    /**
+     * Determine if a product is out of stock - it was previously in Product class
+     *  - O Deny orders
+     *  - 1 Allow orders
+     *  - 2 Use global setting
+     *
+     * @var int
+     */
+    public $out_of_stock = 0;
 
     /** @var string the location of the stock for this product / combination */
     public $location = '';

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -27,7 +27,7 @@ class TaxCore extends ObjectModel
 {
     const TAX_DEFAULT_PRECISION = 3;
 
-    /** @var string Name */
+    /** @var array<int,string> Name */
     public $name;
 
     /** @var float Rate (%) */

--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "johnkary/phpunit-speedtrap": "^3",
         "mikey179/vfsstream": "^1.6",
         "phake/phake": "@stable",
-        "phpstan/phpstan": "^0.12.43",
+        "phpstan/phpstan": "^0.12.48",
         "phpunit/phpunit": "~7.5.18",
         "symfony/phpunit-bridge": "^3.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "2d44a21e198dd26dbc288839f32b2d39",
@@ -9048,16 +9048,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.43",
+            "version": "0.12.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "54221b44766cb4bdfe40d1828d5bba5dd79c38c6"
+                "reference": "d364cfbac9ffd869570cdfea7eaa6541c3dac666"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/54221b44766cb4bdfe40d1828d5bba5dd79c38c6",
-                "reference": "54221b44766cb4bdfe40d1828d5bba5dd79c38c6",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d364cfbac9ffd869570cdfea7eaa6541c3dac666",
+                "reference": "d364cfbac9ffd869570cdfea7eaa6541c3dac666",
                 "shasum": ""
             },
             "require": {

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -541,7 +541,7 @@ class AdminSuppliersControllerCore extends AdminController
                 $id_address = Address::getAddressIdBySupplierId($obj->id);
                 $address = new Address($id_address);
                 if (Validate::isLoadedObject($address)) {
-                    $address->deleted = 1;
+                    $address->deleted = true;
                     $address->save();
                 }
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-	level: 2
+	level: 3
 	bootstrapFiles:
 		- .github/workflows/phpstan/autoload.php
 	paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,8 +5,9 @@ parameters:
 	paths:
 		- src
 	ignoreErrors:
-		- '#^Unsafe usage of new static\(\)\.$#'
 		- '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:#'
+		- '#^Property ContextCore::\$smarty \(Smarty\) does not accept null\.#'
+		- '#^Unsafe usage of new static\(\)\.$#'
 	universalObjectCratesClasses:
 		- Cookie
 		- ObjectModel

--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -79,7 +79,7 @@ class AddonsDataProvider implements AddonsInterface
      *
      * @throws Exception
      */
-    public function downloadModule($module_id)
+    public function downloadModule(int $module_id): bool
     {
         $params = [
             'id_module' => $module_id,
@@ -112,7 +112,7 @@ class AddonsDataProvider implements AddonsInterface
      *
      * @todo Does this function should be in a User related class ?
      */
-    public function isAddonsAuthenticated()
+    public function isAddonsAuthenticated(): bool
     {
         $request = Request::createFromGlobals();
 
@@ -222,7 +222,7 @@ class AddonsDataProvider implements AddonsInterface
      *
      * @return bool
      */
-    public function isAddonsUp()
+    public function isAddonsUp(): bool
     {
         return self::$is_addons_up;
     }

--- a/src/Adapter/Address/CommandHandler/EditCustomerAddressHandler.php
+++ b/src/Adapter/Address/CommandHandler/EditCustomerAddressHandler.php
@@ -68,7 +68,7 @@ final class EditCustomerAddressHandler extends AbstractAddressHandler implements
 
                 // We consider this address as necessarily NOT deleted, in case you were editing a deleted address
                 // from an order then the newly edited address should not be deleted, so that you can select it
-                $editedAddress->deleted = 0;
+                $editedAddress->deleted = false;
                 if (false === $editedAddress->save()) {
                     throw new CannotAddAddressException(sprintf('Failed to add new address "%s"', $command->getAddress()));
                 }

--- a/src/Adapter/Attachment/CommandHandler/AddAttachmentHandler.php
+++ b/src/Adapter/Attachment/CommandHandler/AddAttachmentHandler.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Adapter\Attachment\CommandHandler;
 
 use Attachment;
 use PrestaShop\PrestaShop\Adapter\Attachment\AbstractAttachmentHandler;
-use PrestaShop\PrestaShop\Adapter\File\Uploader\AttachmentFileUploader;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\AttachmentFileUploaderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\AddAttachmentCommand;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\CommandHandler\AddAttachmentHandlerInterface;
@@ -47,7 +46,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final class AddAttachmentHandler extends AbstractAttachmentHandler implements AddAttachmentHandlerInterface
 {
     /**
-     * @var AttachmentFileUploader
+     * @var AttachmentFileUploaderInterface
      */
     protected $fileUploader;
 

--- a/src/Adapter/Attachment/CommandHandler/EditAttachmentHandler.php
+++ b/src/Adapter/Attachment/CommandHandler/EditAttachmentHandler.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Adapter\Attachment\CommandHandler;
 
 use Attachment;
 use PrestaShop\PrestaShop\Adapter\Attachment\AbstractAttachmentHandler;
-use PrestaShop\PrestaShop\Adapter\File\Uploader\AttachmentFileUploader;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\AttachmentFileUploaderInterface;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\EditAttachmentCommand;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\CommandHandler\EditAttachmentHandlerInterface;
@@ -45,7 +44,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final class EditAttachmentHandler extends AbstractAttachmentHandler implements EditAttachmentHandlerInterface
 {
     /**
-     * @var AttachmentFileUploader
+     * @var AttachmentFileUploaderInterface
      */
     protected $fileUploader;
 

--- a/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
+++ b/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
@@ -84,7 +84,7 @@ class AdminAttributeGeneratorControllerWrapper
      * @param int $idAttribute The attribute ID
      * @param int $idProduct The product ID
      *
-     * @return array
+     * @return array|bool
      */
     public function ajaxProcessDeleteProductAttribute($idAttribute, $idProduct)
     {

--- a/src/Adapter/Attribute/AttributeDataProvider.php
+++ b/src/Adapter/Attribute/AttributeDataProvider.php
@@ -87,7 +87,7 @@ class AttributeDataProvider
      *
      * @param int $idProduct
      *
-     * @return array Combinations
+     * @return array|bool
      */
     public function getProductCombinations($idProduct)
     {

--- a/src/Adapter/Cart/CommandHandler/CreateEmptyCustomerCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/CreateEmptyCustomerCartHandler.php
@@ -68,8 +68,8 @@ final class CreateEmptyCustomerCartHandler implements CreateEmptyCustomerCartHan
     {
         $cart = new Cart();
 
-        $cart->recyclable = 0;
-        $cart->gift = 0;
+        $cart->recyclable = false;
+        $cart->gift = false;
         $cart->id_customer = $customer->id;
         $cart->secure_key = $customer->secure_key;
 

--- a/src/Adapter/Cart/CommandHandler/SetFreeShippingToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/SetFreeShippingToCartHandler.php
@@ -134,7 +134,7 @@ final class SetFreeShippingToCartHandler extends AbstractCartHandler implements 
         $freeShippingCartRule->reduction_currency = (int) $cart->id_currency;
         $freeShippingCartRule->date_from = date('Y-m-d H:i:s');
         $freeShippingCartRule->date_to = date('Y-m-d H:i:s', time() + 24 * 36000);
-        $freeShippingCartRule->active = 1;
+        $freeShippingCartRule->active = true;
         $freeShippingCartRule->add();
 
         return $freeShippingCartRule;

--- a/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
@@ -63,7 +63,7 @@ abstract class AbstractDeleteCategoryHandler
                 }
 
                 if ($mode->shouldDisableProducts()) {
-                    $product->active = 0;
+                    $product->active = false;
                 }
 
                 $product->id_category_default = $parentCategoryId;

--- a/src/Adapter/Category/QueryHandler/GetCategoryForEditingHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoryForEditingHandler.php
@@ -141,7 +141,7 @@ final class GetCategoryForEditingHandler implements GetCategoryForEditingHandler
     /**
      * @param CategoryId $categoryId
      *
-     * @return array
+     * @return array|null
      */
     private function getThumbnailImage(CategoryId $categoryId)
     {

--- a/src/Adapter/Configuration/PhpParameters.php
+++ b/src/Adapter/Configuration/PhpParameters.php
@@ -39,7 +39,7 @@ class PhpParameters
     /**
      * @var ArrayFinder the current configuration
      */
-    private $configuration = [];
+    private $configuration;
 
     /**
      * @var string the PHP filename

--- a/src/Adapter/Currency/CommandHandler/AddUnofficialCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddUnofficialCurrencyHandler.php
@@ -87,7 +87,7 @@ final class AddUnofficialCurrencyHandler extends AbstractCurrencyHandler impleme
             $entity = $this->currencyDataProvider->getCurrencyByIsoCodeOrCreate($command->getIsoCode()->getValue());
 
             $entity->unofficial = true;
-            $entity->numeric_iso_code = null;
+            $entity->numeric_iso_code = '';
             if (null !== $command->getPrecision()) {
                 $entity->precision = $command->getPrecision()->getValue();
             }

--- a/src/Adapter/Customer/CommandHandler/BulkDeleteCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/BulkDeleteCustomerHandler.php
@@ -53,7 +53,7 @@ final class BulkDeleteCustomerHandler extends AbstractCustomerHandler implements
                 continue;
             }
 
-            $customer->deleted = 1;
+            $customer->deleted = true;
             $customer->update();
         }
     }

--- a/src/Adapter/Customer/CommandHandler/DeleteCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/DeleteCustomerHandler.php
@@ -55,7 +55,7 @@ final class DeleteCustomerHandler extends AbstractCustomerHandler implements Del
 
         // soft delete customer
         // in order to forbid signing in again
-        $customer->deleted = 1;
+        $customer->deleted = true;
         $customer->update();
     }
 }

--- a/src/Adapter/CustomerService/CommandHandler/ForwardCustomerThreadHandler.php
+++ b/src/Adapter/CustomerService/CommandHandler/ForwardCustomerThreadHandler.php
@@ -131,7 +131,7 @@ final class ForwardCustomerThreadHandler implements ForwardCustomerThreadHandler
         );
 
         if ($forwardEmailSent) {
-            $customerMessage->private = 1;
+            $customerMessage->private = true;
             $customerMessage->message = sprintf(
                 '%s %s %s %s %s %s',
                 $this->translator->trans('Message forwarded to', [], 'Admin.Catalog.Feature'),
@@ -306,7 +306,7 @@ final class ForwardCustomerThreadHandler implements ForwardCustomerThreadHandler
         $customerMessage = new CustomerMessage();
         $customerMessage->id_employee = (int) $this->context->employee->id;
         $customerMessage->id_customer_thread = (int) $command->getCustomerThreadId()->getValue();
-        $customerMessage->ip_address = (int) ip2long(Tools::getRemoteAddr());
+        $customerMessage->ip_address = (string) (int) ip2long(Tools::getRemoteAddr());
 
         if (false === $customerMessage->validateField('message', $command->getComment())) {
             throw new CustomerServiceException(sprintf('Comment "%s" is not valid.', $command->getComment()));

--- a/src/Adapter/CustomerService/CommandHandler/ReplyToCustomerThreadHandler.php
+++ b/src/Adapter/CustomerService/CommandHandler/ReplyToCustomerThreadHandler.php
@@ -101,7 +101,7 @@ final class ReplyToCustomerThreadHandler implements ReplyToCustomerThreadHandler
         $customerMessage = new CustomerMessage();
         $customerMessage->id_employee = (int) $this->context->employee->id;
         $customerMessage->id_customer_thread = $customerThread->id;
-        $customerMessage->ip_address = (int) ip2long(Tools::getRemoteAddr());
+        $customerMessage->ip_address = (string) (int) ip2long(Tools::getRemoteAddr());
         $customerMessage->message = $replyMessage;
 
         if (false === $customerMessage->validateField('message', $customerMessage->message)) {

--- a/src/Adapter/Email/EmailConfigurationTester.php
+++ b/src/Adapter/Email/EmailConfigurationTester.php
@@ -63,7 +63,9 @@ final class EmailConfigurationTester implements EmailConfigurationTesterInterfac
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $config
+     *
+     * @return array<int, string>
      */
     public function testConfiguration(array $config)
     {
@@ -102,8 +104,11 @@ final class EmailConfigurationTester implements EmailConfigurationTesterInterfac
         $errors = [];
 
         if (false === $result || is_string($result)) {
-            $errors[] =
-                $this->translator->trans('Error: Please check your configuration', [], 'Admin.Advparameters.Feature');
+            $errors[] = $this->translator->trans(
+                'Error: Please check your configuration',
+                [],
+                'Admin.Advparameters.Feature'
+            );
         }
 
         if (is_string($result)) {

--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -52,7 +52,7 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
     private $renderingContent = [];
 
     /**
-     * @var bool
+     * @var bool|callable
      */
     private $propagationStoppedCalledBy = false;
 
@@ -188,7 +188,10 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
         $event = new RenderingHookEvent();
         $event->setHookParameters($parameters);
 
-        return $this->dispatch($eventName, $event);
+        /** @var RenderingHookEvent $eventDispatched */
+        $eventDispatched = $this->dispatch($eventName, $event);
+
+        return $eventDispatched;
     }
 
     /**

--- a/src/Adapter/Import/Handler/CategoryImportHandler.php
+++ b/src/Adapter/Import/Handler/CategoryImportHandler.php
@@ -284,7 +284,7 @@ final class CategoryImportHandler extends AbstractImportHandler
                 $unfriendlyError = $this->configuration->getBoolean('UNFRIENDLY_ERROR');
                 $categoryToCreate = new Category();
                 $categoryToCreate->name = $this->dataFormatter->createMultiLangField($category->parent);
-                $categoryToCreate->active = 1;
+                $categoryToCreate->active = true;
                 $linkRewrite = $this->dataFormatter->createFriendlyUrl(
                     $categoryToCreate->name[$this->languageId]
                 );

--- a/src/Adapter/Import/Handler/ProductImportHandler.php
+++ b/src/Adapter/Import/Handler/ProductImportHandler.php
@@ -338,7 +338,7 @@ final class ProductImportHandler extends AbstractImportHandler
 
         $category->id_shop_default = $this->isMultistoreEnabled ? (int) $this->currentContextShopId : 1;
         $category->name = $this->dataFormatter->createMultiLangField(trim($categoryName));
-        $category->active = 1;
+        $category->active = true;
         $category->id_parent = (int) ($parentCategoryId ? $parentCategoryId : $homeCategoryId);
         $category->link_rewrite = $this->dataFormatter->createMultiLangField(
             $this->dataFormatter->createFriendlyUrl($category->name[$defaultLanguageId])
@@ -656,7 +656,7 @@ final class ProductImportHandler extends AbstractImportHandler
                         $category = new Category();
                         $category->id = (int) $value;
                         $category->name = $this->dataFormatter->createMultiLangField($value);
-                        $category->active = 1;
+                        $category->active = true;
                         $category->id_parent = $homeCategoryId;
                         $category->link_rewrite = $this->dataFormatter->createMultiLangField(
                             $this->dataFormatter->createFriendlyUrl($category->name[$defaultLanguageId])

--- a/src/Adapter/Language/LanguageActivator.php
+++ b/src/Adapter/Language/LanguageActivator.php
@@ -60,8 +60,8 @@ final class LanguageActivator implements LanguageActivatorInterface
     {
         $lang = new Language((int) $langId);
 
-        if ((int) $lang->active !== (int) $status) {
-            $lang->active = (int) $status;
+        if ($lang->active !== $status) {
+            $lang->active = $status;
             $lang->save();
         }
     }

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -249,7 +249,7 @@ class LegacyContext
      * @param int|bool $id_shop Shop ID
      * @param bool $ids_only If true, returns an array of language IDs
      *
-     * @return array<int|Language> Languages
+     * @return array<int|array> Languages
      */
     public function getLanguages($active = true, $id_shop = false, $ids_only = false)
     {
@@ -287,7 +287,7 @@ class LegacyContext
     public function getEmployeeCurrency()
     {
         if (null === $this->employeeCurrency && $this->getContext()->currency) {
-            $this->employeeCurrency = $this->getContext()->currency->sign;
+            $this->employeeCurrency = $this->getContext()->currency;
         }
 
         return $this->employeeCurrency;

--- a/src/Adapter/Localization/LocalizationConfiguration.php
+++ b/src/Adapter/Localization/LocalizationConfiguration.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Adapter\Localization;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyManager;
-use PrestaShop\PrestaShop\Adapter\Language\LanguageActivator;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageActivatorInterface;
@@ -45,7 +44,7 @@ class LocalizationConfiguration implements DataConfigurationInterface
     private $configuration;
 
     /**
-     * @var LanguageActivator
+     * @var LanguageActivatorInterface
      */
     private $languageActivator;
 

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -53,7 +53,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     /** @var HookDispatcherInterface */
     private $hookDispatcher;
 
-    /** @var TransformationInterface[] */
+    /** @var TransformationCollection */
     private $transformations;
 
     /**

--- a/src/Adapter/Media/MediaServerConfiguration.php
+++ b/src/Adapter/Media/MediaServerConfiguration.php
@@ -85,7 +85,9 @@ class MediaServerConfiguration implements DataConfigurationInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $configuration
+     *
+     * @return array<int, array<string, array|string>>|bool
      */
     public function validateConfiguration(array $configuration)
     {

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -30,7 +30,6 @@ use Context;
 use Doctrine\Common\Cache\CacheProvider;
 use Employee;
 use Module as LegacyModule;
-use PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilterOrigin;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShopBundle\Service\DataProvider\Admin\AddonsInterface;
@@ -89,7 +88,7 @@ class AdminModuleDataProvider implements ModuleInterface
     private $router = null;
 
     /**
-     * @var AddonsDataProvider
+     * @var AddonsInterface
      */
     private $addonsDataProvider;
 

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -476,7 +476,7 @@ class Module implements ModuleInterface
      *
      * @param int $moduleId Module id
      *
-     * @return Module instance
+     * @return Module|false
      */
     public function getInstanceById($moduleId)
     {

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -101,7 +101,7 @@ class ModuleDataProvider
             $lastAccessDate = '0000-00-00 00:00:00';
 
             if (!Tools::isPHPCLI() && null !== $this->entityManager && $this->employeeID) {
-                $moduleID = (int) $result['id'];
+                $moduleID = isset($result['id']) ? (int) $result['id'] : 0;
 
                 $qb = $this->entityManager->createQueryBuilder();
                 $qb->select('mh')
@@ -291,7 +291,7 @@ class ModuleDataProvider
      *
      * @param string $name The technical module name to check
      *
-     * @return int The devices enabled for this module
+     * @return int|false The devices enabled for this module
      */
     private function getDeviceStatus($name)
     {

--- a/src/Adapter/Module/ModuleDataUpdater.php
+++ b/src/Adapter/Module/ModuleDataUpdater.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Module;
 
 use Module as LegacyModule;
-use PrestaShop\PrestaShop\Adapter\Addons\AddonsDataProvider;
 use PrestaShopBundle\Service\DataProvider\Admin\AddonsInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -38,7 +37,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class ModuleDataUpdater
 {
     /**
-     * @var AddonsDataProvider
+     * @var AddonsInterface
      */
     private $addonsDataProvider;
 
@@ -47,6 +46,10 @@ class ModuleDataUpdater
      */
     private $adminModuleDataProvider;
 
+    /**
+     * @param AddonsInterface $addonsDataProvider
+     * @param AdminModuleDataProvider $adminModuleDataProvider
+     */
     public function __construct(AddonsInterface $addonsDataProvider, AdminModuleDataProvider $adminModuleDataProvider)
     {
         $this->addonsDataProvider = $addonsDataProvider;

--- a/src/Adapter/Module/ModuleZip.php
+++ b/src/Adapter/Module/ModuleZip.php
@@ -33,12 +33,16 @@ namespace PrestaShop\PrestaShop\Adapter\Module;
 class ModuleZip
 {
     /**
-     * @var string Module technical name, guessed from the path [module name]/[module name].php
+     * Module technical name, guessed from the path [module name]/[module name].php
+     *
+     * @var string|null
      */
     private $name;
 
     /**
-     * @var string Temporary path to extract the module files before going into the modules folder
+     * Temporary path to extract the module files before going into the modules folder
+     *
+     * @var string|null
      */
     private $sandboxPath;
 

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -93,17 +93,17 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
         $cartRuleObj->id_customer = $cart->id_customer;
         $cartRuleObj->quantity = 1;
         $cartRuleObj->quantity_per_user = 1;
-        $cartRuleObj->active = 0;
-        $cartRuleObj->highlight = 0;
+        $cartRuleObj->active = false;
+        $cartRuleObj->highlight = false;
 
         if ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_PERCENT) {
             $cartRuleObj->reduction_percent = (float) (string) $command->getDiscountValue();
         } elseif ($command->getCartRuleType() === OrderDiscountType::DISCOUNT_AMOUNT) {
             $discountValueTaxIncluded = (float) (string) $command->getDiscountValue();
             $cartRuleObj->reduction_amount = $discountValueTaxIncluded;
-            $cartRuleObj->reduction_tax = 1;
+            $cartRuleObj->reduction_tax = true;
         } elseif ($command->getCartRuleType() === OrderDiscountType::FREE_SHIPPING) {
-            $cartRuleObj->free_shipping = 1;
+            $cartRuleObj->free_shipping = true;
         }
 
         try {

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -388,7 +388,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $freeShippingCartRule->minimum_amount_currency = $order->id_currency;
             $freeShippingCartRule->reduction_currency = $order->id_currency;
             $freeShippingCartRule->free_shipping = true;
-            $freeShippingCartRule->active = 1;
+            $freeShippingCartRule->active = true;
             $freeShippingCartRule->add();
 
             // Add cart rule to cart and in order

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -207,7 +207,7 @@ class OrderSlipCreator
         $orderSlip->partial = 0;
 
         if ($shipping_cost > 0) {
-            $orderSlip->shipping_cost = true;
+            $orderSlip->shipping_cost = 1;
             $carrier = new Carrier((int) $order->id_carrier);
             // @todo: define if we use invoice or delivery address, or we use configuration PS_TAX_ADDRESS_TYPE
             $address = Address::initialize($order->id_address_delivery, false);
@@ -220,7 +220,7 @@ class OrderSlipCreator
                 $orderSlip->{'total_shipping_tax_' . $inc_or_ex_2} = $orderSlip->{'total_shipping_tax_' . $inc_or_ex_1};
             }
         } else {
-            $orderSlip->shipping_cost = false;
+            $orderSlip->shipping_cost = 0;
         }
 
         $orderSlip->amount = 0;

--- a/src/Adapter/Order/Refund/VoucherGenerator.php
+++ b/src/Adapter/Order/Refund/VoucherGenerator.php
@@ -106,8 +106,8 @@ class VoucherGenerator
         $now = time();
         $cartRule->date_from = date('Y-m-d H:i:s', $now);
         $cartRule->date_to = date('Y-m-d H:i:s', strtotime('+1 year'));
-        $cartRule->partial_use = 1;
-        $cartRule->active = 1;
+        $cartRule->partial_use = true;
+        $cartRule->active = true;
 
         $cartRule->reduction_amount = $voucherAmount;
         $cartRule->reduction_tax = $isTaxIncluded;

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -428,7 +428,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
      *
      * @param string[] $coreParameters The new Core route parameters
      *
-     * @return string[] The URL parameters for Legacy URL (GETs)
+     * @return array<string, int|string> The URL parameters for Legacy URL (GETs)
      */
     public function mapLegacyParametersProductForm($coreParameters = [])
     {

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -80,7 +80,7 @@ class AdminProductDataUpdater implements ProductInterface
 
                 continue;
             }
-            $product->active = ($activate ? 1 : 0);
+            $product->active = (bool) $activate;
             $product->update();
             if (in_array($product->visibility, ['both', 'search']) && Configuration::get('PS_SEARCH_INDEXATION')) {
                 Search::indexation(false, $product->id);
@@ -195,8 +195,8 @@ class AdminProductDataUpdater implements ProductInterface
             $product->id_product
         );
 
-        $product->indexed = 0;
-        $product->active = 0;
+        $product->indexed = false;
+        $product->active = false;
 
         // change product name to prefix it
         foreach ($product->name as $langKey => $oldName) {

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -263,7 +263,7 @@ class AdminProductWrapper
      * @param array $specificPriceValues the posted values
      * @param int|null $idSpecificPrice if this is an update of an existing specific price, null else
      *
-     * @return AdminProductsController instance
+     * @return AdminProductsController|array
      */
     public function processProductSpecificPrice($id_product, $specificPriceValues, $idSpecificPrice = null)
     {
@@ -601,7 +601,7 @@ class AdminProductWrapper
      * @param object $product
      * @param array $data
      *
-     * @return bool
+     * @return array<int, int>
      */
     public function processProductCustomization($product, $data)
     {
@@ -724,7 +724,7 @@ class AdminProductWrapper
      * @param object $product
      * @param array $data
      *
-     * @return bool
+     * @return ProductDownload
      */
     public function updateDownloadProduct($product, $data)
     {
@@ -749,8 +749,8 @@ class AdminProductWrapper
             $download->date_expiration = $data['expiration_date'] ? $data['expiration_date'] . ' 23:59:59' : '';
             $download->nb_days_accessible = (int) $data['nb_days'];
             $download->nb_downloadable = (int) $data['nb_downloadable'];
-            $download->active = 1;
-            $download->is_shareable = 0;
+            $download->active = true;
+            $download->is_shareable = false;
 
             if (!$id_product_download) {
                 $download->save();
@@ -760,7 +760,7 @@ class AdminProductWrapper
         } else {
             if (!empty($id_product_download)) {
                 $download->date_expiration = date('Y-m-d H:i:s', time() - 1);
-                $download->active = 0;
+                $download->active = false;
                 $download->update();
             }
         }
@@ -873,7 +873,7 @@ class AdminProductWrapper
         $img = new Image((int) $idImage);
         if ($data['cover']) {
             Image::deleteCover((int) $img->id_product);
-            $img->cover = 1;
+            $img->cover = true;
         }
         $img->legend = $data['legend'];
         $img->update();
@@ -887,7 +887,7 @@ class AdminProductWrapper
      * @param object $product
      * @param bool $preview
      *
-     * @return string preview url
+     * @return string|bool Preview url
      */
     public function getPreviewUrl($product, $preview = true)
     {

--- a/src/Adapter/Product/CommandHandler/UpdateProductPricesHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductPricesHandler.php
@@ -124,7 +124,7 @@ final class UpdateProductPricesHandler extends AbstractProductHandler implements
         }
 
         if (null !== $command->getWholesalePrice()) {
-            $product->wholesale_price = (float) (string) $command->getWholesalePrice();
+            $product->wholesale_price = (string) $command->getWholesalePrice();
             $this->validateField($product, 'wholesale_price', ProductConstraintException::INVALID_WHOLESALE_PRICE);
             $this->fieldsToUpdate['wholesale_price'] = true;
         }

--- a/src/Adapter/Product/Update/ProductSupplierUpdater.php
+++ b/src/Adapter/Product/Update/ProductSupplierUpdater.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Adapter\Supplier\Repository\SupplierRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Exception\CannotUpdateProductSupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Exception\ProductSupplierNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\ValueObject\ProductSupplierId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
@@ -107,7 +106,7 @@ class ProductSupplierUpdater
     public function resetDefaultSupplier(Product $product): void
     {
         $product->supplier_reference = '';
-        $product->wholesale_price = 0;
+        $product->wholesale_price = '0';
         $product->id_supplier = 0;
 
         $this->productRepository->partialUpdate(
@@ -147,7 +146,7 @@ class ProductSupplierUpdater
         }
 
         $product->supplier_reference = ProductSupplier::getProductSupplierReference($productIdValue, 0, $supplierIdValue);
-        $product->wholesale_price = ProductSupplier::getProductSupplierPrice($productIdValue, 0, $supplierIdValue);
+        $product->wholesale_price = (string) ProductSupplier::getProductSupplierPrice($productIdValue, 0, $supplierIdValue);
         $product->id_supplier = $supplierIdValue;
 
         $this->productRepository->partialUpdate(
@@ -161,7 +160,7 @@ class ProductSupplierUpdater
      * @param int $productId
      * @param ProductSupplier[] $providedProductSuppliers
      *
-     * @return ProductSupplierId[]
+     * @return array<int, int>
      */
     private function getDeletableProductSupplierIds(int $productId, array $providedProductSuppliers): array
     {

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -82,7 +82,7 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     {
         $groupSettings = Shop::getGroupFromShop(Shop::getContextShopID(), false);
 
-        if ($groupSettings['share_customer']) {
+        if (!empty($groupSettings['share_customer'])) {
             return Shop::getContextListShopID(Shop::SHARE_CUSTOMER);
         } else {
             return Shop::getContextListShopID();

--- a/src/Adapter/SymfonyContainer.php
+++ b/src/Adapter/SymfonyContainer.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -35,13 +36,13 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 final class SymfonyContainer
 {
-    /** @var self */
+    /** @var ContainerInterface|null */
     private static $instance = null;
 
     /**
      * Get a singleton instance of SymfonyContainer.
      *
-     * @return \Symfony\Component\DependencyInjection\ContainerInterface;
+     * @return ContainerInterface;
      */
     public static function getInstance()
     {

--- a/src/Adapter/Tax/TaxRuleDataProvider.php
+++ b/src/Adapter/Tax/TaxRuleDataProvider.php
@@ -57,7 +57,7 @@ class TaxRuleDataProvider
      */
     public function getIdTaxRulesGroupMostUsed()
     {
-        return Product::getIdTaxRulesGroupMostUsed();
+        return (int) Product::getIdTaxRulesGroupMostUsed();
     }
 
     /**

--- a/src/Adapter/Webservice/WebserviceKeyEraser.php
+++ b/src/Adapter/Webservice/WebserviceKeyEraser.php
@@ -39,7 +39,7 @@ final class WebserviceKeyEraser
      *
      * @param int[] $webServiceKeyIds
      *
-     * @return string[] - array of errors. If array is empty then erase operation succeeded.
+     * @return array<int, array<string, array|string>> - array of errors. If array is empty then erase operation succeeded.
      *
      * @throws \PrestaShopException
      */

--- a/src/Adapter/Webservice/WebserviceKeyStatusModifier.php
+++ b/src/Adapter/Webservice/WebserviceKeyStatusModifier.php
@@ -91,7 +91,7 @@ final class WebserviceKeyStatusModifier
      * Updates status for multiple fields.
      *
      * @param array $columnIds
-     * @param int $status
+     * @param bool $status
      *
      * @return bool
      *

--- a/src/Core/Addon/AddonListFilter.php
+++ b/src/Core/Addon/AddonListFilter.php
@@ -91,7 +91,7 @@ class AddonListFilter
      */
     public function hasOrigin($origin)
     {
-        return $this->origin & $origin;
+        return (bool) ($this->origin & $origin);
     }
 
     /**
@@ -101,7 +101,7 @@ class AddonListFilter
      */
     public function hasStatus($status)
     {
-        return $this->status & $status;
+        return (bool) ($this->status & $status);
     }
 
     /**
@@ -111,7 +111,7 @@ class AddonListFilter
      */
     public function hasType($type)
     {
-        return $this->type & $type;
+        return (bool) ($this->type & $type);
     }
 
     /**

--- a/src/Core/Addon/AddonsCollection.php
+++ b/src/Core/Addon/AddonsCollection.php
@@ -215,7 +215,7 @@ class AddonsCollection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @param int|string $key
      *
-     * @return bool true if the addon has been found and removed
+     * @return bool|null true if the addon has been found and removed
      */
     public function removeByKey($key)
     {

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -253,7 +253,7 @@ class ModuleManager implements AddonManagerInterface
     /**
      * @param Module $installedProduct
      *
-     * @return array
+     * @return string|array
      */
     protected function getModuleInstallationWarnings(Module $installedProduct)
     {

--- a/src/Core/Addon/Theme/ThemeCollection.php
+++ b/src/Core/Addon/Theme/ThemeCollection.php
@@ -215,7 +215,7 @@ class ThemeCollection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @param int|string $key
      *
-     * @return bool true if the addon has been found and removed
+     * @return bool|null true if the addon has been found and removed
      */
     public function removeByKey($key)
     {

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -254,7 +254,7 @@ class ThemeManager implements AddonManagerInterface
 
         $this->saveTheme($theme);
 
-        return $this;
+        return true;
     }
 
     /**

--- a/src/Core/Backup/BackupInterface.php
+++ b/src/Core/Backup/BackupInterface.php
@@ -57,7 +57,7 @@ interface BackupInterface
     /**
      * Get backup file size in bytes.
      *
-     * @return string
+     * @return int
      */
     public function getSize();
 

--- a/src/Core/Cart/Calculator.php
+++ b/src/Core/Cart/Calculator.php
@@ -244,7 +244,7 @@ class Calculator
     }
 
     /**
-     * @param \CartCore $cart
+     * @param Cart $cart
      *
      * @return Calculator
      */

--- a/src/Core/Configuration/IniConfiguration.php
+++ b/src/Core/Configuration/IniConfiguration.php
@@ -57,7 +57,7 @@ class IniConfiguration
     /**
      * Convert a numeric value to bytes.
      *
-     * @param int $value
+     * @param string $value
      *
      * @return int
      */

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -147,7 +147,7 @@ class TypedRegexValidator extends ConstraintValidator
      * @param string $type
      * @param string $value
      *
-     * @return false|int
+     * @return bool|int
      */
     private function match($pattern, $type, $value)
     {

--- a/src/Core/Data/Layer/AbstractDataLayer.php
+++ b/src/Core/Data/Layer/AbstractDataLayer.php
@@ -28,6 +28,9 @@
 namespace PrestaShop\PrestaShop\Core\Data\Layer;
 
 use Exception;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\CurrencyDataLayerInterface as CldrCurrencyDataLayerInterface;
+use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleDataLayerInterface as CldrLocaleDataLayerInterface;
+use PrestaShop\PrestaShop\Core\Localization\Currency\CurrencyDataLayerInterface as CurrencyCurrencyDataLayerInterface;
 
 /**
  * Abstract data layer class
@@ -43,7 +46,7 @@ abstract class AbstractDataLayer
     /**
      * The lower data layer to communicate with (read/write).
      *
-     * @var AbstractDataLayer|null
+     * @var CldrCurrencyDataLayerInterface|CldrLocaleDataLayerInterface|CurrencyCurrencyDataLayerInterface|null
      */
     protected $lowerDataLayer;
 
@@ -265,12 +268,11 @@ abstract class AbstractDataLayer
      *
      * Might be a file access, cache read, DB select...
      *
-     * @param string $id The data object identifier
+     * @param mixed $id The data object identifier
      *
      * @return mixed|null The wanted data object (null if not found)
      *
-     * @throws DataLayerException
-     *                            When read fails
+     * @throws DataLayerException When read fails
      */
     abstract protected function doRead($id);
 

--- a/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
+++ b/src/Core/Domain/Attachment/Command/EditAttachmentCommand.php
@@ -64,7 +64,7 @@ class EditAttachmentCommand
     private $localizedDescriptions;
 
     /**
-     * @var string|null
+     * @var int|null
      */
     private $fileSize;
 

--- a/src/Core/Domain/Contact/QueryResult/EditableContact.php
+++ b/src/Core/Domain/Contact/QueryResult/EditableContact.php
@@ -89,7 +89,6 @@ class EditableContact
         $this->localisedTitles = $localisedTitles;
         $this->isMessagesSavingEnabled = $isMessagesSavingEnabled;
         $this->localisedDescription = $localisedDescription;
-        $this->contactId = $contactId;
         $this->shopAssociation = $shopAssociation;
         $this->email = $email ? new Email($email) : null;
     }

--- a/src/Core/Domain/Customer/QueryResult/EditableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/EditableCustomer.php
@@ -48,17 +48,17 @@ class EditableCustomer
     private $genderId;
 
     /**
-     * @var string
+     * @var FirstName
      */
     private $firstName;
 
     /**
-     * @var string
+     * @var LastName
      */
     private $lastName;
 
     /**
-     * @var string
+     * @var Email
      */
     private $email;
 

--- a/src/Core/Domain/Customer/QueryResult/GeneralInformation.php
+++ b/src/Core/Domain/Customer/QueryResult/GeneralInformation.php
@@ -37,7 +37,7 @@ class GeneralInformation
     private $privateNote;
 
     /**
-     * @var string
+     * @var bool
      */
     private $customerBySameEmailExists;
 
@@ -60,7 +60,7 @@ class GeneralInformation
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getCustomerBySameEmailExists()
     {

--- a/src/Core/Domain/Language/Command/ToggleLanguageStatusCommand.php
+++ b/src/Core/Domain/Language/Command/ToggleLanguageStatusCommand.php
@@ -40,7 +40,7 @@ class ToggleLanguageStatusCommand implements ToggleLanguageStatusCommandInterfac
     private $expectedStatus;
 
     /**
-     * @var int
+     * @var LanguageId
      */
     private $languageId;
 
@@ -59,7 +59,7 @@ class ToggleLanguageStatusCommand implements ToggleLanguageStatusCommandInterfac
     }
 
     /**
-     * @return int|LanguageId
+     * @return LanguageId
      */
     public function getLanguageId()
     {

--- a/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
+++ b/src/Core/Domain/Order/Command/AddCartRuleToOrderCommand.php
@@ -48,17 +48,17 @@ class AddCartRuleToOrderCommand
     private $cartRuleName;
 
     /**
-     * @var int
+     * @var string
      */
     private $cartRuleType;
 
     /**
-     * @var float
+     * @var DecimalNumber|null
      */
     private $value;
 
     /**
-     * @var int|null
+     * @var OrderInvoiceId|null
      */
     private $orderInvoiceId;
 

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -173,7 +173,7 @@ class OrderForViewing
     private $shopId;
 
     /**
-     * @var int
+     * @var bool
      */
     private $invoiceManagementIsEnabled;
 

--- a/src/Core/Domain/Order/QueryResult/OrderMessageForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderMessageForViewing.php
@@ -26,8 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Order\QueryResult;
 
-use DateTimeImmutable;
-
 class OrderMessageForViewing
 {
     /**
@@ -41,7 +39,7 @@ class OrderMessageForViewing
     private $message;
 
     /**
-     * @var DateTimeImmutable
+     * @var OrderMessageDateForViewing
      */
     private $messageDate;
 

--- a/src/Core/Domain/Order/ValueObject/OrderDetailRefund.php
+++ b/src/Core/Domain/Order/ValueObject/OrderDetailRefund.php
@@ -48,7 +48,7 @@ class OrderDetailRefund
     private $productQuantity;
 
     /**
-     * @var float|null
+     * @var DecimalNumber|null
      */
     private $refundedAmount;
 

--- a/src/Core/Domain/OrderReturnState/Command/EditOrderReturnStateCommand.php
+++ b/src/Core/Domain/OrderReturnState/Command/EditOrderReturnStateCommand.php
@@ -46,7 +46,7 @@ class EditOrderReturnStateCommand
     private $orderReturnStateId;
 
     /**
-     * @var Name|null
+     * @var array<string>|null
      */
     private $name;
 
@@ -72,7 +72,7 @@ class EditOrderReturnStateCommand
     }
 
     /**
-     * @return Name|null
+     * @return array<string>|null
      */
     public function getName()
     {
@@ -80,7 +80,7 @@ class EditOrderReturnStateCommand
     }
 
     /**
-     * @param string $name
+     * @param array<string> $name
      *
      * @return self
      */

--- a/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
@@ -46,7 +46,7 @@ class EditOrderStateCommand
     private $orderStateId;
 
     /**
-     * @var Name|null
+     * @var array<string>|null
      */
     private $name;
 
@@ -122,7 +122,7 @@ class EditOrderStateCommand
     }
 
     /**
-     * @return Name|null
+     * @return array<string>|null
      */
     public function getName()
     {
@@ -130,7 +130,7 @@ class EditOrderStateCommand
     }
 
     /**
-     * @param string $name
+     * @param array<string> $name
      *
      * @return self
      */

--- a/src/Core/Domain/SqlManagement/CommandHandler/AddSqlRequestHandlerInterface.php
+++ b/src/Core/Domain/SqlManagement/CommandHandler/AddSqlRequestHandlerInterface.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\SqlManagement\CommandHandler;
 
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\AddSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
 
 /**
  * Interface AddSqlRequestHandlerInterface defines contract for SqlRequest creation handler.
@@ -36,7 +37,7 @@ interface AddSqlRequestHandlerInterface
     /**
      * @param AddSqlRequestCommand $command
      *
-     * @return int Created SqlRequest id
+     * @return SqlRequestId
      */
     public function handle(AddSqlRequestCommand $command);
 }

--- a/src/Core/Domain/Tax/Command/ToggleTaxStatusCommand.php
+++ b/src/Core/Domain/Tax/Command/ToggleTaxStatusCommand.php
@@ -46,8 +46,8 @@ class ToggleTaxStatusCommand
     private $taxId;
 
     /**
-     * @param string $expectedStatus
      * @param int $taxId
+     * @param bool $expectedStatus
      *
      * @throws TaxException
      */

--- a/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
@@ -44,7 +44,7 @@ class AddWebserviceKeyCommand
     private $description;
 
     /**
-     * @var string
+     * @var bool
      */
     private $status;
 
@@ -96,7 +96,7 @@ class AddWebserviceKeyCommand
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getStatus()
     {

--- a/src/Core/Email/EmailConfigurationTesterInterface.php
+++ b/src/Core/Email/EmailConfigurationTesterInterface.php
@@ -36,7 +36,7 @@ interface EmailConfigurationTesterInterface
      *
      * @param array $config
      *
-     * @return bool
+     * @return array<int, string>
      */
     public function testConfiguration(array $config);
 }

--- a/src/Core/Form/ChoiceProvider/NonInstalledLocalizationChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/NonInstalledLocalizationChoiceProvider.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
-use PrestaShop\PrestaShop\Adapter\Language\LanguageValidator;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageValidatorInterface;
 
@@ -38,7 +37,7 @@ use PrestaShop\PrestaShop\Core\Language\LanguageValidatorInterface;
 final class NonInstalledLocalizationChoiceProvider implements FormChoiceProviderInterface
 {
     /**
-     * @var LanguageValidator
+     * @var LanguageValidatorInterface
      */
     private $languageValidator;
 

--- a/src/Core/Form/IdentifiableObject/Handler/FormHandlerFactory.php
+++ b/src/Core/Form/IdentifiableObject/Handler/FormHandlerFactory.php
@@ -46,7 +46,7 @@ final class FormHandlerFactory implements FormHandlerFactoryInterface
     private $translator;
 
     /**
-     * @var string
+     * @var bool
      */
     private $isDemoModeEnabled;
 

--- a/src/Core/Grid/Data/GridData.php
+++ b/src/Core/Grid/Data/GridData.php
@@ -34,7 +34,7 @@ use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 final class GridData implements GridDataInterface
 {
     /**
-     * @var array
+     * @var RecordCollectionInterface
      */
     private $records;
 

--- a/src/Core/Grid/Data/GridDataInterface.php
+++ b/src/Core/Grid/Data/GridDataInterface.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Data;
 
-use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 
 /**
  * Interface GridDataInterface exposes contract for final grid data.
@@ -36,7 +36,7 @@ interface GridDataInterface
     /**
      * Returns final grid rows ready for rendering.
      *
-     * @return RecordCollection
+     * @return RecordCollectionInterface
      */
     public function getRecords();
 

--- a/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CategoryGridDefinitionFactory.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\AccessibilityCheckerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Category\DeleteCategoryRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
@@ -328,7 +329,7 @@ final class CategoryGridDefinitionFactory extends AbstractFilterableGridDefiniti
     }
 
     /**
-     * @return RowActionCollection
+     * @return RowActionCollectionInterface
      */
     private function getRowActions()
     {

--- a/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/AbstractProductGridDefinitionFactory.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -177,7 +178,7 @@ abstract class AbstractProductGridDefinitionFactory extends AbstractGridDefiniti
     }
 
     /**
-     * @return RowActionCollection
+     * @return RowActionCollectionInterface
      */
     protected function getRowActions()
     {

--- a/src/Core/Grid/Definition/Factory/Monitoring/EmptyCategoryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/EmptyCategoryGridDefinitionFactory.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring;
 
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Category\DeleteCategoryRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
@@ -180,7 +181,7 @@ final class EmptyCategoryGridDefinitionFactory extends AbstractGridDefinitionFac
     }
 
     /**
-     * @return RowActionCollection
+     * @return RowActionCollectionInterface
      */
     private function getRowActions()
     {

--- a/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
@@ -463,8 +463,8 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
      */
     private function getRowActions(): RowActionCollection
     {
-        return (new RowActionCollection())
-            ->add(
+        $rowActionCollection = new RowActionCollection();
+        $rowActionCollection->add(
                 (new LinkRowAction('print_invoice'))
                     ->setName($this->trans('View invoice', [], 'Admin.Orderscustomers.Feature'))
                     ->setIcon('receipt')
@@ -501,5 +501,7 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
                     ])
             )
         ;
+
+        return $rowActionCollection;
     }
 }

--- a/src/Core/Grid/Definition/GridDefinition.php
+++ b/src/Core/Grid/Definition/GridDefinition.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
-use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Exception\InvalidDataException;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
 
@@ -50,7 +49,7 @@ final class GridDefinition implements GridDefinitionInterface
     private $name;
 
     /**
-     * @var ColumnInterface[]
+     * @var ColumnCollectionInterface
      */
     private $columns;
 

--- a/src/Core/Grid/Query/AttachmentQueryBuilder.php
+++ b/src/Core/Grid/Query/AttachmentQueryBuilder.php
@@ -41,7 +41,7 @@ final class AttachmentQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var int
+     * @var string
      */
     private $employeeIdLang;
 

--- a/src/Core/Grid/Query/DoctrineQueryParser.php
+++ b/src/Core/Grid/Query/DoctrineQueryParser.php
@@ -52,7 +52,7 @@ final class DoctrineQueryParser implements QueryParserInterface
     /**
      * @param mixed $value the parameter value
      *
-     * @return string the partial raw parameter
+     * @return string|float|int the partial raw parameter
      *
      * @throws UnsupportedParameterException
      */

--- a/src/Core/Grid/Search/SearchCriteria.php
+++ b/src/Core/Grid/Search/SearchCriteria.php
@@ -47,12 +47,12 @@ final class SearchCriteria implements SearchCriteriaInterface
     private $orderWay;
 
     /**
-     * @var string|null
+     * @var int|null
      */
     private $offset;
 
     /**
-     * @var string|null
+     * @var int|null
      */
     private $limit;
 
@@ -60,8 +60,8 @@ final class SearchCriteria implements SearchCriteriaInterface
      * @param array $filters
      * @param string|null $orderBy
      * @param string|null $orderWay
-     * @param string|null $offset
-     * @param string|null $limit
+     * @param int|null $offset
+     * @param int|null $limit
      */
     public function __construct(array $filters = [], $orderBy = null, $orderWay = null, $offset = null, $limit = null)
     {

--- a/src/Core/Image/Parser/ImageTagSourceParser.php
+++ b/src/Core/Image/Parser/ImageTagSourceParser.php
@@ -50,7 +50,7 @@ final class ImageTagSourceParser implements ImageTagSourceParserInterface
     /**
      * {@inheritdoc}
      */
-    public function parse($imageTag)
+    public function parse(string $imageTag): ?string
     {
         $replacement = 'src="/';
         $imageTag = preg_replace('/src="(\.\.\/|\.\/)+/', $replacement, $imageTag);

--- a/src/Core/Image/Parser/ImageTagSourceParserInterface.php
+++ b/src/Core/Image/Parser/ImageTagSourceParserInterface.php
@@ -34,7 +34,7 @@ interface ImageTagSourceParserInterface
     /**
      * @param string $imageTag Example '<img src="..path/to/image.jpg">'
      *
-     * @return string Parsed "src" attribute
+     * @return string|null Parsed "src" attribute
      */
-    public function parse($imageTag);
+    public function parse(string $imageTag): ?string;
 }

--- a/src/Core/Import/Entity.php
+++ b/src/Core/Import/Entity.php
@@ -60,7 +60,7 @@ final class Entity
      *
      * @param string $importType
      *
-     * @return string
+     * @return int
      */
     public static function getFromName($importType)
     {

--- a/src/Core/Language/LanguageInterface.php
+++ b/src/Core/Language/LanguageInterface.php
@@ -35,7 +35,7 @@ interface LanguageInterface
     /**
      * Database id
      *
-     * @return string
+     * @return int
      */
     public function getId();
 

--- a/src/Core/Localization/Currency.php
+++ b/src/Core/Localization/Currency.php
@@ -70,7 +70,7 @@ class Currency implements CurrencyInterface
      *
      * @see https://www.iso.org/iso-4217-currency-codes.html
      *
-     * @var string
+     * @var int
      */
     protected $numericIsoCode;
 

--- a/src/Core/Localization/Currency/CurrencyCollection.php
+++ b/src/Core/Localization/Currency/CurrencyCollection.php
@@ -31,6 +31,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use PrestaShop\PrestaShop\Core\Localization\Currency;
+use Traversable;
 
 class CurrencyCollection implements IteratorAggregate, Countable
 {
@@ -39,10 +40,7 @@ class CurrencyCollection implements IteratorAggregate, Countable
     /**
      * Gets the current CurrencyCollection as an Iterator that includes all currencies.
      *
-     * It implements \IteratorAggregate.
-     *
-     * @return Currency[] (needed for auto-completion)
-     *                    An ArrayIterator object for iterating over currencies
+     * @return iterable<Currency>|Traversable
      */
     public function getIterator()
     {

--- a/src/Core/Localization/Currency/DataLayer/CurrencyCache.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyCache.php
@@ -72,19 +72,19 @@ class CurrencyCache extends AbstractDataLayer implements CurrencyDataLayerInterf
      *
      * Might be a file access, cache read, DB select...
      *
-     * @param LocalizedCurrencyId $currencyDataId The CurrencyData object identifier (currency code + locale code)
+     * @param LocalizedCurrencyId $id The CurrencyData object identifier (currency code + locale code)
      *
      * @return CurrencyData|null The wanted CurrencyData object (null if not found)
      *
      * @throws LocalizationException When $currencyDataId is invalid
      */
-    protected function doRead($currencyDataId)
+    protected function doRead($id)
     {
-        if (!$currencyDataId instanceof LocalizedCurrencyId) {
+        if (!$id instanceof LocalizedCurrencyId) {
             throw new LocalizationException('$currencyDataId must be a CurrencyDataIdentifier object');
         }
 
-        $cacheItem = $this->cache->getItem((string) $currencyDataId);
+        $cacheItem = $this->cache->getItem((string) $id);
 
         return $cacheItem->isHit()
             ? $cacheItem->get()

--- a/src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php
+++ b/src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Core\Localization\Currency\DataLayer;
 
 use Language;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
-use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Data\Layer\AbstractDataLayer;
 use PrestaShop\PrestaShop\Core\Data\Layer\DataLayerException;
 use PrestaShop\PrestaShop\Core\Localization\Currency\CurrencyData;
@@ -57,10 +56,10 @@ class CurrencyDatabase extends AbstractDataLayer implements CurrencyDataLayerInt
     protected $isWritable = false;
 
     /**
-     * @param CurrencyDataProviderInterface $dataProvider
+     * @param CurrencyDataProvider $dataProvider
      */
     public function __construct(
-        CurrencyDataProviderInterface $dataProvider
+        CurrencyDataProvider $dataProvider
     ) {
         $this->dataProvider = $dataProvider;
     }

--- a/src/Core/Localization/Locale.php
+++ b/src/Core/Localization/Locale.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Number\Formatter as NumberFormatter;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
 use PrestaShop\PrestaShop\Core\Localization\Specification\NumberCollection as PriceSpecificationMap;
-use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
+use PrestaShop\PrestaShop\Core\Localization\Specification\NumberInterface as NumberSpecificationInterface;
 
 /**
  * Locale entity.
@@ -160,7 +160,7 @@ class Locale implements LocaleInterface
      *
      * @param string $currencyCode Currency of the price
      *
-     * @return PriceSpecification
+     * @return NumberSpecificationInterface
      */
     public function getPriceSpecification($currencyCode)
     {

--- a/src/Core/Localization/Number/Formatter.php
+++ b/src/Core/Localization/Number/Formatter.php
@@ -72,11 +72,11 @@ class Formatter
     /**
      * Create a number formatter instance.
      *
-     * @param int $roundingMode
-     *                          The wanted rounding mode when formatting numbers
-     *                          Cf. PrestaShop\Decimal\Operation\Rounding::ROUND_* values
-     * @param string $numberingSystem
-     *                                Numbering system to use when formatting numbers. @see http://cldr.unicode.org/translation/numbering-systems
+     * @param string $roundingMode The wanted rounding mode when formatting numbers
+     *                             Cf. PrestaShop\Decimal\Operation\Rounding::ROUND_* values
+     * @param string $numberingSystem Numbering system to use when formatting numbers
+     *
+     *                             @see http://cldr.unicode.org/translation/numbering-systems
      */
     public function __construct($roundingMode, $numberingSystem)
     {

--- a/src/Core/Localization/Specification/Number.php
+++ b/src/Core/Localization/Specification/Number.php
@@ -329,7 +329,7 @@ class Number implements NumberInterface
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'numberSymbols' => $this->getSymbolsByNumberingSystem()->toArray(),

--- a/src/Core/Localization/Specification/NumberInterface.php
+++ b/src/Core/Localization/Specification/NumberInterface.php
@@ -112,4 +112,11 @@ interface NumberInterface
      * @return int
      */
     public function getSecondaryGroupSize();
+
+    /**
+     * To array function.
+     *
+     * @return array
+     */
+    public function toArray(): array;
 }

--- a/src/Core/Localization/Specification/Price.php
+++ b/src/Core/Localization/Specification/Price.php
@@ -166,7 +166,7 @@ class Price extends NumberSpecification
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return array_merge(
             [

--- a/src/Core/Search/Builder/EventFiltersBuilder.php
+++ b/src/Core/Search/Builder/EventFiltersBuilder.php
@@ -58,6 +58,9 @@ final class EventFiltersBuilder extends AbstractFiltersBuilder
         $filterSearchParametersEvent = new FilterSearchCriteriaEvent($filters);
         $this->dispatcher->dispatch(FilterSearchCriteriaEvent::NAME, $filterSearchParametersEvent);
 
-        return $filterSearchParametersEvent->getSearchCriteria();
+        /** @var Filters $filters */
+        $filters = $filterSearchParametersEvent->getSearchCriteria();
+
+        return $filters;
     }
 }

--- a/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
+++ b/src/PrestaShopBundle/Command/AppendConfigurationFileHooksListCommand.php
@@ -64,7 +64,7 @@ class AppendConfigurationFileHooksListCommand extends ContainerAwareCommand
         if (!in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
             $io->warning('Dev or test environment is required to fully list all the hooks');
 
-            return;
+            return 1;
         }
 
         $hookNames = $this->getHookNames();
@@ -80,12 +80,12 @@ class AppendConfigurationFileHooksListCommand extends ContainerAwareCommand
             $io->title('Hooks added to configuration file');
             $io->note(sprintf('Total hooks added: %s', count($addedHooks)));
 
-            return;
+            return 0;
         }
 
         $io->note('No new hooks have been added to configuration file');
 
-        return;
+        return 0;
     }
 
     /**

--- a/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
+++ b/src/PrestaShopBundle/Command/AppendHooksListForSqlUpgradeFileCommand.php
@@ -73,7 +73,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
         if (!in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
             $io->warning('Dev or test environment is required to fully list all the hooks');
 
-            return;
+            return 1;
         }
 
         $hookNames = $this->getHookNames();
@@ -82,7 +82,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
         if (empty($hookNames)) {
             $io->note('No hooks found.');
 
-            return;
+            return 0;
         }
 
         $hookDescriptions = $this->getHookDescriptions($hookNames);
@@ -92,7 +92,10 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
         } catch (FileNotFoundException $exception) {
             $io->error($exception->getMessage());
 
-            return;
+            return 1;
+        }
+        if (empty($sqlUpgradeFile)) {
+            return 1;
         }
 
         $sqlInsertStatement = $this->getSqlInsertStatement($hookDescriptions);
@@ -107,7 +110,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
             )
         );
 
-        return;
+        return 0;
     }
 
     /**
@@ -162,7 +165,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
      *
      * @param string $version
      *
-     * @return SplFileInfo
+     * @return SplFileInfo|null
      */
     private function getSqlUpgradeFileByPrestaShopVersion($version)
     {
@@ -186,7 +189,7 @@ class AppendHooksListForSqlUpgradeFileCommand extends ContainerAwareCommand
             return $sqlInfo;
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/PrestaShopBundle/Command/ExportThemeCommand.php
+++ b/src/PrestaShopBundle/Command/ExportThemeCommand.php
@@ -61,6 +61,6 @@ class ExportThemeCommand extends ContainerAwareCommand
         $formattedBlock = $formatter->formatBlock($successMsg, 'info', true);
         $output->writeln($formattedBlock);
 
-        return;
+        return 0;
     }
 }

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -61,12 +61,12 @@ class LegacyLinkLinterCommand extends ContainerAwareCommand
             ));
             $io->listing($unconfiguredRoutes);
 
-            return;
+            return 1;
         }
 
         $io->success('There is no routes without _legacy_link settings');
 
-        return;
+        return 0;
     }
 
     /**

--- a/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
+++ b/src/PrestaShopBundle/Command/ListCommandsAndQueriesCommand.php
@@ -68,6 +68,6 @@ class ListCommandsAndQueriesCommand extends ContainerAwareCommand
             $output->writeln('');
         }
 
-        return;
+        return 0;
     }
 }

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -28,7 +28,10 @@ namespace PrestaShopBundle\Command;
 
 use Employee;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager;
+use PrestaShopBundle\Translation\Translator;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -48,22 +51,22 @@ class ModuleCommand extends ContainerAwareCommand
     ];
 
     /**
-     * @var \Symfony\Component\Console\Helper\FormatterHelper
+     * @var FormatterHelper
      */
     protected $formatter;
 
     /**
-     * @var \PrestaShopBundle\Translation\Translator
+     * @var Translator
      */
     protected $translator;
 
     /**
-     * @var \Symfony\Component\Console\Input\Input
+     * @var InputInterface
      */
     protected $input;
 
     /**
-     * @var \Symfony\Component\Console\Output\Output
+     * @var OutputInterface
      */
     protected $output;
 
@@ -111,7 +114,7 @@ class ModuleCommand extends ContainerAwareCommand
                 'error'
             );
 
-            return;
+            return 1;
         }
 
         if ($action === 'configure') {
@@ -120,7 +123,7 @@ class ModuleCommand extends ContainerAwareCommand
             $this->executeGenericModuleAction($action, $moduleName);
         }
 
-        return;
+        return 0;
     }
 
     protected function executeConfigureModuleAction($moduleName, $file = null)
@@ -158,7 +161,7 @@ class ModuleCommand extends ContainerAwareCommand
     protected function executeGenericModuleAction($action, $moduleName)
     {
         /**
-         * @var \PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager
+         * @var ModuleManager
          */
         $moduleManager = $this->getContainer()->get('prestashop.module.manager');
         if ($moduleManager->{$action}($moduleName)) {

--- a/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
+++ b/src/PrestaShopBundle/Command/NamingConventionLinterCommand.php
@@ -79,11 +79,11 @@ final class NamingConventionLinterCommand extends ContainerAwareCommand
             ));
             $io->table($ioTableheaders, $ioTableRows);
 
-            return 1;
+            return 0;
         }
 
         $io->success('Admin routes and controllers follow naming conventions.');
 
-        return 0;
+        return 1;
     }
 }

--- a/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
+++ b/src/PrestaShopBundle/Command/SecurityAnnotationLinterCommand.php
@@ -121,7 +121,7 @@ final class SecurityAnnotationLinterCommand extends ContainerAwareCommand
                 throw new \RuntimeException(sprintf('Unknown action %s', $actionToPerform));
         }
 
-        return;
+        return 0;
     }
 
     /**

--- a/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
+++ b/src/PrestaShopBundle/Command/ThemeEnablerCommand.php
@@ -91,6 +91,6 @@ final class ThemeEnablerCommand extends ContainerAwareCommand
 
         $io->success(sprintf('Theme "%s" enabled with success.', $theme));
 
-        return;
+        return 0;
     }
 }

--- a/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateEUTaxruleGroupsCommand.php
@@ -83,7 +83,11 @@ class UpdateEUTaxruleGroupsCommand extends ContainerAwareCommand
         $localizationPacksRoot = $this->getContainer()->getParameter('kernel.root_dir') . '/../localization';
 
         if (!$localizationPacksRoot) {
-            return $output->writeln("<error>Could not find the folder containing the localization files (should be 'localization' at the root of the PrestaShop folder)</error>");
+            $output->writeln(
+                "<error>Could not find the folder containing the localization files (should be 'localization' at the root of the PrestaShop folder)</error>"
+            );
+
+            return 1;
         }
 
         $euLocalizationFiles = [];
@@ -111,7 +115,9 @@ class UpdateEUTaxruleGroupsCommand extends ContainerAwareCommand
                             'iso_code_country' => basename($entry, '.xml'),
                         ];
                     } else {
-                        return $output->writeln("<error>Too many taxes with eu-tax-group=\"virtual\" found in `$localizationPackFile`.");
+                        $output->writeln("<error>Too many taxes with eu-tax-group=\"virtual\" found in `$localizationPackFile`.");
+
+                        return 1;
                     }
                 }
             }
@@ -181,7 +187,7 @@ class UpdateEUTaxruleGroupsCommand extends ContainerAwareCommand
 
         $output->writeln("<info>Updated the virtual tax groups for $nUpdated localization files</info>");
 
-        return;
+        return 0;
     }
 
     protected function addTax(SimpleXMLElement $taxes, SimpleXMLElement $tax, array $attributesToUpdate = [], array $attributesToRemove = [])

--- a/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateLicensesCommand.php
@@ -104,7 +104,7 @@ class UpdateLicensesCommand extends Command
             $this->findAndCheckExtension($output, $extension);
         }
 
-        return;
+        return 0;
     }
 
     /**

--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -221,6 +221,6 @@ class UpdateSchemaCommand extends ContainerAwareCommand
         $pluralization = (1 > $sqls) ? 'query was' : 'queries were';
         $output->writeln(sprintf('Database schema updated successfully! "<info>%s</info>" %s executed', $sqls, $pluralization));
 
-        return;
+        return 0;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -43,7 +43,7 @@ class SystemInformationController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return array<string, array|bool|string|null>
      */
     public function indexAction(Request $request)
     {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -250,7 +250,7 @@ class WebserviceController extends FrameworkBundleAdminController
         $webserviceToEnable = $request->request->get('webservice_key_bulk_action');
         $statusModifier = $this->get('prestashop.adapter.webservice.webservice_key_status_modifier');
 
-        $statusModifier->setStatus($webserviceToEnable, 1);
+        $statusModifier->setStatus($webserviceToEnable, true);
 
         return $this->redirectToRoute('admin_webservice_keys_index');
     }
@@ -270,7 +270,7 @@ class WebserviceController extends FrameworkBundleAdminController
         $webserviceToEnable = $request->request->get('webservice_key_bulk_action');
         $statusModifier = $this->get('prestashop.adapter.webservice.webservice_key_status_modifier');
 
-        $statusModifier->setStatus($webserviceToEnable, 0);
+        $statusModifier->setStatus($webserviceToEnable, false);
 
         return $this->redirectToRoute('admin_webservice_keys_index');
     }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -58,7 +58,7 @@ class PositionsController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @return Response
+     * @return array<string, mixed>
      */
     public function indexAction(Request $request)
     {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -812,8 +812,9 @@ class ModuleController extends ModuleAbstractController
      */
     private function getCategories(AdminModuleDataProvider $modulesProvider, array $modules)
     {
-        /** @var CategoriesProvider */
-        $categories = $this->get('prestashop.categories_provider')->getCategoriesMenu($modules);
+        /** @var CategoriesProvider $categoriesProvider */
+        $categoriesProvider = $this->get('prestashop.categories_provider');
+        $categories = $categoriesProvider->getCategoriesMenu($modules);
 
         foreach ($categories['categories']->subMenu as $category) {
             $collection = AddonsCollection::createFrom($category->modules);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -31,6 +31,7 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller responsible of "Improve > Shipping > Preferences" page.
@@ -44,7 +45,7 @@ class PreferencesController extends FrameworkBundleAdminController
      *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
-     * @return array Template parameters
+     * @return Response
      */
     public function indexAction(Request $request)
     {

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -411,7 +411,7 @@ class ProductController extends FrameworkBundleAdminController
         /** @var TaxRuleDataProvider $taxRuleDataProvider */
         $taxRuleDataProvider = $this->get('prestashop.adapter.data_provider.tax');
         $product->id_tax_rules_group = $taxRuleDataProvider->getIdTaxRulesGroupMostUsed();
-        $product->active = $productProvider->isNewProductDefaultActivated() ? 1 : 0;
+        $product->active = $productProvider->isNewProductDefaultActivated();
         $product->state = Product::STATE_TEMP;
 
         //set name and link_rewrite in each lang

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -272,6 +272,8 @@ class AddressController extends FrameworkBundleAdminController
         if (!empty($formData['id_customer'])) {
             /** @var CustomerDataProvider $customerDataProvider */
             $customerDataProvider = $this->get('prestashop.adapter.data_provider.customer');
+            /** @todo To Remove when PHPStan is fixed https://github.com/phpstan/phpstan/issues/3700 */
+            /** @phpstan-ignore-next-line */
             $customerId = $formData['id_customer'];
             $customer = $customerDataProvider->getCustomer($customerId);
             $formData['first_name'] = $customer->firstname;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1392,7 +1392,7 @@ class OrderController extends FrameworkBundleAdminController
      *
      * @param int $orderId
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function getDiscountsAction(int $orderId): Response
     {

--- a/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
@@ -120,7 +120,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
      *
      * @param int $idSpecificPrice
      *
-     * @return array
+     * @return Response|array
      */
     public function getUpdateFormAction($idSpecificPrice)
     {
@@ -264,7 +264,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     /**
      * @param string $dateAsString
      *
-     * @return JsonResponse|null If date is 0000-00-00 00:00:00, null is returned
+     * @return string|null If date is 0000-00-00 00:00:00, null is returned
      *
      * @throws \PrestaShopDatabaseExceptionCore if date is not valid
      */

--- a/src/PrestaShopBundle/Entity/ProductDownload.php
+++ b/src/PrestaShopBundle/Entity/ProductDownload.php
@@ -160,7 +160,7 @@ class ProductDownload
     /**
      * Date until the product can be downloaded.
      *
-     * @return string
+     * @return DateTime
      */
     public function getDateExpiration()
     {

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -229,7 +229,7 @@ abstract class StockManagementRepository
     /**
      * @param QueryParamsCollection $queryParams
      *
-     * @return bool|string
+     * @return int
      */
     public function countPages(QueryParamsCollection $queryParams)
     {

--- a/src/PrestaShopBundle/Entity/StockMvt.php
+++ b/src/PrestaShopBundle/Entity/StockMvt.php
@@ -114,7 +114,7 @@ class StockMvt
      *
      * @ORM\Column(name="sign", type="smallint", nullable=false, options={"default":1})
      */
-    private $sign = '1';
+    private $sign = 1;
 
     /**
      * @var string

--- a/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
+++ b/src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php
@@ -34,7 +34,6 @@ use ReflectionObject;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -74,14 +73,14 @@ class DemoModeEnabledListener
      *
      * @param RouterInterface $router
      * @param TranslatorInterface $translator
-     * @param SessionInterface $session
+     * @param Session $session
      * @param Reader $annotationReader
      * @param bool $isDemoModeEnabled
      */
     public function __construct(
         RouterInterface $router,
         TranslatorInterface $translator,
-        SessionInterface $session,
+        Session $session,
         Reader $annotationReader,
         $isDemoModeEnabled
     ) {

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosFormDataProvider.php
@@ -28,7 +28,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\Design\Theme;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Command\UploadLogosCommand;
-use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Form\DTO\ShopRestriction;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\MultiStoreSettingsFormDataProviderInterface;
@@ -71,9 +70,7 @@ final class ShopLogosFormDataProvider implements FormDataProviderInterface
     /**
      * @param array $data
      *
-     * @return void
-     *
-     * @throws ShopException
+     * @return array
      */
     public function setData(array $data)
     {
@@ -98,6 +95,8 @@ final class ShopLogosFormDataProvider implements FormDataProviderInterface
         }
 
         $this->commandBus->handle($command);
+
+        return [];
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/TranslationsSettingsFormHandler.php
@@ -48,7 +48,7 @@ final class TranslationsSettingsFormHandler implements FormHandlerInterface
     protected $hookName;
 
     /**
-     * @var array the list of Form Types
+     * @var string
      */
     protected $form;
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use Currency;
-use Language;
 use PrestaShop\PrestaShop\Adapter\Carrier\CarrierDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
@@ -57,7 +56,7 @@ class ProductShipping extends CommonAbstractType
      */
     public $legacyContext;
     /**
-     * @var array<int|Language>
+     * @var array<int|array>
      */
     public $locales;
     /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Product;
 
 use Currency;
-use Language;
 use PrestaShop\PrestaShop\Adapter\Country\CountryDataProvider;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerDataProvider;
 use PrestaShop\PrestaShop\Adapter\Group\GroupDataProvider;
@@ -52,7 +51,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ProductSpecificPrice extends CommonAbstractType
 {
     /**
-     * @var Context
+     * @var LegacyContext
      */
     public $context;
     /**
@@ -76,7 +75,7 @@ class ProductSpecificPrice extends CommonAbstractType
      */
     private $groups;
     /**
-     * @var array<int|Language>
+     * @var array<int|array>
      */
     public $locales;
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -63,7 +63,7 @@ class TranslatableType extends AbstractType
     private $saveFormLocaleChoice;
 
     /**
-     * @var string default form language ID
+     * @var int default form language ID
      */
     private $defaultFormLanguageId;
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -841,8 +841,8 @@ class Install extends AbstractInstall
             $employee->default_tab = 1;
             $employee->active = true;
             $employee->id_profile = 1;
-            $employee->id_lang = Configuration::get('PS_LANG_DEFAULT');
-            $employee->bo_menu = 1;
+            $employee->id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
+            $employee->bo_menu = true;
             if (!$employee->add()) {
                 $this->setError($this->translator->trans('Cannot create admin account', [], 'Install'));
 

--- a/src/PrestaShopBundle/Install/SqlLoader.php
+++ b/src/PrestaShopBundle/Install/SqlLoader.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Install;
 
-use PrestaShop\PrestaShop\Adapter\Entity\Db;
+use Db;
 use PrestashopInstallerException;
 
 class SqlLoader
@@ -47,7 +47,7 @@ class SqlLoader
     protected $errors = [];
 
     /**
-     * @param Db $db
+     * @param Db|null $db
      */
     public function __construct(Db $db = null)
     {

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -407,7 +407,7 @@ class XmlLoader
      * @param string $entity Name of the entity to load (eg. 'tab')
      * @param string|null $iso Language in which to load said entity. If not found, will fall back to default language.
      *
-     * @return \SimpleXMLElement
+     * @return \SimpleXMLElement|void
      */
     protected function loadEntity($entity, $iso = null)
     {

--- a/src/PrestaShopBundle/Kernel/ModuleRepositoryFactory.php
+++ b/src/PrestaShopBundle/Kernel/ModuleRepositoryFactory.php
@@ -45,7 +45,7 @@ class ModuleRepositoryFactory
     private static $instance;
 
     /**
-     * @var string
+     * @var array|null
      */
     private $parameters;
 

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -56,7 +56,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
     private $contextShop;
     /** @var AdminProductWrapper */
     private $adminProductWrapper;
-    /** @var array */
+    /** @var array<int|array> */
     private $locales;
     /** @var string */
     private $defaultLocale;

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
@@ -29,13 +29,13 @@
     <td class="attribute-price">
         <div class="input-group">
             <div class="input-group-prepend">
-                <span class="input-group-text">{{ default_currency }}</span>
+                <span class="input-group-text">{{ default_currency_symbol }}</span>
             </div>
             <input type="text" class="attribute_priceTE form-control text-sm-right" value="{{ form.vars.value.attribute_price }}">
         </div>
     </td>
     <td class="attribute-finalprice text-sm-right">
-      <span data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}
+      <span data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency_symbol }}
     </td>
     {% if 'PS_STOCK_MANAGEMENT'|configuration %}
       <td class="attribute-quantity">
@@ -161,7 +161,7 @@
                         </fieldset>
                     </div>
                     <div class="col-md-3">
-                      <small class="form-control-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'Admin.Catalog.Feature') }} <span class="final-price" data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency }}</small>
+                      <small class="form-control-label vcenter">{{ "Final retail price (tax excl.) will be"|trans({}, 'Admin.Catalog.Feature') }} <span class="final-price" data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency_symbol }}</small>
                     </div>
                 </div>
                 <div class="row">

--- a/src/PrestaShopBundle/Security/Role/DynamicRoleHierarchy.php
+++ b/src/PrestaShopBundle/Security/Role/DynamicRoleHierarchy.php
@@ -37,9 +37,10 @@ class DynamicRoleHierarchy implements RoleHierarchyInterface
     /**
      * @param array<RoleInterface> $roles An array of directly assigned roles
      *
-     * @return void
+     * @return RoleInterface[] An array of all reachable roles
      */
     public function getReachableRoles(array $roles)
     {
+        return [];
     }
 }

--- a/src/PrestaShopBundle/Service/DataProvider/Admin/AddonsInterface.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/AddonsInterface.php
@@ -34,6 +34,25 @@ namespace PrestaShopBundle\Service\DataProvider\Admin;
 interface AddonsInterface
 {
     /**
+     * @param int $module_id
+     *
+     * @return bool
+     */
+    public function downloadModule(int $module_id): bool;
+
+    /**
+     * @return bool
+     */
+    public function isAddonsAuthenticated(): bool;
+
+    /**
+     * Check if a request has already failed.
+     *
+     * @return bool
+     */
+    public function isAddonsUp(): bool;
+
+    /**
      * Send a request to addons.prestashop.com to retrieve Modules/Addons data.
      *
      * @param string $action the query type

--- a/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Admin/CategoriesProvider.php
@@ -52,7 +52,7 @@ class CategoriesProvider
     private $categories;
 
     /**
-     * @var array
+     * @var object
      */
     private $categoriesFromSource;
 
@@ -96,9 +96,9 @@ class CategoriesProvider
      * Initialize categories from API or if this one is empty,
      * use theme and my modules categories.
      *
-     * @param array|stdClass $categoriesListing Category listing
+     * @param object $categoriesListing Category listing
      *
-     * @return array
+     * @return array<string, stdClass>
      */
     private function initializeCategories($categoriesListing)
     {
@@ -220,9 +220,7 @@ class CategoriesProvider
         );
 
         // Convert array to object to be consistent with current API call
-        $categories = json_decode(json_encode($categories));
-
-        return $categories;
+        return json_decode(json_encode($categories));
     }
 
     /**

--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -235,7 +235,7 @@ class ApiClient
             return $responseDecoded->themes;
         }
 
-        return [];
+        return new \stdClass();
     }
 
     public function getResponse()

--- a/src/PrestaShopBundle/Service/Hook/HookFinder.php
+++ b/src/PrestaShopBundle/Service/Hook/HookFinder.php
@@ -39,7 +39,7 @@ class HookFinder
      * instance of specific classes.
      * Please note it must implement the function toArray().
      *
-     * @var string
+     * @var array<int, string>
      */
     protected $expectedInstanceClasses = [];
 

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -209,6 +209,9 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
         $databaseCatalogue = new MessageCatalogue($this->locale);
 
         foreach ($this->getTranslationDomains() as $translationDomain) {
+            if (!($this->getDatabaseLoader() instanceof DatabaseTranslationLoader)) {
+                continue;
+            }
             $domainCatalogue = $this->getDatabaseLoader()->load(null, $this->locale, $translationDomain, $theme);
 
             if ($domainCatalogue instanceof MessageCatalogue) {
@@ -228,7 +231,7 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     }
 
     /**
-     * @return DatabaseTranslationLoader The database loader
+     * @return LoaderInterface
      */
     public function getDatabaseLoader()
     {

--- a/src/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProvider.php
@@ -43,22 +43,22 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 class ExternalModuleLegacySystemProvider extends AbstractProvider implements UseDefaultCatalogueInterface, SearchProviderInterface, UseModuleInterface
 {
     /**
-     * @var ModuleProvider the module provider
+     * @var ModuleProvider Module provider
      */
     private $moduleProvider;
 
     /**
-     * @var LoaderInterface the translation loader from legacy files
+     * @var LoaderInterface Translation loader from legacy files
      */
     private $legacyFileLoader;
 
     /**
-     * @var LegacyModuleExtractorInterface the extractor
+     * @var LegacyModuleExtractorInterface Extractor
      */
     private $legacyModuleExtractor;
 
     /**
-     * @var string the module name
+     * @var string Module name
      */
     private $moduleName;
 
@@ -72,7 +72,7 @@ class ExternalModuleLegacySystemProvider extends AbstractProvider implements Use
         $resourceDirectory,
         LoaderInterface $legacyFileLoader,
         LegacyModuleExtractorInterface $legacyModuleExtractor,
-        SearchProviderInterface $moduleProvider
+        ModuleProvider $moduleProvider
     ) {
         $this->moduleProvider = $moduleProvider;
         $this->legacyFileLoader = $legacyFileLoader;

--- a/src/PrestaShopBundle/Translation/Provider/ProviderInterface.php
+++ b/src/PrestaShopBundle/Translation/Provider/ProviderInterface.php
@@ -28,6 +28,7 @@
 namespace PrestaShopBundle\Translation\Provider;
 
 use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 
 /**
  * Define contract to retrieve translations.
@@ -59,7 +60,7 @@ interface ProviderInterface
     public function getLocale();
 
     /**
-     * @return MessageCatalogue A provider must return a MessageCatalogue
+     * @return MessageCatalogueInterface A provider must return a MessageCatalogue
      */
     public function getMessageCatalogue();
 

--- a/src/PrestaShopBundle/Translation/Provider/SearchProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/SearchProvider.php
@@ -120,7 +120,9 @@ class SearchProvider extends AbstractProvider implements UseDefaultCatalogueInte
     }
 
     /**
-     * {@inheritdoc}
+     * @return MessageCatalogue|MessageCatalogueInterface
+     *
+     * @throws FileNotFoundException
      */
     public function getXliffCatalogue()
     {

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Twig;
 
+use Currency;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
@@ -97,6 +98,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
         return [
             'theme' => $this->context->getContext()->shop->theme,
             'default_currency' => $defaultCurrency,
+            'default_currency_symbol' => $defaultCurrency instanceof Currency ? $defaultCurrency->getSymbol() : null,
             'root_url' => $rootUrl,
             'js_translatable' => [],
         ];

--- a/src/PrestaShopBundle/Twig/TranslationsExtension.php
+++ b/src/PrestaShopBundle/Twig/TranslationsExtension.php
@@ -27,18 +27,22 @@
 namespace PrestaShopBundle\Twig;
 
 use Doctrine\Common\Util\Inflector;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Twig_Extension;
+use Twig_SimpleFunction;
 
-class TranslationsExtension extends \Twig_Extension
+class TranslationsExtension extends Twig_Extension
 {
     /**
-     * @var \Symfony\Component\Translation\TranslatorInterface
+     * @var TranslatorInterface
      */
     public $translator;
 
     /**
-     * @var \Psr\Log\LoggerInterface
+     * @var LoggerInterface
      */
     public $logger;
 
@@ -71,8 +75,8 @@ class TranslationsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('getTranslationsTree', [$this, 'getTranslationsTree']),
-            new \Twig_SimpleFunction('getTranslationsForms', [$this, 'getTranslationsForms']),
+            new Twig_SimpleFunction('getTranslationsTree', [$this, 'getTranslationsTree']),
+            new Twig_SimpleFunction('getTranslationsForms', [$this, 'getTranslationsForms']),
         ];
     }
 
@@ -80,7 +84,7 @@ class TranslationsExtension extends \Twig_Extension
      * Returns concatenated edit translation forms.
      *
      * @param array $translationsTree
-     * @param null $themeName
+     * @param string|null $themeName
      *
      * @return string
      */
@@ -132,7 +136,7 @@ class TranslationsExtension extends \Twig_Extension
      * Returns a tree of translations key values.
      *
      * @param array $translationsTree
-     * @param null $themeName
+     * @param string|null $themeName
      *
      * @return string
      */

--- a/tests/Integration/Behaviour/Features/Context/CLDRFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CLDRFeatureContext.php
@@ -76,7 +76,7 @@ class CLDRFeatureContext extends AbstractPrestaShopFeatureContext
             $currency->name = $isoCode;
             $currency->iso_code = $isoCode;
             $currency->active = 1;
-            $currency->deleted = 0;
+            $currency->deleted = false;
             $currency->conversion_rate = 1;
             $currency->precision = 2;
             $currency->unofficial = $unofficial;

--- a/tests/Integration/Behaviour/Features/Context/Domain/TaxFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TaxFeatureContext.php
@@ -268,7 +268,7 @@ class TaxFeatureContext extends AbstractDomainFeatureContext
         $taxRulesGroup = new TaxRulesGroup();
         $taxRulesGroup->name = $data['name'];
         $taxRulesGroup->active = 1;
-        $taxRulesGroup->deleted = 0;
+        $taxRulesGroup->deleted = false;
         $taxRulesGroup->save();
         SharedStorage::getStorage()->set($data['name'], $taxRulesGroup->id);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PHPStan (Level 3)
| Type?         | improvement
| Category?     | TE
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #16471
| How to test?  | PHPStan is 💚  & Travis CI is 💚 & Exploratory Tests :green_heart: & UI Test :green_heart: 

:notebook: **BC Breaks :**
**Added**
* `src/Core/Localization/Specification/NumberInterface.php` : Added 1 method :
  * `public function toArray(): array`
* `src/PrestaShopBundle/Service/DataProvider/Admin/AddonsInterface.php`: Added 3 methods : 
  * `public function downloadModule(int $module_id): bool;`
  * `public function isAddonsAuthenticated(): bool;`
  * `public function isAddonsUp(): bool;`

**Modified**
* `src/Core/Localization/Currency/DataLayer/CurrencyDatabase.php` : The parameter $dataProvider is now a PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider, and was a PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface object, because we need some method not defined in interface.
* `src/PrestaShopBundle/EventListener/DemoModeEnabledListener.php` : The parameter $session is now a Symfony\Component\HttpFoundation\Session\Session, and was a Symfony\Component\HttpFoundation\Session\SessionInterface object, because we need some method not defined in interface.
* `src/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProvider.php` : The parameter $moduleProvider is now a PrestaShopBundle\Translation\Provider\ModuleProvider, and was a PrestaShopBundle\Translation\Provider\SearchProviderInterface object, because we need some method not defined in interface.
* `src/Core/Image/Parser/ImageTagSourceParserInterface.php` : Changed the signature for `parse`method :
  * `public function parse(string $imageTag): ?string;`

**Changed**
* In `src/PrestaShopBundle/Twig/LayoutExtension.php`, global variables are sent in Twig : 
  * **BEFORE** : `default_currency` returns the symbol
  * **AFTER** : `default_currency` returns the currency, the symbol is available in `default_currency_symbol`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21241)
<!-- Reviewable:end -->
