### PR TITLE
Refacto UpdateProductOptionsHandler to use Product repository

### DIFF
--- a/src/Adapter/Manufacturer/Repository/ManufacturerRepository.php
+++ b/src/Adapter/Manufacturer/Repository/ManufacturerRepository.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Manufacturer\Repository;
+
+use PrestaShop\PrestaShop\Adapter\AbstractObjectModelRepository;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
+
+class ManufacturerRepository extends AbstractObjectModelRepository
+{
+    /**
+     * @param ManufacturerId $manufacturerId
+     *
+     * @throws ManufacturerNotFoundException
+     */
+    public function assertManufacturerExists(ManufacturerId $manufacturerId): void
+    {
+        $this->assertObjectModelExists(
+            $manufacturerId->getValue(),
+            'manufacturer',
+            ManufacturerNotFoundException::class
+        );
+    }
+}

--- a/src/Adapter/Product/CommandHandler/RemoveAllAssociatedProductSuppliersHandler.php
+++ b/src/Adapter/Product/CommandHandler/RemoveAllAssociatedProductSuppliersHandler.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\AbstractProductSupplierHandler;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductSupplierRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\ProductSupplierUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\RemoveAllAssociatedProductSuppliersCommand;
@@ -39,7 +39,7 @@ use ProductSupplier;
 /**
  * Handles @see RemoveAllAssociatedProductSuppliersCommand using legacy object model
  */
-final class RemoveAllAssociatedProductSuppliersHandler extends AbstractProductSupplierHandler implements RemoveAllAssociatedProductSuppliersHandlerInterface
+final class RemoveAllAssociatedProductSuppliersHandler implements RemoveAllAssociatedProductSuppliersHandlerInterface
 {
     /**
      * @var ProductSupplierRepository
@@ -52,15 +52,23 @@ final class RemoveAllAssociatedProductSuppliersHandler extends AbstractProductSu
     private $productSupplierUpdater;
 
     /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
      * @param ProductSupplierRepository $productSupplierRepository
      * @param ProductSupplierUpdater $productSupplierUpdater
+     * @param ProductRepository $productRepository
      */
     public function __construct(
         ProductSupplierRepository $productSupplierRepository,
-        ProductSupplierUpdater $productSupplierUpdater
+        ProductSupplierUpdater $productSupplierUpdater,
+        ProductRepository $productRepository
     ) {
         $this->productSupplierRepository = $productSupplierRepository;
         $this->productSupplierUpdater = $productSupplierUpdater;
+        $this->productRepository = $productRepository;
     }
 
     /**
@@ -68,7 +76,7 @@ final class RemoveAllAssociatedProductSuppliersHandler extends AbstractProductSu
      */
     public function handle(RemoveAllAssociatedProductSuppliersCommand $command): void
     {
-        $product = $this->getProduct($command->getProductId());
+        $product = $this->productRepository->get($command->getProductId());
 
         $productSupplierIds = [];
         foreach (ProductSupplier::getSupplierCollection($product->id) as $productSupplier) {

--- a/src/Adapter/Product/CommandHandler/UpdateProductOptionsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductOptionsHandler.php
@@ -28,11 +28,10 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use Manufacturer;
+use PrestaShop\PrestaShop\Adapter\Manufacturer\Repository\ManufacturerRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerIdInterface;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductOptionsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
@@ -49,12 +48,20 @@ final class UpdateProductOptionsHandler implements UpdateProductOptionsHandlerIn
     private $productRepository;
 
     /**
+     * @var ManufacturerRepository
+     */
+    private $manufacturerRepository;
+
+    /**
      * @param ProductRepository $productRepository
+     * @param ManufacturerRepository $manufacturerRepository
      */
     public function __construct(
-        ProductRepository $productRepository
+        ProductRepository $productRepository,
+        ManufacturerRepository $manufacturerRepository
     ) {
         $this->productRepository = $productRepository;
+        $this->manufacturerRepository = $manufacturerRepository;
     }
 
     /**
@@ -140,15 +147,11 @@ final class UpdateProductOptionsHandler implements UpdateProductOptionsHandlerIn
 
     /**
      * @param ManufacturerIdInterface $manufacturerId
-     *
-     * @throws ManufacturerNotFoundException
      */
     private function assertManufacturerExists(ManufacturerIdInterface $manufacturerId): void
     {
-        if ($manufacturerId instanceof NoManufacturerId || Manufacturer::manufacturerExists($manufacturerId->getValue())) {
-            return;
+        if ($manufacturerId instanceof ManufacturerId) {
+            $this->manufacturerRepository->assertManufacturerExists($manufacturerId);
         }
-
-        throw new ManufacturerNotFoundException(sprintf('Manufacturer #%d does not exist', $manufacturerId->getValue()));
     }
 }

--- a/src/Adapter/Product/Validate/ProductValidator.php
+++ b/src/Adapter/Product/Validate/ProductValidator.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Validate;
 use PrestaShop\PrestaShop\Adapter\AbstractObjectModelValidator;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use Product;
 
 /**
@@ -50,6 +51,7 @@ class ProductValidator extends AbstractObjectModelValidator
     {
         $this->validateCustomizability($product);
         $this->validateBasicInfo($product);
+        $this->validateOptions($product);
         //@todo; more properties when refactoring other handlers to use updater/validator
     }
 
@@ -90,6 +92,77 @@ class ProductValidator extends AbstractObjectModelValidator
             'description_short',
             ProductConstraintException::class,
             ProductConstraintException::INVALID_SHORT_DESCRIPTION
+        );
+    }
+
+    /**
+     * @param Product $product
+     *
+     * @throws CoreException
+     */
+    private function validateOptions(Product $product): void
+    {
+        $this->validateObjectModelProperty(
+            $product,
+            'available_for_order',
+            ProductConstraintException::class
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'online_only',
+            ProductConstraintException::class
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'show_price',
+            ProductConstraintException::class
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'id_manufacturer',
+            ProductConstraintException::class
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'visibility',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_VISIBILITY
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'condition',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_CONDITION
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'ean13',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_EAN_13
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'isbn',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_ISBN
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'mpn',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_MPN
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'reference',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_REFERENCE
+        );
+        $this->validateObjectModelProperty(
+            $product,
+            'upc',
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_UPC
         );
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/manufacturer.yml
@@ -54,3 +54,6 @@ services:
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Manufacturer\Query\GetManufacturerForViewing
+
+  prestashop.adapter.manufacturer.repository.manufacturer_repository:
+      class: 'PrestaShop\PrestaShop\Adapter\Manufacturer\Repository\ManufacturerRepository'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -117,6 +117,7 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductOptionsHandler
         arguments:
             - '@prestashop.adapter.product.product_repository'
+            - '@prestashop.adapter.manufacturer.repository.manufacturer_repository'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -115,6 +115,8 @@ services:
 
     prestashop.adapter.product.command_handler.update_product_options_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductOptionsHandler
+        arguments:
+            - '@prestashop.adapter.product.product_repository'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -240,6 +240,7 @@ services:
         arguments:
             - '@prestashop.adapter.product.repository.product_supplier_repository'
             - '@prestashop.adapter.product.update.product_supplier_updater'
+            - '@prestashop.adapter.product.product_repository'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\RemoveAllAssociatedProductSuppliersCommand


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Refacto UpdateProductOptionsHandler to use Product repository. (None of refactored classes are released yet, so there is **no BC break**). Also removes AbstractProductHandler usability in RemoveAllProductSuppliersCommand.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #14777
| How to test?  | CI :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21307)
<!-- Reviewable:end -->
