### PR TITLE
WIP: GridPositionMultiStoreUpdater implementation for CMS Pages

### DIFF
--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -248,7 +248,7 @@ class CMSCore extends ObjectModel
         }
 
         if (!$idCategory) {
-            throw new InvalidArgumentException('You need to provide valid idCategory');
+            throw new InvalidArgumentException('You need to provide valid CMS Category ID');
         }
 
         return Db::getInstance()->execute('
@@ -275,7 +275,7 @@ class CMSCore extends ObjectModel
         }
 
         if (!$idCategory) {
-            throw new InvalidArgumentException('You need to provide valid idCategory');
+            throw new InvalidArgumentException('You need to provide valid CMS Category ID');
         }
 
         $sql = '

--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -127,7 +127,7 @@ class CMSCore extends ObjectModel
 
     /**
      * @deprecated 1.7.8.0 Use CMS::getCMSPages() instead
-     * 
+     *
      * Get links.
      *
      * @param int $idLang Language ID
@@ -166,7 +166,7 @@ class CMSCore extends ObjectModel
 
     /**
      * @deprecated 1.7.8.0 Use CMS::getCMSPages() instead
-     * 
+     *
      * @param null $idLang
      * @param bool $idBlock
      * @param bool $active
@@ -252,13 +252,13 @@ class CMSCore extends ObjectModel
         }
 
         return Db::getInstance()->execute('
-            UPDATE `'._DB_PREFIX_.'cms_shop` cp1 JOIN (
+            UPDATE `' . _DB_PREFIX_ . 'cms_shop` cp1 JOIN (
                 SELECT c.`id_cms_category`, c.`id_cms`, @i := @i+1 `new_position`
-                FROM `'._DB_PREFIX_.'cms` c
+                FROM `' . _DB_PREFIX_ . 'cms` c
                 LEFT JOIN `' . _DB_PREFIX_ . 'cms_shop` cs ON (cs.`id_cms` = c.`id_cms`), (select @i:=-1) temp
-                WHERE cs.`id_shop` = ' . (int) $idShop. ' AND c.`id_cms_category` = ' . (int) $idCategory . '
+                WHERE cs.`id_shop` = ' . (int) $idShop . ' AND c.`id_cms_category` = ' . (int) $idCategory . '
                 ORDER BY cs.`position`
-            ) cp2 on (cp1.id_cms = cp2.id_cms AND cp1.id_shop = 2) set cp1.`position` = cp2.`new_position`'
+            ) cp2 on (cp1.id_cms = cp2.id_cms AND cp1.id_shop = ' . (int) $idShop . ') set cp1.`position` = cp2.`new_position`'
         );
     }
 
@@ -282,7 +282,7 @@ class CMSCore extends ObjectModel
             SELECT MAX(cs.`position`) + 1
             FROM `' . _DB_PREFIX_ . 'cms_shop` cs
             LEFT JOIN `' . _DB_PREFIX_ . 'cms` c ON (c.`id_cms` = cs.id_cms)
-            WHERE cs.`id_shop` = ' . (int) $idShop. ' AND c.`id_cms_category` = ' . (int) $idCategory
+            WHERE cs.`id_shop` = ' . (int) $idShop . ' AND c.`id_cms_category` = ' . (int) $idCategory
         ;
 
         return Db::getInstance()->getValue($sql);
@@ -311,7 +311,7 @@ class CMSCore extends ObjectModel
         if (!$idShop) {
             $idShop = $context->shop->id;
         }
-        
+
         $sql->innerJoin('cms_lang', 'l', 'c.id_cms = l.id_cms AND l.id_lang = ' . (int) $idLang . ' AND l.id_shop = ' . (int) $idShop);
         $sql->innerJoin('cms_shop', 'cs', 'c.id_cms = cs.id_cms AND cs.id_shop = ' . (int) $idShop);
 
@@ -334,6 +334,7 @@ class CMSCore extends ObjectModel
         $cmsPages = array_map(
             function ($page) use ($idLang, $context) {
                 $page['url'] = $context->link->getCMSLink((int) $page['id_cms'], $page['link_rewrite'], null, $idLang);
+
                 return $page;
             },
             $cmsPages

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -393,6 +393,7 @@ CREATE TABLE `PREFIX_category_product` (
 CREATE TABLE `PREFIX_cms` (
   `id_cms` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `id_cms_category` int(10) unsigned NOT NULL,
+  `position` int(10) unsigned NOT NULL DEFAULT '0',
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `indexation` tinyint(1) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`id_cms`)

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -393,7 +393,6 @@ CREATE TABLE `PREFIX_category_product` (
 CREATE TABLE `PREFIX_cms` (
   `id_cms` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `id_cms_category` int(10) unsigned NOT NULL,
-  `position` int(10) unsigned NOT NULL DEFAULT '0',
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `indexation` tinyint(1) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`id_cms`)
@@ -2329,6 +2328,7 @@ CREATE TABLE `PREFIX_address_format` (
 CREATE TABLE `PREFIX_cms_shop` (
   `id_cms` INT(11) UNSIGNED NOT NULL,
   `id_shop` INT(11) UNSIGNED NOT NULL,
+  `position` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_cms`, `id_shop`),
   KEY `id_shop` (`id_shop`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -25,4 +25,10 @@ ALTER TABLE `PREFIX_hook` ADD `active` TINYINT(1) UNSIGNED DEFAULT 1 NOT NULL AF
 
 ALTER TABLE `PREFIX_orders` ADD COLUMN `note` TEXT AFTER `date_upd`;
 
+ALTER TABLE `PREFIX_cms_shop` ADD COLUMN `position` int(10) unsigned NOT NULL DEFAULT '0';
+UPDATE `PREFIX_cms_shop` cs
+JOIN `PREFIX_cms` c ON c.`id_cms` = cs.`id_cms`
+SET cs.`position` = c.`position`;
+
+
 ALTER TABLE `PREFIX_currency` CHANGE `numeric_iso_code` `numeric_iso_code` varchar(3) NULL DEFAULT NULL;

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -194,7 +194,7 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
             )
         ;
 
-        if ($this->isAllShopContextOrShopFeatureIsNotUsed()) {
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
             $columnCollection
                 ->addAfter(
                     'head_seo_title',
@@ -282,7 +282,7 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
             )
         ;
 
-        if ($this->isAllShopContextOrShopFeatureIsNotUsed()) {
+        if ($this->multistoreContextChecker->isSingleShopContext()) {
             $filterCollection
                 ->add((new Filter('position', TextType::class))
                 ->setTypeOptions([

--- a/src/Core/Grid/Position/GridPositionMultiStoreUpdater.php
+++ b/src/Core/Grid/Position/GridPositionMultiStoreUpdater.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Position;
+
+use PrestaShop\PrestaShop\Core\Grid\Position\UpdateHandler\PositionUpdateHandlerInterface;
+
+/**
+ * Class GridPositionMultiStoreUpdater, this class is responsible for updating the position of items
+ * of a grid using the information from a PositionUpdateInterface object but with respecting multi-store.
+ */
+final class GridPositionMultiStoreUpdater implements GridPositionUpdaterInterface
+{
+    /**
+     * @var PositionUpdateHandlerInterface
+     */
+    private $updateHandler;
+
+    /**
+     * @param PositionUpdateHandlerInterface $updateHandler
+     */
+    public function __construct(PositionUpdateHandlerInterface $updateHandler)
+    {
+        $this->updateHandler = $updateHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update(PositionUpdateInterface $positionUpdate)
+    {
+        $newPositions = $this->getNewPositions($positionUpdate);
+        $this->sortByPositionValue($newPositions);
+        $this->updateHandler->updatePositions($positionUpdate->getPositionDefinition(), $newPositions);
+    }
+
+    /**
+     * @param PositionUpdateInterface $positionUpdate
+     *
+     * @return array
+     */
+    private function getNewPositions(PositionUpdateInterface $positionUpdate)
+    {
+        $positions = $this->updateHandler->getCurrentPositions($positionUpdate->getPositionDefinition(), $positionUpdate->getParentId());
+
+        /** @var PositionModificationInterface $rowModification */
+        foreach ($positionUpdate->getPositionModificationCollection() as $rowModification) {
+            $positions[$rowModification->getId()] = $rowModification->getNewPosition();
+        }
+
+        return $positions;
+    }
+
+    /**
+     * @param array $positions
+     */
+    private function sortByPositionValue(&$positions)
+    {
+        asort($positions);
+    }
+}

--- a/src/Core/Grid/Position/GridPositionMultiStoreUpdater.php
+++ b/src/Core/Grid/Position/GridPositionMultiStoreUpdater.php
@@ -23,6 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Position;
 
@@ -62,7 +63,7 @@ final class GridPositionMultiStoreUpdater implements GridPositionUpdaterInterfac
      *
      * @return array
      */
-    private function getNewPositions(PositionUpdateInterface $positionUpdate)
+    private function getNewPositions(PositionUpdateInterface $positionUpdate): array
     {
         $positions = $this->updateHandler->getCurrentPositions($positionUpdate->getPositionDefinition(), $positionUpdate->getParentId());
 

--- a/src/Core/Grid/Position/PositionDefinition.php
+++ b/src/Core/Grid/Position/PositionDefinition.php
@@ -53,21 +53,29 @@ final class PositionDefinition implements PositionDefinitionInterface
     private $parentIdField;
 
     /**
+     * @var int|null
+     */
+    private $shopId;
+
+    /**
      * @param string $table
      * @param string $idField
      * @param string $positionField
      * @param string|null $parentIdField
+     * @param int|null $shopId
      */
     public function __construct(
         $table,
         $idField,
         $positionField,
-        $parentIdField = null
+        $parentIdField = null,
+        $shopId = null
     ) {
         $this->table = $table;
         $this->idField = $idField;
         $this->positionField = $positionField;
         $this->parentIdField = $parentIdField;
+        $this->shopId = $shopId;
     }
 
     /**
@@ -100,5 +108,16 @@ final class PositionDefinition implements PositionDefinitionInterface
     public function getParentIdField()
     {
         return $this->parentIdField;
+    }
+
+    /**
+     * If shop id is available we try to update position
+     * in relation to multi-store table
+     * 
+     * @return int|null
+     */
+    public function getShopId()
+    {
+        return $this->shopId;
     }
 }

--- a/src/Core/Grid/Position/PositionDefinition.php
+++ b/src/Core/Grid/Position/PositionDefinition.php
@@ -116,7 +116,7 @@ final class PositionDefinition implements PositionDefinitionInterface
      *
      * @return int|null
      */
-    public function getShopId()
+    public function getShopId(): ?int
     {
         return $this->shopId;
     }

--- a/src/Core/Grid/Position/PositionDefinition.php
+++ b/src/Core/Grid/Position/PositionDefinition.php
@@ -113,7 +113,7 @@ final class PositionDefinition implements PositionDefinitionInterface
     /**
      * If shop id is available we try to update position
      * in relation to multi-store table
-     * 
+     *
      * @return int|null
      */
     public function getShopId()

--- a/src/Core/Grid/Position/PositionDefinitionInterface.php
+++ b/src/Core/Grid/Position/PositionDefinitionInterface.php
@@ -68,5 +68,5 @@ interface PositionDefinitionInterface
      *
      * @return int|null
      */
-    public function getShopId();
+    public function getShopId(): ?int;
 }

--- a/src/Core/Grid/Position/PositionDefinitionInterface.php
+++ b/src/Core/Grid/Position/PositionDefinitionInterface.php
@@ -61,4 +61,12 @@ interface PositionDefinitionInterface
      * @return string|null
      */
     public function getParentIdField();
+
+    /**
+     * Id of the shop, if not null we are trying to update position
+     * in relation to multi-store context
+     *
+     * @return int|null
+     */
+    public function getShopId();
 }

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Position\UpdateHandler;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ConnectionException;
+use Doctrine\DBAL\Statement;
+use PrestaShop\PrestaShop\Core\Grid\Position\Exception\PositionUpdateException;
+use PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinitionInterface;
+
+/**
+ * Class DoctrinePositionMultiStoreUpdateHandler updates the grid positions using a Doctrine
+ * Connection.
+ */
+final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHandlerInterface
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
+     * @var int
+     */
+    private $shopId;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param int $shopId
+     */
+    public function __construct(
+        Connection $connection,
+        $dbPrefix,
+        $shopId
+    ) {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+        $this->shopId = $shopId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentPositions(PositionDefinitionInterface $positionDefinition, $parentId = null)
+    {
+        if (null != $positionDefinition->getShopId()) {
+            $this->shopId = $positionDefinition->getShopId();
+        }
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->from($this->dbPrefix . $positionDefinition->getTable().'_shop', 't')
+            ->select('t.' . $positionDefinition->getIdField() . ', t.' . $positionDefinition->getPositionField())
+            ->addOrderBy('t.' . $positionDefinition->getPositionField(), 'ASC');
+
+        if (null !== $parentId && null !== $positionDefinition->getParentIdField()) {
+            $qb
+                ->leftJoin(
+                    't',
+                    $this->dbPrefix . $positionDefinition->getTable(),
+                    'tr',
+                    'tr.id_cms_category =:parentId'
+                )
+                ->setParameter('parentId', $parentId);
+        }
+
+        $positions = $qb->execute()->fetchAll();
+        $currentPositions = [];
+        foreach ($positions as $position) {
+            $positionId = $position[$positionDefinition->getIdField()];
+            $currentPositions[$positionId] = $position[$positionDefinition->getPositionField()];
+        }
+
+        return $currentPositions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updatePositions(PositionDefinitionInterface $positionDefinition, array $newPositions)
+    {
+        try {
+            $this->connection->beginTransaction();
+            $positionIndex = 0;
+            foreach ($newPositions as $rowId => $newPosition) {
+                $qb = $this->connection->createQueryBuilder();
+                $qb
+                    ->update($this->dbPrefix . $positionDefinition->getTable() . '_shop')
+                    ->set($positionDefinition->getPositionField(), ':position')
+                    ->andWhere($positionDefinition->getIdField() . ' = :rowId')
+                    ->andWhere('id_shop = :shopId')
+                    ->setParameter('shopId', $this->shopId)
+                    ->setParameter('rowId', $rowId)
+                    ->setParameter('position', $positionIndex);
+
+                $statement = $qb->execute();
+                if ($statement instanceof Statement && $statement->errorCode()) {
+                    throw new PositionUpdateException('Could not update #%i', 'Admin.Catalog.Notification', [$rowId]);
+                }
+                ++$positionIndex;
+            }
+            $this->connection->commit();
+        } catch (ConnectionException $e) {
+            $this->connection->rollBack();
+
+            throw new PositionUpdateException('Could not update.', 'Admin.Catalog.Notification');
+        }
+    }
+}

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -23,6 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Position\UpdateHandler;
 
@@ -60,8 +61,8 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
      */
     public function __construct(
         Connection $connection,
-        $dbPrefix,
-        $shopId
+        string $dbPrefix,
+        int $shopId
     ) {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;
@@ -71,7 +72,7 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
     /**
      * {@inheritdoc}
      */
-    public function getCurrentPositions(PositionDefinitionInterface $positionDefinition, $parentId = null)
+    public function getCurrentPositions(PositionDefinitionInterface $positionDefinition, int $parentId = null)
     {
         if (null != $positionDefinition->getShopId()) {
             $this->shopId = $positionDefinition->getShopId();

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -79,13 +79,12 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
 
         $qb = $this->connection->createQueryBuilder();
         $qb
-            ->from($this->dbPrefix . $positionDefinition->getTable(). '_shop', 't')
+            ->from($this->dbPrefix . $positionDefinition->getTable() . '_shop', 't')
             ->select('t.' . $positionDefinition->getIdField() . ', t.' . $positionDefinition->getPositionField())
             ->andWhere('t.id_shop = :shopId')
             ->andWhere('tr.' . $positionDefinition->getParentIdField() . ' = :parentId')
             ->setParameter('shopId', $this->shopId)
             ->addOrderBy('t.' . $positionDefinition->getPositionField(), 'ASC');
-            
 
         if (null !== $parentId && null !== $positionDefinition->getParentIdField()) {
             $qb
@@ -93,7 +92,7 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
                     't',
                     $this->dbPrefix . $positionDefinition->getTable(),
                     'tr',
-                    'tr.' . $positionDefinition->getIdField() .' = t.' . $positionDefinition->getIdField()
+                    'tr.' . $positionDefinition->getIdField() . ' = t.' . $positionDefinition->getIdField()
                 )
                 ->setParameter('parentId', $parentId);
         }

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -82,12 +82,12 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
             ->from($this->dbPrefix . $positionDefinition->getTable() . '_shop', 't')
             ->select('t.' . $positionDefinition->getIdField() . ', t.' . $positionDefinition->getPositionField())
             ->andWhere('t.id_shop = :shopId')
-            ->andWhere('tr.' . $positionDefinition->getParentIdField() . ' = :parentId')
             ->setParameter('shopId', $this->shopId)
             ->addOrderBy('t.' . $positionDefinition->getPositionField(), 'ASC');
 
         if (null !== $parentId && null !== $positionDefinition->getParentIdField()) {
             $qb
+                ->andWhere('tr.' . $positionDefinition->getParentIdField() . ' = :parentId')
                 ->leftJoin(
                     't',
                     $this->dbPrefix . $positionDefinition->getTable(),

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -81,7 +81,11 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
         $qb
             ->from($this->dbPrefix . $positionDefinition->getTable().'_shop', 't')
             ->select('t.' . $positionDefinition->getIdField() . ', t.' . $positionDefinition->getPositionField())
+            ->andWhere('t.id_shop = :shopId')
+            ->andWhere('tr.' . $positionDefinition->getParentIdField() . ' = :parentId')
+            ->setParameter('shopId', $this->shopId)
             ->addOrderBy('t.' . $positionDefinition->getPositionField(), 'ASC');
+            
 
         if (null !== $parentId && null !== $positionDefinition->getParentIdField()) {
             $qb
@@ -89,7 +93,7 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
                     't',
                     $this->dbPrefix . $positionDefinition->getTable(),
                     'tr',
-                    'tr.id_cms_category =:parentId'
+                    'tr.' . $positionDefinition->getIdField() .' = t.' . $positionDefinition->getIdField()
                 )
                 ->setParameter('parentId', $parentId);
         }
@@ -111,6 +115,11 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
     {
         try {
             $this->connection->beginTransaction();
+
+            if (null != $positionDefinition->getShopId()) {
+                $this->shopId = $positionDefinition->getShopId();
+            }
+
             $positionIndex = 0;
             foreach ($newPositions as $rowId => $newPosition) {
                 $qb = $this->connection->createQueryBuilder();

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -79,7 +79,7 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
 
         $qb = $this->connection->createQueryBuilder();
         $qb
-            ->from($this->dbPrefix . $positionDefinition->getTable().'_shop', 't')
+            ->from($this->dbPrefix . $positionDefinition->getTable(). '_shop', 't')
             ->select('t.' . $positionDefinition->getIdField() . ', t.' . $positionDefinition->getPositionField())
             ->andWhere('t.id_shop = :shopId')
             ->andWhere('tr.' . $positionDefinition->getParentIdField() . ' = :parentId')

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionMultiStoreUpdateHandler.php
@@ -72,7 +72,7 @@ final class DoctrinePositionMultiStoreUpdateHandler implements PositionUpdateHan
     /**
      * {@inheritdoc}
      */
-    public function getCurrentPositions(PositionDefinitionInterface $positionDefinition, int $parentId = null)
+    public function getCurrentPositions(PositionDefinitionInterface $positionDefinition, $parentId = null)
     {
         if (null != $positionDefinition->getShopId()) {
             $this->shopId = $positionDefinition->getShopId();

--- a/src/Core/Grid/Query/CmsPageQueryBuilder.php
+++ b/src/Core/Grid/Query/CmsPageQueryBuilder.php
@@ -78,7 +78,7 @@ final class CmsPageQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
 
         $qb
-            ->select('c.`id_cms`, cl.`link_rewrite`, c.`active`, c.`position`, cl.`meta_title`, cl.`head_seo_title`')
+            ->select('c.`id_cms`, cl.`link_rewrite`, c.`active`, cs.`position`, cl.`meta_title`, cl.`head_seo_title`')
             ->addSelect('c.`id_cms_category`')
             ->groupBy('c.`id_cms`')
         ;
@@ -167,7 +167,7 @@ final class CmsPageQueryBuilder extends AbstractDoctrineQueryBuilder
 
             if ('position' === $filterName) {
                 $modifiedPositionFilter = $this->getModifiedPositionFilter($value);
-                $qb->andWhere('c.`' . $filterName . '` = :' . $filterName);
+                $qb->andWhere('cs.`' . $filterName . '` = :' . $filterName);
                 $qb->setParameter($filterName, $modifiedPositionFilter);
                 continue;
             }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -595,7 +595,7 @@ class CmsPageController extends FrameworkBundleAdminController
             return $this->redirectToParentIndexPage($cmsCategoryParentId);
         }
 
-        $updater = $this->get('prestashop.core.grid.position.doctrine_grid_position_updater');
+        $updater = $this->get('prestashop.core.grid.position.doctrine_grid_multi_store_position_updater');
 
         try {
             $updater->update($positionUpdate);

--- a/src/PrestaShopBundle/Resources/config/services/core/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid.yml
@@ -40,5 +40,17 @@ services:
     arguments:
       - '@prestashop.core.grid.position.update_handler.doctrine_position_update_handler'
 
+  prestashop.core.grid.position.update_handler.doctrine_position_multi_store_update_handler:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Position\UpdateHandler\DoctrinePositionMultiStoreUpdateHandler'
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
+      - '@=service("prestashop.adapter.shop.context").getContextShopID()'
+
+  prestashop.core.grid.position.doctrine_grid_multi_store_position_updater:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Position\GridPositionMultiStoreUpdater'
+    arguments:
+      - '@prestashop.core.grid.position.update_handler.doctrine_position_multi_store_update_handler'
+
   prestashop.core.grid.query.filter.doctrine_filter_applicator:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\Filter\DoctrineFilterApplicator'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
@@ -17,6 +17,7 @@ services:
       $idField: 'id_cms'
       $positionField: 'position'
       $parentIdField: 'id_cms_category'
+      $shopId: '@=service("prestashop.adapter.shop.context").getContextShopID()'
 
   prestashop.core.grid.attribute.position_definition:
     class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Possibility to sort entities in relation to shop table
| Type?         | improvement
| Category?     | CO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #18965
| How to test?  | Play with CMS pages drag&drop sort, with and without categories, with & without multi-store

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

## Some thoughts

1. Is it good to almost copy `DoctrinePositionUpdateHandler `? I didn't want to introduce to much changes to core for this, we have an easy way (IFs), and a bit more clear solution introduced with this PR **but** it is something to think about.
2. Implementation in `CategoryGrid` is cleaner but I think that it would be better for developers to have it (sorting capability for modern controllers) implemented in some way directly in core architecture of `Grid`... btw. sorting on Category pages in context of two different stores doesn't work 🤷
3. As there's a decision to use `final`, I wasn't able to extend base `GridPositionUpdater`, I think that at this point we cannot implement any strategy class to handle this because it would introduce unacceptable breaking change?
4. I changed interface, and at this point I wonder if we should start with splitting between multi-store/single here, as this is breaking change

## TODO

- [ ] architectural decisions
- [x] sorting fully working in BO for single store context
- [x] sorting fully working in BO for single store context and different categories
- [x] refacto `CMS::updatePosition`
- [x] refacto `CMS::cleanPositions`
- [x] refacto `CMS::getLastPosition`
- [x] refacto `CMS::getCMSPages`
- [ ] check for backward compatibility issues
- [ ] document changes in `CMS` class
- [ ] check for tests implementation, eg. for `PositionUpdater`
- [ ] E2E

## DEPRECATED METHODS

- `CMS::listCms` - no `block_cms` in PrestaShop anymore, not possible to sort pages if they're are in few stores
- `CMS::getLinks` same as above, hard to get real CMS position, data between this and proper `CMS::getPages` are different



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21352)
<!-- Reviewable:end -->
