### PR TITLE
Introduce ProductPackUpdater & add behats for packing combinations

### DIFF
--- a/src/Adapter/Product/CommandHandler/RemoveAllProductsFromPackHandler.php
+++ b/src/Adapter/Product/CommandHandler/RemoveAllProductsFromPackHandler.php
@@ -28,13 +28,10 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use Pack;
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Adapter\Product\Update\ProductPackUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllProductsFromPackCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\RemoveAllProductsFromPackHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductPackException;
-use PrestaShopException;
 
 /**
  * Handles @see RemoveAllProductsFromPackCommand using legacy object model
@@ -42,31 +39,24 @@ use PrestaShopException;
 final class RemoveAllProductsFromPackHandler extends AbstractProductHandler implements RemoveAllProductsFromPackHandlerInterface
 {
     /**
+     * @var ProductPackUpdater
+     */
+    private $productPackUpdater;
+
+    /**
+     * @param ProductPackUpdater $productPackUpdater
+     */
+    public function __construct(
+        ProductPackUpdater $productPackUpdater
+    ) {
+        $this->productPackUpdater = $productPackUpdater;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(RemoveAllProductsFromPackCommand $command): void
     {
-        $packId = $command->getPackId();
-        $pack = $this->getProduct($packId);
-
-        try {
-            if (false === Pack::deleteItems($pack->id)) {
-                throw new ProductPackException(
-                    sprintf('Failed removing all products from pack #%d', $pack->id),
-                    ProductPackException::FAILED_DELETING_PRODUCTS_FROM_PACK
-                );
-            }
-        } catch (PrestaShopException $e) {
-            throw new ProductPackException(
-                sprintf('Error occurred when trying to remove products from pack #%s', $pack->id),
-                0,
-                $e
-            );
-        } finally {
-            Pack::resetStaticCache();
-        }
-
-        //reset cache_default_attribute
-        $pack->setDefaultAttribute(CombinationId::NO_COMBINATION);
+        $this->productPackUpdater->set($command->getPackId(), []);
     }
 }

--- a/src/Adapter/Product/CommandHandler/RemoveAllProductsFromPackHandler.php
+++ b/src/Adapter/Product/CommandHandler/RemoveAllProductsFromPackHandler.php
@@ -57,6 +57,6 @@ final class RemoveAllProductsFromPackHandler extends AbstractProductHandler impl
      */
     public function handle(RemoveAllProductsFromPackCommand $command): void
     {
-        $this->productPackUpdater->set($command->getPackId(), []);
+        $this->productPackUpdater->setPackProducts($command->getPackId(), []);
     }
 }

--- a/src/Adapter/Product/CommandHandler/SetPackProductsHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetPackProductsHandler.php
@@ -28,15 +28,10 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use Pack;
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Adapter\Product\Update\ProductPackUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetPackProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetPackProductsHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductPackException;
-use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
-use PrestaShopException;
 
 /**
  * Handles @see SetPackProductsCommand using legacy object model
@@ -44,96 +39,24 @@ use PrestaShopException;
 final class SetPackProductsHandler extends AbstractProductHandler implements SetPackProductsHandlerInterface
 {
     /**
+     * @var ProductPackUpdater
+     */
+    private $productPackUpdater;
+
+    /**
+     * @param ProductPackUpdater $productPackUpdater
+     */
+    public function __construct(
+        ProductPackUpdater $productPackUpdater
+    ) {
+        $this->productPackUpdater = $productPackUpdater;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(SetPackProductsCommand $command): void
     {
-        $productsForPacking = $command->getProducts();
-        $pack = $this->getProduct($command->getPackId());
-        $packId = (int) $pack->id;
-
-        // validate all products first
-        foreach ($productsForPacking as $productForPacking) {
-            $this->assertProductIsAvailableForPacking($productForPacking->getProductId()->getValue());
-        }
-
-        if (false === Pack::deleteItems($packId)) {
-            throw new ProductPackException(
-                sprintf('Failed to remove previous products from pack #%d before adding new ones', $packId),
-                ProductPackException::FAILED_DELETING_PRODUCTS_FROM_PACK
-            );
-        }
-
-        //reset cache_default_attribute
-        $pack->setDefaultAttribute(CombinationId::NO_COMBINATION);
-
-        foreach ($productsForPacking as $productForPacking) {
-            $productId = $productForPacking->getProductId()->getValue();
-
-            if (null === $productForPacking->getCombinationId()) {
-                $combinationId = CombinationId::NO_COMBINATION;
-            } else {
-                $combinationId = $productForPacking->getCombinationId();
-            }
-
-            try {
-                $packed = Pack::addItem($packId, $productId, $productForPacking->getQuantity(), $combinationId);
-
-                if (false === $packed) {
-                    throw new ProductPackException(
-                        $this->appendIdsToMessage('Failed to add product to pack.', $productForPacking, $packId),
-                        ProductPackException::FAILED_ADDING_TO_PACK
-                    );
-                }
-            } catch (PrestaShopException $e) {
-                throw new ProductException(
-                    $this->appendIdsToMessage('Error occurred when trying to add product to pack.', $productForPacking, $packId),
-                    0,
-                    $e
-                );
-            } finally {
-                Pack::resetStaticCache();
-            }
-        }
-        // reset cache also if products array is empty and in-loop cache resetting isn't reached
-        Pack::resetStaticCache();
-    }
-
-    /**
-     * @param int $productId
-     *
-     * @throws ProductPackException
-     */
-    private function assertProductIsAvailableForPacking(int $productId): void
-    {
-        if (Pack::isPack($productId)) {
-            throw new ProductPackException(
-                sprintf('Product #%d is a pack itself. It cannot be packed', $productId),
-                ProductPackException::CANNOT_ADD_PACK_INTO_PACK
-            );
-        }
-    }
-
-    /**
-     * Builds string with ids, that will help to identify objects that was being updated in case of error
-     *
-     * @param string $messageBody
-     * @param QuantifiedProduct $product
-     * @param int $packId
-     *
-     * @return string
-     */
-    private function appendIdsToMessage(string $messageBody, QuantifiedProduct $product, int $packId): string
-    {
-        if ($product->getCombinationId()) {
-            $combinationId = sprintf(' combinationId #%d', $product->getCombinationId()->getValue());
-        }
-
-        return sprintf(
-            "$messageBody. [packId #%d; productId #%d;%s]",
-            $packId,
-            $product->getProductId()->getValue(),
-            isset($combinationId) ? $combinationId : ''
-        );
+        $this->productPackUpdater->set($command->getPackId(), $command->getProducts());
     }
 }

--- a/src/Adapter/Product/CommandHandler/SetPackProductsHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetPackProductsHandler.php
@@ -57,6 +57,6 @@ final class SetPackProductsHandler extends AbstractProductHandler implements Set
      */
     public function handle(SetPackProductsCommand $command): void
     {
-        $this->productPackUpdater->set($command->getPackId(), $command->getProducts());
+        $this->productPackUpdater->setPackProducts($command->getPackId(), $command->getProducts());
     }
 }

--- a/src/Adapter/Product/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Repository/ProductPackRepository.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
+
+use Pack;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductPackException;
+use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\PackId;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShopException;
+
+class ProductPackRepository
+{
+    /**
+     * @param PackId $packId
+     * @param QuantifiedProduct $productForPacking
+     *
+     * @throws CoreException
+     * @throws ProductPackException
+     */
+    public function addProductToPack(PackId $packId, QuantifiedProduct $productForPacking): void
+    {
+        $packIdValue = $packId->getValue();
+
+        try {
+            $packed = Pack::addItem(
+                $packIdValue,
+                $productForPacking->getProductId()->getValue(),
+                $productForPacking->getQuantity(),
+                $productForPacking->getCombinationId() ?
+                    $productForPacking->getCombinationId()->getValue() :
+                    CombinationId::NO_COMBINATION
+            );
+            if (!$packed) {
+                throw new ProductPackException(
+                    $this->appendIdsToMessage('Failed to add product to pack.', $productForPacking, $packIdValue),
+                    ProductPackException::FAILED_ADDING_TO_PACK
+                );
+            }
+        } catch (PrestaShopException $e) {
+            throw new CoreException(
+                $this->appendIdsToMessage('Error occurred when trying to add product to pack.', $productForPacking, $packIdValue),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * @param PackId $packId
+     *
+     * @throws CoreException
+     * @throws ProductPackException
+     */
+    public function removePackedProducts(PackId $packId): void
+    {
+        $packIdValue = $packId->getValue();
+
+        try {
+            if (!Pack::deleteItems($packIdValue)) {
+                throw new ProductPackException(
+                    sprintf('Failed to remove products from pack #%d', $packIdValue),
+                    ProductPackException::FAILED_DELETING_PRODUCTS_FROM_PACK
+                );
+            }
+        } catch (PrestaShopException $e) {
+            throw new CoreException(
+                sprintf('Error occurred when trying to remove pack items from pack #%d', $packIdValue),
+                0,
+                $e
+            );
+        }
+    }
+
+    /**
+     * Builds string with ids, that will help to identify objects that was being updated in case of error
+     *
+     * @param string $messageBody
+     * @param QuantifiedProduct $product
+     * @param int $packId
+     *
+     * @return string
+     */
+    private function appendIdsToMessage(string $messageBody, QuantifiedProduct $product, int $packId): string
+    {
+        if ($product->getCombinationId()) {
+            $combinationId = sprintf(' combinationId #%d', $product->getCombinationId()->getValue());
+        }
+
+        return sprintf(
+            "$messageBody. [packId #%d; productId #%d;%s]",
+            $packId,
+            $product->getProductId()->getValue(),
+            isset($combinationId) ? $combinationId : ''
+        );
+    }
+}

--- a/src/Adapter/Product/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Repository/ProductPackRepository.php
@@ -79,7 +79,7 @@ class ProductPackRepository
      * @throws CoreException
      * @throws ProductPackException
      */
-    public function removePackedProducts(PackId $packId): void
+    public function removeAllProductsFromPack(PackId $packId): void
     {
         $packIdValue = $packId->getValue();
 

--- a/src/Adapter/Product/Update/ProductPackUpdater.php
+++ b/src/Adapter/Product/Update/ProductPackUpdater.php
@@ -82,7 +82,7 @@ class ProductPackUpdater
             $this->assertProductIsAvailableForPacking($productForPacking->getProductId()->getValue());
         }
 
-        $this->productPackRepository->removePackedProducts($packId);
+        $this->productPackRepository->removeAllProductsFromPack($packId);
 
         //reset cache_default_attribute
         $pack->setDefaultAttribute(CombinationId::NO_COMBINATION);

--- a/src/Adapter/Product/Update/ProductPackUpdater.php
+++ b/src/Adapter/Product/Update/ProductPackUpdater.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update;
+
+use Pack;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductPackRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductPackException;
+use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\PackId;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShopException;
+
+/**
+ * Provides methods related to Product Pack update
+ */
+class ProductPackUpdater
+{
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
+     * @var ProductPackRepository
+     */
+    private $productPackRepository;
+
+    /**
+     * @param ProductRepository $productRepository
+     * @param ProductPackRepository $productPackRepository
+     */
+    public function __construct(
+        ProductRepository $productRepository,
+        ProductPackRepository $productPackRepository
+    ) {
+        $this->productRepository = $productRepository;
+        $this->productPackRepository = $productPackRepository;
+    }
+
+    /**
+     * @param PackId $packId
+     * @param QuantifiedProduct[] $productsForPacking
+     *
+     * @throws ProductException
+     * @throws ProductPackException
+     */
+    public function set(PackId $packId, array $productsForPacking): void
+    {
+        $pack = $this->productRepository->get($packId);
+
+        // validate if provided products are available for packing before emptying the pack
+        foreach ($productsForPacking as $productForPacking) {
+            $this->assertProductIsAvailableForPacking($productForPacking->getProductId()->getValue());
+        }
+
+        $this->productPackRepository->removePackedProducts($packId);
+
+        //reset cache_default_attribute
+        $pack->setDefaultAttribute(CombinationId::NO_COMBINATION);
+
+        try {
+            foreach ($productsForPacking as $productForPacking) {
+                $this->productPackRepository->addProductToPack($packId, $productForPacking);
+            }
+        } finally {
+            Pack::resetStaticCache();
+        }
+    }
+
+    /**
+     * @param int $productId
+     *
+     * @throws ProductPackException
+     */
+    private function assertProductIsAvailableForPacking(int $productId): void
+    {
+        try {
+            if (Pack::isPack($productId)) {
+                throw new ProductPackException(
+                    sprintf('Product #%d is a pack itself. It cannot be packed', $productId),
+                    ProductPackException::CANNOT_ADD_PACK_INTO_PACK
+                );
+            }
+        } catch (PrestaShopException $e) {
+            throw new CoreException(
+                sprintf('Error occurred when asserting if product #%d is pack', $productId),
+                0,
+                $e
+            );
+        }
+    }
+}

--- a/src/Adapter/Product/Update/ProductPackUpdater.php
+++ b/src/Adapter/Product/Update/ProductPackUpdater.php
@@ -73,7 +73,7 @@ class ProductPackUpdater
      * @throws ProductException
      * @throws ProductPackException
      */
-    public function set(PackId $packId, array $productsForPacking): void
+    public function setPackProducts(PackId $packId, array $productsForPacking): void
     {
         $pack = $this->productRepository->get($packId);
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -133,12 +133,16 @@ services:
 
     prestashop.adapter.product.command_handler.set_pack_products_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetPackProductsHandler
+        arguments:
+            - '@prestashop.adapter.product.update.product_pack_updater'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetPackProductsCommand
 
     prestashop.adapter.product.command_handler.remove_all_products_from_pack_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\RemoveAllProductsFromPackHandler
+        arguments:
+            - '@prestashop.adapter.product.update.product_pack_updater'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllProductsFromPackCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -122,6 +122,15 @@ services:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand
 
+    prestashop.adapter.product.repository.product_pack_repository:
+        class: PrestaShop\PrestaShop\Adapter\Product\Repository\ProductPackRepository
+
+    prestashop.adapter.product.update.product_pack_updater:
+        class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductPackUpdater
+        arguments:
+            - '@prestashop.adapter.product.repository.product_repository'
+            - '@prestashop.adapter.product.repository.product_pack_repository'
+
     prestashop.adapter.product.command_handler.set_pack_products_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetPackProductsHandler
         tags:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -12,79 +12,109 @@ Feature: Add product to pack from Back Office (BO)
       | is_virtual | false                       |
     And product "productPack1" type should be standard
     And I add product "product2" with following information:
-      | name       | en-US: shady sunglasses     |
-      | is_virtual | false                       |
+      | name       | en-US: shady sunglasses |
+      | is_virtual | false                   |
     And product "product2" type should be standard
     When I update pack "productPack1" with following product quantities:
-      | product2        | 5                      |
+      | product  | quantity |
+      | product2 | 5        |
     Then product "productPack1" type should be pack
     And pack "productPack1" should contain products with following quantities:
-      | product2        | 5                      |
+      | product  | quantity |
+      | product2 | 5        |
 
   Scenario: I add virtual products to a pack
     Given I add product "productPack2" with following information:
-      | name       | en-US: street photos        |
-      | is_virtual | false                       |
+      | name       | en-US: street photos |
+      | is_virtual | false                |
     And product "productPack2" type should be standard
     And I add product "product3" with following information:
-      | name       | en-US: summerstreet         |
-      | is_virtual | true                        |
+      | name       | en-US: summerstreet |
+      | is_virtual | true                |
     And I add product "product4" with following information:
-      | name       | en-US: winterstreet         |
-      | is_virtual | true                        |
+      | name       | en-US: winterstreet |
+      | is_virtual | true                |
     And product "product3" type should be virtual
     When I update pack "productPack2" with following product quantities:
-      | product3   | 3                           |
-      | product4   | 20                          |
+      | product  | quantity |
+      | product3 | 3        |
+      | product4 | 20       |
     Then product "productPack2" type should be pack
     And pack productPack2 should contain products with following quantities:
-      | product3   | 3                           |
-      | product4   | 20                          |
+      | product  | quantity |
+      | product3 | 3        |
+      | product4 | 20       |
 
   Scenario: I update pack by removing one of the products
     Given pack productPack2 should contain products with following quantities:
-      | product3   | 3                           |
-      | product4   | 20                          |
+      | product  | quantity |
+      | product3 | 3        |
+      | product4 | 20       |
     When I update pack "productPack2" with following product quantities:
-      | product3   | 3                           |
+      | product  | quantity |
+      | product3 | 3        |
     And pack productPack2 should contain products with following quantities:
-      | product3   | 3                           |
+      | product  | quantity |
+      | product3 | 3        |
 
   Scenario: I add pack product to a pack
     Given product "productPack1" type should be pack
     And product "productPack2" type should be pack
     When I update pack productPack2 with following product quantities:
-      | productPack1   | 1               |
+      | product      | quantity |
+      | productPack1 | 1        |
     Then I should get error that I cannot add pack into a pack
 
   Scenario: I add virtual and standard product to the same pack
     Given I add product productPack4 with following information:
-      | name       | en-US: mixed pack           |
-      | is_virtual | false                       |
+      | name       | en-US: mixed pack |
+      | is_virtual | false             |
     Given product "product2" type should be standard
     And product "product3" type should be virtual
     When I update pack productPack4 with following product quantities:
-      | product2 | 2 |
-      | product3 | 3 |
+      | product  | quantity |
+      | product2 | 2        |
+      | product3 | 3        |
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
-      | product2   | 2                          |
-      | product3   | 3                          |
+      | product  | quantity |
+      | product2 | 2        |
+      | product3 | 3        |
 
-    Scenario: I add product with negative quantity to a pack
-      Given product "product2" type should be standard
-      Then product "productPack4" type should be pack
-      When I update pack productPack4 with following product quantities:
-        | product2 | -10                        |
-        | product3 | 3                          |
-      Then I should get error that product for packing quantity is invalid
+  Scenario: I add product with negative quantity to a pack
+    Given product "product2" type should be standard
+    Then product "productPack4" type should be pack
+    When I update pack productPack4 with following product quantities:
+      | product  | quantity |
+      | product2 | -10      |
+      | product3 | 3        |
+    Then I should get error that product for packing quantity is invalid
 
-    Scenario: I remove all products from existing pack
-      Given product "productPack4" type should be pack
-      And pack productPack4 should contain products with following quantities:
-        | product2   | 2                          |
-        | product3   | 3                          |
-      When I remove all products from pack productPack4
-      Then product "productPack4" type should be standard
+  Scenario: I remove all products from existing pack
+    Given product "productPack4" type should be pack
+    And pack productPack4 should contain products with following quantities:
+      | product  | quantity |
+      | product2 | 2        |
+      | product3 | 3        |
+    When I remove all products from pack productPack4
+    Then product "productPack4" type should be standard
 
-#@todo: add combination product to a pack
+  Scenario: Add combination product to a pack
+    Given I add product "productSkirt1" with following information:
+      | name       | en-US:regular skirt |
+      | is_virtual | false               |
+    And product "productSkirt1" has following combinations:
+      | reference | quantity | attributes         |
+      | whiteS    | 15       | Size:S;Color:White |
+      | blackM    | 13       | Size:M;Color:Black |
+    And product productSkirt1 type should be combination
+    And product "productPack4" type should be standard
+    When I update pack productPack4 with following product quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | blackM      | 10       |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | blackM      | 10       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -1,4 +1,4 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack
+# `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack`
 @reset-database-before-feature
 @clear-cache-after-feature
 @update-pack
@@ -106,24 +106,70 @@ Feature: Add product to pack from Back Office (BO)
     And product "productSkirt1" has following combinations:
       | reference | quantity | attributes         |
       | whiteS    | 15       | Size:S;Color:White |
+      | whiteM    | 15       | Size:M;Color:White |
       | blackM    | 13       | Size:M;Color:Black |
     And product productSkirt1 type should be combination
     And product "productPack4" type should be standard
     When I update pack productPack4 with following product quantities:
       | product       | combination | quantity |
       | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | blackM      | 10       |
+      | productSkirt1 | whiteM      | 11       |
+      | productSkirt1 | blackM      | 12       |
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
       | product       | combination | quantity |
       | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | blackM      | 10       |
+      | productSkirt1 | whiteM      | 11       |
+      | productSkirt1 | blackM      | 12       |
 
-  Scenario: I remove all combination products from existing pack
+  Scenario: Add combination & standard product to a pack
+    Given product "product2" type should be standard
+    And product productSkirt1 type should be combination
+    And product "productSkirt1" has following combinations:
+      | reference | quantity | attributes         |
+      | whiteS    | 15       | Size:S;Color:White |
+      | whiteM    | 15       | Size:M;Color:White |
+      | blackM    | 13       | Size:M;Color:Black |
+    When I update pack productPack4 with following product quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | whiteM      | 11       |
+      | productSkirt1 | blackM      | 12       |
+      | product2      |             | 2        |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | whiteM      | 11       |
+      | productSkirt1 | blackM      | 12       |
+      | product2      |             | 2        |
+
+  Scenario: I remove one combination of same product from existing pack and change another combination quantity
     Given product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
       | product       | combination | quantity |
       | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | blackM      | 10       |
+      | productSkirt1 | whiteM      | 11       |
+      | productSkirt1 | blackM      | 12       |
+      | product2      |             | 2        |
+    When I update pack productPack4 with following product quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | blackM      | 9        |
+      | product2      |             | 2        |
+    Then pack productPack4 should contain products with following quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | blackM      | 9        |
+      | product2      |             | 2        |
+    Then product "productPack4" type should be pack
+
+  Scenario: I remove all products from existing pack when it contains combination and standard products
+    Given product "productPack4" type should be pack
+    And pack productPack4 should contain products with following quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | blackM      | 9        |
+      | product2      |             | 2        |
     When I remove all products from pack productPack4
     Then product "productPack4" type should be standard

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -1,4 +1,4 @@
-# `./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack`
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack
 @reset-database-before-feature
 @clear-cache-after-feature
 @update-pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -118,3 +118,12 @@ Feature: Add product to pack from Back Office (BO)
       | product       | combination | quantity |
       | productSkirt1 | whiteS      | 10       |
       | productSkirt1 | blackM      | 10       |
+
+  Scenario: I remove all combination products from existing pack
+    Given product "productPack4" type should be pack
+    And pack productPack4 should contain products with following quantities:
+      | product       | combination | quantity |
+      | productSkirt1 | whiteS      | 10       |
+      | productSkirt1 | blackM      | 10       |
+    When I remove all products from pack productPack4
+    Then product "productPack4" type should be standard

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -17,7 +17,8 @@ Feature: Update product related products from Back Office (BO)
       | name       | en-US:lovely books package |
       | is_virtual | false                      |
     And I update pack "product3" with following product quantities:
-      | product2 | 5 |
+      | product  | quantity |
+      | product2 | 5        |
     And I add product "product4" with following information:
       | name       | en-US:Reading glasses |
       | is_virtual | false                 |
@@ -30,23 +31,23 @@ Feature: Update product related products from Back Office (BO)
     And product "product3" type should be pack
     And product product4 type should be combination
     When I set following related products to product product1:
-      | product2          |
-      | product3          |
-      | product4          |
+      | product2 |
+      | product3 |
+      | product4 |
     Then product product1 should have following related products:
-      | product2          |
-      | product3          |
-      | product4          |
+      | product2 |
+      | product3 |
+      | product4 |
     When I set following related products to product product1:
-      | product2          |
-      | product4          |
+      | product2 |
+      | product4 |
     Then product product1 should have following related products:
-      | product2          |
-      | product4          |
+      | product2 |
+      | product4 |
 
   Scenario: Remove all related products
     Given product product1 should have following related products:
-      | product2          |
-      | product4          |
+      | product2 |
+      | product4 |
     When I remove all related products from product product1
     Then product product1 should have no related products

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -96,10 +96,6 @@ Feature: Update product suppliers from Back Office (BO)
     And product product2 type should be combination
     And product product2 should not have any suppliers assigned
     And product product2 default supplier reference should be empty
-    And product "product2" has following combinations:
-      | reference | quantity | attributes          |
-      | whiteM    | 15       | Size:M;Color:White  |
-      | whiteL    | 13       | Size:L;Color:White  |
     When I set product product2 default supplier to supplier1 and following suppliers:
       | reference      | supplier reference    | product supplier reference        | currency      | price tax excluded | combination |
       | product2whiteM | supplier1             | sup white shirt M 1               | USD           | 5                  | whiteM      |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Part of product page migration. Introduce `ProductPackUpdater` and use it in `SetProductPackCommand`&`RemoveAllProductsFromPackCommand`. Add behat scenarios for packing/deleting combination type products. Non of refactored classes are released yet, so there is no BC breaks.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #19523
| How to test?  | CI :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21400)
<!-- Reviewable:end -->
