### PR TITLE
Possibility to check if we're in product quick view mode

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -52,6 +52,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     protected $quantity_discounts;
     protected $adminNotifications = [];
 
+    /**
+     * @var bool
+     */
     protected $isQuickView = false;
 
     public function canonicalRedirection($canonical_url = '')

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -456,7 +456,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
             'product_title' => $product['title'],
-            'is_quick_view' => $isQuickView
+            'is_quick_view' => $isQuickView,
         ]));
     }
 
@@ -1325,8 +1325,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
-     * Return information whether we are or not in quick view mode
-     * 
+     * Return information whether we are or not in quick view mode.
+     *
      * @return bool
      */
     public function isQuickView()
@@ -1335,9 +1335,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
-     * Set if product is in quick view mode or not
-     * 
-     * @return void
+     * Set quick view mode.
      */
     public function setQuickViewMode($enabled = true)
     {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -52,6 +52,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     protected $quantity_discounts;
     protected $adminNotifications = [];
 
+    protected $isQuickView = false;
+
     public function canonicalRedirection($canonical_url = '')
     {
         if (Validate::isLoadedObject($this->product)) {
@@ -394,6 +396,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $productForTemplate = $this->getTemplateVarProduct();
         ob_end_clean();
         header('Content-Type: application/json');
+
+        $this->setQuickViewMode();
+
         $this->ajaxRender(Tools::jsonEncode([
             'quickview_html' => $this->render(
                 'catalog/_partials/quickview',
@@ -410,6 +415,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product = $this->getTemplateVarProduct();
         $minimalProductQuantity = $this->getProductMinimalQuantity($product);
         $isPreview = ('1' === Tools::getValue('preview'));
+        $isQuickView = ('1' === Tools::getValue('quickview'));
+
+        if ($isQuickView) {
+            $this->setQuickViewMode();
+        }
 
         ob_end_clean();
         header('Content-Type: application/json');
@@ -446,6 +456,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
             'product_title' => $product['title'],
+            'is_quick_view' => $isQuickView
         ]));
     }
 
@@ -1311,5 +1322,25 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         }
 
         return false;
+    }
+
+    /**
+     * Return information whether we are or not in quick view mode
+     * 
+     * @return bool
+     */
+    public function isQuickView()
+    {
+        return $this->isQuickView;
+    }
+
+    /**
+     * Set if product is in quick view mode or not
+     * 
+     * @return void
+     */
+    public function setQuickViewMode($enabled = true)
+    {
+        $this->isQuickView = $enabled;
     }
 }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1329,15 +1329,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return bool
      */
-    public function isQuickView()
+    public function isQuickView(): bool
     {
         return $this->isQuickView;
     }
 
     /**
      * Set quick view mode.
+     *
+     * @param bool $enabled
      */
-    public function setQuickViewMode($enabled = true)
+    public function setQuickViewMode(bool $enabled = true)
     {
         $this->isQuickView = $enabled;
     }

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -154,6 +154,7 @@ function updateProduct(event, eventType, updateUrl) {
       url: updateUrl + ((updateUrl.indexOf('?') === -1) ? '?' : '&') + formSerialized + preview,
       method: 'POST',
       data: {
+        quickview: parseInt($('.modal.quickview.in').length),
         ajax: 1,
         action: 'refresh',
         quantity_wanted: eventType === 'updatedProductCombination' ? $quantityWantedInput.attr('min') : $quantityWantedInput.val()

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -154,7 +154,7 @@ function updateProduct(event, eventType, updateUrl) {
       url: updateUrl + ((updateUrl.indexOf('?') === -1) ? '?' : '&') + formSerialized + preview,
       method: 'POST',
       data: {
-        quickview: parseInt($('.modal.quickview.in').length),
+        quickview: $('.modal.quickview.in').length,
         ajax: 1,
         action: 'refresh',
         quantity_wanted: eventType === 'updatedProductCombination' ? $quantityWantedInput.attr('min') : $quantityWantedInput.val()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Follow #21359 
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21359 
| How to test?  | Edit ps_sharebutton module and try to check if you're in quick view mode using code below
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

### Method to check if we're in quick view mode

#### In module .tpl (worth checking of we're 

```
{if $page.page_name == 'product' && Context::getContext()->controller->isQuickView()}
  we're in quick view mode for {$product.id_product} and attribute {$product.id_product_attribute}
{/if}
```

### In module .php files

```
if ($this->context->controller instanceof ProductController && $this->context->controller->isQuickView()) {
echo 'yep';
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21362)
<!-- Reviewable:end -->
