### PR TITLE
Simplified carrier preferences

### DIFF
--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -106,7 +106,6 @@ class AdminLegacyLayoutControllerCore extends AdminController
      */
     public function initProcess()
     {
-
     }
 
     /**

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -101,6 +101,15 @@ class AdminLegacyLayoutControllerCore extends AdminController
     }
 
     /**
+     * This helps avoiding handling legacy processes when in Symfony Controllers.
+     * Otherwise when using POST action to render form you sometimes get an exception.
+     */
+    public function initProcess()
+    {
+
+    }
+
+    /**
      * @param bool $isNewTheme
      */
     public function setMedia($isNewTheme = false)

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Shipping;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -83,6 +82,7 @@ class PreferencesController extends FrameworkBundleAdminController
 
             if (0 === count($saveErrors)) {
                 $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
                 return $this->redirectToRoute('admin_shipping_preferences');
             }
             $this->flashErrors($saveErrors);
@@ -119,6 +119,7 @@ class PreferencesController extends FrameworkBundleAdminController
 
             if (0 === count($saveErrors)) {
                 $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
                 return $this->redirectToRoute('admin_shipping_preferences');
             }
         }
@@ -146,6 +147,7 @@ class PreferencesController extends FrameworkBundleAdminController
      * @param $handlingForm
      * @param $carrierOptionsForm
      * @param $request
+     *
      * @return Response|null
      */
     protected function renderForm($handlingForm, $carrierOptionsForm, $request)

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -144,9 +144,9 @@ class PreferencesController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param $handlingForm
-     * @param $carrierOptionsForm
-     * @param $request
+     * @param Form $handlingForm
+     * @param Form $carrierOptionsForm
+     * @param Request $request
      *
      * @return Response|null
      */

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Shipping;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -80,14 +80,44 @@ class CarrierOptionsType extends TranslatorAwareType
         $builder
             ->add('default_carrier', ChoiceType::class, [
                 'choices' => $carrierChoices,
+                'required' => false,
+                'placeholder' => false,
+                'label' => $this->trans(
+                    'Default carrier',
+                    'Admin.Shipping.Feature'
+                ),
+                'help' => $this->trans(
+                    'Your shop\'s default carrier.',
+                    'Admin.Shipping.Help'
+                ),
             ])
             ->add('carrier_default_order_by', ChoiceType::class, [
                 'choices' => $this->orderByChoices,
+                'required' => false,
+                'placeholder' => false,
                 'choice_translation_domain' => 'Admin.Global',
+                'label' => $this->trans(
+                    'Sort by',
+                    'Admin.Actions'
+                ),
+                'help' => $this->trans(
+                    'This will only be visible in the front office.',
+                    'Admin.Shipping.Help'
+                ),
             ])
             ->add('carrier_default_order_way', ChoiceType::class, [
                 'choices' => $this->orderWayChoices,
+                'required' => false,
+                'placeholder' => false,
                 'choice_translation_domain' => 'Admin.Global',
+                'label' => $this->trans(
+                    'Order by',
+                    'Admin.Actions'
+                ),
+                'help' => $this->trans(
+                    'This will only be visible in the front office.',
+                    'Admin.Shipping.Help'
+                ),
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -80,8 +80,6 @@ class CarrierOptionsType extends TranslatorAwareType
         $builder
             ->add('default_carrier', ChoiceType::class, [
                 'choices' => $carrierChoices,
-                'required' => false,
-                'placeholder' => false,
                 'label' => $this->trans(
                     'Default carrier',
                     'Admin.Shipping.Feature'
@@ -93,8 +91,6 @@ class CarrierOptionsType extends TranslatorAwareType
             ])
             ->add('carrier_default_order_by', ChoiceType::class, [
                 'choices' => $this->orderByChoices,
-                'required' => false,
-                'placeholder' => false,
                 'choice_translation_domain' => 'Admin.Global',
                 'label' => $this->trans(
                     'Sort by',
@@ -107,8 +103,6 @@ class CarrierOptionsType extends TranslatorAwareType
             ])
             ->add('carrier_default_order_way', ChoiceType::class, [
                 'choices' => $this->orderWayChoices,
-                'required' => false,
-                'placeholder' => false,
                 'choice_translation_domain' => 'Admin.Global',
                 'label' => $this->trans(
                     'Order by',

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -35,6 +35,9 @@ use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class generates "Handling" form
@@ -71,6 +74,10 @@ class HandlingType extends TranslatorAwareType
                 'suffix' => $this->trans('(tax excl.)', 'Admin.Global'),
                 'required' => false,
                 'empty_data' => '0',
+                'constraints' => [
+                    new GreaterThanOrEqual(['value' => '0',]),
+                    new Type(['type' => 'numeric'])
+                ],
                 'label' => $this->trans(
                     'Handling charges',
                     'Admin.Shipping.Feature'
@@ -80,6 +87,10 @@ class HandlingType extends TranslatorAwareType
                 'currency' => $defaultCurrency->iso_code,
                 'required' => false,
                 'empty_data' => '0',
+                'constraints' => [
+                    new GreaterThanOrEqual(['value' => '0',]),
+                    new Type(['type' => 'numeric'])
+                ],
                 'label' => $this->trans(
                     'Free shipping starts at',
                     'Admin.Shipping.Feature'
@@ -93,6 +104,10 @@ class HandlingType extends TranslatorAwareType
                     'Free shipping starts at',
                     'Admin.Shipping.Feature'
                 ),
+                'constraints' => [
+                    new GreaterThanOrEqual(['value' => '0',]),
+                    new Type(['type' => 'numeric'])
+                ]
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -35,7 +35,6 @@ use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -75,8 +74,8 @@ class HandlingType extends TranslatorAwareType
                 'required' => false,
                 'empty_data' => '0',
                 'constraints' => [
-                    new GreaterThanOrEqual(['value' => '0',]),
-                    new Type(['type' => 'numeric'])
+                    new GreaterThanOrEqual(['value' => '0']),
+                    new Type(['type' => 'numeric']),
                 ],
                 'label' => $this->trans(
                     'Handling charges',
@@ -88,8 +87,8 @@ class HandlingType extends TranslatorAwareType
                 'required' => false,
                 'empty_data' => '0',
                 'constraints' => [
-                    new GreaterThanOrEqual(['value' => '0',]),
-                    new Type(['type' => 'numeric'])
+                    new GreaterThanOrEqual(['value' => '0']),
+                    new Type(['type' => 'numeric']),
                 ],
                 'label' => $this->trans(
                     'Free shipping starts at',
@@ -105,9 +104,9 @@ class HandlingType extends TranslatorAwareType
                     'Admin.Shipping.Feature'
                 ),
                 'constraints' => [
-                    new GreaterThanOrEqual(['value' => '0',]),
-                    new Type(['type' => 'numeric'])
-                ]
+                    new GreaterThanOrEqual(['value' => '0']),
+                    new Type(['type' => 'numeric']),
+                ],
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -87,7 +87,7 @@ class HandlingType extends TranslatorAwareType
                 'required' => false,
                 'empty_data' => '0',
                 'constraints' => [
-                    new GreaterThanOrEqual(['value' => '0']),
+                    new GreaterThanOrEqual(['value' => 0]),
                     new Type(['type' => 'numeric']),
                 ],
                 'label' => $this->trans(
@@ -104,7 +104,7 @@ class HandlingType extends TranslatorAwareType
                     'Admin.Shipping.Feature'
                 ),
                 'constraints' => [
-                    new GreaterThanOrEqual(['value' => '0']),
+                    new GreaterThanOrEqual(['value' => 0]),
                     new Type(['type' => 'numeric']),
                 ],
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -71,16 +71,28 @@ class HandlingType extends TranslatorAwareType
                 'suffix' => $this->trans('(tax excl.)', 'Admin.Global'),
                 'required' => false,
                 'empty_data' => '0',
+                'label' => $this->trans(
+                    'Handling charges',
+                    'Admin.Shipping.Feature'
+                ),
             ])
             ->add('free_shipping_price', MoneyType::class, [
                 'currency' => $defaultCurrency->iso_code,
                 'required' => false,
                 'empty_data' => '0',
+                'label' => $this->trans(
+                    'Free shipping starts at',
+                    'Admin.Shipping.Feature'
+                ),
             ])
             ->add('free_shipping_weight', TextWithUnitType::class, [
                 'unit' => $weightUnit,
                 'required' => false,
                 'empty_data' => '0',
+                'label' => $this->trans(
+                    'Free shipping starts at',
+                    'Admin.Shipping.Feature'
+                ),
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/PreferencesHandlingFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/PreferencesHandlingFormDataProvider.php
@@ -68,49 +68,6 @@ class PreferencesHandlingFormDataProvider implements FormDataProviderInterface
      */
     public function setData(array $data)
     {
-        if ($errors = $this->validate($data)) {
-            return $errors;
-        }
-
         return $this->dataConfiguration->updateConfiguration($data);
-    }
-
-    /**
-     * Perform validation on form data before saving it.
-     *
-     * @param array $data
-     *
-     * @return array Returns array of errors
-     */
-    protected function validate(array $data)
-    {
-        $errors = [];
-        $numericFields = [
-            [
-                'value' => $data['shipping_handling_charges'],
-                'name' => $this->translator->trans('Handling charges', [], 'Admin.Shipping.Feature'),
-            ],
-            [
-                'value' => $data['free_shipping_price'],
-                'name' => $this->translator->trans('Free shipping starts at', [], 'Admin.Shipping.Feature'),
-            ],
-            [
-                'value' => $data['free_shipping_weight'],
-                'name' => $this->translator->trans('Free shipping starts at', [], 'Admin.Shipping.Feature'),
-            ],
-        ];
-
-        // Check if all numeric fields are positive numbers
-        foreach ($numericFields as $field) {
-            if (!is_numeric($field['value']) || $field['value'] < 0) {
-                $errors[] = [
-                    'key' => 'The %s field is invalid.',
-                    'domain' => 'Admin.Notifications.Error',
-                    'parameters' => [$field['name']],
-                ];
-            }
-        }
-
-        return $errors;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shipping.Feature" %}
+{% form_theme carrierOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block shipping_preferences_carrier_options %}
   <div class="col-xl-10">
@@ -33,30 +34,7 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="form-group row">
-            <label class="form-control-label">{{ 'Default carrier'|trans }}</label>
-            <div class="col-sm">
-              {{ form_errors(carrierOptionsForm.default_carrier) }}
-              {{ form_widget(carrierOptionsForm.default_carrier) }}
-              <small class="form-text">{{ 'Your shop\'s default carrier'|trans({}, 'Admin.Shipping.Help') }}</small>
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">{{ 'Sort by'|trans({}, 'Admin.Actions') }}</label>
-            <div class="col-sm">
-              {{ form_errors(carrierOptionsForm.carrier_default_order_by) }}
-              {{ form_widget(carrierOptionsForm.carrier_default_order_by) }}
-              <small class="form-text">{{ 'This will only be visible in the front office.'|trans({}, 'Admin.Shipping.Help') }}</small>
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">{{ 'Order by'|trans({}, 'Admin.Actions') }}</label>
-            <div class="col-sm">
-              {{ form_errors(carrierOptionsForm.carrier_default_order_way) }}
-              {{ form_widget(carrierOptionsForm.carrier_default_order_way) }}
-              <small class="form-text">{{ 'This will only be visible in the front office.'|trans({}, 'Admin.Shipping.Help') }}</small>
-            </div>
-          </div>
+          {{ form_widget(carrierOptionsForm) }}
         </div>
       </div>
       <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shipping.Feature" %}
+{% form_theme handlingForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block shipping_preferences_handling %}
   <div class="col-xl-10">
@@ -47,30 +48,7 @@
               </div>
             </div>
           </div>
-
-          <div class="form-group row">
-            <label class="form-control-label">{{ 'Handling charges'|trans }}</label>
-            <div class="col-sm">
-              {{ form_errors(handlingForm.shipping_handling_charges) }}
-              {{ form_widget(handlingForm.shipping_handling_charges) }}
-            </div>
-          </div>
-
-          <div class="form-group row">
-            <label class="form-control-label">{{ 'Free shipping starts at'|trans }}</label>
-            <div class="col-sm">
-              {{ form_errors(handlingForm.free_shipping_price) }}
-              {{ form_widget(handlingForm.free_shipping_price) }}
-            </div>
-          </div>
-
-          <div class="form-group row">
-            <label class="form-control-label">{{ 'Free shipping starts at'|trans }}</label>
-            <div class="col-sm">
-              {{ form_errors(handlingForm.free_shipping_weight) }}
-              {{ form_widget(handlingForm.free_shipping_weight) }}
-            </div>
-          </div>
+          {{ form_widget(handlingForm) }}
         </div>
       </div>
       <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplfiies carrier preferences form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Improve -> Carrier -> Preferences form. Everything must look the same.


Aside for form simplification this PR does 2 things: Makes it so Symfony handles validation via constraint functionality and adds postProcess to LegacyController to make sure it actually works. Some of the params may will have red * next to it as they were required before but now it's actually displayed.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
