### PR TITLE
Added 404 page without redirections on category page if category doesn't exists

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -45,16 +45,14 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         if (Validate::isLoadedObject($this->category)) {
             parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
-        } elseif (!Validate::isLoadedObject($this->category) && $canonicalURL == '') {
+        } elseif ($canonicalURL) {
+            parent::canonicalRedirection($canonicalURL);
+        } else {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans("This category doesn't exists.", [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
-
-            return;
-        } elseif ($canonicalURL) {
-            parent::canonicalRedirection($canonicalURL);
-        }
+        } 
     }
 
     public function getCanonicalURL()

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -88,7 +88,7 @@ class CategoryControllerCore extends ProductListingFrontController
         if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
-            $this->errors[] = $this->trans("This category doesn't exist.", [], 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('This category does not exist.', [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
 
             return;

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -50,7 +50,7 @@ class CategoryControllerCore extends ProductListingFrontController
         } else {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
-            $this->errors[] = $this->trans("This category doesn't exists.", [], 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans("This category does not exist.", [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
         }
     }

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -45,7 +45,7 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         if (Validate::isLoadedObject($this->category)) {
             parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
-        } elseif (!Validate::isLoadedObject($this->category) && $canonicalUR == '') {
+        } elseif (!Validate::isLoadedObject($this->category) && $canonicalURL == '') {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans("This category doesn't exists.", [], 'Shop.Notifications.Error');

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -1,12 +1,11 @@
 <?php
 /**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ * 2007-2019 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
+ * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/OSL-3.0
  * If you did not receive a copy of the license and are unable to
@@ -17,11 +16,12 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
+ * needs please refer to https://www.prestashop.com for more information.
  *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
  */
 use PrestaShop\PrestaShop\Adapter\Category\CategoryProductSearchProvider;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
@@ -45,6 +45,13 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         if (Validate::isLoadedObject($this->category)) {
             parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
+        } elseif (!Validate::isLoadedObject($this->category) && $canonicalUR == '') {
+            header('HTTP/1.1 404 Not Found');
+            header('Status: 404 Not Found');
+            $this->errors[] = $this->trans("This category doesn't exists.", [], 'Shop.Notifications.Error');
+            $this->setTemplate('errors/404');
+
+            return;
         } elseif ($canonicalURL) {
             parent::canonicalRedirection($canonicalURL);
         }
@@ -57,7 +64,7 @@ class CategoryControllerCore extends ProductListingFrontController
         if (isset($parsedUrl['query'])) {
             parse_str($parsedUrl['query'], $params);
         } else {
-            $params = [];
+            $params = array();
         }
         $page = (int) Tools::getValue('page');
         if ($page > 1) {
@@ -85,16 +92,12 @@ class CategoryControllerCore extends ProductListingFrontController
             $this->context->language->id
         );
 
-        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
-            Tools::redirect('pagenotfound');
-        }
-
         parent::init();
 
-        if (!$this->category->checkAccess($this->context->customer->id)) {
+        if (Validate::isLoadedObject($this->category) && !$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
-            $this->errors[] = $this->trans('You do not have access to this category.', [], 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
             $this->setTemplate('errors/forbidden');
 
             return;
@@ -104,7 +107,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         $filteredCategory = Hook::exec(
             'filterCategoryContent',
-            ['object' => $categoryVar],
+            array('object' => $categoryVar),
             $id_module = null,
             $array_return = false,
             $check_exceptions = true,
@@ -116,10 +119,10 @@ class CategoryControllerCore extends ProductListingFrontController
             $categoryVar = $filteredCategory['object'];
         }
 
-        $this->context->smarty->assign([
+        $this->context->smarty->assign(array(
             'category' => $categoryVar,
             'subcategories' => $this->getTemplateVarSubCategories(),
-        ]);
+        ));
     }
 
     /**
@@ -157,7 +160,7 @@ class CategoryControllerCore extends ProductListingFrontController
     protected function getAjaxProductSearchVariables()
     {
         $data = parent::getAjaxProductSearchVariables();
-        $rendered_products_header = $this->render('catalog/_partials/category-header', ['listing' => $data]);
+        $rendered_products_header = $this->render('catalog/_partials/category-header', array('listing' => $data));
         $data['rendered_products_header'] = $rendered_products_header;
 
         return $data;
@@ -233,9 +236,7 @@ class CategoryControllerCore extends ProductListingFrontController
             }
         }
 
-        if ($this->category->id_parent != 0 && !$this->category->is_root_category) {
-            $breadcrumb['links'][] = $this->getCategoryPath($this->category);
-        }
+        $breadcrumb['links'][] = $this->getCategoryPath($this->category);
 
         return $breadcrumb;
     }
@@ -268,7 +269,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         return $this->trans(
             'Category: %category_name%',
-            ['%category_name%' => $this->category->name],
+            array('%category_name%' => $this->category->name),
             'Shop.Theme.Catalog'
         );
     }

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -92,7 +92,7 @@ class CategoryControllerCore extends ProductListingFrontController
             $this->setTemplate('errors/404');
 
             return;
-        } else if (!$this->category->checkAccess($this->context->customer->id)) {
+        } elseif (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
             $this->errors[] = $this->trans('You do not have access to this category.', [], 'Shop.Notifications.Error');

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -45,13 +45,6 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         if (Validate::isLoadedObject($this->category)) {
             parent::canonicalRedirection($this->context->link->getCategoryLink($this->category));
-        } elseif ($canonicalURL) {
-            parent::canonicalRedirection($canonicalURL);
-        } else {
-            header('HTTP/1.1 404 Not Found');
-            header('Status: 404 Not Found');
-            $this->errors[] = $this->trans("This category does not exist.", [], 'Shop.Notifications.Error');
-            $this->setTemplate('errors/404');
         }
     }
 
@@ -90,13 +83,16 @@ class CategoryControllerCore extends ProductListingFrontController
             $this->context->language->id
         );
 
-        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
-            Tools::redirect('pagenotfound');
-        }
-
         parent::init();
 
-        if (!$this->category->checkAccess($this->context->customer->id)) {
+        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
+            header('HTTP/1.1 404 Not Found');
+            header('Status: 404 Not Found');
+            $this->errors[] = $this->trans("This category doesn't exist.", [], 'Shop.Notifications.Error');
+            $this->setTemplate('errors/404');
+
+            return;
+        } else if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
             $this->errors[] = $this->trans('You do not have access to this category.', [], 'Shop.Notifications.Error');

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * 2007-2019 PrestaShop and Contributors
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
+ * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/OSL-3.0
  * If you did not receive a copy of the license and are unable to
@@ -16,12 +17,11 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
  *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- * International Registered Trademark & Property of PrestaShop SA
  */
 use PrestaShop\PrestaShop\Adapter\Category\CategoryProductSearchProvider;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
@@ -64,7 +64,7 @@ class CategoryControllerCore extends ProductListingFrontController
         if (isset($parsedUrl['query'])) {
             parse_str($parsedUrl['query'], $params);
         } else {
-            $params = array();
+            $params = [];
         }
         $page = (int) Tools::getValue('page');
         if ($page > 1) {
@@ -92,12 +92,16 @@ class CategoryControllerCore extends ProductListingFrontController
             $this->context->language->id
         );
 
+        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
+            Tools::redirect('pagenotfound');
+        }
+
         parent::init();
 
-        if (Validate::isLoadedObject($this->category) && !$this->category->checkAccess($this->context->customer->id)) {
+        if (!$this->category->checkAccess($this->context->customer->id)) {
             header('HTTP/1.1 403 Forbidden');
             header('Status: 403 Forbidden');
-            $this->errors[] = $this->trans('You do not have access to this category.', array(), 'Shop.Notifications.Error');
+            $this->errors[] = $this->trans('You do not have access to this category.', [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/forbidden');
 
             return;
@@ -107,7 +111,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         $filteredCategory = Hook::exec(
             'filterCategoryContent',
-            array('object' => $categoryVar),
+            ['object' => $categoryVar],
             $id_module = null,
             $array_return = false,
             $check_exceptions = true,
@@ -119,10 +123,10 @@ class CategoryControllerCore extends ProductListingFrontController
             $categoryVar = $filteredCategory['object'];
         }
 
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'category' => $categoryVar,
             'subcategories' => $this->getTemplateVarSubCategories(),
-        ));
+        ]);
     }
 
     /**
@@ -160,7 +164,7 @@ class CategoryControllerCore extends ProductListingFrontController
     protected function getAjaxProductSearchVariables()
     {
         $data = parent::getAjaxProductSearchVariables();
-        $rendered_products_header = $this->render('catalog/_partials/category-header', array('listing' => $data));
+        $rendered_products_header = $this->render('catalog/_partials/category-header', ['listing' => $data]);
         $data['rendered_products_header'] = $rendered_products_header;
 
         return $data;
@@ -236,7 +240,9 @@ class CategoryControllerCore extends ProductListingFrontController
             }
         }
 
-        $breadcrumb['links'][] = $this->getCategoryPath($this->category);
+        if ($this->category->id_parent != 0 && !$this->category->is_root_category) {
+            $breadcrumb['links'][] = $this->getCategoryPath($this->category);
+        }
 
         return $breadcrumb;
     }
@@ -269,7 +275,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         return $this->trans(
             'Category: %category_name%',
-            array('%category_name%' => $this->category->name),
+            ['%category_name%' => $this->category->name],
             'Shop.Theme.Catalog'
         );
     }

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -52,7 +52,7 @@ class CategoryControllerCore extends ProductListingFrontController
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans("This category doesn't exists.", [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
-        } 
+        }
     }
 
     public function getCanonicalURL()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Before this PR, if a category doesn't exists, it returns a 404 page with a 301 redirection. That's bad for SEO...and all devs love SEO right? 😊 Now if category doesn't exists, Prestashop return a direct 404 page without redirects.
| Type?         | improvement 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19892
| How to test?  | On the demo version, try to access to any non-existing-category-page. It must return a 404 error without redirects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21258)
<!-- Reviewable:end -->
