### PR TITLE
Simplifies geolocation form

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -27,6 +27,7 @@ import TranslatableField from '@js/components/translatable-field.js';
 import TranslatableInput from '@js/components/translatable-input.js';
 import TinyMCEEditor from '@js/components/tinymce-editor.js';
 import TaggableField from '@js/components/taggable-field.js';
+import ChoiceTable from '@js/components/choice-table.js';
 
 const initPrestashopComponents = () => {
   window.prestashop = {...window.prestashop};
@@ -58,6 +59,7 @@ const initPrestashopComponents = () => {
     TinyMCEEditor,
     TranslatableInput,
     TaggableField,
+    ChoiceTable,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/pages/geolocation/index.js
+++ b/admin-dev/themes/new-theme/js/pages/geolocation/index.js
@@ -23,8 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTable from '@components/choice-table';
-
 const {$} = window;
 
 $(() => {

--- a/admin-dev/themes/new-theme/js/pages/geolocation/index.js
+++ b/admin-dev/themes/new-theme/js/pages/geolocation/index.js
@@ -28,5 +28,9 @@ import ChoiceTable from '@components/choice-table';
 const {$} = window;
 
 $(() => {
-  new ChoiceTable();
+  window.prestashop.component.initComponents(
+    [
+      'ChoiceTable',
+    ],
+  );
 });

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
@@ -28,7 +28,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Geolocation;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -51,7 +50,7 @@ class GeolocationByIpAddressType extends TranslatorAwareType
                 'help' => $this->trans(
                     'This option allows you, among other things, to restrict access to your shop for certain countries. See below.',
                     'Admin.International.Help'
-                )
+                ),
             ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
@@ -43,7 +43,6 @@ class GeolocationByIpAddressType extends TranslatorAwareType
     {
         $builder
             ->add('geolocation_enabled', SwitchType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Geolocation by IP address',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
@@ -43,6 +43,7 @@ class GeolocationByIpAddressType extends TranslatorAwareType
     {
         $builder
             ->add('geolocation_enabled', SwitchType::class, [
+                'required' => false,
                 'label' => $this->trans(
                     'Geolocation by IP address',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationByIpAddressType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Geolocation;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -34,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * Class GeolocationByIpAddressType is responsible for handling "Improve > International > Localization > Geolocation"
  * IP addresses whitelist form.
  */
-class GeolocationByIpAddressType extends AbstractType
+class GeolocationByIpAddressType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -42,6 +43,15 @@ class GeolocationByIpAddressType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('geolocation_enabled', SwitchType::class);
+            ->add('geolocation_enabled', SwitchType::class, [
+                'label' => $this->trans(
+                    'Geolocation by IP address',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'This option allows you, among other things, to restrict access to your shop for certain countries. See below.',
+                    'Admin.International.Help'
+                )
+            ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Geolocation;
 
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -35,7 +36,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * Class GeolocationIpAddressWhitelistType is responsible for handling "Improve > International > Localization > Geolocation"
  * IP addresses whitelist form.
  */
-class GeolocationIpAddressWhitelistType extends AbstractType
+class GeolocationIpAddressWhitelistType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -44,6 +45,10 @@ class GeolocationIpAddressWhitelistType extends AbstractType
     {
         $builder
             ->add('geolocation_whitelist', TextareaType::class, [
+                'label' => $this->trans(
+                    'Whitelisted IP addresses',
+                    'Admin.International.Feature'
+                ),
                 'required' => false,
                 'attr' => [
                     'col' => 15,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Geolocation;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
@@ -48,7 +48,6 @@ class GeolocationIpAddressWhitelistType extends TranslatorAwareType
                     'Whitelisted IP addresses',
                     'Admin.International.Feature'
                 ),
-                'required' => false,
                 'attr' => [
                     'col' => 15,
                     'rows' => 30,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationIpAddressWhitelistType.php
@@ -44,6 +44,7 @@ class GeolocationIpAddressWhitelistType extends TranslatorAwareType
     {
         $builder
             ->add('geolocation_whitelist', TextareaType::class, [
+                'required' => false,
                 'label' => $this->trans(
                     'Whitelisted IP addresses',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -75,6 +75,10 @@ class GeolocationOptionsType extends TranslatorAwareType
     {
         $builder
             ->add('geolocation_behaviour', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Geolocation behavior for restricted countries',
+                    'Admin.International.Feature'
+                ),
                 'choices' => [
                     $this->trans('Visitors cannot see your catalog.', 'Admin.International.Feature') => $this->configuration->get('_PS_GEOLOCATION_NO_CATALOG_'),
                     $this->trans('Visitors can see your catalog but cannot place an order.', 'Admin.International.Feature') => $this->configuration->get('_PS_GEOLOCATION_NO_ORDER_'),
@@ -82,6 +86,10 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('geolocation_na_behaviour', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Geolocation behavior for other countries',
+                    'Admin.International.Feature'
+                ),
                 'choices' => [
                     $this->trans('All features are available', 'Admin.International.Feature') => '-1',
                     $this->trans('Visitors cannot see your catalog.', 'Admin.International.Feature') => $this->configuration->get('_PS_GEOLOCATION_NO_CATALOG_'),
@@ -90,6 +98,10 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('geolocation_countries', MaterialChoiceTableType::class, [
+                'label' => $this->trans(
+                    'Select the countries from which your store is accessible',
+                    'Admin.International.Feature'
+                ),
                 'choices' => $this->countryChoices,
                 'choice_translation_domain' => false,
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -75,8 +75,6 @@ class GeolocationOptionsType extends TranslatorAwareType
     {
         $builder
             ->add('geolocation_behaviour', ChoiceType::class, [
-                'required' => false,
-                'placeholder' => false,
                 'label' => $this->trans(
                     'Geolocation behavior for restricted countries',
                     'Admin.International.Feature'
@@ -88,8 +86,6 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('geolocation_na_behaviour', ChoiceType::class, [
-                'required' => false,
-                'placeholder' => false,
                 'label' => $this->trans(
                     'Geolocation behavior for other countries',
                     'Admin.International.Feature'
@@ -102,7 +98,6 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('geolocation_countries', MaterialChoiceTableType::class, [
-                'required' => false,
                 'label' => $this->trans(
                     'Select the countries from which your store is accessible',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -75,6 +75,8 @@ class GeolocationOptionsType extends TranslatorAwareType
     {
         $builder
             ->add('geolocation_behaviour', ChoiceType::class, [
+                'required' => false,
+                'placeholder' => false,
                 'label' => $this->trans(
                     'Geolocation behavior for restricted countries',
                     'Admin.International.Feature'
@@ -86,6 +88,8 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('geolocation_na_behaviour', ChoiceType::class, [
+                'required' => false,
+                'placeholder' => false,
                 'label' => $this->trans(
                     'Geolocation behavior for other countries',
                     'Admin.International.Feature'
@@ -98,6 +102,7 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('geolocation_countries', MaterialChoiceTableType::class, [
+                'required' => false,
                 'label' => $this->trans(
                     'Select the countries from which your store is accessible',
                     'Admin.International.Feature'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -480,6 +480,20 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.geolocation.by_address:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Geolocation\GeolocationByIpAddressType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
+    form.type.geolocation.ip_address_white_list:
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Geolocation\GeolocationIpAddressWhitelistType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.geolocation.options:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Geolocation\GeolocationOptionsType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme geolocationByIpAddressForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block geolocation_by_ip_address %}
   <div class="card">
@@ -33,17 +33,7 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          {{ ps.label_with_help(('Geolocation by IP address'|trans), ('This option allows you, among other things, to restrict access to your shop for certain countries. See below.'|trans({}, 'Admin.International.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(geolocationByIpAddressForm.geolocation_enabled) }}
-            {{ form_widget(geolocationByIpAddressForm.geolocation_enabled) }}
-          </div>
-        </div>
-
-        {% block geolocation_by_ip_address_form_rest %}
-          {{ form_rest(geolocationByIpAddressForm) }}
-        {% endblock %}
+        {{ form_widget(geolocationByIpAddressForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% form_theme geolocationIpAddressWhitelistForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block geolocation_ip_address_whitelist %}
   <div class="card">
@@ -41,20 +42,7 @@
             </div>
           </div>
         </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Whitelisted IP addresses'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(geolocationIpAddressWhitelistForm.geolocation_whitelist) }}
-            {{ form_widget(geolocationIpAddressWhitelistForm.geolocation_whitelist) }}
-          </div>
-        </div>
-
-        {% block geolocation_whitelist_form_rest %}
-          {{ form_rest(geolocationIpAddressWhitelistForm) }}
-        {% endblock %}
+        {{ form_widget(geolocationIpAddressWhitelistForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
+{% form_theme geolocationOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block geolocation_options %}
   <div class="card">
@@ -41,43 +42,7 @@
             </div>
           </div>
         </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Geolocation behavior for restricted countries'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(geolocationOptionsForm.geolocation_behaviour) }}
-            {{ form_widget(geolocationOptionsForm.geolocation_behaviour) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Geolocation behavior for other countries'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(geolocationOptionsForm.geolocation_na_behaviour) }}
-            {{ form_widget(geolocationOptionsForm.geolocation_na_behaviour) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Select the countries from which your store is accessible'|trans }}
-          </label>
-
-          <div class="col-sm">
-            <div class="form-group">
-              {{ form_errors(geolocationOptionsForm.geolocation_countries) }}
-              {{ form_widget(geolocationOptionsForm.geolocation_countries) }}
-            </div>
-          </div>
-        </div>
-
-        {% block geolocation_options_form_rest %}
-          {{ form_rest(geolocationOptionsForm) }}
-        {% endblock %}
+        {{ form_widget(geolocationOptionsForm) }}
       </div>
     </div>
     <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplfies geolocation form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Improve -> International -> Geolocation form. Everything must look and work mostly the same. Main changes are replacement of blue help box by help text under input.

:notebook: **BC Break**
Backwards compatibility break introduced due to GeolocationIpAddressWhitelistTypea and GeolocationByIpAddressType extending of TranslationAwareType. This means if any module extends any of those file they will get an exception.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
