### PR TITLE
Return a real 404 when product doesn't exist instead of a 302 redirection

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -102,7 +102,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
-            $this->setTemplate('errors/404');   
+            $this->setTemplate('errors/404');
         } else {
             $this->canonicalRedirection();
             /*
@@ -1253,12 +1253,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $page = parent::getTemplateVarPage();
 
         if (!Validate::isLoadedObject($this->product)) {
-            $page['title'] = $this->trans('The page you are looking for was not found.', array(), 'Shop.Theme.Global');
+            $page['title'] = $this->trans('The page you are looking for was not found.', [], 'Shop.Theme.Global');
             $page['page_name'] = 'pagenotfound';
 
             return $page;
         }
-        
+
         $page['body_classes']['product-id-' . $this->product->id] = true;
         $page['body_classes']['product-' . $this->product->name] = true;
         $page['body_classes']['product-id-category-' . $this->product->id_category_default] = true;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -99,7 +99,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
 
         if (!Validate::isLoadedObject($this->product)) {
-            Tools::redirect('pagenotfound');
+            header('HTTP/1.1 404 Not Found');
+            header('Status: 404 Not Found');
+            $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
+            $this->setTemplate('errors/404');   
         } else {
             $this->canonicalRedirection();
             /*
@@ -1248,6 +1251,14 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function getTemplateVarPage()
     {
         $page = parent::getTemplateVarPage();
+
+        if (!Validate::isLoadedObject($this->product)) {
+            $page['title'] = $this->trans('The page you are looking for was not found.', array(), 'Shop.Theme.Global');
+            $page['page_name'] = 'pagenotfound';
+
+            return $page;
+        }
+        
         $page['body_classes']['product-id-' . $this->product->id] = true;
         $page['body_classes']['product-' . $this->product->name] = true;
         $page['body_classes']['product-id-category-' . $this->product->id_category_default] = true;

--- a/themes/classic/templates/errors/404.tpl
+++ b/themes/classic/templates/errors/404.tpl
@@ -24,6 +24,8 @@
  *}
 {extends file='page.tpl'}
 
+{block name="breadcrumb"}{/block}
+
 {block name='page_title'}
   {$page.title}
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | As agreed in a [previous PR](https://github.com/PrestaShop/PrestaShop/pull/20410), this PR allows you to return a real 404 error when a product does not exist instead of redirecting to the PageNotFound controller via a 302 redirection. 
| Type?         | improvement
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes 
| How to test?  | You can go to a product URL which not exists and see the page returns a 404 error code
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21330)
<!-- Reviewable:end -->
