### PR TITLE
Correct product meta-title after changing variant

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -455,7 +455,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
-            'product_title' => $product['title'],
+            'product_title' => $product['meta_title'],
         ]));
     }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -455,6 +455,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
+            // We use the meta_title key because product_title is used for the title of the page
             'product_title' => $product['meta_title'],
         ]));
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Follow #21391
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21391 
| How to test?  | Instruction below
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Follow these steps before, and after change:

1. Edit product with combinations, set custom meta title.
2. Visit product, see if meta title is OK
3. Change variant, meta title NOK
4. To confirm that it's only bugged in ajax request refresh page, meta title OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21394)
<!-- Reviewable:end -->
