### PR TITLE
Add override list to admin Information page

### DIFF
--- a/src/Adapter/Shop/ShopInformation.php
+++ b/src/Adapter/Shop/ShopInformation.php
@@ -27,8 +27,8 @@
 namespace PrestaShop\PrestaShop\Adapter\Shop;
 
 use AppKernel;
-use Tools;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use Tools;
 
 /**
  * Retrieve common information from a the actual Shop.

--- a/src/Adapter/Shop/ShopInformation.php
+++ b/src/Adapter/Shop/ShopInformation.php
@@ -66,7 +66,7 @@ class ShopInformation
     /**
      * @return array
      */
-    public function getOverridesList()
+    public function getOverridesList(): array
     {
         return array_filter(Tools::scandir(_PS_OVERRIDE_DIR_, 'php', '', true), function ($file) {
             return basename($file) != 'index.php';

--- a/src/Adapter/Shop/ShopInformation.php
+++ b/src/Adapter/Shop/ShopInformation.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Shop;
 
 use AppKernel;
+use Tools;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 
 /**
@@ -60,5 +61,15 @@ class ShopInformation
             'path' => _PS_ROOT_DIR_,
             'theme' => $this->context->shop->theme->getName(),
         ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getOverridesList()
+    {
+        return array_filter(Tools::scandir(_PS_OVERRIDE_DIR_, 'php', '', true), function ($file) {
+            return basename($file) != 'index.php';
+        });
     }
 }

--- a/src/Adapter/System/SystemInformation.php
+++ b/src/Adapter/System/SystemInformation.php
@@ -71,6 +71,7 @@ class SystemInformation
             'instaWebInstalled' => $this->hostingInformation->isApacheInstawebModule(),
             'uname' => $this->hostingInformation->getUname(),
             'database' => $this->hostingInformation->getDatabaseInformation(),
+            'overrides' => $this->shopInformation->getOverridesList(),
             'shop' => $this->shopInformation->getShopInformation(),
             'isNativePHPmail' => $this->mailingInformation->isNativeMailUsed(),
             'smtp' => $this->mailingInformation->getSmtpInformation(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -47,7 +47,7 @@
           <div class="card-text">
             {% if system.uname is not empty %}
               <p>
-                <strong>{{ 'Server information'|trans }}</strong> {{ system.uname }}
+                <strong>{{ 'Server information:'|trans }}</strong> {{ system.uname }}
               </p>
             {% endif %}
             <p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -148,38 +148,39 @@
       </h3>
       <div class="card-block">
         <div class="card-text">
-          <p>
-            <strong>{{ 'Mail method:'|trans }}</strong>
-
-            {% if system.isNativePHPmail %}
-            {{ 'You are using /usr/sbin/sendmail'|trans }}
-            {% else %}
-            {{ 'You are using your own SMTP parameters.'|trans }}</p>
-          <p>
-            <strong>{{ 'SMTP server:'|trans }}</strong> {{ system.smtp.server }}
-          </p>
-          <p>
-            <strong>{{ 'SMTP username:'|trans }}</strong>
-            {% if system.smtp.user is not empty %}
-              {{ 'Defined'|trans }}
-            {% else %}
-              <span style="color:red;">{{ 'Not defined'|trans }}</span>
-            {% endif %}
-          </p>
-          <p>
-            <strong>{{ 'SMTP password:'|trans }}</strong>
-            {% if system.smtp.password is not empty %}
-              {{ 'Defined'|trans }}
-            {% else %}
-              <span style="color:red;">{{ 'Not defined'|trans }}</span>
-            {% endif %}
-          </p>
-          <p>
-            <strong>{{ 'Encryption:'|trans }}</strong> {{ system.smtp.encryption }}
-          </p>
-          <p>
-            <strong>{{ 'SMTP port:'|trans }}</strong> {{ system.smtp.port }}
-          </p>
+          {% if system.isNativePHPmail %}
+            <p>
+              <strong>{{ 'Mail method:'|trans }}</strong> {{ 'You are using /usr/sbin/sendmail'|trans }}
+            </p>
+          {% else %}
+            <p>
+              <strong>{{ 'Mail method:'|trans }}</strong> {{ 'You are using your own SMTP parameters.'|trans }}
+            </p>
+            <p>
+              <strong>{{ 'SMTP server:'|trans }}</strong> {{ system.smtp.server }}
+            </p>
+            <p>
+              <strong>{{ 'SMTP username:'|trans }}</strong>
+              {% if system.smtp.user is not empty %}
+                {{ 'Defined'|trans }}
+              {% else %}
+                <span style="color:red;">{{ 'Not defined'|trans }}</span>
+              {% endif %}
+            </p>
+            <p>
+              <strong>{{ 'SMTP password:'|trans }}</strong>
+              {% if system.smtp.password is not empty %}
+                {{ 'Defined'|trans }}
+              {% else %}
+                <span style="color:red;">{{ 'Not defined'|trans }}</span>
+              {% endif %}
+            </p>
+            <p>
+              <strong>{{ 'Encryption:'|trans }}</strong> {{ system.smtp.encryption }}
+            </p>
+            <p>
+              <strong>{{ 'SMTP port:'|trans }}</strong> {{ system.smtp.port }}
+            </p>
           {% endif %}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -205,13 +205,15 @@
       </h3>
       <div class="card-block">
         <div class="card-text">
-          <p>
-            <strong>{{ 'Required parameters:'|trans }}</strong>
           {% if requirements.failRequired == false %}
-            <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-          </p>
+            <p>
+              <strong>{{ 'Required parameters:'|trans }}</strong>
+              <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+            </p>
           {% else %}
-            <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+            <p>
+              <strong>{{ 'Required parameters:'|trans }}</strong>
+              <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
             </p>
             <ul>
               {% for key, value in requirements.testsRequired %}
@@ -222,13 +224,15 @@
             </ul>
           {% endif %}
           {% if requirements.failOptional is defined %}
-            <p>
-            <strong>{{ 'Optional parameters:'|trans }}</strong>
             {% if requirements.failOptional == false %}
-              <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+              <p>
+                <strong>{{ 'Optional parameters:'|trans }}</strong>
+                <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
               </p>
             {% else %}
-              <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+              <p>
+                <strong>{{ 'Optional parameters:'|trans }}</strong>
+                <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
               </p>
               <ul>
                 {% for key, value in requirements.testsOptional %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -108,13 +108,13 @@
         <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
       </h3>
       <div class="card-block">
-      <div class="card-text">
-        <ul>
-          {% for override in system.overrides %}
-            <li>{{ override }}</li>
-          {% endfor %}
-        </ul>
-      </div>
+        <div class="card-text">
+          <ul>
+            {% for override in system.overrides %}
+              <li>{{ override }}</li>
+            {% endfor %}
+          </ul>
+        </div>
       </div>
     </div>
     {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -283,10 +283,11 @@
             'updated': translations.updated,
           };
 
-          if (json.missing.length || json.updated.length)
-            $('#changedFiles').html('<div class="alert alert-warning" role="alert"><p class="alert-text">'+ translations.changesDetected +'</p></div>');
-          else
-            $('#changedFiles').html('<div class="alert alert-success" role="alert"><p class="alert-text">'+ translations.noChangeDetected +'</p></div>');
+          if (json.missing.length || json.updated.length) {
+            $('#changedFiles').html('<div class="alert alert-warning" role="alert"><p class="alert-text">' + translations.changesDetected + '</p></div>');
+          } else {
+            $('#changedFiles').html('<div class="alert alert-success" role="alert"><p class="alert-text">' + translations.noChangeDetected + '</p></div>');
+          }
 
           $.each(tab, function(key, lang) {
             if (json[key].length) {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -265,10 +265,10 @@
     $(document).ready(function()
     {
       var translations = {
-        missing: '{{ "Missing files"|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
-        updated: '{{ "Updated files"|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
-        changesDetected: '{{ "Changed/missing files have been detected."|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
-        noChangeDetected: '{{ "No change has been detected in your files."|trans({}, "Admin.Advparameters.Notification")|e('js') }}'
+        missing: '{{ 'Missing files'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
+        updated: '{{ 'Updated files'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
+        changesDetected: '{{ 'Changed/missing files have been detected.'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',
+        noChangeDetected: '{{ 'No change has been detected in your files.'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}'
       };
 
       $.ajax({

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -102,6 +102,21 @@
                 </div>
             </div>
         </div>
+
+        <div class="card">
+          <h3 class="card-header">
+            <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
+          </h3>
+          <div class="card-block">
+            <div class="card-text">
+              <ul>
+                {% for override in system.overrides %}
+                  <li>{{ override }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
     </div>
     {% endif %}
     <div class="col-lg-6">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -39,71 +39,71 @@
             </div>
         </div>
         {% if system.notHostMode %}
-        <div class="card">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    {% if system.uname is not empty %}
-                        <p>
-                            <strong>{{ 'Server information'|trans }}</strong> {{ system.uname }}
-                        </p>
-                    {% endif %}
-                    <p>
-                        <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
-                    </p>
-                    <p>
-                        <strong>{{ 'PHP version:'|trans }}</strong> {{ system.server.php.version }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Memory limit:'|trans }}</strong> {{ system.server.php.memoryLimit }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Max execution time:'|trans }}</strong> {{ system.server.php.maxExecutionTime }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Upload Max File size:'|trans }}</strong> {{ system.server.php.maxFileSizeUpload }}
-                    </p>
-                    {% if system.instaWebInstalled %}
-                        <p>{{ 'PageSpeed module for Apache installed (mod_instaweb)'|trans }}</p>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
+          <div class="card">
+              <h3 class="card-header">
+                  <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
+              </h3>
+              <div class="card-block">
+                  <div class="card-text">
+                      {% if system.uname is not empty %}
+                          <p>
+                              <strong>{{ 'Server information'|trans }}</strong> {{ system.uname }}
+                          </p>
+                      {% endif %}
+                      <p>
+                          <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
+                      </p>
+                      <p>
+                          <strong>{{ 'PHP version:'|trans }}</strong> {{ system.server.php.version }}
+                      </p>
+                      <p>
+                          <strong>{{ 'Memory limit:'|trans }}</strong> {{ system.server.php.memoryLimit }}
+                      </p>
+                      <p>
+                          <strong>{{ 'Max execution time:'|trans }}</strong> {{ system.server.php.maxExecutionTime }}
+                      </p>
+                      <p>
+                          <strong>{{ 'Upload Max File size:'|trans }}</strong> {{ system.server.php.maxFileSizeUpload }}
+                      </p>
+                      {% if system.instaWebInstalled %}
+                          <p>{{ 'PageSpeed module for Apache installed (mod_instaweb)'|trans }}</p>
+                      {% endif %}
+                  </div>
+              </div>
+          </div>
 
-        <div class="card">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    <p>
-                        <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
-                    </p>
-                    <p>
-                        <strong>{{ 'MySQL server:'|trans }}</strong> {{ system.database.server }}
-                    </p>
-                    <p>
-                        <strong>{{ 'MySQL name:'|trans }}</strong> {{ system.database.name }}
-                    </p>
-                    <p>
-                        <strong>{{ 'MySQL user:'|trans }}</strong> {{ system.database.user }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Tables prefix:'|trans }}</strong> {{ system.database.prefix }}
-                    </p>
-                    <p>
-                        <strong>{{ 'MySQL engine:'|trans }}</strong> {{ system.database.engine }}
-                    </p>
-                    <p>
-                        <strong>{{ 'MySQL driver:'|trans }}</strong> {{ system.database.driver }}
-                    </p>
-                </div>
-            </div>
-        </div>
+          <div class="card">
+              <h3 class="card-header">
+                  <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
+              </h3>
+              <div class="card-block">
+                  <div class="card-text">
+                      <p>
+                          <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
+                      </p>
+                      <p>
+                          <strong>{{ 'MySQL server:'|trans }}</strong> {{ system.database.server }}
+                      </p>
+                      <p>
+                          <strong>{{ 'MySQL name:'|trans }}</strong> {{ system.database.name }}
+                      </p>
+                      <p>
+                          <strong>{{ 'MySQL user:'|trans }}</strong> {{ system.database.user }}
+                      </p>
+                      <p>
+                          <strong>{{ 'Tables prefix:'|trans }}</strong> {{ system.database.prefix }}
+                      </p>
+                      <p>
+                          <strong>{{ 'MySQL engine:'|trans }}</strong> {{ system.database.engine }}
+                      </p>
+                      <p>
+                          <strong>{{ 'MySQL driver:'|trans }}</strong> {{ system.database.driver }}
+                      </p>
+                  </div>
+              </div>
+          </div>
 
-        <div class="card">
+          <div class="card">
           <h3 class="card-header">
             <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
           </h3>
@@ -117,8 +117,8 @@
             </div>
           </div>
         </div>
+        {% endif %}
     </div>
-    {% endif %}
     <div class="col-lg-6">
         <div class="card">
             <h3 class="card-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -105,14 +105,14 @@
 
       <div class="card">
       <h3 class="card-header">
-      <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
+        <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
       </h3>
       <div class="card-block">
       <div class="card-text">
         <ul>
-        {% for override in system.overrides %}
-          <li>{{ override }}</li>
-        {% endfor %}
+          {% for override in system.overrides %}
+            <li>{{ override }}</li>
+          {% endfor %}
         </ul>
       </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -34,7 +34,7 @@
       </h3>
       <div class="card-block">
         <div class="card-text">
-          <p>{{ 'This information must be provided when you report an issue on our bug tracker or forum.'|trans }}</p>
+          <p>{{ 'This information must be provided when you report an issue on GitHub or on the forum.'|trans }}</p>
         </div>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -18,7 +18,7 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to https://devdocs.prestashop.com/ for more information.
  *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @author  PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
@@ -27,276 +27,276 @@
 
 {% block content %}
 <div class="row">
-    <div class="col-lg-6">
-        <div class="card">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Configuration information'|trans }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    <p>{{ 'This information must be provided when you report an issue on our bug tracker or forum.'|trans }}</p>
-                </div>
-            </div>
-        </div>
-        {% if system.notHostMode %}
-          <div class="card">
-              <h3 class="card-header">
-                  <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
-              </h3>
-              <div class="card-block">
-                  <div class="card-text">
-                      {% if system.uname is not empty %}
-                          <p>
-                              <strong>{{ 'Server information'|trans }}</strong> {{ system.uname }}
-                          </p>
-                      {% endif %}
-                      <p>
-                          <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
-                      </p>
-                      <p>
-                          <strong>{{ 'PHP version:'|trans }}</strong> {{ system.server.php.version }}
-                      </p>
-                      <p>
-                          <strong>{{ 'Memory limit:'|trans }}</strong> {{ system.server.php.memoryLimit }}
-                      </p>
-                      <p>
-                          <strong>{{ 'Max execution time:'|trans }}</strong> {{ system.server.php.maxExecutionTime }}
-                      </p>
-                      <p>
-                          <strong>{{ 'Upload Max File size:'|trans }}</strong> {{ system.server.php.maxFileSizeUpload }}
-                      </p>
-                      {% if system.instaWebInstalled %}
-                          <p>{{ 'PageSpeed module for Apache installed (mod_instaweb)'|trans }}</p>
-                      {% endif %}
-                  </div>
-              </div>
-          </div>
-
-          <div class="card">
-              <h3 class="card-header">
-                  <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
-              </h3>
-              <div class="card-block">
-                  <div class="card-text">
-                      <p>
-                          <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
-                      </p>
-                      <p>
-                          <strong>{{ 'MySQL server:'|trans }}</strong> {{ system.database.server }}
-                      </p>
-                      <p>
-                          <strong>{{ 'MySQL name:'|trans }}</strong> {{ system.database.name }}
-                      </p>
-                      <p>
-                          <strong>{{ 'MySQL user:'|trans }}</strong> {{ system.database.user }}
-                      </p>
-                      <p>
-                          <strong>{{ 'Tables prefix:'|trans }}</strong> {{ system.database.prefix }}
-                      </p>
-                      <p>
-                          <strong>{{ 'MySQL engine:'|trans }}</strong> {{ system.database.engine }}
-                      </p>
-                      <p>
-                          <strong>{{ 'MySQL driver:'|trans }}</strong> {{ system.database.driver }}
-                      </p>
-                  </div>
-              </div>
-          </div>
-
-          <div class="card">
-          <h3 class="card-header">
-            <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
-          </h3>
-          <div class="card-block">
-            <div class="card-text">
-              <ul>
-                {% for override in system.overrides %}
-                  <li>{{ override }}</li>
-                {% endfor %}
-              </ul>
-            </div>
-          </div>
-        </div>
-        {% endif %}
-    </div>
-    <div class="col-lg-6">
-        <div class="card">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Store information'|trans }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    <p>
-                        <strong>{{ 'PrestaShop version:'|trans }}</strong> {{ system.shop.version }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Shop URL:'|trans }}</strong> {{ system.shop.url }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Shop path:'|trans }}</strong> {{ system.shop.path }}
-                    </p>
-                    <p>
-                        <strong>{{ 'Current theme in use:'|trans }}</strong> {{ system.shop.theme }}
-                    </p>
-                </div>
-            </div>
-        </div>
-
-        <div class="card">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Mail configuration'|trans }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    <p>
-                        <strong>{{ 'Mail method:'|trans }}</strong>
-
-                        {% if system.isNativePHPmail %}
-                        {{ 'You are using /usr/sbin/sendmail'|trans }}
-                        {% else %}
-                        {{ 'You are using your own SMTP parameters.'|trans }}</p>
-                    <p>
-                        <strong>{{ 'SMTP server:'|trans }}</strong> {{ system.smtp.server }}
-                    </p>
-                    <p>
-                        <strong>{{ 'SMTP username:'|trans }}</strong>
-                        {% if system.smtp.user is not empty %}
-                            {{ 'Defined'|trans }}
-                        {% else %}
-                            <span style="color:red;">{{ 'Not defined'|trans }}</span>
-                        {% endif %}
-                    </p>
-                    <p>
-                        <strong>{{ 'SMTP password:'|trans }}</strong>
-                        {% if system.smtp.password is not empty %}
-                            {{ 'Defined'|trans }}
-                        {% else %}
-                            <span style="color:red;">{{ 'Not defined'|trans }}</span>
-                        {% endif %}
-                    </p>
-                    <p>
-                        <strong>{{ 'Encryption:'|trans }}</strong> {{ system.smtp.encryption }}
-                    </p>
-                    <p>
-                        <strong>{{ 'SMTP port:'|trans }}</strong> {{ system.smtp.port }}
-                    </p>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-
-        <div class="card">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Your information'|trans }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    <p>
-                        <strong>{{ 'Your web browser:'|trans }}</strong> {{ userAgent }}
-                    </p>
-                </div>
-            </div>
-        </div>
-
-        <div class="card" id="checkConfiguration">
-            <h3 class="card-header">
-                <i class="material-icons">info_outline</i> {{ 'Check your configuration'|trans }}
-            </h3>
-            <div class="card-block">
-                <div class="card-text">
-                    <p>
-                        <strong>{{ 'Required parameters:'|trans }}</strong>
-                    {% if requirements.failRequired == false %}
-                        <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-                    </p>
-                    {% else %}
-                        <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-                        </p>
-                        <ul>
-                            {% for key, value in requirements.testsRequired %}
-                                {% if 'fail' == value %}
-                                    <li>{{ requirements.testsErrors[key] }}</li>
-                                {% endif %}
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                    {% if requirements.failOptional is defined %}
-                        <p>
-                        <strong>{{ 'Optional parameters:'|trans }}</strong>
-                        {% if requirements.failOptional == false %}
-                            <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-                            </p>
-                        {% else %}
-                            <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-                            </p>
-                            <ul>
-                                {% for key, value in requirements.testsOptional %}
-                                    {% if 'fail' == value %}
-                                        <li>{{ requirements.testsErrors[key] }}</li>
-                                    {% endif %}
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-{% if system.notHostMode %}
+  <div class="col-lg-6">
     <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">info_outline</i> {{ 'Configuration information'|trans }}
+      </h3>
+      <div class="card-block">
+        <div class="card-text">
+          <p>{{ 'This information must be provided when you report an issue on our bug tracker or forum.'|trans }}</p>
+        </div>
+      </div>
+    </div>
+    {% if system.notHostMode %}
+      <div class="card">
         <h3 class="card-header">
-            <i class="material-icons">info_outline</i> {{ 'List of changed files'|trans }}
+          <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
         </h3>
         <div class="card-block">
-            <div class="card-text" id="changedFiles">
-                <i class="material-icons">loop</i> {{ 'Checking files...'|trans({}, 'Admin.Advparameters.Notification') }}
-            </div>
+          <div class="card-text">
+            {% if system.uname is not empty %}
+              <p>
+                <strong>{{ 'Server information'|trans }}</strong> {{ system.uname }}
+              </p>
+            {% endif %}
+            <p>
+              <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
+            </p>
+            <p>
+              <strong>{{ 'PHP version:'|trans }}</strong> {{ system.server.php.version }}
+            </p>
+            <p>
+              <strong>{{ 'Memory limit:'|trans }}</strong> {{ system.server.php.memoryLimit }}
+            </p>
+            <p>
+              <strong>{{ 'Max execution time:'|trans }}</strong> {{ system.server.php.maxExecutionTime }}
+            </p>
+            <p>
+              <strong>{{ 'Upload Max File size:'|trans }}</strong> {{ system.server.php.maxFileSizeUpload }}
+            </p>
+            {% if system.instaWebInstalled %}
+              <p>{{ 'PageSpeed module for Apache installed (mod_instaweb)'|trans }}</p>
+            {% endif %}
+          </div>
         </div>
+      </div>
+
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
+        </h3>
+        <div class="card-block">
+          <div class="card-text">
+            <p>
+              <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
+            </p>
+            <p>
+              <strong>{{ 'MySQL server:'|trans }}</strong> {{ system.database.server }}
+            </p>
+            <p>
+              <strong>{{ 'MySQL name:'|trans }}</strong> {{ system.database.name }}
+            </p>
+            <p>
+              <strong>{{ 'MySQL user:'|trans }}</strong> {{ system.database.user }}
+            </p>
+            <p>
+              <strong>{{ 'Tables prefix:'|trans }}</strong> {{ system.database.prefix }}
+            </p>
+            <p>
+              <strong>{{ 'MySQL engine:'|trans }}</strong> {{ system.database.engine }}
+            </p>
+            <p>
+              <strong>{{ 'MySQL driver:'|trans }}</strong> {{ system.database.driver }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+      <h3 class="card-header">
+      <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
+      </h3>
+      <div class="card-block">
+      <div class="card-text">
+        <ul>
+        {% for override in system.overrides %}
+          <li>{{ override }}</li>
+        {% endfor %}
+        </ul>
+      </div>
+      </div>
     </div>
+    {% endif %}
+  </div>
+  <div class="col-lg-6">
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">info_outline</i> {{ 'Store information'|trans }}
+      </h3>
+      <div class="card-block">
+        <div class="card-text">
+          <p>
+            <strong>{{ 'PrestaShop version:'|trans }}</strong> {{ system.shop.version }}
+          </p>
+          <p>
+            <strong>{{ 'Shop URL:'|trans }}</strong> {{ system.shop.url }}
+          </p>
+          <p>
+            <strong>{{ 'Shop path:'|trans }}</strong> {{ system.shop.path }}
+          </p>
+          <p>
+            <strong>{{ 'Current theme in use:'|trans }}</strong> {{ system.shop.theme }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">info_outline</i> {{ 'Mail configuration'|trans }}
+      </h3>
+      <div class="card-block">
+        <div class="card-text">
+          <p>
+            <strong>{{ 'Mail method:'|trans }}</strong>
+
+            {% if system.isNativePHPmail %}
+            {{ 'You are using /usr/sbin/sendmail'|trans }}
+            {% else %}
+            {{ 'You are using your own SMTP parameters.'|trans }}</p>
+          <p>
+            <strong>{{ 'SMTP server:'|trans }}</strong> {{ system.smtp.server }}
+          </p>
+          <p>
+            <strong>{{ 'SMTP username:'|trans }}</strong>
+            {% if system.smtp.user is not empty %}
+              {{ 'Defined'|trans }}
+            {% else %}
+              <span style="color:red;">{{ 'Not defined'|trans }}</span>
+            {% endif %}
+          </p>
+          <p>
+            <strong>{{ 'SMTP password:'|trans }}</strong>
+            {% if system.smtp.password is not empty %}
+              {{ 'Defined'|trans }}
+            {% else %}
+              <span style="color:red;">{{ 'Not defined'|trans }}</span>
+            {% endif %}
+          </p>
+          <p>
+            <strong>{{ 'Encryption:'|trans }}</strong> {{ system.smtp.encryption }}
+          </p>
+          <p>
+            <strong>{{ 'SMTP port:'|trans }}</strong> {{ system.smtp.port }}
+          </p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">info_outline</i> {{ 'Your information'|trans }}
+      </h3>
+      <div class="card-block">
+        <div class="card-text">
+          <p>
+            <strong>{{ 'Your web browser:'|trans }}</strong> {{ userAgent }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="card" id="checkConfiguration">
+      <h3 class="card-header">
+        <i class="material-icons">info_outline</i> {{ 'Check your configuration'|trans }}
+      </h3>
+      <div class="card-block">
+        <div class="card-text">
+          <p>
+            <strong>{{ 'Required parameters:'|trans }}</strong>
+          {% if requirements.failRequired == false %}
+            <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+          </p>
+          {% else %}
+            <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+            </p>
+            <ul>
+              {% for key, value in requirements.testsRequired %}
+                {% if 'fail' == value %}
+                  <li>{{ requirements.testsErrors[key] }}</li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endif %}
+          {% if requirements.failOptional is defined %}
+            <p>
+            <strong>{{ 'Optional parameters:'|trans }}</strong>
+            {% if requirements.failOptional == false %}
+              <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+              </p>
+            {% else %}
+              <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+              </p>
+              <ul>
+                {% for key, value in requirements.testsOptional %}
+                  {% if 'fail' == value %}
+                    <li>{{ requirements.testsErrors[key] }}</li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            {% endif %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% if system.notHostMode %}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">info_outline</i> {{ 'List of changed files'|trans }}
+    </h3>
+    <div class="card-block">
+      <div class="card-text" id="changedFiles">
+        <i class="material-icons">loop</i> {{ 'Checking files...'|trans({}, 'Admin.Advparameters.Notification') }}
+      </div>
+    </div>
+  </div>
 {% endif %}
 {% if system.notHostMode %}
-    <script>
-        $(document).ready(function()
+  <script>
+    $(document).ready(function()
+    {
+      var translations = {
+        missing: '{{ "Missing files"|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
+        updated: '{{ "Updated files"|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
+        changesDetected: '{{ "Changed/missing files have been detected."|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
+        noChangeDetected: '{{ "No change has been detected in your files."|trans({}, "Admin.Advparameters.Notification")|e('js') }}'
+      };
+
+      $.ajax({
+        type: 'POST',
+        url: '{{ path("admin_system_information_check_files") }}',
+        data: {},
+        dataType: 'json',
+        success: function(json)
         {
-            var translations = {
-                missing: '{{ "Missing files"|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
-                updated: '{{ "Updated files"|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
-                changesDetected: '{{ "Changed/missing files have been detected."|trans({}, "Admin.Advparameters.Notification")|e('js') }}',
-                noChangeDetected: '{{ "No change has been detected in your files."|trans({}, "Admin.Advparameters.Notification")|e('js') }}'
-            };
+          var tab = {
+            'missing': translations.missing,
+            'updated': translations.updated,
+          };
 
-            $.ajax({
-                type: 'POST',
-                url: '{{ path("admin_system_information_check_files") }}',
-                data: {},
-                dataType: 'json',
-                success: function(json)
-                {
-                    var tab = {
-                        'missing': translations.missing,
-                        'updated': translations.updated,
-                    };
+          if (json.missing.length || json.updated.length)
+            $('#changedFiles').html('<div class="alert alert-warning" role="alert"><p class="alert-text">'+ translations.changesDetected +'</p></div>');
+          else
+            $('#changedFiles').html('<div class="alert alert-success" role="alert"><p class="alert-text">'+ translations.noChangeDetected +'</p></div>');
 
-                    if (json.missing.length || json.updated.length)
-                        $('#changedFiles').html('<div class="alert alert-warning" role="alert"><p class="alert-text">'+ translations.changesDetected +'</p></div>');
-                    else
-                        $('#changedFiles').html('<div class="alert alert-success" role="alert"><p class="alert-text">'+ translations.noChangeDetected +'</p></div>');
-
-                    $.each(tab, function(key, lang) {
-                        if (json[key].length) {
-                            var html = $('<ul>').attr('id', key+'_files');
-                            $(json[key]).each(function(key, file) {
-                                html.append($('<li>').html(file))
-                            });
-                            $('#changedFiles')
-                                .append($('<h4>').html(lang+' ('+json[key].length+')'))
-                                .append(html);
-                        }
-                    });
-                }
-            });
-        });
-    </script>
+          $.each(tab, function(key, lang) {
+            if (json[key].length) {
+              var html = $('<ul>').attr('id', key+'_files');
+              $(json[key]).each(function(key, file) {
+                html.append($('<li>').html(file))
+              });
+              $('#changedFiles')
+                .append($('<h4>').html(lang+' ('+json[key].length+')'))
+                .append(html);
+            }
+          });
+        }
+      });
+    });
+  </script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add override list to the information page
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21368 
| How to test?  | Open the backoffice Information page, it should be displayed like so ![image](https://user-images.githubusercontent.com/793712/95510499-ede2fb80-09ad-11eb-938f-8f34e7893c5e.png)

I made it the easy way, maybe there is a better way to fetch effective overrides and not just the php files list
If you know, please let me know

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21375)
<!-- Reviewable:end -->
