### PR TITLE
Feature/simplifiy localization form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/AdvancedConfigurationType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -34,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * Class AdvancedConfigurationType is responsible for building 'Improve > International > Localization' page
  * 'Advanced' form.
  */
-class AdvancedConfigurationType extends AbstractType
+class AdvancedConfigurationType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -42,7 +43,25 @@ class AdvancedConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('language_identifier', TextType::class)
-            ->add('country_identifier', TextType::class);
+            ->add('language_identifier', TextType::class, [
+                'label' => $this->trans(
+                    'Language identifier',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The ISO 639-1 identifier for the language of the country where your web server is located (en, fr, sp, ru, pl, nl, etc.).',
+                    'Admin.International.Help'
+                ),
+            ])
+            ->add('country_identifier', TextType::class, [
+                'label' => $this->trans(
+                    'Country identifier',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).',
+                    'Admin.International.Help'
+                ),
+            ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
@@ -66,8 +66,6 @@ class ImportLocalizationPackType extends TranslatorAwareType
     {
         $builder
             ->add('iso_localization_pack', ChoiceType::class, [
-                'placeholder' => false,
-                'required' => false,
                 'label' => $this->trans(
                     'Localization pack you want to import',
                     'Admin.International.Feature'
@@ -82,7 +80,6 @@ class ImportLocalizationPackType extends TranslatorAwareType
                 ),
                 'expanded' => true,
                 'multiple' => true,
-                'required' => false,
                 'choices' => $this->getContentToImportChoices(),
                 'data' => [
                     LocalizationPackImportConfigInterface::CONTENT_STATES,
@@ -94,7 +91,6 @@ class ImportLocalizationPackType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('download_pack_data', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Download pack data',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/ImportLocalizationPackType.php
@@ -66,12 +66,23 @@ class ImportLocalizationPackType extends TranslatorAwareType
     {
         $builder
             ->add('iso_localization_pack', ChoiceType::class, [
+                'placeholder' => false,
+                'required' => false,
+                'label' => $this->trans(
+                    'Localization pack you want to import',
+                    'Admin.International.Feature'
+                ),
                 'choices' => $this->localizationPackChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('content_to_import', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Content to import',
+                    'Admin.International.Feature'
+                ),
                 'expanded' => true,
                 'multiple' => true,
+                'required' => false,
                 'choices' => $this->getContentToImportChoices(),
                 'data' => [
                     LocalizationPackImportConfigInterface::CONTENT_STATES,
@@ -83,6 +94,15 @@ class ImportLocalizationPackType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('download_pack_data', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Download pack data',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'If set to yes then the localization pack will be downloaded from prestashop.com. Otherwise the local xml file found in the localization folder of your PrestaShop installation will be used.',
+                    'Admin.International.Help'
+                ),
                 'data' => 1,
             ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -34,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * Class LocalUnitsType is responsible for building 'Improve > International > Localization' page
  * 'Local units' form.
  */
-class LocalUnitsType extends AbstractType
+class LocalUnitsType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -42,9 +43,49 @@ class LocalUnitsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('weight_unit', TextType::class)
-            ->add('distance_unit', TextType::class)
-            ->add('volume_unit', TextType::class)
-            ->add('dimension_unit', TextType::class);
+            ->add('weight_unit', TextType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Weight unit',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).',
+                    'Admin.International.Help'
+                ),
+            ])
+            ->add('distance_unit', TextType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Distance unit',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).',
+                    'Admin.International.Help'
+                ),
+            ])
+            ->add('volume_unit', TextType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Volume unit',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).',
+                    'Admin.International.Help'
+                ),
+            ])
+            ->add('dimension_unit', TextType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Dimension unit',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).',
+                    'Admin.International.Help'
+                ),
+            ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
@@ -43,7 +43,6 @@ class LocalUnitsType extends TranslatorAwareType
     {
         $builder
             ->add('weight_unit', TextType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Weight unit',
                     'Admin.International.Feature'
@@ -54,7 +53,6 @@ class LocalUnitsType extends TranslatorAwareType
                 ),
             ])
             ->add('distance_unit', TextType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Distance unit',
                     'Admin.International.Feature'
@@ -65,7 +63,6 @@ class LocalUnitsType extends TranslatorAwareType
                 ),
             ])
             ->add('volume_unit', TextType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Volume unit',
                     'Admin.International.Feature'
@@ -76,7 +73,6 @@ class LocalUnitsType extends TranslatorAwareType
                 ),
             ])
             ->add('dimension_unit', TextType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Dimension unit',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalUnitsType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -99,8 +99,8 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 'choice_translation_domain' => false,
                 'attr' => [
                     'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2'
-                ]
+                    'data-toggle' => 'select2',
+                ],
             ])
             ->add('detect_language_from_browser', SwitchType::class, [
                 'required' => false,
@@ -127,20 +127,20 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 'choice_translation_domain' => false,
                 'attr' => [
                     'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2'
-                ]
+                    'data-toggle' => 'select2',
+                ],
             ])
             ->add('detect_country_from_browser', SwitchType::class, [
-                    'required' => false,
-                    'label' => $this->trans(
-                        'Default country',
-                        'Admin.International.Feature'
-                    ),
-                    'help' => $this->trans(
-                        'The default country used in your shop.',
-                        'Admin.International.Help'
-                    ),
-                ]
+                'required' => false,
+                'label' => $this->trans(
+                    'Default country',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default country used in your shop.',
+                    'Admin.International.Help'
+                ),
+            ]
             )
             ->add('default_currency', ChoiceType::class, [
                 'required' => false,
@@ -157,8 +157,8 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 'attr' => [
                     'data-warning-message' => 'Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.',
                     'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2'
-                ]
+                    'data-toggle' => 'select2',
+                ],
             ])
             ->add('timezone', ChoiceType::class, [
                 'required' => false,
@@ -170,8 +170,8 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 'choice_translation_domain' => false,
                 'attr' => [
                     'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => 'select2'
-                ]
+                    'data-toggle' => 'select2',
+                ],
             ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -27,15 +27,16 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Localization;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class LocalizationConfigurationType is responsible for building 'Improve > International > Localization' page
  * 'Configuration' form.
  */
-class LocalizationConfigurationType extends AbstractType
+class LocalizationConfigurationType extends TranslatorAwareType
 {
     /**
      * @var array
@@ -64,11 +65,14 @@ class LocalizationConfigurationType extends AbstractType
      * @param array $timezoneChoices
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         array $languageChoices,
         array $countryChoices,
         array $currencyChoices,
         array $timezoneChoices
     ) {
+        parent::__construct($translator, $locales);
         $this->languageChoices = $languageChoices;
         $this->countryChoices = $countryChoices;
         $this->currencyChoices = $currencyChoices;
@@ -82,22 +86,92 @@ class LocalizationConfigurationType extends AbstractType
     {
         $builder
             ->add('default_language', ChoiceType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Default language',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default language used in your shop.',
+                    'Admin.International.Help'
+                ),
                 'choices' => $this->languageChoices,
                 'choice_translation_domain' => false,
+                'attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => 'select2'
+                ]
             ])
-            ->add('detect_language_from_browser', SwitchType::class)
+            ->add('detect_language_from_browser', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Set language from browser',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'Set browser language as default language',
+                    'Admin.International.Help'
+                ),
+            ])
             ->add('default_country', ChoiceType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Set language from browser',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'Set browser language as default language',
+                    'Admin.International.Help'
+                ),
                 'choices' => $this->countryChoices,
                 'choice_translation_domain' => false,
+                'attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => 'select2'
+                ]
             ])
-            ->add('detect_country_from_browser', SwitchType::class)
+            ->add('detect_country_from_browser', SwitchType::class, [
+                    'required' => false,
+                    'label' => $this->trans(
+                        'Default country',
+                        'Admin.International.Feature'
+                    ),
+                    'help' => $this->trans(
+                        'The default country used in your shop.',
+                        'Admin.International.Help'
+                    ),
+                ]
+            )
             ->add('default_currency', ChoiceType::class, [
+                'required' => false,
                 'choices' => $this->currencyChoices,
                 'choice_translation_domain' => false,
+                'label' => $this->trans(
+                    'Default currency',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'The default currency used in your shop.',
+                    'Admin.International.Help'
+                ),
+                'attr' => [
+                    'data-warning-message' => 'Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.',
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => 'select2'
+                ]
             ])
             ->add('timezone', ChoiceType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Time zone',
+                    'Admin.International.Feature'
+                ),
                 'choices' => $this->timezoneChoices,
                 'choice_translation_domain' => false,
+                'attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => 'select2'
+                ]
             ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -107,17 +107,17 @@ class LocalizationConfigurationType extends TranslatorAwareType
                     'Admin.International.Feature'
                 ),
                 'help' => $this->trans(
-                    'Set browser language as default language',
+                    'Set browser language as default language.',
                     'Admin.International.Help'
                 ),
             ])
             ->add('default_country', ChoiceType::class, [
                 'label' => $this->trans(
-                    'Set language from browser',
+                    'Default country',
                     'Admin.International.Feature'
                 ),
                 'help' => $this->trans(
-                    'Set browser language as default language',
+                    'The default country used in your shop.',
                     'Admin.International.Help'
                 ),
                 'choices' => $this->countryChoices,
@@ -129,11 +129,11 @@ class LocalizationConfigurationType extends TranslatorAwareType
             ])
             ->add('detect_country_from_browser', SwitchType::class, [
                 'label' => $this->trans(
-                    'Default country',
+                    'Set default country from browser language',
                     'Admin.International.Feature'
                 ),
                 'help' => $this->trans(
-                    'The default country used in your shop.',
+                    'Set country corresponding to browser language.',
                     'Admin.International.Help'
                 ),
             ]

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Localization/LocalizationConfigurationType.php
@@ -86,7 +86,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
     {
         $builder
             ->add('default_language', ChoiceType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Default language',
                     'Admin.International.Feature'
@@ -103,7 +102,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ],
             ])
             ->add('detect_language_from_browser', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Set language from browser',
                     'Admin.International.Feature'
@@ -114,7 +112,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ),
             ])
             ->add('default_country', ChoiceType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Set language from browser',
                     'Admin.International.Feature'
@@ -131,7 +128,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ],
             ])
             ->add('detect_country_from_browser', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Default country',
                     'Admin.International.Feature'
@@ -143,7 +139,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
             ]
             )
             ->add('default_currency', ChoiceType::class, [
-                'required' => false,
                 'choices' => $this->currencyChoices,
                 'choice_translation_domain' => false,
                 'label' => $this->trans(
@@ -161,7 +156,6 @@ class LocalizationConfigurationType extends TranslatorAwareType
                 ],
             ])
             ->add('timezone', ChoiceType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Time zone',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -704,8 +704,6 @@ services:
 
     form.type.common.translatable:
         class: 'PrestaShopBundle\Form\Admin\Type\TranslatableType'
-        parent: 'form.type.translatable.aware'
-        public: true
         arguments:
             - "@=service('prestashop.adapter.legacy.context').getAvailableLanguages()"
             - '@router.default'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -463,6 +463,8 @@ services:
 
     form.type.localization_configuration:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Localization\LocalizationConfigurationType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.core.form.choice_provider.language_by_id").getChoices()'
             - '@=service("prestashop.core.form.choice_provider.country_by_id").getChoices()'
@@ -477,6 +479,20 @@ services:
         public: true
         arguments:
             - '@=service("prestashop.core.form.choice_provider.localization_pack_by_iso_code").getChoices()'
+        tags:
+            - { name: form.type }
+
+    form.type.localization.local_units:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Localization\LocalUnitsType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
+    form.type.localization.advanced_configuration:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Localization\AdvancedConfigurationType'
+        parent: 'form.type.translatable.aware'
+        public: true
         tags:
             - { name: form.type }
 
@@ -688,6 +704,8 @@ services:
 
     form.type.common.translatable:
         class: 'PrestaShopBundle\Form\Admin\Type\TranslatableType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - "@=service('prestashop.adapter.legacy.context').getAvailableLanguages()"
             - '@router.default'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme advancedForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block localization_advanced_configuration %}
   <div class="card">
@@ -34,21 +34,7 @@
 
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          {{ ps.label_with_help(('Language identifier'|trans), ('The ISO 639-1 identifier for the language of the country where your web server is located (en, fr, sp, ru, pl, nl, etc.).'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(advancedForm.language_identifier) }}
-            {{ form_widget(advancedForm.language_identifier) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Country identifier'|trans), ('The ISO 3166-1 alpha-2 identifier for the country/region where your web server is located, in lowercase (us, gb, fr, sp, ru, pl, nl, etc.).'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(advancedForm.country_identifier) }}
-            {{ form_widget(advancedForm.country_identifier) }}
-          </div>
-        </div>
+        {{ form_widget(advancedForm) }}
       </div>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme configurationForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block localization_configuration %}
   <div class="card">
@@ -33,68 +33,8 @@
     </h3>
 
     <div class="card-block row">
-      <div class="card-text">
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default language'|trans), ('The default language used in your shop.'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(configurationForm.default_language) }}
-            {{ form_widget(configurationForm.default_language, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Set language from browser'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(configurationForm.detect_language_from_browser) }}
-            {{ form_widget(configurationForm.detect_language_from_browser) }}
-            <small class="form-text">{{ 'Set browser language as default language'|trans({}, 'Admin.International.Help') }}</small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default country'|trans), ('The default country used in your shop.'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(configurationForm.default_country) }}
-            {{ form_widget(configurationForm.default_country, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Set default country from browser language'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(configurationForm.detect_country_from_browser) }}
-            {{ form_widget(configurationForm.detect_country_from_browser) }}
-            <small class="form-text">{{ 'Set country corresponding to browser language'|trans({}, 'Admin.International.Help') }}</small>
-          </div>
-        </div>
-
-        <div class="form-group row js-default-currency-block">
-          {% set currencyChangeWarningMessage = 'Before changing the default currency, we strongly recommend that you enable maintenance mode. Indeed, any change on the default currency requires a manual adjustment of the price of each product and its combinations.'|trans({}, 'Admin.International.Notification') %}
-
-          {{ ps.label_with_help(('Default currency'|trans), ('The default currency used in your shop.'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(configurationForm.default_currency) }}
-            {{ form_widget(configurationForm.default_currency, {'attr': {'data-warning-message': currencyChangeWarningMessage, 'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Time zone'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(configurationForm.timezone) }}
-            {{ form_widget(configurationForm.timezone, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-          </div>
-        </div>
-
-        {% block localization_settings_configuration_form_rest %}
-          {{ form_rest(configurationForm) }}
-        {% endblock %}
+      <div class="card-text">`
+        {{ form_widget(configurationForm) }}
       </div>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% form_theme localizationPackImportForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block import_localization_pack %}
   {{ form_start(localizationPackImportForm, {'action': path('admin_localization_import_pack')}) }}
@@ -34,36 +35,7 @@
 
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Localization pack you want to import'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(localizationPackImportForm.iso_localization_pack) }}
-            {{ form_widget(localizationPackImportForm.iso_localization_pack, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Content to import'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(localizationPackImportForm.content_to_import) }}
-            {{ form_widget(localizationPackImportForm.content_to_import) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Download pack data'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(localizationPackImportForm.download_pack_data) }}
-            {{ form_widget(localizationPackImportForm.download_pack_data) }}
-            <small class="form-text">{{ 'If set to yes then the localization pack will be downloaded from prestashop.com. Otherwise the local xml file found in the localization folder of your PrestaShop installation will be used.'|trans({}, 'Admin.International.Help') }}</small>
-          </div>
-        </div>
+        {{ form_widget(localizationPackImportForm) }}
       </div>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme localUnitsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block localization_local_units %}
   <div class="card">
@@ -34,37 +34,7 @@
 
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          {{ ps.label_with_help(('Weight unit'|trans), ('The default weight unit for your shop (e.g. "kg" for kilograms, "lbs" for pound-mass, etc.).'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(localUnitsForm.weight_unit) }}
-            {{ form_widget(localUnitsForm.weight_unit) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Distance unit'|trans), ('The default distance unit for your shop (e.g. "km" for kilometer, "mi" for mile, etc.).'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(localUnitsForm.distance_unit) }}
-            {{ form_widget(localUnitsForm.distance_unit) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Volume unit'|trans), ('The default volume unit for your shop (e.g. "L" for liter, "gal" for gallon, etc.).'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(localUnitsForm.volume_unit) }}
-            {{ form_widget(localUnitsForm.volume_unit) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Dimension unit'|trans), ('The default dimension unit for your shop (e.g. "cm" for centimeter, "in" for inch, etc.).'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(localUnitsForm.dimension_unit) }}
-            {{ form_widget(localUnitsForm.dimension_unit) }}
-          </div>
-        </div>
+        {{ form_widget(localUnitsForm) }}
       </div>
     </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplfies localization form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Improve -> International -> Localization form. Everything must look and work mostly the same. Main changes are replacement of blue help box by help text under input. Another change is that there is now a red * next to some type as they are actually required fields. 

:notebook: **BC Break**
Backwards compatibility break introduced due to LocalUnitsType, AdvancedConfigurationType and LocalizationConfigurationType extending of TranslationAwareType. This means if any module extends any of those files they will get an exception.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
