### PR TITLE
Removed order of languages in TranslatableType field for migrated pages

### DIFF
--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -253,7 +253,7 @@ class LegacyContext
      */
     public function getLanguages($active = true, $id_shop = false, $ids_only = false)
     {
-        $languages = Language::getLanguages($active, $id_shop, $ids_only);
+        $languages = $this->getLegacyLanguages($active, $id_shop, $ids_only);
         $defaultLanguageFirst = $this->getLanguage();
         usort($languages, function ($a, $b) use ($defaultLanguageFirst) {
             if ($a['id_lang'] == $defaultLanguageFirst->id) {
@@ -341,6 +341,18 @@ class LegacyContext
      */
     public function getAvailableLanguages()
     {
-        return $this->getLanguages(false);
+        return $this->getLegacyLanguages(false);
+    }
+
+    /**
+     * @param bool $active
+     * @param bool|int $id_shop
+     * @param bool $ids_only
+     *
+     * @return array
+     */
+    private function getLegacyLanguages(bool $active = true, $id_shop = false, bool $ids_only = false): array
+    {
+        return Language::getLanguages($active, $id_shop, $ids_only);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Removed order of languages in TranslatableType field for migrated pages
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20341
| How to test?  | * Install the Shop in English<br>* Add French from the BO<br>* Add Spanish from the BO<br>* Set default language for employee in French<br>**BEFORE** <br>* The order in Migrated pages must be by ID and the default language for employee in priority (French, English, Spanish)<br>* The order in non Migrated pages must be by ID (English, French, Spanish)<br>**AFTER** <br>* The order in Migrated pages must be by ID (English, French, Spanish)<br>* The order in non Migrated pages must be by ID (English, French, Spanish)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21346)
<!-- Reviewable:end -->
