### PR TITLE
The status name is not visible in the listing when the colors field is empty

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2251,13 +2251,13 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             return $this->color;
         }
 
-        return !empty($this->color) ? $this->color : self::DEFAULT_COLOR;
+        return !empty($this->color) ? $this->color : static::DEFAULT_COLOR;
     }
 
     public function setDefautlColor()
     {
         if ($this->hasColorField() && $this->use_default_color) {
-            $this->{$this->color_field_name} = $this->{$this->color_field_name} ?: self::DEFAULT_COLOR;
+            $this->{$this->color_field_name} = $this->{$this->color_field_name} ?: static::DEFAULT_COLOR;
         }
     }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2251,7 +2251,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             return $this->color;
         }
 
-        return !empty($this->color) ? $this->color : static::DEFAULT_COLOR;
+        return $this->color ?: static::DEFAULT_COLOR;
     }
 
     public function setDefautlColor()

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2244,13 +2244,13 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     public function getColor()
     {
         if (!$this->hasColorField()) {
-			return null;
-		}
-        
+            return null;
+        }
+
         if (!$this->use_default_color) {
             return $this->color;
         }
-        
+
         return !empty($this->color) ? $this->color : self::DEFAULT_COLOR;
     }
 
@@ -2260,8 +2260,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             $this->{$this->color_field_name} = $this->{$this->color_field_name} ?: self::DEFAULT_COLOR;
         }
     }
-    
-    public function getColorFieldName() {
-		return $this->color_field_name;
-	}
+
+    public function getColorFieldName()
+    {
+        return $this->color_field_name;
+    }
 }

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -261,6 +261,15 @@ class HelperListCore extends Helper
                 $this->_list[$index]['short_shop_name'] = Tools::strlen($tr['shop_name']) > 15 ? Tools::substr($tr['shop_name'], 0, 15) . '...' : $tr['shop_name'];
             }
 
+            if (class_exists($this->className)) {
+                $object = new $this->className($id);
+                $colorField = $object->getColorFieldName();
+
+                if (Validate::isLoadedObject($object) && $object->hasColorField() && isset($tr[$colorField])) {
+                    $this->_list[$index][$colorField] = $object->getColor();
+                }
+            }
+
             $is_first = true;
             // Check all available actions to add to the current list row
             foreach ($this->actions as $action) {

--- a/classes/order/OrderReturnState.php
+++ b/classes/order/OrderReturnState.php
@@ -30,6 +30,8 @@ class OrderReturnStateCore extends ObjectModel
 
     /** @var string Display state in the specified color */
     public $color;
+    
+    protected $use_default_color = true;
 
     /**
      * @see ObjectModel::$definition

--- a/classes/order/OrderReturnState.php
+++ b/classes/order/OrderReturnState.php
@@ -30,7 +30,7 @@ class OrderReturnStateCore extends ObjectModel
 
     /** @var string Display state in the specified color */
     public $color;
-    
+
     protected $use_default_color = true;
 
     /**

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -67,6 +67,8 @@ class OrderStateCore extends ObjectModel
 
     /** @var bool True if carrier has been deleted (staying in database as deleted) */
     public $deleted = 0;
+    
+    protected $use_default_color = true;
 
     /**
      * @see ObjectModel::$definition

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -67,7 +67,7 @@ class OrderStateCore extends ObjectModel
 
     /** @var bool True if carrier has been deleted (staying in database as deleted) */
     public $deleted = 0;
-    
+
     protected $use_default_color = true;
 
     /**

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -174,17 +174,11 @@ class AdminStatusesControllerCore extends AdminController
         $helper->default_form_language = $this->default_form_language;
         $helper->allow_employee_form_lang = $this->allow_employee_form_lang;
 
-        if ($order_return_state->id) {
-            $helper->fields_value = [
-                'name' => $this->getFieldValue($order_return_state, 'name'),
-                'color' => $this->getFieldValue($order_return_state, 'color'),
-            ];
-        } else {
-            $helper->fields_value = [
-                'name' => $this->getFieldValue($order_return_state, 'name'),
-                'color' => '#ffffff',
-            ];
-        }
+        $helper->fields_value = [
+           'name' => $this->getFieldValue($order_return_state, 'name'),
+           'color' => $order_return_state->getColor(),
+        ];
+
 
         $helper->toolbar_btn = $this->toolbar_btn;
         $helper->title = $this->trans('Edit return status', [], 'Admin.Shopparameters.Feature');
@@ -446,13 +440,8 @@ class AdminStatusesControllerCore extends AdminController
             'delivery_on' => $this->getFieldValue($obj, 'delivery'),
             'pdf_delivery_on' => $this->getFieldValue($obj, 'pdf_delivery'),
             'pdf_invoice_on' => $this->getFieldValue($obj, 'pdf_invoice'),
-        ];
-
-        if ($this->getFieldValue($obj, 'color') !== false) {
-            $this->fields_value['color'] = $this->getFieldValue($obj, 'color');
-        } else {
-            $this->fields_value['color'] = '#ffffff';
-        }
+            'color' => $obj->getColor(),
+        ];        
 
         return parent::renderForm();
     }

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -175,10 +175,9 @@ class AdminStatusesControllerCore extends AdminController
         $helper->allow_employee_form_lang = $this->allow_employee_form_lang;
 
         $helper->fields_value = [
-           'name' => $this->getFieldValue($order_return_state, 'name'),
-           'color' => $order_return_state->getColor(),
+            'name' => $this->getFieldValue($order_return_state, 'name'),
+            'color' => $order_return_state->getColor(),
         ];
-
 
         $helper->toolbar_btn = $this->toolbar_btn;
         $helper->title = $this->trans('Edit return status', [], 'Admin.Shopparameters.Feature');
@@ -441,7 +440,7 @@ class AdminStatusesControllerCore extends AdminController
             'pdf_delivery_on' => $this->getFieldValue($obj, 'pdf_delivery'),
             'pdf_invoice_on' => $this->getFieldValue($obj, 'pdf_invoice'),
             'color' => $obj->getColor(),
-        ];        
+        ];
 
         return parent::renderForm();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The status name is not visible in the listing when the colors field is empty.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21280 part of https://github.com/PrestaShop/PrestaShop/issues/21281
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/21280

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21282)
<!-- Reviewable:end -->
