### PR TITLE
Fix address item different height in checkout

### DIFF
--- a/themes/classic/_dev/css/components/checkout.scss
+++ b/themes/classic/_dev/css/components/checkout.scss
@@ -170,6 +170,11 @@ body#checkout {
       margin-bottom: $small-space;
       background: $gray-lighter;
       border: 3px solid transparent;
+
+      > header {
+        min-height: 11.7rem;
+      }
+
       &.selected {
         background: #fff;
         border: $brand-primary 3px solid;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Address items had different heights depending on every informations filled in
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20952.
| How to test?  | Create multiple address with different number of informations inside it, and see if every blocks has the same height instead of random height

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21401)
<!-- Reviewable:end -->
