### PR TITLE
Rename product price fields labels

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -159,7 +159,7 @@ class ProductPrice extends CommonAbstractType
             FormType\MoneyType::class,
             [
                 'required' => false,
-                'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                'label' => $this->translator->trans('Retail price (tax excl.)', [], 'Admin.Catalog.Feature'),
                 'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
                 'currency' => $this->currency->iso_code,
                 'constraints' => [
@@ -174,7 +174,7 @@ class ProductPrice extends CommonAbstractType
                 [
                     'required' => false,
                     'mapped' => false,
-                    'label' => $this->translator->trans('Price (tax incl.)', [], 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Retail price (tax incl.)', [], 'Admin.Catalog.Feature'),
                     'currency' => $this->currency->iso_code,
                 ]
             )
@@ -228,7 +228,7 @@ class ProductPrice extends CommonAbstractType
                 FormType\MoneyType::class,
                 [
                     'required' => false,
-                    'label' => $this->translator->trans('Price (tax excl.)', [], 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Cost price (tax excl.)', [], 'Admin.Catalog.Feature'),
                     'currency' => $this->currency->iso_code,
                 ]
             )
@@ -237,7 +237,7 @@ class ProductPrice extends CommonAbstractType
                 FormType\MoneyType::class,
                 [
                     'required' => false,
-                    'label' => $this->translator->trans('Price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
+                    'label' => $this->translator->trans('Retail price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
                     'currency' => $this->currency->iso_code,
                 ]
             )

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig
@@ -47,7 +47,7 @@
             <tr >
               <th width="30%">{{ 'Product name'|trans({}, 'Admin.Catalog.Feature') }}</th>
               <th width="30%">{{ 'Supplier reference'|trans({}, 'Admin.Catalog.Feature') }}</th>
-              <th width="20%">{{ 'Price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
+              <th width="20%">{{ 'Cost price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
               <th width="20%">{{ 'Currency'|trans({}, 'Admin.Global') }}</th>
             </tr>
           </thead>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Rename the product price fields names
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #18701
| How to test?  | In BO > Catalog > Products > Edit > Price tab, you should see the labels: Retail price (tax excl.), Retail price (tax incl.), Retail price per unit (tax excl.), Cost price (tax excl.) and in Options tab, you should see for the suppliers table the label Cost price (tax excl.)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21253)
<!-- Reviewable:end -->
