### PR TITLE
Make sure the force ssl is used in Cookie class when we are in admin context

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -171,10 +171,10 @@ if ($cookie_lifetime > 0) {
     $cookie_lifetime = time() + (max($cookie_lifetime, 1) * 3600);
 }
 
+$force_ssl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
 if (defined('_PS_ADMIN_DIR_')) {
-    $cookie = new Cookie('psAdmin', '', $cookie_lifetime);
+    $cookie = new Cookie('psAdmin', '', $cookie_lifetime, null, false, $force_ssl);
 } else {
-    $force_ssl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE');
     if ($context->shop->getGroup()->share_order) {
         $cookie = new Cookie('ps-sg' . $context->shop->getGroup()->id, '', $cookie_lifetime, $context->shop->getUrlsSharedCart(), false, $force_ssl);
     } else {

--- a/src/Adapter/Preferences/PreferencesConfiguration.php
+++ b/src/Adapter/Preferences/PreferencesConfiguration.php
@@ -71,6 +71,16 @@ class PreferencesConfiguration implements DataConfigurationInterface
      */
     public function updateConfiguration(array $configuration)
     {
+        if (false === $this->validateConfiguration($configuration)) {
+            return [
+                [
+                    'key' => 'Invalid configuration',
+                    'domain' => 'Admin.Advparameters.Notification',
+                    'parameters' => [],
+                ],
+            ];
+        }
+
         if ($this->validateSameSiteConfiguration($configuration)) {
             return [
                 [
@@ -81,20 +91,18 @@ class PreferencesConfiguration implements DataConfigurationInterface
             ];
         }
 
-        if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_SSL_ENABLED', $configuration['enable_ssl']);
-            $this->configuration->set('PS_SSL_ENABLED_EVERYWHERE', $configuration['enable_ssl_everywhere']);
-            $this->configuration->set('PS_TOKEN_ENABLE', $configuration['enable_token']);
-            $this->configuration->set('PS_ALLOW_HTML_IFRAME', $configuration['allow_html_iframes']);
-            $this->configuration->set('PS_USE_HTMLPURIFIER', $configuration['use_htmlpurifier']);
-            $this->configuration->set('PS_PRICE_ROUND_MODE', $configuration['price_round_mode']);
-            $this->configuration->set('PS_ROUND_TYPE', $configuration['price_round_type']);
-            $this->configuration->set('PS_DISPLAY_SUPPLIERS', $configuration['display_suppliers']);
-            $this->configuration->set('PS_DISPLAY_MANUFACTURERS', $configuration['display_manufacturers']);
-            $this->configuration->set('PS_DISPLAY_BEST_SELLERS', $configuration['display_best_sellers']);
-            $this->configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', $configuration['multishop_feature_active']);
-            $this->configuration->set('PS_SHOP_ACTIVITY', $configuration['shop_activity']);
-        }
+        $this->configuration->set('PS_SSL_ENABLED', $configuration['enable_ssl']);
+        $this->configuration->set('PS_SSL_ENABLED_EVERYWHERE', $configuration['enable_ssl_everywhere']);
+        $this->configuration->set('PS_TOKEN_ENABLE', $configuration['enable_token']);
+        $this->configuration->set('PS_ALLOW_HTML_IFRAME', $configuration['allow_html_iframes']);
+        $this->configuration->set('PS_USE_HTMLPURIFIER', $configuration['use_htmlpurifier']);
+        $this->configuration->set('PS_PRICE_ROUND_MODE', $configuration['price_round_mode']);
+        $this->configuration->set('PS_ROUND_TYPE', $configuration['price_round_type']);
+        $this->configuration->set('PS_DISPLAY_SUPPLIERS', $configuration['display_suppliers']);
+        $this->configuration->set('PS_DISPLAY_MANUFACTURERS', $configuration['display_manufacturers']);
+        $this->configuration->set('PS_DISPLAY_BEST_SELLERS', $configuration['display_best_sellers']);
+        $this->configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', $configuration['multishop_feature_active']);
+        $this->configuration->set('PS_SHOP_ACTIVITY', $configuration['shop_activity']);
 
         return [];
     }

--- a/src/Adapter/Preferences/PreferencesConfiguration.php
+++ b/src/Adapter/Preferences/PreferencesConfiguration.php
@@ -75,7 +75,7 @@ class PreferencesConfiguration implements DataConfigurationInterface
             return [
                 [
                     'key' => 'Invalid configuration',
-                    'domain' => 'Admin.Advparameters.Notification',
+                    'domain' => 'Admin.Notifications.Warning',
                     'parameters' => [],
                 ],
             ];

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\Adapter;
+
+use Cookie;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Preferences\PreferencesConfiguration;
+
+class PreferencesConfigurationTest extends TestCase
+{
+    /**
+     * @var PreferencesConfiguration
+     */
+    private $object;
+
+    /**
+     * @var Configuration
+     */
+    private $mockConfiguration;
+
+    protected function setUp()
+    {
+        $this->mockConfiguration = $this->getMockBuilder(Configuration::class)
+            ->setMethods(['get', 'getBoolean', 'set'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->object = new PreferencesConfiguration($this->mockConfiguration);
+    }
+
+    public function testGetConfiguration()
+    {
+        $this->mockConfiguration->method('get')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['PS_PRICE_ROUND_MODE', null, null, 'test'],
+                        ['PS_ROUND_TYPE', null, null, 'test'],
+                        ['PS_SHOP_ACTIVITY', null, null, 'test'],
+                    ]
+                )
+            );
+
+        $this->mockConfiguration->method('getBoolean')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['PS_SSL_ENABLED', false, true],
+                        ['PS_SSL_ENABLED_EVERYWHERE', false, true],
+                        ['PS_TOKEN_ENABLE', false, true],
+                        ['PS_ALLOW_HTML_IFRAME', false, true],
+                        ['PS_USE_HTMLPURIFIER', false, true],
+                        ['PS_DISPLAY_SUPPLIERS', false, false],
+                        ['PS_DISPLAY_MANUFACTURERS', false, true],
+                        ['PS_DISPLAY_BEST_SELLERS', false, false],
+                        ['PS_MULTISHOP_FEATURE_ACTIVE', false, true],
+                    ]
+                )
+            );
+
+        $result = $this->object->getConfiguration();
+        $this->assertSame(
+            [
+                'enable_ssl' => true,
+                'enable_ssl_everywhere' => true,
+                'enable_token' => true,
+                'allow_html_iframes' => true,
+                'use_htmlpurifier' => true,
+                'price_round_mode' => 'test',
+                'price_round_type' => 'test',
+                'display_suppliers' => false,
+                'display_manufacturers' => true,
+                'display_best_sellers' => false,
+                'multishop_feature_active' => true,
+                'shop_activity' => 'test',
+            ],
+            $result
+        );
+    }
+
+    public function testUpdateConfigurationWithInvalidConfiguration()
+    {
+        $this->assertSame(
+            [
+                [
+                    'key' => 'Invalid configuration',
+                    'domain' => 'Admin.Advparameters.Notification',
+                    'parameters' => [],
+                ],
+            ],
+            $this->object->updateConfiguration([])
+        );
+    }
+
+    public function testUpdateConfigurationWithInvalidSSLConfiguration()
+    {
+        $this->mockConfiguration->method('get')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
+                    ]
+                )
+            );
+
+        $this->assertSame(
+            [
+                [
+                    'key' => 'Cannot disable SSL configuration due to the Cookie SameSite=None.',
+                    'domain' => 'Admin.Advparameters.Notification',
+                    'parameters' => [],
+                ],
+            ],
+
+            $this->object->updateConfiguration(
+                [
+                    'enable_ssl' => false,
+                    'enable_ssl_everywhere' => false,
+                    'enable_token' => true,
+                    'allow_html_iframes' => true,
+                    'use_htmlpurifier' => true,
+                    'price_round_mode' => 'test',
+                    'price_round_type' => 'test',
+                    'display_suppliers' => false,
+                    'display_manufacturers' => true,
+                    'display_best_sellers' => false,
+                    'multishop_feature_active' => true,
+                    'shop_activity' => 'test',
+                ]
+            )
+        );
+    }
+
+    public function testUpdateConfiguration()
+    {
+        $this->mockConfiguration->method('get')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
+                    ]
+                )
+            );
+        $this->mockConfiguration->method('set')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['PS_SSL_ENABLED', true],
+                        ['PS_SSL_ENABLED_EVERYWHERE', true],
+                        ['PS_TOKEN_ENABLE', true],
+                        ['PS_ALLOW_HTML_IFRAME', true],
+                        ['PS_USE_HTMLPURIFIER', true],
+                        ['PS_DISPLAY_SUPPLIERS', false],
+                        ['PS_DISPLAY_MANUFACTURERS', true],
+                        ['PS_DISPLAY_BEST_SELLERS', false],
+                        ['PS_MULTISHOP_FEATURE_ACTIVE', true],
+                        ['PS_PRICE_ROUND_MODE', 'test'],
+                        ['PS_ROUND_TYPE', 'test'],
+                        ['PS_SHOP_ACTIVITY', 'test'],
+                    ]
+                )
+            );
+
+        $this->assertSame(
+            [
+                [
+                    'key' => 'Cannot disable SSL configuration due to the Cookie SameSite=None.',
+                    'domain' => 'Admin.Advparameters.Notification',
+                    'parameters' => [],
+                ],
+            ],
+
+            $this->object->updateConfiguration(
+                [
+                    'enable_ssl' => false,
+                    'enable_ssl_everywhere' => false,
+                    'enable_token' => true,
+                    'allow_html_iframes' => true,
+                    'use_htmlpurifier' => true,
+                    'price_round_mode' => 'test',
+                    'price_round_type' => 'test',
+                    'display_suppliers' => false,
+                    'display_manufacturers' => true,
+                    'display_best_sellers' => false,
+                    'multishop_feature_active' => true,
+                    'shop_activity' => 'test',
+                ]
+            )
+        );
+    }
+}

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -109,7 +109,7 @@ class PreferencesConfigurationTest extends TestCase
             [
                 [
                     'key' => 'Invalid configuration',
-                    'domain' => 'Admin.Advparameters.Notification',
+                    'domain' => 'Admin.Notifications.Warning',
                     'parameters' => [],
                 ],
             ],

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -57,32 +57,30 @@ class PreferencesConfigurationTest extends TestCase
 
     public function testGetConfiguration()
     {
-        $this->mockConfiguration->method('get')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['PS_PRICE_ROUND_MODE', null, null, 'test'],
-                        ['PS_ROUND_TYPE', null, null, 'test'],
-                        ['PS_SHOP_ACTIVITY', null, null, 'test'],
-                    ]
-                )
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_PRICE_ROUND_MODE', null, null, 'test'],
+                    ['PS_ROUND_TYPE', null, null, 'test'],
+                    ['PS_SHOP_ACTIVITY', null, null, 'test'],
+                ]
             );
 
-        $this->mockConfiguration->method('getBoolean')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['PS_SSL_ENABLED', false, true],
-                        ['PS_SSL_ENABLED_EVERYWHERE', false, true],
-                        ['PS_TOKEN_ENABLE', false, true],
-                        ['PS_ALLOW_HTML_IFRAME', false, true],
-                        ['PS_USE_HTMLPURIFIER', false, true],
-                        ['PS_DISPLAY_SUPPLIERS', false, false],
-                        ['PS_DISPLAY_MANUFACTURERS', false, true],
-                        ['PS_DISPLAY_BEST_SELLERS', false, false],
-                        ['PS_MULTISHOP_FEATURE_ACTIVE', false, true],
-                    ]
-                )
+        $this->mockConfiguration
+            ->method('getBoolean')
+            ->willReturnMap(
+                [
+                    ['PS_SSL_ENABLED', false, true],
+                    ['PS_SSL_ENABLED_EVERYWHERE', false, true],
+                    ['PS_TOKEN_ENABLE', false, true],
+                    ['PS_ALLOW_HTML_IFRAME', false, true],
+                    ['PS_USE_HTMLPURIFIER', false, true],
+                    ['PS_DISPLAY_SUPPLIERS', false, false],
+                    ['PS_DISPLAY_MANUFACTURERS', false, true],
+                    ['PS_DISPLAY_BEST_SELLERS', false, false],
+                    ['PS_MULTISHOP_FEATURE_ACTIVE', false, true],
+                ]
             );
 
         $result = $this->object->getConfiguration();
@@ -121,13 +119,12 @@ class PreferencesConfigurationTest extends TestCase
 
     public function testUpdateConfigurationWithInvalidSSLConfiguration()
     {
-        $this->mockConfiguration->method('get')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
-                    ]
-                )
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
+                ]
             );
 
         $this->assertSame(
@@ -160,32 +157,30 @@ class PreferencesConfigurationTest extends TestCase
 
     public function testUpdateConfiguration()
     {
-        $this->mockConfiguration->method('get')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
-                    ]
-                )
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
+                ]
             );
-        $this->mockConfiguration->method('set')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['PS_SSL_ENABLED', true],
-                        ['PS_SSL_ENABLED_EVERYWHERE', true],
-                        ['PS_TOKEN_ENABLE', true],
-                        ['PS_ALLOW_HTML_IFRAME', true],
-                        ['PS_USE_HTMLPURIFIER', true],
-                        ['PS_DISPLAY_SUPPLIERS', false],
-                        ['PS_DISPLAY_MANUFACTURERS', true],
-                        ['PS_DISPLAY_BEST_SELLERS', false],
-                        ['PS_MULTISHOP_FEATURE_ACTIVE', true],
-                        ['PS_PRICE_ROUND_MODE', 'test'],
-                        ['PS_ROUND_TYPE', 'test'],
-                        ['PS_SHOP_ACTIVITY', 'test'],
-                    ]
-                )
+        $this->mockConfiguration
+            ->method('set')
+            ->willReturnMap(
+                [
+                    ['PS_SSL_ENABLED', true],
+                    ['PS_SSL_ENABLED_EVERYWHERE', true],
+                    ['PS_TOKEN_ENABLE', true],
+                    ['PS_ALLOW_HTML_IFRAME', true],
+                    ['PS_USE_HTMLPURIFIER', true],
+                    ['PS_DISPLAY_SUPPLIERS', false],
+                    ['PS_DISPLAY_MANUFACTURERS', true],
+                    ['PS_DISPLAY_BEST_SELLERS', false],
+                    ['PS_MULTISHOP_FEATURE_ACTIVE', true],
+                    ['PS_PRICE_ROUND_MODE', 'test'],
+                    ['PS_ROUND_TYPE', 'test'],
+                    ['PS_SHOP_ACTIVITY', 'test'],
+                ]
             );
 
         $this->assertSame(

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Adapter;
 
 use Cookie;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Make sure the `Cookie` class receives the `$force_ssl` parameter when running in the admin directory.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12783 
| How to test?  | Install PrestaShop with SSL forced, use SameSite=None in cookie configuration.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21249)
<!-- Reviewable:end -->
