### PR TITLE
Restore See More & See less for the Module Manager

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -415,11 +415,7 @@ class AdminModuleController {
       }
 
       container.show();
-      if (nbModulesInContainer >= self.DEFAULT_MAX_PER_CATEGORIES) {
-        container.find(`${self.seeMoreSelector}, ${self.seeLessSelector}`).show();
-      } else {
-        container.find(`${self.seeMoreSelector}, ${self.seeLessSelector}`).hide();
-      }
+      container.find(`${self.seeMoreSelector}, ${self.seeLessSelector}`).toggle(nbModulesInContainer >= self.DEFAULT_MAX_PER_CATEGORIES);
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -443,6 +443,7 @@ class AdminModuleController {
     let moduleCategory;
     let tagExists;
     let newValue;
+    let defaultMax;
 
     const modulesListLength = self.modulesList.length;
     const counter = {};
@@ -493,11 +494,10 @@ class AdminModuleController {
             counter[moduleCategory] = 0;
           }
 
-          if (moduleCategory === self.CATEGORY_RECENTLY_USED) {
-            if (counter[moduleCategory] >= self.DEFAULT_MAX_RECENTLY_USED) {
-              isVisible &= self.currentCategoryDisplay[moduleCategory];
-            }
-          } else if (counter[moduleCategory] >= self.DEFAULT_MAX_PER_CATEGORIES) {
+          defaultMax = moduleCategory === self.CATEGORY_RECENTLY_USED
+            ? self.DEFAULT_MAX_RECENTLY_USED
+            : self.DEFAULT_MAX_PER_CATEGORIES;
+          if (counter[moduleCategory] >= defaultMax) {
             isVisible &= self.currentCategoryDisplay[moduleCategory];
           }
 

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -415,7 +415,9 @@ class AdminModuleController {
       }
 
       container.show();
-      container.find(`${self.seeMoreSelector}, ${self.seeLessSelector}`).toggle(nbModulesInContainer >= self.DEFAULT_MAX_PER_CATEGORIES);
+      container
+        .find(`${self.seeMoreSelector}, ${self.seeLessSelector}`)
+        .toggle(nbModulesInContainer >= self.DEFAULT_MAX_PER_CATEGORIES);
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -39,6 +39,7 @@ class AdminModuleController {
     this.moduleCardController = moduleCardController;
 
     this.DEFAULT_MAX_RECENTLY_USED = 10;
+    this.DEFAULT_MAX_PER_CATEGORIES = 6;
     this.DISPLAY_GRID = 'grid';
     this.DISPLAY_LIST = 'list';
     this.CATEGORY_RECENTLY_USED = 'recently-used';
@@ -67,6 +68,9 @@ class AdminModuleController {
     this.addonsCardList = null;
 
     this.moduleShortList = '.module-short-list';
+    // See more & See less selector
+    this.seeMoreSelector = '.see-more';
+    this.seeLessSelector = '.see-less';
 
     // Selectors into vars to make it easier to change them while keeping same code logic
     this.moduleItemGridSelector = '.module-item-grid';
@@ -85,7 +89,11 @@ class AdminModuleController {
 
     // Upgrade All selectors
     this.upgradeAllSource = '.module_action_menu_upgrade_all';
-    this.upgradeAllTargets = '#modules-list-container-update .module_action_menu_upgrade:visible';
+    this.upgradeContainer = '#modules-list-container-update';
+    this.upgradeAllTargets = `${this.upgradeContainer}' .module_action_menu_upgrade:visible`;
+
+    // Notification selectors
+    this.notificationContainer = '#modules-list-container-notification';
 
     // Bulk action selectors
     this.bulkActionDropDownSelector = '.module-bulk-actions';
@@ -151,6 +159,7 @@ class AdminModuleController {
     this.initFilterStatusDropdown();
     this.fetchModulesList();
     this.getNotificationsCount();
+    this.initializeSeeMore();
   }
 
   initFilterStatusDropdown() {
@@ -222,11 +231,16 @@ class AdminModuleController {
 
   initBOEventRegistering() {
     window.BOEvent.on('Module Disabled', this.onModuleDisabled, this);
+    window.BOEvent.on('Module Uninstalled', this.updateTotalResults, this);
   }
 
   onModuleDisabled() {
     const self = this;
     self.getModuleItemSelector();
+
+    $('.modules-list').each(() => {
+      self.updateTotalResults();
+    });
   }
 
   initPlaceholderMechanism() {
@@ -324,7 +338,9 @@ class AdminModuleController {
           container,
         });
 
-        $this.remove();
+        if (self.isModulesPage()) {
+          $this.remove();
+        }
       });
     });
 
@@ -399,6 +415,11 @@ class AdminModuleController {
       }
 
       container.show();
+      if (nbModulesInContainer >= self.DEFAULT_MAX_PER_CATEGORIES) {
+        container.find(`${self.seeMoreSelector}, ${self.seeLessSelector}`).show();
+      } else {
+        container.find(`${self.seeMoreSelector}, ${self.seeLessSelector}`).hide();
+      }
     });
   }
 
@@ -407,12 +428,14 @@ class AdminModuleController {
 
     self.updateModuleSorting();
 
-    $(self.recentlyUsedSelector)
-      .find('.module-item')
-      .remove();
-    $('.modules-list')
-      .find('.module-item')
-      .remove();
+    if (self.isModulesPage()) {
+      $(self.recentlyUsedSelector)
+        .find('.module-item')
+        .remove();
+      $('.modules-list')
+        .find('.module-item')
+        .remove();
+    }
 
     // Modules visibility management
     let isVisible;
@@ -474,6 +497,8 @@ class AdminModuleController {
             if (counter[moduleCategory] >= self.DEFAULT_MAX_RECENTLY_USED) {
               isVisible &= self.currentCategoryDisplay[moduleCategory];
             }
+          } else if (counter[moduleCategory] >= self.DEFAULT_MAX_PER_CATEGORIES) {
+            isVisible &= self.currentCategoryDisplay[moduleCategory];
           }
 
           counter[moduleCategory] += 1;
@@ -495,6 +520,8 @@ class AdminModuleController {
     if (self.currentTagsList.length) {
       $('.modules-list').append(this.currentDisplay === self.DISPLAY_GRID ? this.addonsCardGrid : this.addonsCardList);
     }
+
+    self.updateTotalResults();
   }
 
   initPageChangeProtection() {
@@ -1159,6 +1186,67 @@ class AdminModuleController {
     $(`#module-sort-${switchTo}`).addClass('module-sort-active');
     this.currentDisplay = switchTo;
     this.updateModuleVisibility();
+  }
+
+  initializeSeeMore() {
+    const self = this;
+
+    $(`${self.moduleShortList} ${self.seeMoreSelector}`).on('click', function seeMore() {
+      self.currentCategoryDisplay[$(this).data('category')] = true;
+      $(this).addClass('d-none');
+      $(this).closest(self.moduleShortList).find(self.seeLessSelector).removeClass('d-none');
+      self.updateModuleVisibility();
+    });
+
+    $(`${self.moduleShortList} ${self.seeLessSelector}`).on('click', function seeMore() {
+      self.currentCategoryDisplay[$(this).data('category')] = false;
+      $(this).addClass('d-none');
+      $(this).closest(self.moduleShortList).find(self.seeMoreSelector).removeClass('d-none');
+      self.updateModuleVisibility();
+    });
+  }
+
+  updateTotalResults() {
+    const self = this;
+    const replaceFirstWordBy = (element, value) => {
+      const explodedText = element.text().split(' ');
+      explodedText[0] = value;
+      element.text(explodedText.join(' '));
+    };
+
+    // If there are some shortlist: each shortlist count the modules on the next container.
+    const $shortLists = $('.module-short-list');
+    if ($shortLists.length > 0) {
+      $shortLists.each(function shortLists() {
+        const $this = $(this);
+        replaceFirstWordBy(
+          $this.find('.module-search-result-wording'),
+          $this.next('.modules-list').find('.module-item').length,
+        );
+      });
+
+      // If there is no shortlist: the wording directly update from the only module container.
+    } else {
+      const modulesCount = $('.modules-list').find('.module-item').length;
+      replaceFirstWordBy($('.module-search-result-wording'), modulesCount);
+
+      const selectorToToggle = (self.currentDisplay === self.DISPLAY_LIST)
+        ? this.addonItemListSelector
+        : this.addonItemGridSelector;
+      $(selectorToToggle).toggle(modulesCount !== (this.modulesList.length / 2));
+
+      if (modulesCount === 0) {
+        $('.module-addons-search-link').attr(
+          'href',
+          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`,
+        );
+      }
+    }
+  }
+
+  isModulesPage() {
+    return $(this.upgradeContainer).length === 0
+      && $(this.notificationContainer).length === 0;
   }
 }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -57,6 +57,8 @@ class ModuleController extends ModuleAbstractController
 {
     const CONTROLLER_NAME = 'ADMINMODULESSF';
 
+    const MAX_MODULES_DISPLAYED = 6;
+
     /**
      * @AdminSecurity("is_granted(['read'], 'ADMINMODULESSF_')")
      *
@@ -126,6 +128,7 @@ class ModuleController extends ModuleAbstractController
         return $this->render(
             '@PrestaShop/Admin/Module/manage.html.twig',
             [
+                'maxModulesDisplayed' => self::MAX_MODULES_DISPLAYED,
                 'bulkActions' => $bulkActions,
                 'layoutHeaderToolbarBtn' => $this->getToolbarButtons(),
                 'layoutTitle' => $this->trans('Module manager', 'Admin.Modules.Feature'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig
@@ -1,0 +1,34 @@
+{#**
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://devdocs.prestashop.com/ for more information.
+  *
+  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  *#}
+<div class="col-12">
+  <p class="text-center">
+    <button type="button" class="btn btn-link see-more" data-category="{{ id }}">
+      {{ 'See more' | trans({}, 'Admin.Actions') }}
+    </button>
+    <button type="button" class="btn btn-link see-less d-none" data-category="{{ id }}">
+      {{ 'See less' | trans({}, 'Admin.Actions') }}
+    </button>
+  </p>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -49,6 +49,12 @@
               {% include '@PrestaShop/Admin/Module/Includes/grid_manage_empty.html.twig' with { 'category': category, 'display_type': 'list', 'origin': 'manage' } %}
             {% else  %}
               {% include '@PrestaShop/Admin/Module/Includes/grid_manage_installed.html.twig' with { 'modules': category.modules, 'display_type': 'list', 'origin': 'manage', 'id': category.refMenu } %}
+
+              {% block addon_card_see_more %}
+                {% if (category.modules | length) > maxModulesDisplayed %}
+                  {% include '@PrestaShop/Admin/Module/Includes/see_more.html.twig' with { 'id': category.refMenu } %}
+                {% endif %}
+              {% endblock %}
             {% endif %}
           </div>
         {% endfor %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The code pagination has been deleted in #19580, restore it, and add an exclusion for pages that are not Module Manager page. 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21054
| How to test?  | Pagination is still removed on the Alerts and Updates page, but buttons are now present in the Modules section.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21309)
<!-- Reviewable:end -->
