### PR TITLE
Filters : Set Placeholder for Yes/NO & Fix bug when filters are emptied

### DIFF
--- a/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ContactGridDefinitionFactory.php
@@ -49,6 +49,8 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
     use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
+    public const GRID_ID = 'contact';
+
     /**
      * @var string
      */
@@ -79,7 +81,7 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'contact';
+        return self::GRID_ID;
     }
 
     /**
@@ -195,10 +197,11 @@ final class ContactGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add(
                 (new Filter('actions', SearchAndResetType::class))
                     ->setTypeOptions([
-                        'attr' => [
-                            'data-url' => $this->resetSearchUrl,
-                            'data-redirect' => $this->redirectionUrl,
+                        'reset_route' => 'admin_common_reset_search_by_filter_id',
+                        'reset_route_params' => [
+                            'filterId' => self::GRID_ID,
                         ],
+                        'redirect_route' => 'admin_contacts_index',
                     ])
                     ->setAssociatedColumn('actions')
             );

--- a/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CurrencyGridDefinitionFactory.php
@@ -215,10 +215,6 @@ final class CurrencyGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->setAssociatedColumn('iso_code')
             )
             ->add((new Filter('active', YesAndNoChoiceType::class))
-            ->setTypeOptions([
-                'required' => false,
-                'choice_translation_domain' => false,
-            ])
             ->setAssociatedColumn('active')
             )
             ->add((new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -52,6 +52,8 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
     use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
+    public const GRID_ID = 'email_logs';
+
     /**
      * @var string the URL to reset Grid filters
      */
@@ -90,7 +92,7 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'email_logs';
+        return self::GRID_ID;
     }
 
     /**
@@ -224,10 +226,11 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
             ->add(
                 (new Filter('actions', SearchAndResetType::class))
                     ->setTypeOptions([
-                        'attr' => [
-                            'data-url' => $this->resetActionUrl,
-                            'data-redirect' => $this->redirectionUrl,
+                        'reset_route' => 'admin_common_reset_search_by_filter_id',
+                        'reset_route_params' => [
+                            'filterId' => self::GRID_ID,
                         ],
+                        'redirect_route' => 'admin_emails_index',
                     ])
                     ->setAssociatedColumn('actions')
             );

--- a/src/Core/Grid/Definition/Factory/EmployeeGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmployeeGridDefinitionFactory.php
@@ -54,6 +54,8 @@ final class EmployeeGridDefinitionFactory extends AbstractGridDefinitionFactory
     use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
+    public const GRID_ID = 'employee';
+
     /**
      * @var string
      */
@@ -84,7 +86,7 @@ final class EmployeeGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'employee';
+        return self::GRID_ID;
     }
 
     /**
@@ -231,16 +233,18 @@ final class EmployeeGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
                     ->setAssociatedColumn('profile')
             )
-            ->add((new Filter('active', YesAndNoChoiceType::class))
-            ->setAssociatedColumn('active')
+            ->add(
+                (new Filter('active', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('active')
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))
                     ->setTypeOptions([
-                        'attr' => [
-                            'data-url' => $this->resetUrl,
-                            'data-redirect' => $this->redirectUrl,
+                        'reset_route' => 'admin_common_reset_search_by_filter_id',
+                        'reset_route_params' => [
+                            'filterId' => self::GRID_ID,
                         ],
+                        'redirect_route' => 'admin_employees_index',
                     ])
                     ->setAssociatedColumn('actions')
             );

--- a/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LanguageGridDefinitionFactory.php
@@ -42,7 +42,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
@@ -242,15 +242,7 @@ final class LanguageGridDefinitionFactory extends AbstractGridDefinitionFactory
                      ->setAssociatedColumn('date_format_full')
              )
             ->add(
-                 (new Filter('active', ChoiceType::class))
-                     ->setTypeOptions([
-                         'choices' => [
-                             $this->trans('Yes', [], 'Admin.Global') => 1,
-                             $this->trans('No', [], 'Admin.Global') => 0,
-                         ],
-                         'required' => false,
-                         'choice_translation_domain' => false,
-                     ])
+                 (new Filter('active', YesAndNoChoiceType::class))
                      ->setAssociatedColumn('active')
              )
             ->add(

--- a/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php
@@ -218,8 +218,9 @@ final class ManufacturerGridDefinitionFactory extends AbstractGridDefinitionFact
             ])
             ->setAssociatedColumn('name')
             )
-            ->add((new Filter('active', YesAndNoChoiceType::class))
-            ->setAssociatedColumn('active')
+            ->add(
+                (new Filter('active', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('active')
             )
             ->add((new Filter('actions', SearchAndResetType::class))
             ->setAssociatedColumn('actions')

--- a/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OrderGridDefinitionFactory.php
@@ -310,11 +310,9 @@ final class OrderGridDefinitionFactory extends AbstractFilterableGridDefinitionF
             ])
             ->setAssociatedColumn('reference')
             )
-            ->add((new Filter('new', YesAndNoChoiceType::class))
-            ->setTypeOptions([
-                'required' => false,
-            ])
-            ->setAssociatedColumn('new')
+            ->add(
+                (new Filter('new', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('new')
             )
             ->add((new Filter('customer', TextType::class))
             ->setTypeOptions([

--- a/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProfileGridDefinitionFactory.php
@@ -50,6 +50,8 @@ final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
     use BulkDeleteActionTrait;
     use DeleteActionTrait;
 
+    public const GRID_ID = 'profile';
+
     /**
      * @var string
      */
@@ -88,7 +90,7 @@ final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getId()
     {
-        return 'profile';
+        return self::GRID_ID;
     }
 
     /**
@@ -196,10 +198,11 @@ final class ProfileGridDefinitionFactory extends AbstractGridDefinitionFactory
             )
             ->add((new Filter('actions', SearchAndResetType::class))
             ->setTypeOptions([
-                'attr' => [
-                    'data-url' => $this->resetActionUrl,
-                    'data-redirect' => $this->redirectionUrl,
+                'reset_route' => 'admin_common_reset_search_by_filter_id',
+                'reset_route_params' => [
+                    'filterId' => self::GRID_ID,
                 ],
+                'redirect_route' => 'admin_profiles_index',
             ])
             ->setAssociatedColumn('actions')
             )

--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -192,11 +192,9 @@ final class SupplierGridDefinitionFactory extends AbstractFilterableGridDefiniti
                 'required' => false,
             ])
             )
-            ->add((new Filter('active', YesAndNoChoiceType::class))
-            ->setAssociatedColumn('active')
-            ->setTypeOptions([
-                'required' => false,
-            ])
+            ->add(
+                (new Filter('active', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('active')
             )
             ->add((new Filter('actions', SearchAndResetType::class))
             ->setAssociatedColumn('actions')

--- a/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TaxGridDefinitionFactory.php
@@ -175,12 +175,9 @@ final class TaxGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
                     ->setAssociatedColumn('rate')
             )
-            ->add((new Filter('active', YesAndNoChoiceType::class))
-            ->setTypeOptions([
-                'required' => false,
-                'choice_translation_domain' => false,
-            ])
-            ->setAssociatedColumn('active')
+            ->add(
+                (new Filter('active', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('active')
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/TaxRulesGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/TaxRulesGroupGridDefinitionFactory.php
@@ -162,12 +162,9 @@ final class TaxRulesGroupGridDefinitionFactory extends AbstractFilterableGridDef
                     ])
                     ->setAssociatedColumn('name')
             )
-            ->add((new Filter('active', YesAndNoChoiceType::class))
-            ->setTypeOptions([
-                'required' => false,
-                'choice_translation_domain' => false,
-            ])
-            ->setAssociatedColumn('active')
+            ->add(
+                (new Filter('active', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('active')
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
@@ -41,7 +41,7 @@ use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
@@ -180,12 +180,7 @@ final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setAssociatedColumn('description')
             )
             ->add(
-                (new Filter('active', ChoiceType::class))
-                    ->setTypeOptions([
-                        'required' => false,
-                        'choices' => $this->statusChoices,
-                        'choice_translation_domain' => false,
-                    ])
+                (new Filter('active', YesAndNoChoiceType::class))
                     ->setAssociatedColumn('active')
             )
             ->add(

--- a/src/Core/Search/Filters/ContactFilters.php
+++ b/src/Core/Search/Filters/ContactFilters.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ContactGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 
 /**
@@ -33,6 +34,11 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
  */
 final class ContactFilters extends Filters
 {
+    /**
+     * @var string
+     */
+    protected $filterId = ContactGridDefinitionFactory::GRID_ID;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Core/Search/Filters/EmailLogsFilter.php
+++ b/src/Core/Search/Filters/EmailLogsFilter.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 
 /**
@@ -33,6 +34,11 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
  */
 final class EmailLogsFilter extends Filters
 {
+    /**
+     * @var string
+     */
+    protected $filterId = EmailLogsDefinitionFactory::GRID_ID;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Core/Search/Filters/EmployeeFilters.php
+++ b/src/Core/Search/Filters/EmployeeFilters.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmployeeGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 
 /**
@@ -33,6 +34,11 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
  */
 final class EmployeeFilters extends Filters
 {
+    /**
+     * @var string
+     */
+    protected $filterId = EmployeeGridDefinitionFactory::GRID_ID;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Core/Search/Filters/ProfileFilters.php
+++ b/src/Core/Search/Filters/ProfileFilters.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProfileGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters;
 
 /**
@@ -33,6 +34,11 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
  */
 final class ProfileFilters extends Filters
 {
+    /**
+     * @var string
+     */
+    protected $filterId = ProfileGridDefinitionFactory::GRID_ID;
+
     /**
      * {@inheritdoc}
      */

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -66,11 +66,8 @@ class EmailController extends FrameworkBundleAdminController
 
         $isEmailLogsEnabled = $configuration->get('PS_LOG_EMAILS');
 
-        $presentedEmailLogsGrid = null;
-
         if ($isEmailLogsEnabled) {
-            $emailLogsGridFactory = $this->get('prestashop.core.grid.factory.email_logs');
-            $emailLogsGrid = $emailLogsGridFactory->getGrid($filters);
+            $emailLogsGrid = $this->get('prestashop.core.grid.factory.email_logs')->getGrid($filters);
             $presentedEmailLogsGrid = $this->presentGrid($emailLogsGrid);
         }
 
@@ -79,7 +76,7 @@ class EmailController extends FrameworkBundleAdminController
             'isOpenSslExtensionLoaded' => $extensionChecker->loaded('openssl'),
             'smtpMailMethod' => MailOption::METHOD_SMTP,
             'testEmailSendingForm' => $testEmailSendingForm->createView(),
-            'emailLogsGrid' => $presentedEmailLogsGrid,
+            'emailLogsGrid' => $presentedEmailLogsGrid ?? null,
             'isEmailLogsEnabled' => $isEmailLogsEnabled,
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
@@ -87,6 +84,8 @@ class EmailController extends FrameworkBundleAdminController
     }
 
     /**
+     * @deprecated since 8.0 and will be removed in next major. Use CommonController:searchGridAction instead
+     *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -346,21 +346,15 @@ class WebserviceController extends FrameworkBundleAdminController
      */
     protected function renderPage(Request $request, WebserviceKeyFilters $filters, FormInterface $form): Response
     {
-        $gridWebserviceFactory = $this->get('prestashop.core.grid.factory.webservice_key');
-        $grid = $gridWebserviceFactory->getGrid($filters);
-
-        $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
-        $presentedGrid = $gridPresenter->present($grid);
-
-        $configurationWarnings = $this->lookForWarnings();
+        $grid = $this->get('prestashop.core.grid.factory.webservice_key')->getGrid($filters);
 
         return $this->render(
             '@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/index.html.twig',
             [
                 'help_link' => $this->generateSidebarLink($request->get('_legacy_controller')),
                 'webserviceConfigurationForm' => $form->createView(),
-                'grid' => $presentedGrid,
-                'configurationWarnings' => $configurationWarnings,
+                'grid' => $this->presentGrid($grid),
+                'configurationWarnings' => $this->lookForWarnings(),
                 'webserviceStatus' => $this->getWebServiceStatus($request),
             ]
         );

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -78,6 +78,8 @@ class ContactsController extends FrameworkBundleAdminController
     }
 
     /**
+     * @deprecated since 8.0 and will be removed in next major. Use CommonController:searchGridAction instead
+     *
      * Grid search action.
      *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -429,8 +429,7 @@ class MetaController extends FrameworkBundleAdminController
         if ($isGridDisplayed) {
             $grid = $seoUrlsGridFactory->getGrid($filters);
 
-            $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
-            $presentedGrid = $gridPresenter->present($grid);
+            $presentedGrid = $this->presentGrid($grid);
         }
 
         $tools = $this->get('prestashop.adapter.tools');

--- a/src/PrestaShopBundle/Form/Admin/Type/CountryChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CountryChoiceType.php
@@ -87,14 +87,10 @@ class CountryChoiceType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $choices = array_merge(
-            ['--' => ''],
-            $this->countriesChoiceProvider->getChoices()
-        );
-
         $resolver->setDefaults([
-            'choices' => $choices,
+            'choices' => $this->countriesChoiceProvider->getChoices(),
             'choice_attr' => [$this, 'getChoiceAttr'],
+            'placeholder' => '--',
             'with_dni_attr' => false,
             'with_postcode_attr' => false,
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/YesAndNoChoiceType.php
@@ -45,6 +45,7 @@ class YesAndNoChoiceType extends TranslatorAwareType
                 $this->trans('No', 'Admin.Global') => 0,
             ],
             'required' => false,
+            'placeholder' => $this->trans('All', 'Admin.Global'),
             'choice_translation_domain' => false,
         ]);
     }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/email.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/email.yml
@@ -10,7 +10,9 @@ admin_emails_search:
   path: /
   methods: [ POST ]
   defaults:
-    _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\EmailController::searchAction'
+    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.email_logs
+    redirectRoute: admin_emails_index
     _legacy_controller: AdminEmails
     _legacy_link: AdminEmails:search
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/employee.yml
@@ -10,11 +10,11 @@ admin_employees_search:
   path: /
   methods: [ POST ]
   defaults:
-    _controller: 'PrestaShopBundle\Controller\Admin\CommonController::searchGridAction'
-    _legacy_controller: AdminEmployees
-    _legacy_link: AdminEmployees:submitFilteremployee
+    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
     gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.employee
     redirectRoute: admin_employees_index
+    _legacy_controller: AdminEmployees
+    _legacy_link: AdminEmployees:submitFilteremployee
 
 admin_employees_save_options:
   path: /save-options

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/contacts.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/contacts.yml
@@ -10,7 +10,9 @@ admin_contacts_search:
   path: /
   methods: [ POST ]
   defaults:
-    _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\ContactsController::searchAction'
+    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.contacts
+    redirectRoute: admin_contacts_index
     _legacy_controller: AdminContacts
     _legacy_link: AdminContacts:submitFiltercontact
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/grid.yml
@@ -7,6 +7,9 @@ services:
     arguments:
       - '@prestashop.core.grid.filter.form_factory'
       - '@router'
+      - '@prestashop.core.admin.admin_filter.repository'
+      - '@=service("prestashop.adapter.legacy.context").getContext().employee.id'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
 
   prestashop.bundle.grid.controller_response_builder:
     class: PrestaShopBundle\Service\Grid\ControllerResponseBuilder

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -20,11 +20,11 @@ services:
   prestashop.core.grid.definition.factory.email_logs:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\EmailLogsDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    public: true
     arguments:
       - "@=service('router').generate('admin_common_reset_search', {'controller': 'email', 'action': 'index'})"
       - "@=service('router').generate('admin_emails_index')"
       - '@prestashop.core.form.choice_provider.language_by_id'
-    public: true
 
   prestashop.core.grid.definition.factory.request_sql:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\RequestSqlGridDefinitionFactory'

--- a/src/PrestaShopBundle/Service/Grid/ResponseBuilder.php
+++ b/src/PrestaShopBundle/Service/Grid/ResponseBuilder.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Service\Grid;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactoryInterface;
+use PrestaShopBundle\Entity\Repository\AdminFilterRepository;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,22 +37,40 @@ use Symfony\Component\Routing\Router;
 
 class ResponseBuilder
 {
+    /** @var AdminFilterRepository */
+    private $adminFilterRepository;
+
+    /** @var int|null */
+    private $employeeId;
+
     /** @var GridFilterFormFactoryInterface */
     private $filterFormFactory;
 
     /** @var Router */
     private $router;
 
+    /** @var int */
+    private $shopId;
+
     /**
      * @param GridFilterFormFactoryInterface $filterFormFactory
      * @param Router $router
+     * @param AdminFilterRepository $adminFilterRepository
+     * @param int|null $employeeId
+     * @param int $shopId
      */
     public function __construct(
         GridFilterFormFactoryInterface $filterFormFactory,
-        Router $router
+        Router $router,
+        AdminFilterRepository $adminFilterRepository,
+        ?int $employeeId,
+        int $shopId
     ) {
         $this->filterFormFactory = $filterFormFactory;
         $this->router = $router;
+        $this->adminFilterRepository = $adminFilterRepository;
+        $this->employeeId = $employeeId;
+        $this->shopId = $shopId;
     }
 
     /**
@@ -79,6 +98,10 @@ class ResponseBuilder
 
         $redirectParams = [];
         if ($filtersForm->isSubmitted()) {
+            if ($this->checkIsFormDataEmpty($filtersForm->getData())) {
+                $this->resetPersistedFilter($filterId);
+            }
+
             $redirectParams = [
                 $filterId => [
                     'filters' => $filtersForm->getData(),
@@ -98,5 +121,49 @@ class ResponseBuilder
         $redirectUrl = $this->router->generate($redirectRoute, $redirectParams);
 
         return new RedirectResponse($redirectUrl, 302);
+    }
+
+    /**
+     * @param string $filterId
+     *
+     * @return void
+     */
+    private function resetPersistedFilter(string $filterId): void
+    {
+        if (empty($filterId)) {
+            return;
+        }
+        $adminFilter = $this->adminFilterRepository->findByEmployeeAndFilterId(
+            $this->employeeId,
+            $this->shopId,
+            $filterId
+        );
+        if (!$adminFilter) {
+            return;
+        }
+        $this->adminFilterRepository->unsetFilters($adminFilter);
+    }
+
+    /**
+     * Return true if array is empty (null values or empty array)
+     *
+     * @param array $formData
+     *
+     * @return bool
+     */
+    private function checkIsFormDataEmpty(array $formData): bool
+    {
+        foreach ($formData as $data) {
+            if ($data === null) {
+                continue;
+            }
+            if (is_array($data) && $this->checkIsFormDataEmpty($data)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/PrestaShopBundle/Service/Grid/ResponseBuilderTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Grid/ResponseBuilderTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Service\Grid;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactoryInterface;
+use PrestaShopBundle\Entity\Repository\AdminFilterRepository;
+use PrestaShopBundle\Service\Grid\ResponseBuilder;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Router;
+
+class ResponseBuilderTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderBuildSearchResponse
+     *
+     * @param array $data
+     * @param array $redirectParams
+     */
+    public function testBuildSearchResponse(array $data, array $redirectParams): void
+    {
+        $mockForm = $this->createMock(FormInterface::class);
+        $mockForm->method('isSubmitted')->willReturn(true);
+        $mockForm->method('getData')->willReturn($data);
+
+        $mockFilterFormFactory = $this->createMock(GridFilterFormFactoryInterface::class);
+        $mockFilterFormFactory->method('create')->willReturn($mockForm);
+
+        $mockDefinitionFactory = $this->createMock(GridDefinitionFactoryInterface::class);
+        $mockDefinitionFactory->method('getDefinition')->willReturn(
+            $this->createMock(GridDefinitionInterface::class)
+        );
+
+        $mockRouter = $this->createMock(Router::class);
+        $mockRouter->method('generate')->willReturnCallback(function (string $name, array $parameters = []) {
+            return $name . '?' . http_build_query($parameters);
+        });
+
+        $mockRequest = $this->createMock(Request::class);
+        $mockRequest->setMethod('POST');
+        $mockRequest->request = $this->createMock(ParameterBag::class);
+
+        $responseBuilder = new ResponseBuilder(
+            $mockFilterFormFactory,
+            $mockRouter,
+            $this->createMock(AdminFilterRepository::class),
+            1,
+            1
+        );
+
+        $response = $responseBuilder->buildSearchResponse(
+            $mockDefinitionFactory,
+            $mockRequest,
+            'filterId',
+            'index',
+            []
+        );
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+
+        $parts = parse_url($response->getTargetUrl());
+        // Path
+        self::assertEquals('index', $parts['path']);
+        // Query
+        parse_str($parts['query'] ?? '', $query);
+        self::assertEquals($redirectParams, $query);
+    }
+
+    public function dataProviderBuildSearchResponse(): array
+    {
+        return [
+            [
+                [
+                    'a' => 'b',
+                ],
+                [
+                    'filterId' => [
+                        'filters' => [
+                            'a' => 'b',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'a' => null,
+                ],
+                [],
+            ],
+            [
+                [
+                    'a' => 'b',
+                    'c' => null,
+                ],
+                [
+                    'filterId' => [
+                        'filters' => [
+                            'a' => 'b',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'a' => [
+                        'b' => 'c',
+                    ],
+                ],
+                [
+                    'filterId' => [
+                        'filters' => [
+                            'a' => [
+                                'b' => 'c',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'a' => [
+                        'b' => null,
+                    ],
+                ],
+                [],
+            ],
+            [
+                [
+                    'a' => [
+                        'b' => 'c',
+                        'd' => null,
+                    ],
+                ],
+                [
+                    'filterId' => [
+                        'filters' => [
+                            'a' => [
+                                'b' => 'c',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Filters : Set Placeholder for Yes/NO & Fix bug when filters are emptied 
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #18480
| How to test?  | 1. Go to BO on a migrated page that contain a list with drop-down filter<br>2. On the drop-down list select one one the item and click on search<br>3. Only the required items are displayed on the list<br>4. Now on the drop-down select another item and click on search<br>5. The list is refreshed an the new required items are displayed<br>6. Now select the "All" item in the drop-down list and click on search<br>7. **BEFORE** : The list display the items from step 5<br>7. **AFTER** : The list display all the items

**:notebook: BC Break**
* The class `PrestaShopBundle\Service\Grid\ResponseBuilder` adds 3 parameters : 
  * `\PrestaShopBundle\Entity\Repository\AdminFilterRepository $adminFilterRepository`
  * `int|null $employeeId`
  * `int $shopId`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21420)
<!-- Reviewable:end -->
