### PR TITLE
Improve SQL requests on specific prices

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -283,7 +283,7 @@ class SpecificPriceCore extends ObjectModel
         $key_cache = __FUNCTION__ . '-' . $field_name . '-' . $threshold;
         $specific_list = [];
         if (!array_key_exists($key_cache, self::$_filterOutCache)) {
-            $query_count = 'SELECT COUNT(DISTINCT `' . $name . '`) FROM `' . _DB_PREFIX_ . 'specific_price` WHERE `' . $name . '` != 0';
+            $query_count = 'SELECT COUNT(*) FROM (SELECT DISTINCT `' . $name . '` FROM `' . _DB_PREFIX_ . 'specific_price` WHERE `' . $name . '` != 0 GROUP BY id_product ) AS counted';
             $specific_count = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query_count);
             if ($specific_count == 0) {
                 self::$_no_specific_values[$field_name] = true;


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When you manage specific prices with a big catalog, there is some trouble to finish saving a specific price rules. <br><br>Test on a 10.4.14-MariaDB server <br/> 1 000 000 specifics_prices and 100 000 products <br/> ![image](https://user-images.githubusercontent.com/52157233/95228072-2f817400-07ff-11eb-9827-1869dc05c054.png)
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21328)
<!-- Reviewable:end -->
