### PR TITLE
Introduce Command/Query handlers for related products

### DIFF
--- a/src/Adapter/Product/CommandHandler/RemoveAllRelatedProductsHandler.php
+++ b/src/Adapter/Product/CommandHandler/RemoveAllRelatedProductsHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\RelatedProductsUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllRelatedProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\RemoveAllRelatedProductsHandlerInterface;
@@ -39,24 +38,16 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\RemoveAllRelatedPro
 final class RemoveAllRelatedProductsHandler implements RemoveAllRelatedProductsHandlerInterface
 {
     /**
-     * @var ProductRepository
-     */
-    private $productRepository;
-
-    /**
      * @var RelatedProductsUpdater
      */
     private $relatedProductsUpdater;
 
     /**
-     * @param ProductRepository $productRepository
      * @param RelatedProductsUpdater $relatedProductsUpdater
      */
     public function __construct(
-        ProductRepository $productRepository,
         RelatedProductsUpdater $relatedProductsUpdater
     ) {
-        $this->productRepository = $productRepository;
         $this->relatedProductsUpdater = $relatedProductsUpdater;
     }
 
@@ -65,7 +56,6 @@ final class RemoveAllRelatedProductsHandler implements RemoveAllRelatedProductsH
      */
     public function handle(RemoveAllRelatedProductsCommand $command): void
     {
-        $product = $this->productRepository->get($command->getProductId());
-        $this->relatedProductsUpdater->set($product, []);
+        $this->relatedProductsUpdater->setRelatedProducts($command->getProductId(), []);
     }
 }

--- a/src/Adapter/Product/CommandHandler/SetRelatedProductsHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetRelatedProductsHandler.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Update\RelatedProductsUpdater;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetRelatedProductsHandlerInterface;
+
+/**
+ * handles @see SetRelatedProductsCommand using legacy object models
+ */
+final class SetRelatedProductsHandler implements SetRelatedProductsHandlerInterface
+{
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
+     * @var RelatedProductsUpdater
+     */
+    private $relatedProductsUpdater;
+
+    /**
+     * @param ProductRepository $productRepository
+     * @param RelatedProductsUpdater $relatedProductsUpdater
+     */
+    public function __construct(
+        ProductRepository $productRepository,
+        RelatedProductsUpdater $relatedProductsUpdater
+    ) {
+        $this->productRepository = $productRepository;
+        $this->relatedProductsUpdater = $relatedProductsUpdater;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(SetRelatedProductsCommand $command): void
+    {
+        $product = $this->productRepository->get($command->getProductId());
+        $this->relatedProductsUpdater->set($product, $command->getRelatedProductIds());
+    }
+}

--- a/src/Adapter/Product/CommandHandler/SetRelatedProductsHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetRelatedProductsHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\RelatedProductsUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetRelatedProductsHandlerInterface;
@@ -39,24 +38,16 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetRelatedProductsH
 final class SetRelatedProductsHandler implements SetRelatedProductsHandlerInterface
 {
     /**
-     * @var ProductRepository
-     */
-    private $productRepository;
-
-    /**
      * @var RelatedProductsUpdater
      */
     private $relatedProductsUpdater;
 
     /**
-     * @param ProductRepository $productRepository
      * @param RelatedProductsUpdater $relatedProductsUpdater
      */
     public function __construct(
-        ProductRepository $productRepository,
         RelatedProductsUpdater $relatedProductsUpdater
     ) {
-        $this->productRepository = $productRepository;
         $this->relatedProductsUpdater = $relatedProductsUpdater;
     }
 
@@ -65,7 +56,6 @@ final class SetRelatedProductsHandler implements SetRelatedProductsHandlerInterf
      */
     public function handle(SetRelatedProductsCommand $command): void
     {
-        $product = $this->productRepository->get($command->getProductId());
-        $this->relatedProductsUpdater->set($product, $command->getRelatedProductIds());
+        $this->relatedProductsUpdater->setRelatedProducts($command->getProductId(), $command->getRelatedProductIds());
     }
 }

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -51,7 +51,7 @@ use Tag;
 /**
  * Handles the query GetEditableProduct using legacy ObjectModel
  */
-class GetProductForEditingHandler extends AbstractProductHandler implements GetProductForEditingHandlerInterface
+final class GetProductForEditingHandler extends AbstractProductHandler implements GetProductForEditingHandlerInterface
 {
     /**
      * @var NumberExtractor

--- a/src/Adapter/Product/QueryHandler/GetRelatedProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetRelatedProductsHandler.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetRelatedProductsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\RelatedProduct;
+
+final class GetRelatedProductsHandler implements GetRelatedProductsHandlerInterface
+{
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
+     * @var int
+     */
+    private $contextLangId;
+
+    /**
+     * @param ProductRepository $productRepository
+     * @param int $contextLangId
+     */
+    public function __construct(
+        ProductRepository $productRepository,
+        int $contextLangId
+    ) {
+        $this->productRepository = $productRepository;
+        $this->contextLangId = $contextLangId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(GetRelatedProducts $query): array
+    {
+        $results = $this->productRepository->getRelatedProducts($query->getProductId(), new LanguageId($this->contextLangId));
+
+        $relatedProducts = [];
+
+        foreach ($results as $result) {
+            $relatedProducts[] = new RelatedProduct(
+                (int) $result['id_product'],
+                $result['name'],
+                $result['reference']
+            );
+        }
+
+        return $relatedProducts;
+    }
+}

--- a/src/Adapter/Product/QueryHandler/GetRelatedProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetRelatedProductsHandler.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
 
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
-use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetRelatedProductsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\RelatedProduct;
@@ -42,20 +41,12 @@ final class GetRelatedProductsHandler implements GetRelatedProductsHandlerInterf
     private $productRepository;
 
     /**
-     * @var int
-     */
-    private $contextLangId;
-
-    /**
      * @param ProductRepository $productRepository
-     * @param int $contextLangId
      */
     public function __construct(
-        ProductRepository $productRepository,
-        int $contextLangId
+        ProductRepository $productRepository
     ) {
         $this->productRepository = $productRepository;
-        $this->contextLangId = $contextLangId;
     }
 
     /**
@@ -63,7 +54,7 @@ final class GetRelatedProductsHandler implements GetRelatedProductsHandlerInterf
      */
     public function handle(GetRelatedProducts $query): array
     {
-        $results = $this->productRepository->getRelatedProducts($query->getProductId(), new LanguageId($this->contextLangId));
+        $results = $this->productRepository->getRelatedProducts($query->getProductId(), $query->getLanguageId());
 
         $relatedProducts = [];
 

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -114,7 +114,11 @@ class ProductRepository extends AbstractObjectModelRepository
      * @param ProductId $productId
      * @param LanguageId $languageId
      *
-     * @return array<string, mixed>
+     * @return array<string, string>
+     *                       e.g [
+     *                       ['id_product' => '1', 'name' => 'Product name', 'reference' => 'demo15'],
+     *                       ['id_product' => '2', 'name' => 'Product name2', 'reference' => 'demo16'],
+     *                       ]
      *
      * @throws CoreException
      */

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -95,14 +95,15 @@ class ProductRepository extends AbstractObjectModelRepository
         $ids = array_map(function (ProductId $productId): int {
             return $productId->getValue();
         }, $productIds);
+        $ids = array_unique($ids);
 
         $qb = $this->connection->createQueryBuilder();
         $qb->select('COUNT(id_product) as product_count')
             ->from($this->dbPrefix . 'product')
-            ->where('IN (:productIds)')
-            ->setParameter('productId', $ids, Connection::PARAM_INT_ARRAY);
+            ->where('id_product IN (:productIds)')
+            ->setParameter('productIds', $ids, Connection::PARAM_INT_ARRAY);
 
-        $results = $qb->execute()->fetchAll();
+        $results = $qb->execute()->fetch();
 
         if (!$results || (int) $results['product_count'] !== count($ids)) {
             throw new ProductNotFoundException('Some of products does not exist');

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -85,7 +85,7 @@ class ProductRepository extends AbstractObjectModelRepository
     }
 
     /**
-     * @param int[] $productIds
+     * @param ProductId[] $productIds
      *
      * @throws ProductNotFoundException
      */

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -89,7 +89,7 @@ class ProductRepository extends AbstractObjectModelRepository
      *
      * @throws ProductNotFoundException
      */
-    public function assertProductsExists(array $productIds): void
+    public function assertAllProductsExists(array $productIds): void
     {
         //@todo: no shop association. Should it be checked here?
         $ids = array_map(function (ProductId $productId): int {

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -106,7 +106,12 @@ class ProductRepository extends AbstractObjectModelRepository
         $results = $qb->execute()->fetch();
 
         if (!$results || (int) $results['product_count'] !== count($ids)) {
-            throw new ProductNotFoundException('Some of products does not exist');
+            throw new ProductNotFoundException(
+                    sprintf(
+                        'Some of these products do not exist: %s',
+                        implode(',', $ids)
+                    )
+                );
         }
     }
 

--- a/src/Adapter/Product/Update/RelatedProductsUpdater.php
+++ b/src/Adapter/Product/Update/RelatedProductsUpdater.php
@@ -66,7 +66,7 @@ class RelatedProductsUpdater
                 return;
             }
 
-            $this->productRepository->assertProductsExists($relatedProductIds);
+            $this->productRepository->assertAllProductsExists($relatedProductIds);
             $ids = array_map(function (ProductId $productId): int {
                 return $productId->getValue();
             }, $relatedProductIds);

--- a/src/Adapter/Product/Update/RelatedProductsUpdater.php
+++ b/src/Adapter/Product/Update/RelatedProductsUpdater.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update;
+
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShopException;
+use Product;
+
+/**
+ * Provides methods to update related products (a.k.a accessories)
+ */
+class RelatedProductsUpdater
+{
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
+     * @param ProductRepository $productRepository
+     */
+    public function __construct(
+        ProductRepository $productRepository
+    ) {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * @param Product $product
+     * @param ProductId $relatedProductIds
+     */
+    public function set(Product $product, array $relatedProductIds): void
+    {
+        try {
+            if (empty($relatedProductIds)) {
+                $product->deleteAccessories();
+
+                return;
+            }
+
+            $this->productRepository->assertProductsExists($relatedProductIds);
+            $ids = array_map(function (ProductId $productId): int {
+                return $productId->getValue();
+            }, $relatedProductIds);
+
+            $product->deleteAccessories();
+            $product->changeAccessories($ids);
+        } catch (PrestaShopException $e) {
+            throw new CoreException(sprintf(
+                'Error occurred when updating related products for product #%d',
+                $product->id
+            ));
+        }
+    }
+}

--- a/src/Adapter/Product/Update/RelatedProductsUpdater.php
+++ b/src/Adapter/Product/Update/RelatedProductsUpdater.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Update;
 
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShopException;
@@ -54,25 +55,62 @@ class RelatedProductsUpdater
     }
 
     /**
-     * @param Product $product
+     * @param ProductId $productId
      * @param ProductId[] $relatedProductIds
      */
-    public function set(Product $product, array $relatedProductIds): void
+    public function setRelatedProducts(ProductId $productId, array $relatedProductIds): void
+    {
+        $product = $this->productRepository->get($productId);
+
+        if (empty($relatedProductIds)) {
+            $this->deleteRelatedProducts($product);
+
+            return;
+        }
+
+        $this->productRepository->assertAllProductsExists($relatedProductIds);
+
+        $this->deleteRelatedProducts($product);
+        $this->insertRelatedProducts($product, $relatedProductIds);
+    }
+
+    /**
+     * @param Product $product
+     * @param array $relatedProductIds
+     *
+     * @throws CoreException
+     */
+    private function insertRelatedProducts(Product $product, array $relatedProductIds): void
+    {
+        $ids = array_map(function (ProductId $productId): int {
+            return $productId->getValue();
+        }, $relatedProductIds);
+
+        try {
+            $product->changeAccessories($ids);
+        } catch (PrestaShopException $e) {
+            throw new CoreException(sprintf(
+                'Error occurred when updating related products for product #%d',
+                $product->id
+            ));
+        }
+    }
+
+    /**
+     * @param Product $product
+     *
+     * @throws CannotUpdateProductException
+     * @throws CoreException
+     */
+    private function deleteRelatedProducts(Product $product): void
     {
         try {
-            if (empty($relatedProductIds)) {
-                $product->deleteAccessories();
-
-                return;
+            if (!$product->deleteAccessories()) {
+                throw new CannotUpdateProductException(sprintf(
+                    'Failed to delete related products for product #%d',
+                    $product->id
+                ));
             }
-
-            $this->productRepository->assertAllProductsExists($relatedProductIds);
-            $ids = array_map(function (ProductId $productId): int {
-                return $productId->getValue();
-            }, $relatedProductIds);
-
-            $product->deleteAccessories();
-            $product->changeAccessories($ids);
         } catch (PrestaShopException $e) {
             throw new CoreException(sprintf(
                 'Error occurred when updating related products for product #%d',

--- a/src/Core/Domain/Product/Command/RemoveAllRelatedProductsCommand.php
+++ b/src/Core/Domain/Product/Command/RemoveAllRelatedProductsCommand.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+/**
+ * Removes all related products from given product
+ */
+class RemoveAllRelatedProductsCommand
+{
+    /**
+     * @var ProductId
+     */
+    private $productId;
+
+    /**
+     * @param int $productId
+     */
+    public function __construct(int $productId)
+    {
+        $this->productId = new ProductId($productId);
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+}

--- a/src/Core/Domain/Product/Command/SetRelatedProductsCommand.php
+++ b/src/Core/Domain/Product/Command/SetRelatedProductsCommand.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use RuntimeException;
+
+/**
+ * Sets related products for product
+ */
+class SetRelatedProductsCommand
+{
+    /**
+     * @var ProductId
+     */
+    private $productId;
+
+    /**
+     * @var ProductId[]
+     */
+    private $relatedProductIds;
+
+    /**
+     * @param int $productId
+     * @param int[] $relatedProductIds
+     */
+    public function __construct(
+        int $productId,
+        array $relatedProductIds
+    ) {
+        $this->productId = $productId;
+        $this->setRelatedProductIds($relatedProductIds);
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return ProductId[]
+     */
+    public function getRelatedProductIds(): array
+    {
+        return $this->relatedProductIds;
+    }
+
+    /**
+     * @param int[] $ids
+     */
+    private function setRelatedProductIds(array $ids): void
+    {
+        if (empty($ids)) {
+            throw new RuntimeException(sprintf(
+                'Empty array of related products provided in %s. To remove all related products use %s.',
+                self::class,
+                //@todo: use class
+                'RemoveAllRelatedProductsCommand'
+            ));
+        }
+
+        foreach ($ids as $id) {
+            $this->relatedProductIds[] = new ProductId($id);
+        }
+    }
+}

--- a/src/Core/Domain/Product/Command/SetRelatedProductsCommand.php
+++ b/src/Core/Domain/Product/Command/SetRelatedProductsCommand.php
@@ -54,7 +54,7 @@ class SetRelatedProductsCommand
         int $productId,
         array $relatedProductIds
     ) {
-        $this->productId = $productId;
+        $this->productId = new ProductId($productId);
         $this->setRelatedProductIds($relatedProductIds);
     }
 

--- a/src/Core/Domain/Product/Command/SetRelatedProductsCommand.php
+++ b/src/Core/Domain/Product/Command/SetRelatedProductsCommand.php
@@ -83,8 +83,7 @@ class SetRelatedProductsCommand
             throw new RuntimeException(sprintf(
                 'Empty array of related products provided in %s. To remove all related products use %s.',
                 self::class,
-                //@todo: use class
-                'RemoveAllRelatedProductsCommand'
+                RemoveAllRelatedProductsCommand::class
             ));
         }
 

--- a/src/Core/Domain/Product/CommandHandler/RemoveAllRelatedProductsHandlerInterface.php
+++ b/src/Core/Domain/Product/CommandHandler/RemoveAllRelatedProductsHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllRelatedProductsCommand;
+
+/**
+ * Defines interface to handle @see RemoveAllRelatedProductsCommand
+ */
+interface RemoveAllRelatedProductsHandlerInterface
+{
+    /**
+     * @param RemoveAllRelatedProductsCommand $command
+     */
+    public function handle(RemoveAllRelatedProductsCommand $command): void;
+}

--- a/src/Core/Domain/Product/CommandHandler/SetRelatedProductsHandlerInterface.php
+++ b/src/Core/Domain/Product/CommandHandler/SetRelatedProductsHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand;
+
+/**
+ * Defines contract to handle @see SetRelatedProductsCommand
+ */
+interface SetRelatedProductsHandlerInterface
+{
+    /**
+     * @param SetRelatedProductsCommand $command
+     */
+    public function handle(SetRelatedProductsCommand $command): void;
+}

--- a/src/Core/Domain/Product/Query/GetRelatedProducts.php
+++ b/src/Core/Domain/Product/Query/GetRelatedProducts.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Query;
 
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
 /**
@@ -41,11 +42,20 @@ class GetRelatedProducts
     private $productId;
 
     /**
-     * @param int $productId
+     * @var LanguageId
      */
-    public function __construct(int $productId)
-    {
+    private $languageId;
+
+    /**
+     * @param int $productId
+     * @param int $languageId
+     */
+    public function __construct(
+        int $productId,
+        int $languageId
+    ) {
         $this->productId = new ProductId($productId);
+        $this->languageId = new LanguageId($languageId);
     }
 
     /**
@@ -54,5 +64,13 @@ class GetRelatedProducts
     public function getProductId(): ProductId
     {
         return $this->productId;
+    }
+
+    /**
+     * @return LanguageId
+     */
+    public function getLanguageId(): LanguageId
+    {
+        return $this->languageId;
     }
 }

--- a/src/Core/Domain/Product/Query/GetRelatedProducts.php
+++ b/src/Core/Domain/Product/Query/GetRelatedProducts.php
@@ -26,49 +26,33 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Query;
 
-use Pack;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetPackedProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetPackedProductsHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\PackedProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
 /**
- * Handles GetPackedProducts query using legacy object model
+ * Provides related products for given product
  */
-final class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
+class GetRelatedProducts
 {
     /**
-     * @var int
+     * @var ProductId
      */
-    private $defaultLangId;
+    private $productId;
 
     /**
-     * @param int $defaultLangId
+     * @param int $productId
      */
-    public function __construct(int $defaultLangId)
+    public function __construct(int $productId)
     {
-        $this->defaultLangId = $defaultLangId;
+        $this->productId = new ProductId($productId);
     }
 
     /**
-     * {@inheritdoc}
+     * @return ProductId
      */
-    public function handle(GetPackedProducts $query): array
+    public function getProductId(): ProductId
     {
-        $packId = $query->getPackId()->getValue();
-
-        $packedItems = Pack::getItems($packId, $this->defaultLangId);
-
-        $packedProducts = [];
-        foreach ($packedItems as $packedItem) {
-            $packedProducts[] = new PackedProduct(
-                (int) $packedItem->id,
-                (int) $packedItem->pack_quantity,
-                (int) $packedItem->id_pack_product_attribute
-            );
-        }
-
-        return $packedProducts;
+        return $this->productId;
     }
 }

--- a/src/Core/Domain/Product/QueryHandler/GetRelatedProductsHandlerInterface.php
+++ b/src/Core/Domain/Product/QueryHandler/GetRelatedProductsHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\RelatedProduct;
+
+/**
+ * Defines contract to handle @see GetRelatedProducts query
+ */
+interface GetRelatedProductsHandlerInterface
+{
+    /**
+     * @param GetRelatedProducts $query
+     *
+     * @return RelatedProduct[]
+     */
+    public function handle(GetRelatedProducts $query): array;
+}

--- a/src/Core/Domain/Product/QueryResult/RelatedProduct.php
+++ b/src/Core/Domain/Product/QueryResult/RelatedProduct.php
@@ -26,49 +26,64 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
-
-use Pack;
-use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetPackedProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\GetPackedProductsHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\PackedProduct;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\QueryResult;
 
 /**
- * Handles GetPackedProducts query using legacy object model
+ * Transfers related product data
  */
-final class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
+class RelatedProduct
 {
     /**
      * @var int
      */
-    private $defaultLangId;
+    private $productId;
 
     /**
-     * @param int $defaultLangId
+     * @var string
      */
-    public function __construct(int $defaultLangId)
-    {
-        $this->defaultLangId = $defaultLangId;
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $reference;
+
+    /**
+     * @param int $productId
+     * @param string $name
+     * @param string $reference
+     */
+    public function __construct(
+        int $productId,
+        string $name,
+        string $reference
+    ) {
+        $this->productId = $productId;
+        $this->name = $name;
+        $this->reference = $reference;
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
-    public function handle(GetPackedProducts $query): array
+    public function getProductId(): int
     {
-        $packId = $query->getPackId()->getValue();
+        return $this->productId;
+    }
 
-        $packedItems = Pack::getItems($packId, $this->defaultLangId);
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
 
-        $packedProducts = [];
-        foreach ($packedItems as $packedItem) {
-            $packedProducts[] = new PackedProduct(
-                (int) $packedItem->id,
-                (int) $packedItem->pack_quantity,
-                (int) $packedItem->id_pack_product_attribute
-            );
-        }
-
-        return $packedProducts;
+    /**
+     * @return string
+     */
+    public function getReference(): string
+    {
+        return $this->reference;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -247,6 +247,8 @@ services:
     prestashop.adapter.product.repository.product_repository:
         class: PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository
         arguments:
+            - '@doctrine.dbal.default_connection'
+            - '%database_prefix%'
             - '@prestashop.adapter.product.validate.product_validator'
 
     prestashop.adapter.product.validate.customization_field_validator:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -307,3 +307,17 @@ services:
             - '@prestashop.adapter.product.repository.product_repository'
             - '@prestashop.adapter.supplier.repository.supplier_repository'
             - '@prestashop.adapter.product.repository.product_supplier_repository'
+
+    prestashop.adapter.product.update.related_products_updater:
+        class: PrestaShop\PrestaShop\Adapter\Product\Update\RelatedProductsUpdater
+        arguments:
+            - '@prestashop.adapter.product.repository.product_repository'
+
+    prestashop.adapter.product.command_handler.set_related_products_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetRelatedProductsHandler
+        arguments:
+            - '@prestashop.adapter.product.repository.product_repository'
+            - '@prestashop.adapter.product.update.related_products_updater'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -318,7 +318,6 @@ services:
     prestashop.adapter.product.command_handler.set_related_products_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetRelatedProductsHandler
         arguments:
-            - '@prestashop.adapter.product.repository.product_repository'
             - '@prestashop.adapter.product.update.related_products_updater'
         tags:
             - name: tactician.handler
@@ -335,7 +334,6 @@ services:
     prestashop.adapter.product.query_handler.remove_all_related_products_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\RemoveAllRelatedProductsHandler
         arguments:
-            - '@prestashop.adapter.product.repository.product_repository'
             - '@prestashop.adapter.product.update.related_products_updater'
         tags:
             - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -328,7 +328,6 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetRelatedProductsHandler
         arguments:
             - '@prestashop.adapter.product.repository.product_repository'
-            - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -321,3 +321,12 @@ services:
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand
+
+    prestashop.adapter.product.query_handler.get_related_products_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetRelatedProductsHandler
+        arguments:
+            - '@prestashop.adapter.product.repository.product_repository'
+            - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -332,3 +332,12 @@ services:
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts
+
+    prestashop.adapter.product.query_handler.remove_all_related_products_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\RemoveAllRelatedProductsHandler
+        arguments:
+            - '@prestashop.adapter.product.repository.product_repository'
+            - '@prestashop.adapter.product.update.related_products_updater'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllRelatedProductsCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
@@ -31,6 +31,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllRelatedProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\RelatedProduct;
@@ -112,7 +113,7 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
     {
         $productId = $this->getSharedStorage()->get($productReference);
         try {
-            $this->getCommandBus()->handle(new SetRelatedProductsCommand($productId, []));
+            $this->getCommandBus()->handle(new RemoveAllRelatedProductsCommand($productId));
         } catch (DomainException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
@@ -47,7 +47,7 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
     {
         $productId = $this->getSharedStorage()->get($productReference);
         try {
-            $relatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId));
+            $relatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId, $this->getDefaultLangId()));
             Assert::assertEmpty(
                 $relatedProducts,
                 sprintf('Product %s expected to have no related products', $productReference)
@@ -91,7 +91,7 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
         $productId = $this->getSharedStorage()->get($productReference);
 
         $expectedReferences = array_keys($tableNode->getRowsHash());
-        $actualRelatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId));
+        $actualRelatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId, $this->getDefaultLangId()));
 
         $expectedIds = array_map(function (string $reference): int {
             return $this->getSharedStorage()->get($reference);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
+
+class RelatedProductsFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @Then product :productReference should have no related products
+     *
+     * @param string $productReference
+     */
+    public function assertProductHasNoRelatedProducts(string $productReference): void
+    {
+        $productId = $this->getSharedStorage()->get($productReference);
+        try {
+            $relatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId));
+            Assert::assertEmpty(
+                $relatedProducts,
+                sprintf('Product %s expected to have no related products', $productReference)
+            );
+        } catch (DomainException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
@@ -102,4 +102,19 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
 
         Assert::assertEquals($expectedIds, $actualIds, 'Unexpected related products');
     }
+
+    /**
+     * @When I remove all related products from product :productReference
+     *
+     * @param string $productReference
+     */
+    public function removeAllRelatedProducts(string $productReference)
+    {
+        $productId = $this->getSharedStorage()->get($productReference);
+        try {
+            $this->getCommandBus()->handle(new SetRelatedProductsCommand($productId, []));
+        } catch (DomainException $e) {
+            $this->setLastException($e);
+        }
+    }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/RelatedProductsFeatureContext.php
@@ -30,7 +30,6 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllRelatedProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
@@ -46,15 +45,12 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
     public function assertProductHasNoRelatedProducts(string $productReference): void
     {
         $productId = $this->getSharedStorage()->get($productReference);
-        try {
-            $relatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId, $this->getDefaultLangId()));
-            Assert::assertEmpty(
-                $relatedProducts,
-                sprintf('Product %s expected to have no related products', $productReference)
-            );
-        } catch (DomainException $e) {
-            $this->setLastException($e);
-        }
+        $relatedProducts = $this->getQueryBus()->handle(new GetRelatedProducts($productId, $this->getDefaultLangId()));
+
+        Assert::assertEmpty(
+            $relatedProducts,
+            sprintf('Product %s expected to have no related products', $productReference)
+        );
     }
 
     /**
@@ -73,11 +69,7 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
             $relatedProductIds[] = $this->getSharedStorage()->get($reference);
         }
 
-        try {
-            $this->getCommandBus()->handle(new SetRelatedProductsCommand($productId, $relatedProductIds));
-        } catch (DomainException $e) {
-            $this->setLastException($e);
-        }
+        $this->getCommandBus()->handle(new SetRelatedProductsCommand($productId, $relatedProductIds));
     }
 
     /**
@@ -112,10 +104,6 @@ class RelatedProductsFeatureContext extends AbstractProductFeatureContext
     public function removeAllRelatedProducts(string $productReference)
     {
         $productId = $this->getSharedStorage()->get($productReference);
-        try {
-            $this->getCommandBus()->handle(new RemoveAllRelatedProductsCommand($productId));
-        } catch (DomainException $e) {
-            $this->setLastException($e);
-        }
+        $this->getCommandBus()->handle(new RemoveAllRelatedProductsCommand($productId));
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -27,7 +27,7 @@ Feature: Update product related products from Back Office (BO)
       | blackFramed | 10       | Color:Black |
     And product product1 should have no related products
     And product product2 type should be standard
-    Then product "product3" type should be pack
+    And product "product3" type should be pack
     And product product4 type should be combination
     When I set following related products to product product1:
       | product2          |
@@ -37,3 +37,16 @@ Feature: Update product related products from Back Office (BO)
       | product2          |
       | product3          |
       | product4          |
+    When I set following related products to product product1:
+      | product2          |
+      | product4          |
+    Then product product1 should have following related products:
+      | product2          |
+      | product4          |
+
+  Scenario: Remove all related products
+    Given product product1 should have following related products:
+      | product2          |
+      | product4          |
+    When I remove all related products from product product1
+    Then product product1 should have no related products

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -1,0 +1,12 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags related-products
+@reset-database-before-feature
+@related-products
+Feature: Update product related products from Back Office (BO)
+  As an employee
+  I need to be able to update related products of a product from Back Office
+
+  Scenario: I set related products
+    When I add product "product1" with following information:
+      | name       | en-US:book of law;fr-Fr:livre de droit |
+      | is_virtual | false                |
+    Then product product1 should have no related products

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -1,12 +1,39 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags related-products
 @reset-database-before-feature
+@clear-cache-before-feature
 @related-products
 Feature: Update product related products from Back Office (BO)
   As an employee
   I need to be able to update related products of a product from Back Office
 
   Scenario: I set related products
-    When I add product "product1" with following information:
-      | name       | en-US:book of law;fr-Fr:livre de droit |
-      | is_virtual | false                |
-    Then product product1 should have no related products
+    Given I add product "product1" with following information:
+      | name       | en-US:book of law |
+      | is_virtual | false             |
+    And I add product "product2" with following information:
+      | name       | en-US:book of love |
+      | is_virtual | false              |
+    And I add product "product3" with following information:
+      | name       | en-US:lovely books package |
+      | is_virtual | false                      |
+    And I update pack "product3" with following product quantities:
+      | product2 | 5 |
+    And I add product "product4" with following information:
+      | name       | en-US:Reading glasses |
+      | is_virtual | false                 |
+    And product "product4" has following combinations:
+      | reference   | quantity | attributes  |
+      | whiteFramed | 10       | Color:White |
+      | blackFramed | 10       | Color:Black |
+    And product product1 should have no related products
+    And product product2 type should be standard
+    Then product "product3" type should be pack
+    And product product4 type should be combination
+    When I set following related products to product product1:
+      | product2          |
+      | product3          |
+      | product4          |
+    Then product product1 should have following related products:
+      | product2          |
+      | product3          |
+      | product4          |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -226,3 +226,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateAttachmentFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttachmentFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPricePrioritiesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\RelatedProductsFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Part of product page migration. Implemented following command handlers: `SetRelatedProducts, GetRelatedProducts, RemoveAllRelatedProducts`. Add some basic behat scenarios to support its behavior.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #19522
| How to test?  | CI :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
As discussed privately with @matks, It might be relevant to rename database table of related products in future. Currently the table is called "accessory". **EDIT**: issue created in this regard https://github.com/PrestaShop/PrestaShop/issues/21419

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21417)
<!-- Reviewable:end -->
