### PR TITLE
Do not recalculate initial shipping fees when discount is applied

### DIFF
--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -253,6 +253,7 @@ class OrderAmountUpdater
             $orderCartRule->id_cart_rule = $cartRule->id;
             $orderCartRule->id_order_invoice = $orderInvoiceId ?? 0;
             $orderCartRule->name = $cartRule->name;
+            $orderCartRule->free_shipping = $cartRule->free_shipping;
             $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
             $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
             $orderCartRule->save();

--- a/src/Core/Cart/CartRuleCalculator.php
+++ b/src/Core/Cart/CartRuleCalculator.php
@@ -99,10 +99,7 @@ class CartRuleCalculator
 
         // Free shipping on selected carriers
         if ($cartRule->free_shipping && $withFreeShipping) {
-            $initialShippingFees = new AmountImmutable(
-                $cart->getOrderTotal(true, Cart::ONLY_SHIPPING),
-                $cart->getOrderTotal(false, Cart::ONLY_SHIPPING)
-            );
+            $initialShippingFees = $this->calculator->getFees()->getInitialShippingFees();
             $this->calculator->getFees()->subDiscountValueShipping($initialShippingFees);
             $cartRuleData->addDiscountApplied($initialShippingFees);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Initial shpping cost was relaculated when the free shipping voucher was applied. Now we take the already calculated shipping cost to apply the discount on
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21254
| How to test?  | Go to FO, make an order with a free carrier<br>Go to BO > Orders > Open order > Change carrier for a carrier with a fee<br>Add a "Free Shipping" voucher : It's value must be equal to the initial shipping cost

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21299)
<!-- Reviewable:end -->
