### PR TITLE
WIP: Check that hooks registered by a module have a related listener implemented

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -583,13 +583,12 @@ class HookCore extends ObjectModel
             }
 
             // check that hook listener is implemented by the module
-            $expectedHookListenerMethod = sprintf('hook%s', ucfirst($hook_name));
-            if (_PS_MODE_DEV_ && !method_exists($module_instance, $expectedHookListenerMethod)) {
+            if (_PS_MODE_DEV_ && !Hook::isHookCallableOn($module_instance, $hook_name)) {
                 $missingHookListenerErrorMsg = sprintf(
                     'Hook with the name %s has been registered by %s, but the corresponding method %s has not been defined in the Module class.',
                     $hook_name,
                     get_class($module_instance),
-                    $expectedHookListenerMethod
+                    sprintf('hook%s', ucfirst($hook_name))
                 );
                 throw new PrestaShopException($missingHookListenerErrorMsg);
             }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -583,7 +583,7 @@ class HookCore extends ObjectModel
             }
 
             // check that hook listener is implemented by the module
-            if (_PS_MODE_DEV_ && !Hook::isHookCallableOn($module_instance, $hook_name)) {
+            if (_PS_MODE_DEV_ && !Hook::isHookCallableOn($module_instance, $hook_name) && !($module_instance instanceof WidgetInterface)) {
                 $missingHookListenerErrorMsg = sprintf(
                     'Hook with the name %s has been registered by %s, but the corresponding method %s has not been defined in the Module class.',
                     $hook_name,

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -582,6 +582,18 @@ class HookCore extends ObjectModel
                 return false;
             }
 
+            // check that hook listener is implemented by the module
+            $expectedHookListenerMethod = sprintf('hook%s', ucfirst($hook_name));
+            if (!method_exists($module_instance, $expectedHookListenerMethod)) {
+                $missingHookListenerErrorMsg = sprintf(
+                    'Hook with the name %s has been registered by %s, but the corresponding method %s has not been defined in the Module class.',
+                    $hook_name,
+                    get_class($module_instance),
+                    $expectedHookListenerMethod
+                );
+                throw new PrestaShopException($missingHookListenerErrorMsg);
+            }
+
             Hook::exec(
                 'actionModuleRegisterHookBefore',
                 [

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -585,7 +585,7 @@ class HookCore extends ObjectModel
             }
 
             // check that hook listener is implemented by the module
-            if (_PS_MODE_DEV_ && !Hook::isHookCallableOn($module_instance, $hook_name) && !($module_instance instanceof WidgetInterface)) {
+            if (!Hook::isHookCallableOn($module_instance, $hook_name) && !($module_instance instanceof WidgetInterface)) {
                 $missingHookListenerErrorMsg = sprintf(
                     'Hook with the name %s has been registered by %s, but the corresponding method %s has not been defined in the Module class.',
                     $hook_name,

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -584,7 +584,7 @@ class HookCore extends ObjectModel
 
             // check that hook listener is implemented by the module
             $expectedHookListenerMethod = sprintf('hook%s', ucfirst($hook_name));
-            if (!method_exists($module_instance, $expectedHookListenerMethod)) {
+            if (_PS_MODE_DEV_ && !method_exists($module_instance, $expectedHookListenerMethod)) {
                 $missingHookListenerErrorMsg = sprintf(
                     'Hook with the name %s has been registered by %s, but the corresponding method %s has not been defined in the Module class.',
                     $hook_name,

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -23,6 +23,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
@@ -590,7 +592,11 @@ class HookCore extends ObjectModel
                     get_class($module_instance),
                     sprintf('hook%s', ucfirst($hook_name))
                 );
-                throw new PrestaShopException($missingHookListenerErrorMsg);
+                if (_PS_MODE_DEV_) {
+                    throw new PrestaShopException($missingHookListenerErrorMsg);
+                }
+                $logger = new LegacyLogger();
+                $logger->warning($missingHookListenerErrorMsg);
             }
 
             Hook::exec(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When installing a module, we want to check that all registered hooks have corresponding listeners implemented in the module, otherwise throw an exception;
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19230
| How to test?  | Install a module that registers an existing hook without implementing a listener for it. In debug mode.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21450)
<!-- Reviewable:end -->
