### PR TITLE
Deprecated AddSpecificPriceCommand getter/setter & clarified misnamed property

### DIFF
--- a/src/Adapter/SpecificPrice/CommandHandler/AddSpecificPriceHandler.php
+++ b/src/Adapter/SpecificPrice/CommandHandler/AddSpecificPriceHandler.php
@@ -93,7 +93,7 @@ final class AddSpecificPriceHandler extends AbstractSpecificPriceHandler impleme
         $specificPrice->id_cart = $command->getCartId() ?? 0;
         $specificPrice->id_product_attribute = $command->getProductAttributeId() ?? 0;
         $specificPrice->id_currency = $command->getCurrencyId() ?? 0;
-        $specificPrice->id_specific_price_rule = $command->getCartRuleId() ?? 0;
+        $specificPrice->id_specific_price_rule = $command->getCatalogPriceRuleId() ?? 0;
         $specificPrice->id_country = $command->getCountryId() ?? 0;
         $specificPrice->id_group = $command->getGroupId() ?? 0;
         $specificPrice->id_customer = $command->getCustomerId() ?? 0;

--- a/src/Core/Domain/SpecificPrice/Command/AddSpecificPriceCommand.php
+++ b/src/Core/Domain/SpecificPrice/Command/AddSpecificPriceCommand.php
@@ -92,7 +92,7 @@ class AddSpecificPriceCommand
     /**
      * @var int|null
      */
-    private $cartRuleId;
+    private $catalogPriceRuleId;
 
     /**
      * @var int|null
@@ -282,18 +282,38 @@ class AddSpecificPriceCommand
 
     /**
      * @return int|null
+     *
+     * @deprecated use getCatalogPriceRuleId() instead. (wrong naming used in migration process)
      */
     public function getCartRuleId(): ?int
     {
-        return $this->cartRuleId;
+        return $this->catalogPriceRuleId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getCatalogPriceRuleId(): ?int
+    {
+        return $this->catalogPriceRuleId;
     }
 
     /**
      * @param int $cartRuleId
+     *
+     * @deprecated use setCatalogPriceRuleId() instead. (wrong naming used in migration process)
      */
     public function setCartRuleId(int $cartRuleId): void
     {
-        $this->cartRuleId = $cartRuleId;
+        $this->catalogPriceRuleId = $cartRuleId;
+    }
+
+    /**
+     * @param int $catalogPriceRuleId
+     */
+    public function setCatalogPriceRuleId(int $catalogPriceRuleId): void
+    {
+        $this->catalogPriceRuleId = $catalogPriceRuleId;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | AddSpecificPriceCommand contained property named $cartRuleId. It was named incorrectly during migration and should be CatalogPriceRuleId instead. (CatalgoPriceRule === SpecificPriceRule). Deprecated getter/setter & renamed the private property to CatalogPriceRuleId.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes
| Fixed ticket? | related #19673
| How to test?  | none. CI :heavy_check_mark:

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21295)
<!-- Reviewable:end -->
