### PR TITLE
Fixed "Add new alias" button which was disappearing after adding a new alias. [BO][Shop param][search]

### DIFF
--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -364,7 +364,7 @@ class AdminSearchConfControllerCore extends AdminController
 
     public function initPageHeaderToolbar()
     {
-        if (empty($this->display)) {
+        if (empty($this->display) || $this->display == 'list') {
             $this->page_header_toolbar_btn['new_alias'] = [
                 'href' => self::$currentIndex . '&addalias&token=' . $this->token,
                 'desc' => $this->trans('Add new alias', [], 'Admin.Shopparameters.Feature'),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | See #21274 by @ngodefroy.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21274.
| How to test?  | See #21274 by @ngodefroy.

The fix is about "add new alias" button in _Shop Parameters > Search_ which wasn't behaving properly, as well explained inside issue PrestaShop#21274 by @ngodefroy.
The commit is just a tiny addition to the if statement in **AdminSearchConfController::initPageHeaderToolbar()**.
On the first click to "Search" `$this->display == null`. When you add a new alias and save instead `$this->display == 'list'`. Despite the fact I would prefer `$this->display` to be equal to `list` at the first side (first click to search); I decided to just allow both situations. This shouldn't impact, in other ways, any other alias process (listing/editing/creation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21335)
<!-- Reviewable:end -->
