### PR TITLE
Do not escape already escaped module description

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/tab-module-line.html.twig
@@ -55,7 +55,7 @@
       </div>
       <p class="module_description">
         {% if module.attributes.description is defined and module.attributes.description is not empty %}
-          {{ module.attributes.description }}
+          {{ module.attributes.description|raw }}
         {% endif %}
       </p>
       {% if (module.attributes.message is defined and module.attributes.name is not empty) and (module.attributes.type is not defined or module.attributes.type != 'addonsMustHave' or module.attributes.type != 'addonsNative') %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because we tried to escape content already escaped in module suggestions brought by the module ps_mbo, special characters were not well displayed in the BO. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21298
| How to test?  | Please see #21298

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21329)
<!-- Reviewable:end -->
