### PR TITLE
Add autocomplete attributes on FO login form

### DIFF
--- a/classes/form/CustomerLoginFormatter.php
+++ b/classes/form/CustomerLoginFormatter.php
@@ -43,6 +43,7 @@ class CustomerLoginFormatterCore implements FormFormatterInterface
             'email' => (new FormField())
                 ->setName('email')
                 ->setType('email')
+                ->setAutocomplete('email')
                 ->setRequired(true)
                 ->setLabel($this->translator->trans(
                     'Email',
@@ -53,6 +54,7 @@ class CustomerLoginFormatterCore implements FormFormatterInterface
             'password' => (new FormField())
                 ->setName('password')
                 ->setType('password')
+                ->setAutocomplete('current-password')
                 ->setRequired(true)
                 ->setLabel($this->translator->trans(
                     'Password',

--- a/classes/form/CustomerLoginFormatter.php
+++ b/classes/form/CustomerLoginFormatter.php
@@ -43,7 +43,7 @@ class CustomerLoginFormatterCore implements FormFormatterInterface
             'email' => (new FormField())
                 ->setName('email')
                 ->setType('email')
-                ->setAutocomplete('email')
+                ->setAutocompleteAttribute('email')
                 ->setRequired(true)
                 ->setLabel($this->translator->trans(
                     'Email',
@@ -54,7 +54,7 @@ class CustomerLoginFormatterCore implements FormFormatterInterface
             'password' => (new FormField())
                 ->setName('password')
                 ->setType('password')
-                ->setAutocomplete('current-password')
+                ->setAutocompleteAttribute('current-password')
                 ->setRequired(true)
                 ->setLabel($this->translator->trans(
                     'Password',

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -187,7 +187,7 @@ class FormFieldCore
         return $this->constraints;
     }
 
-    public function setAutocompleteAttribute($autocomplete): FormFieldCore
+    public function setAutocompleteAttribute(string $autocomplete): FormFieldCore
     {
         $this->autocomplete = $autocomplete;
 

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -34,6 +34,7 @@ class FormFieldCore
     private $maxLength = null;
     private $errors = [];
     private $constraints = [];
+    private $autocomplete = '';
 
     public function toArray()
     {
@@ -46,6 +47,7 @@ class FormFieldCore
             'availableValues' => $this->getAvailableValues(),
             'maxLength' => $this->getMaxLength(),
             'errors' => $this->getErrors(),
+            'autocomplete' => $this->getAutocomplete(),
         ];
     }
 
@@ -180,5 +182,17 @@ class FormFieldCore
     public function getConstraints()
     {
         return $this->constraints;
+    }
+
+    public function setAutocomplete($autocomplete)
+    {
+        $this->autocomplete = $autocomplete;
+
+        return $this;
+    }
+
+    public function getAutocomplete()
+    {
+        return $this->autocomplete;
     }
 }

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -34,6 +34,9 @@ class FormFieldCore
     private $maxLength = null;
     private $errors = [];
     private $constraints = [];
+    /**
+     * @var string
+     */
     private $autocomplete = '';
 
     public function toArray()

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -187,6 +187,11 @@ class FormFieldCore
         return $this->constraints;
     }
 
+    /**
+     * @param string $autocomplete
+     *
+     * @return FormFieldCore
+     */
     public function setAutocompleteAttribute(string $autocomplete): FormFieldCore
     {
         $this->autocomplete = $autocomplete;
@@ -194,6 +199,9 @@ class FormFieldCore
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getAutocompleteAttribute(): string
     {
         return $this->autocomplete;

--- a/classes/form/FormField.php
+++ b/classes/form/FormField.php
@@ -47,7 +47,7 @@ class FormFieldCore
             'availableValues' => $this->getAvailableValues(),
             'maxLength' => $this->getMaxLength(),
             'errors' => $this->getErrors(),
-            'autocomplete' => $this->getAutocomplete(),
+            'autocomplete' => $this->getAutocompleteAttribute(),
         ];
     }
 
@@ -184,14 +184,14 @@ class FormFieldCore
         return $this->constraints;
     }
 
-    public function setAutocomplete($autocomplete)
+    public function setAutocompleteAttribute($autocomplete): FormFieldCore
     {
         $this->autocomplete = $autocomplete;
 
         return $this;
     }
 
-    public function getAutocomplete()
+    public function getAutocompleteAttribute(): string
     {
         return $this->autocomplete;
     }

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -138,6 +138,7 @@
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
               type="password"
+              {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
               value=""
               pattern=".{literal}{{/literal}5,{literal}}{/literal}"
               {if $field.required}required{/if}
@@ -164,6 +165,7 @@
             name="{$field.name}"
             type="{$field.type}"
             value="{$field.value}"
+            {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
             {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
             {if $field.maxLength}maxlength="{$field.maxLength}"{/if}
             {if $field.required}required{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Autocomplete is enabled by default on many browsers, but it can provide warnings or fill wrong information, this is better to force them.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14506.
| How to test?  | Go on login form, log for a first time if you want, then see if chrome provide you an autocomplete (if you saved you'r mail/password inside it (you may already refused that years ago, this means that you won't have an autocomplete), also a lot of browsers have this by default, but it display a warning if you doesn't have it, it may change nothing exept kicking the warning

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21425)
<!-- Reviewable:end -->
