### PR TITLE
Fix left sidebar while onboarding is on

### DIFF
--- a/admin-dev/themes/default/sass/partials/_nav.sass
+++ b/admin-dev/themes/default/sass/partials/_nav.sass
@@ -141,7 +141,7 @@
 				padding: 0.9375rem 1.25rem
 
 .main-menu
-	padding: 0 0 5.313rem 0
+	padding: 0 0 13.313rem 0
 	margin: 0
 
 	&.sidebar-closed

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -176,7 +176,7 @@
 }
 
 .main-menu {
-  padding: 0 0 5.313rem;
+  padding: 0 0 8.313rem;
   margin: 0;
 
   &.sidebar-closed {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Onboarding was hiding last menu items on the lef navbar in the BO
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21095.
| How to test?  | Go on a prestashop shop with the onboarding plugin on, you should be able to scroll and see every items in the navbar on legacy and migrated layout (dashboard page and order for example), see the issue for more infos!

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21250)
<!-- Reviewable:end -->
