### PR TITLE
Fix delete order state confirmation

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -629,7 +629,17 @@ class AdminStatusesControllerCore extends AdminController
             if (!$order_state->isRemovable()) {
                 $this->errors[] = $this->trans('For security reasons, you cannot delete default order statuses.', [], 'Admin.Shopparameters.Notification');
             } else {
-                return $order_state->softDelete();
+                try {
+                    if (!$order_state->softDelete()) {
+                        throw new PrestaShopException('Error when soft deleting order status');
+                    }
+                } catch (PrestaShopException $e) { // see ObjectModel::softDelete too
+                    $this->errors[] = $this->trans('An error occurred during deletion.', [], 'Admin.Notifications.Error');
+
+                    return $order_state;
+                }
+
+                Tools::redirectAdmin(self::$currentIndex . '&conf=1&token=' . $this->token);
             }
         } elseif (Tools::isSubmit('submitBulkdelete' . $this->table)) {
             if (!$this->access('delete')) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Redirect after order state deletion to display success alert
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21269
| How to test?  | Go to BO > Order Settings > Statuses page<br>Delete an order status<br>You are redirected to the order statuses list and a green alert confirms Successful deletion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21310)
<!-- Reviewable:end -->
