### PR TITLE
Sanitize product sort order

### DIFF
--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -120,6 +120,9 @@ class SortOrder
      */
     public static function newFromString($sortOrderConfiguration)
     {
+        if (count(explode('.', $sortOrderConfiguration)) !== 3) {
+            return new static('', '', 'asc');
+        }
         list($entity, $field, $direction) = explode('.', $sortOrderConfiguration);
 
         return new static($entity, $field, $direction);

--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -120,10 +120,13 @@ class SortOrder
      */
     public static function newFromString($sortOrderConfiguration)
     {
-        if (count(explode('.', $sortOrderConfiguration)) !== 3) {
-            return new static('', '', 'asc');
+        $sortParams = explode('.', $sortOrderConfiguration);
+
+        if (count($sortParams) < 3) {
+            return static::random();
         }
-        list($entity, $field, $direction) = explode('.', $sortOrderConfiguration);
+
+        list($entity, $field, $direction) = $sortParams;
 
         return new static($entity, $field, $direction);
     }

--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Product\Search;
 
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Product\Search\Exception\InvalidSortOrderDirectionException;
 
 /**
@@ -123,7 +124,7 @@ class SortOrder
         $sortParams = explode('.', $sortOrderConfiguration);
 
         if (count($sortParams) < 3) {
-            throw new \PrestaShopException('Invalid argument');
+            throw new CoreException('Invalid argument');
         }
 
         list($entity, $field, $direction) = $sortParams;

--- a/src/Core/Product/Search/SortOrder.php
+++ b/src/Core/Product/Search/SortOrder.php
@@ -123,7 +123,7 @@ class SortOrder
         $sortParams = explode('.', $sortOrderConfiguration);
 
         if (count($sortParams) < 3) {
-            return static::random();
+            throw new \PrestaShopException('Invalid argument');
         }
 
         list($entity, $field, $direction) = $sortParams;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In category page, sort order can be changed in the url for an unexpected value : this generate a php notice in debug mode et an 500 error without. Sort order has to be sanitized, it's not secure like this.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21312.
| How to test?  | Just remove .asc in order var in category page : /3-vetements?order=product.position

Hello to Hacktoberfest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21313)
<!-- Reviewable:end -->
