### PR TITLE
Fix symfony cache clear

### DIFF
--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -55,15 +55,18 @@ final class SymfonyCacheClearer implements CacheClearerInterface
             return;
         }
 
-        $application = new Application($kernel);
-        $application->setAutoExit(false);
+        register_shutdown_function(function () use ($kernel) {
+            $application = new Application($kernel);
+            $application->setAutoExit(false);
 
-        $input = new ArrayInput([
-            'command' => 'cache:pool:prune',
-        ]);
+            $input = new ArrayInput([
+                'command' => 'cache:clear',
+                '--no-warmup',
+            ]);
 
-        $output = new NullOutput();
-        $application->run($input, $output);
-        Hook::exec('actionClearSf2Cache');
+            $output = new NullOutput();
+            $application->run($input, $output);
+            Hook::exec('actionClearSf2Cache');
+        });
     }
 }

--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -56,6 +56,14 @@ final class SymfonyCacheClearer implements CacheClearerInterface
         }
 
         register_shutdown_function(function () use ($kernel) {
+            // The cache may have been removed by Tools::clearSf2Cache, it happens during install
+            // process, in which case we don't run the cache:clear command because it is not only
+            // useless it will simply fail as the container caches classes have been removed
+            $cacheDir = _PS_ROOT_DIR_ . '/var/cache/' . _PS_ENV_ . '/';
+            if (!file_exists($cacheDir)) {
+                return;
+            }
+
             $application = new Application($kernel);
             $application->setAutoExit(false);
 

--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -59,13 +59,21 @@ final class SymfonyCacheClearer implements CacheClearerInterface
             $application = new Application($kernel);
             $application->setAutoExit(false);
 
+            // Clear cache
             $input = new ArrayInput([
                 'command' => 'cache:clear',
-                '--no-warmup',
+                '--no-warmup' => true,
+                '--env' => _PS_ENV_,
             ]);
 
             $output = new NullOutput();
             $application->run($input, $output);
+
+            // Reboot kernel
+            $realCacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
+            $warmupDir = substr($realCacheDir, 0, -1) . ('_' === substr($realCacheDir, -1) ? '-' : '_');
+            $kernel->reboot($warmupDir);
+
             Hook::exec('actionClearSf2Cache');
         });
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Remove pools:prune command which does not clear the container enough Launch the command only on process shutdown to avoid error during process and memory overloading In previous fix the Clear cache command was not executed correctly, the input arguments were not correctly set (use `'--no-warmup' => true,` not `'--no-warmup',`)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21413
| How to test?  | See issue to reproduce issue regarding `ps_linklist` routing problem Also try to uninstall, clear cache and reinstall `productcomments` to check Doctrine is correctly initialized

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21429)
<!-- Reviewable:end -->
