### PR TITLE
Fix test 'CRUD carrier' in nightly 07/10/2020

### DIFF
--- a/tests/UI/campaigns/functional/BO/09_shipping/01_carriers/01_CRUDCarrier.js
+++ b/tests/UI/campaigns/functional/BO/09_shipping/01_carriers/01_CRUDCarrier.js
@@ -35,7 +35,13 @@ let numberOfCarriers = 0;
 let carrierID = 0;
 
 const createCarrierData = new CarrierFaker({freeShipping: false, zoneID: 4, allZones: false});
-const editCarrierData = new CarrierFaker({freeShipping: false, allZones: true, enable: true});
+const editCarrierData = new CarrierFaker(
+  {
+    freeShipping: false,
+    rangeSup: 50,
+    allZones: true,
+    enable: true,
+  });
 
 /*
 Create new carrier


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix test 'CRUD carrier' by adding a range sup value in edit carrier data because when out of range = 'Disable carrier' and the range sup is less than the price, the carrier will be not visible.
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | TEST_PATH="functional/BO/09_shipping/01_carriers/01_CRUDCarrier.js" URL_FO=yourShopURL npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21341)
<!-- Reviewable:end -->
