### PR TITLE
Made it so order preferences uses the same form theme as all others simplified forms

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme generalForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block order_preferences_general %}
 <div class="col-xl-10">
@@ -34,9 +34,7 @@
         </h3>
         <div class="card-block row">
             <div class="card-text">
-                {% block order_general_preferences_form_rest %}
-                  {{ form_rest(generalForm) }}
-                {% endblock %}
+              {{ form_widget(generalForm) }}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme giftOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block order_preferences_gift_options %}
 <div class="col-xl-10">
@@ -34,9 +34,7 @@
         </h3>
         <div class="card-block row">
             <div class="card-text">
-                {% block order_gift_options_preferences_form_rest %}
-                  {{ form_rest(giftOptionsForm) }}
-                {% endblock %}
+              {{ form_widget(giftOptionsForm) }}
             </div>
         </div>
         <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -127,6 +127,8 @@
       </div>
     {% endif %}
   </div>
+
+  {{ block('form_help') }}
 {%- endblock money_widget %}
 
 {% block percent_widget -%}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Standartise order preferences. It seems this form was already simplified, however it was done slightly differently
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no 
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Everything must look and work exactly the same in Shop Paramters -> Order Settings -> Order settings

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20243)
<!-- Reviewable:end -->
