### PR TITLE
Simplify traffic and seo

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -70,6 +70,7 @@ class MetaController extends FrameworkBundleAdminController
         if ($isRewriteSettingEnabled) {
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
+
         return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
@@ -249,7 +250,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-         return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -64,7 +64,7 @@ class MetaController extends FrameworkBundleAdminController
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->get('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -243,7 +243,7 @@ class MetaController extends FrameworkBundleAdminController
         );
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->get('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -271,7 +271,7 @@ class MetaController extends FrameworkBundleAdminController
             'ShopUrls'
         );
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->get('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -323,7 +323,7 @@ class MetaController extends FrameworkBundleAdminController
             $this->getSeoOptionsFormHandler(),
             'SeoOptions'
         );
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->get('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -378,7 +378,7 @@ class MetaController extends FrameworkBundleAdminController
      * @param FormInterface $seoOptionsForm
      * @param FormInterface|null $urlSchemaForm
      *
-     * @return  Response
+     * @return Response
      */
     protected function renderForm(
         Request $request,

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -377,7 +377,7 @@ class MetaController extends FrameworkBundleAdminController
         FormInterface $shopUrlsForm,
         FormInterface $seoOptionsForm,
         ?FormInterface $urlSchemaForm = null
-    ) {
+    ): Response {
         $seoUrlsGridFactory = $this->get('prestashop.core.grid.factory.meta');
 
         $context = $this->get('prestashop.adapter.shop.context');

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -370,6 +370,16 @@ class MetaController extends FrameworkBundleAdminController
         return $this->redirectToRoute('admin_metas_index');
     }
 
+    /**
+     * @param Request $request
+     * @param MetaFilters $filters
+     * @param FormInterface $setUpUrlsForm
+     * @param FormInterface $shopUrlsForm
+     * @param FormInterface $seoOptionsForm
+     * @param FormInterface|null $urlSchemaForm
+     *
+     * @return  Response
+     */
     protected function renderForm(
         Request $request,
         MetaFilters $filters,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
@@ -27,13 +27,13 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * SEOOptionsType manages some options for your SEO meta tags (like product title)
  */
-class SEOOptionsType extends AbstractType
+class SEOOptionsType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -41,7 +41,16 @@ class SEOOptionsType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('product_attributes_in_title', SwitchType::class)
+            ->add('product_attributes_in_title', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display attributes in the product meta title',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Enable this option if you want to display your product\'s attributes in its meta title.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ])
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -101,7 +101,7 @@ class SetUpUrlType extends TranslatorAwareType
 
         if (!$this->tools->isModRewriteActive()) {
             $friendlyUrlHelp .=
-                '</br>' . $this->trans(
+                '<br/>' . $this->trans(
                 'URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.',
                     'Admin.Shopparameters.Help'
             );

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -69,7 +70,7 @@ class SetUpUrlType extends TranslatorAwareType
      * @param array $canonicalUrlChoices
      * @param bool $isHtaccessFileWritable
      * @param bool $isHostMode
-     * @param $tools
+     * @param Tools $tools
      */
     public function __construct(
         TranslatorInterface $translator,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
-use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -54,12 +53,14 @@ class SetUpUrlType extends TranslatorAwareType
      */
     private $isHostMode;
 
-    /*
-    * @var Tools
-    */
-    private $tools;
+    /**
+     * @var bool
+     */
+    private $isModRewriteActive;
 
-    /** @var bool */
+    /**
+     * @var bool
+     */
     private $doesMainShopUrlExist;
 
     /**
@@ -70,7 +71,7 @@ class SetUpUrlType extends TranslatorAwareType
      * @param array $canonicalUrlChoices
      * @param bool $isHtaccessFileWritable
      * @param bool $isHostMode
-     * @param Tools $tools
+     * @param bool $doesMainShopUrlExist
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -85,7 +86,6 @@ class SetUpUrlType extends TranslatorAwareType
         $this->canonicalUrlChoices = $canonicalUrlChoices;
         $this->isHtaccessFileWritable = $isHtaccessFileWritable;
         $this->isHostMode = $isHostMode;
-        $this->tools = $tools;
         $this->doesMainShopUrlExist = $doesMainShopUrlExist;
     }
 
@@ -99,7 +99,7 @@ class SetUpUrlType extends TranslatorAwareType
             'Admin.Shopparameters.Help'
         );
 
-        if (!$this->tools->isModRewriteActive()) {
+        if (!$this->isModRewriteActive) {
             $friendlyUrlHelp .=
                 '<br/>' . $this->trans(
                 'URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -27,15 +27,16 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class SetUpUrlType is responsible for providing form fields for Set up urls block located in
  * Shop parameters -> Traffic & Seo -> Seo & urls page.
  */
-class SetUpUrlType extends AbstractType
+class SetUpUrlType extends TranslatorAwareType
 {
     /**
      * @var array
@@ -52,21 +53,39 @@ class SetUpUrlType extends AbstractType
      */
     private $isHostMode;
 
+    /*
+    * @var Tools
+    */
+    private $tools;
+
+    /** @var bool */
+    private $doesMainShopUrlExist;
+
     /**
      * SetUpUrlType constructor.
      *
+     * @param TranslatorInterface $translator
+     * @param array $locales
      * @param array $canonicalUrlChoices
      * @param bool $isHtaccessFileWritable
      * @param bool $isHostMode
+     * @param $tools
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         array $canonicalUrlChoices,
         $isHtaccessFileWritable,
-        $isHostMode
+        $isHostMode,
+        $tools,
+        $doesMainShopUrlExist
     ) {
+        parent::__construct($translator, $locales);
         $this->canonicalUrlChoices = $canonicalUrlChoices;
         $this->isHtaccessFileWritable = $isHtaccessFileWritable;
         $this->isHostMode = $isHostMode;
+        $this->tools = $tools;
+        $this->doesMainShopUrlExist = $doesMainShopUrlExist;
     }
 
     /**
@@ -74,22 +93,57 @@ class SetUpUrlType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $friendlyUrlHelp = $this->trans(
+            'Enable this option only if your server allows URL rewriting (recommended).',
+            'Admin.Shopparameters.Help'
+        );
+
+        if (!$this->tools->isModRewriteActive()) {
+            $friendlyUrlHelp.=
+                '</br>' . $this->trans(
+                'URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.',
+                    'Admin.Shopparameters.Help'
+            );
+        }
+
         $builder
-            ->add('friendly_url', SwitchType::class)
-            ->add('accented_url', SwitchType::class)
+            ->add('friendly_url', SwitchType::class, [
+                'label' => $this->trans('Friendly URL', 'Admin.Global'),
+                'help' => $friendlyUrlHelp,
+            ])
+            ->add('accented_url', SwitchType::class, [
+                'label' => $this->trans('Accented URL', 'Admin.Global'),
+                'help' => $this->trans(
+                    'Enable this option if you want to allow accented characters in your friendly URLs. You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.',
+                    'Admin.Shopparameters.Help'
+                ),
+            ])
             ->add(
                 'canonical_url_redirection',
                 ChoiceType::class,
                 [
                     'choices' => $this->canonicalUrlChoices,
                     'translation_domain' => false,
+                    'label' => $this->trans('Redirect to the canonical URL', 'Admin.Global'),
                 ]
             );
 
-        if (!$this->isHostMode && $this->isHtaccessFileWritable) {
+        if (!$this->isHostMode && $this->isHtaccessFileWritable && $this->doesMainShopUrlExist) {
             $builder
-                ->add('disable_apache_multiview', SwitchType::class)
-                ->add('disable_apache_mod_security', SwitchType::class);
+                ->add('disable_apache_multiview', SwitchType::class, [
+                    'label' => $this->trans('Disable Apache\'s MultiViews option', 'Admin.Global'),
+                    'help' => $this->trans(
+                        'Enable this option only if you have problems with URL rewriting.',
+                        'Admin.Shopparameters.Help'
+                    ),
+                ])
+                ->add('disable_apache_mod_security', SwitchType::class, [
+                    'label' => $this->trans('Disable Apache\'s mod_security module', 'Admin.Global'),
+                    'help' => $this->trans(
+                        'Some of PrestaShop\'s features might not work correctly with a specific configuration of Apache\'s mod_security module. We recommend to turn it off.',
+                        'Admin.Shopparameters.Help'
+                    ),
+                ]);
         }
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -79,11 +79,13 @@ class SetUpUrlType extends TranslatorAwareType
         array $canonicalUrlChoices,
         $isHtaccessFileWritable,
         $isHostMode,
+        $isModRewriteActive,
         $doesMainShopUrlExist
     ) {
         parent::__construct($translator, $locales);
         $this->canonicalUrlChoices = $canonicalUrlChoices;
         $this->isHtaccessFileWritable = $isHtaccessFileWritable;
+        $this->isModRewriteActive = $isModRewriteActive;
         $this->isHostMode = $isHostMode;
         $this->doesMainShopUrlExist = $doesMainShopUrlExist;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -99,7 +99,7 @@ class SetUpUrlType extends TranslatorAwareType
         );
 
         if (!$this->tools->isModRewriteActive()) {
-            $friendlyUrlHelp.=
+            $friendlyUrlHelp .=
                 '</br>' . $this->trans(
                 'URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.',
                     'Admin.Shopparameters.Help'

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -113,7 +113,7 @@ class SetUpUrlType extends TranslatorAwareType
                 'help' => $friendlyUrlHelp,
             ])
             ->add('accented_url', SwitchType::class, [
-                'label' => $this->trans('Accented URL', 'Admin.Global'),
+                'label' => $this->trans('Accented URL', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans(
                     'Enable this option if you want to allow accented characters in your friendly URLs. You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.',
                     'Admin.Shopparameters.Help'
@@ -125,21 +125,21 @@ class SetUpUrlType extends TranslatorAwareType
                 [
                     'choices' => $this->canonicalUrlChoices,
                     'translation_domain' => false,
-                    'label' => $this->trans('Redirect to the canonical URL', 'Admin.Global'),
+                    'label' => $this->trans('Redirect to the canonical URL', 'Admin.Shopparameters.Feature'),
                 ]
             );
 
         if (!$this->isHostMode && $this->isHtaccessFileWritable && $this->doesMainShopUrlExist) {
             $builder
                 ->add('disable_apache_multiview', SwitchType::class, [
-                    'label' => $this->trans('Disable Apache\'s MultiViews option', 'Admin.Global'),
+                    'label' => $this->trans('Disable Apache\'s MultiViews option', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
                         'Enable this option only if you have problems with URL rewriting.',
                         'Admin.Shopparameters.Help'
                     ),
                 ])
                 ->add('disable_apache_mod_security', SwitchType::class, [
-                    'label' => $this->trans('Disable Apache\'s mod_security module', 'Admin.Global'),
+                    'label' => $this->trans('Disable Apache\'s mod_security module', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
                         'Some of PrestaShop\'s features might not work correctly with a specific configuration of Apache\'s mod_security module. We recommend to turn it off.',
                         'Admin.Shopparameters.Help'

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -115,7 +115,7 @@ class SetUpUrlType extends TranslatorAwareType
             ->add('accented_url', SwitchType::class, [
                 'label' => $this->trans('Accented URL', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans(
-                    'Enable this option if you want to allow accented characters in your friendly URLs. You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.',
+                    'Enable this option if you want to allow accented characters in your friendly URLs. You should only activate this option if you are using non-Latin characters; for all the Latin charsets, your SEO will be better without this option.',
                     'Admin.Shopparameters.Help'
                 ),
             ])

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -79,7 +79,6 @@ class SetUpUrlType extends TranslatorAwareType
         array $canonicalUrlChoices,
         $isHtaccessFileWritable,
         $isHostMode,
-        $tools,
         $doesMainShopUrlExist
     ) {
         parent::__construct($translator, $locales);

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -63,7 +62,7 @@ class ShopUrlType extends TranslatorAwareType
      */
     public function __construct(
         TranslatorInterface $translator,
-        array $locales,$isHostMode,
+        array $locales, $isHostMode,
         $isShopFeatureActive,
         $doesMainShopUrlExist
     ) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -26,16 +26,18 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class ShopUrlType is responsible for providing form fields for
  * Shop parameters -> Traffic & Seo -> Seo & Urls -> Shop urls block.
  */
-class ShopUrlType extends AbstractType
+class ShopUrlType extends TranslatorAwareType
 {
     /**
      * @var bool
@@ -59,8 +61,13 @@ class ShopUrlType extends AbstractType
      * @param bool $isShopFeatureActive
      * @param bool $doesMainShopUrlExist
      */
-    public function __construct($isHostMode, $isShopFeatureActive, $doesMainShopUrlExist)
-    {
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,$isHostMode,
+        $isShopFeatureActive,
+        $doesMainShopUrlExist
+    ) {
+        parent::__construct($translator, $locales);
         $this->isHostMode = $isHostMode;
         $this->isShopFeatureActive = $isShopFeatureActive;
         $this->doesMainShopUrlExist = $doesMainShopUrlExist;
@@ -73,9 +80,24 @@ class ShopUrlType extends AbstractType
     {
         if (!$this->isHostMode && !$this->isShopFeatureActive && $this->doesMainShopUrlExist) {
             $builder
-                ->add('domain', TextType::class)
-                ->add('domain_ssl', TextType::class)
-                ->add('physical_uri', TextType::class);
+                ->add('domain', TextType::class, [
+                    'label' => $this->trans(
+                        'Shop domain',
+                        'Admin.Shopparameters.Feature'
+                    ),
+                ])
+                ->add('domain_ssl', TextType::class, [
+                    'label' => $this->trans(
+                        'SSL domain',
+                        'Admin.Shopparameters.Feature'
+                    ),
+                ])
+                ->add('physical_uri', TextType::class, [
+                    'label' => $this->trans(
+                        'Base URI',
+                        'Admin.Shopparameters.Feature'
+                    ),
+                ]);
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -56,13 +56,16 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * ShopUrlType constructor.
      *
+     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param array $locales
      * @param bool $isHostMode
      * @param bool $isShopFeatureActive
      * @param bool $doesMainShopUrlExist
      */
     public function __construct(
         TranslatorInterface $translator,
-        array $locales, $isHostMode,
+        array $locales,
+        $isHostMode,
         $isShopFeatureActive,
         $doesMainShopUrlExist
     ) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/ShopUrlType.php
@@ -56,7 +56,7 @@ class ShopUrlType extends TranslatorAwareType
     /**
      * ShopUrlType constructor.
      *
-     * @param \Symfony\Component\Translation\TranslatorInterface $translator
+     * @param TranslatorInterface $translator
      * @param array $locales
      * @param bool $isHostMode
      * @param bool $isShopFeatureActive
@@ -65,9 +65,9 @@ class ShopUrlType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        $isHostMode,
-        $isShopFeatureActive,
-        $doesMainShopUrlExist
+        bool $isHostMode,
+        bool $isShopFeatureActive,
+        bool $doesMainShopUrlExist
     ) {
         parent::__construct($translator, $locales);
         $this->isHostMode = $isHostMode;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -73,13 +73,6 @@ class UrlSchemaType extends TranslatorAwareType
                 ),
                 'help' => $this->getKeywords('category_rule'),
             ])
-            ->add('layered_rule', TextType::class, [
-                'label' => $this->trans(
-                    'Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module',
-                    'Admin.Shopparameters.Feature'
-                ),
-                'help' => $this->getKeywords('layered_rule'),
-            ])
             ->add('supplier_rule', TextType::class, [
                 'label' => $this->trans(
                     'Route to supplier',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -152,7 +152,7 @@ class UrlSchemaType extends TranslatorAwareType
                 'Keywords: %keywords%',
                 'Admin.Shopparameters.Feature',
                 [
-                    '%keywords%' => implode(', ', $formattedKeyWords)
+                    '%keywords%' => implode(', ', $formattedKeyWords),
                 ]
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -26,31 +26,95 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
-use Symfony\Component\Form\AbstractType;
+use PrestaShop\PrestaShop\Adapter\Routes\DefaultRouteProvider;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class UrlSchemaType is responsible for providing form fields for
  * Shop parameters -> Traffic & Seo -> Seo & Urls -> Schema of urls block.
  */
-class UrlSchemaType extends AbstractType
+class UrlSchemaType extends TranslatorAwareType
 {
+    /**
+     * @var DefaultRouteProvider
+     */
+    private $defaultRouteProvider;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        DefaultRouteProvider $defaultRouteProvider
+    ) {
+        parent::__construct($translator, $locales);
+        $this->defaultRouteProvider = $defaultRouteProvider;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('product_rule', TextType::class)
-            ->add('category_rule', TextType::class)
-            ->add('layered_rule', TextType::class)
-            ->add('supplier_rule', TextType::class)
-            ->add('manufacturer_rule', TextType::class)
-            ->add('cms_rule', TextType::class)
-            ->add('cms_category_rule', TextType::class)
-            ->add('module', TextType::class);
+            ->add('product_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to products',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('product_rule'),
+            ])
+            ->add('category_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to category',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('category_rule'),
+            ])
+            ->add('layered_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('layered_rule'),
+            ])
+            ->add('supplier_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to supplier',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('supplier_rule'),
+            ])
+            ->add('manufacturer_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to brand',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('manufacturer_rule'),
+            ])
+            ->add('cms_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to page',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('cms_rule'),
+            ])
+            ->add('cms_category_rule', TextType::class, [
+                'label' => $this->trans(
+                    'Route to page category',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('cms_category_rule'),
+            ])
+            ->add('module', TextType::class, [
+                'label' => $this->trans(
+                    'Route to modules',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->getKeywords('module'),
+            ]);
     }
 
     /**
@@ -61,5 +125,34 @@ class UrlSchemaType extends AbstractType
         $resolver->setDefaults([
             'label' => false,
         ]);
+    }
+
+    /**
+     * @param string $idRoute
+     *
+     * @return string
+     * @throws \PrestaShopException
+     */
+    private function getKeywords($idRoute)
+    {
+        $keyWords = $this->defaultRouteProvider->getKeywords();
+        $formattedKeyWords = [];
+        if ($keyWords[$idRoute]) {
+            foreach ($keyWords[$idRoute] as $key => $keyWord) {
+                $value = $key;
+                if (isset($keyWord['param'])) {
+                    $value .= '*';
+                }
+                $formattedKeyWords[] = $value;
+            }
+        }
+
+        return sprintf(
+            $this->trans(
+                'Keywords: %s',
+                'Admin.Shopparameters.Feature'
+            ),
+            implode(', ', $formattedKeyWords)
+        );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -148,12 +148,12 @@ class UrlSchemaType extends TranslatorAwareType
             }
         }
 
-        return sprintf(
-            $this->trans(
-                'Keywords: %s',
-                'Admin.Shopparameters.Feature'
-            ),
-            implode(', ', $formattedKeyWords)
+        return $this->trans(
+                'Keywords: %keywords%',
+                'Admin.Shopparameters.Feature',
+                [
+                    '%keywords%' => implode(', ', $formattedKeyWords)
+                ]
         );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -131,6 +131,7 @@ class UrlSchemaType extends TranslatorAwareType
      * @param string $idRoute
      *
      * @return string
+     *
      * @throws \PrestaShopException
      */
     private function getKeywords($idRoute)

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -591,7 +591,7 @@ services:
             - '@=service("prestashop.core.form.choice_provider.canonical_redirect_type").getChoices()'
             - '@=service("prestashop.core.util.url.url_file_checker").isHtaccessFileWritable()'
             - '@=service("prestashop.adapter.hosting_information").isHostMode()'
-            - '@prestashop.adapter.tools'
+            - '@=service("prestashop.adapter.tools").isModRewriteActive()'
             - '@=service("prestashop.adapter.shop.shop_url").doesMainShopUrlExist()'
         tags:
             - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -585,15 +585,21 @@ services:
 
     form.type.shop.traffic_seo.meta.set_up_url:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\SetUpUrlType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.core.form.choice_provider.canonical_redirect_type").getChoices()'
             - '@=service("prestashop.core.util.url.url_file_checker").isHtaccessFileWritable()'
             - '@=service("prestashop.adapter.hosting_information").isHostMode()'
+            - '@prestashop.adapter.tools'
+            - '@=service("prestashop.adapter.shop.shop_url").doesMainShopUrlExist()'
         tags:
             - { name: form.type }
 
     form.type.shop.traffic_seo.meta.shop_url:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\ShopUrlType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.adapter.hosting_information").isHostMode()'
             - '@=service("prestashop.adapter.multistore_feature").isActive()'
@@ -603,8 +609,17 @@ services:
 
     form.type.shop.traffic_seo.meta.url_schema:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\UrlSchemaType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
-            - '@=service("prestashop.adapter.legacy.configuration").get("PS_REWRITING_SETTINGS")'
+            - '@prestashop.adapter.data_provider.default_route'
+        tags:
+            - { name: form.type }
+
+    form.type.shop.traffic_seo.meta.seo_options:
+        class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta\SEOOptionsType'
+        parent: 'form.type.translatable.aware'
+        public: true
         tags:
             - { name: form.type }
 
@@ -1235,7 +1250,7 @@ services:
         public: true
         tags:
             - { name: form.type }
-            
+
     form.type.logs_by_email:
         class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Logs\LogsByEmailType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme seoOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block seo_options_configuration %}
   <div class="card">
@@ -33,18 +33,7 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Display attributes in the product meta title'|trans), ('Enable this option if you want to display your product\'s attributes in its meta title.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(seoOptionsForm.product_attributes_in_title) }}
-            {{ form_widget(seoOptionsForm.product_attributes_in_title) }}
-          </div>
-        </div>
-
-        {% block meta_seo_options_form_rest %}
-          {{ form_rest(seoOptionsForm) }}
-        {% endblock %}
+        {{ form_widget(seoOptionsForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme setUpUrlsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block set_up_urls_configuration %}
   <div class="card">
@@ -33,78 +33,7 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
-
-        {% if not isHtaccessFileValid %}
-          <div class="row">
-            <div class="col-sm">
-              <div class="alert alert-info" role="alert">
-                <div class="alert-text">
-                  {{ 'Before you can use this tool, you need to:'|trans({}, 'Admin.Shopparameters.Notification') }}
-                  <br>
-                  {{ '1) Create a blank .htaccess file in your root directory.'|trans({}, 'Admin.Shopparameters.Notification') }}
-                  <br>
-                  {{ '2) Give it write permissions (CHMOD 666 on Unix system).'|trans({}, 'Admin.Shopparameters.Notification') }}
-                </div>
-              </div>
-            </div>
-          </div>
-        {% endif %}
-
-        <div class="form-group row">
-          {% if isModRewriteActive %}
-            {{ ps.label_with_help('Friendly URL'|trans({}, 'Admin.Global'), ('Enable this option only if your server allows URL rewriting (recommended).'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          {% endif %}
-          <div class="col-sm">
-            {{ form_errors(setUpUrlsForm.friendly_url) }}
-            {{ form_widget(setUpUrlsForm.friendly_url) }}
-
-            {% if not isModRewriteActive %}
-              <small class="form-text">
-                {{ 'URL rewriting (mod_rewrite) is not active on your server, or it is not possible to check your server configuration. If you want to use Friendly URLs, you must activate this mod.'|trans({}, 'Admin.Shopparameters.Help') }}
-              </small>
-            {% endif %}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Accented URL'|trans), ('Enable this option if you want to allow accented characters in your friendly URLs.'|trans({}, 'Admin.Shopparameters.Help') ~ ' ' ~ 'You should only activate this option if you are using non-latin characters ; for all the latin charsets, your SEO will be better without this option.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(setUpUrlsForm.accented_url) }}
-            {{ form_widget(setUpUrlsForm.accented_url) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">{{ 'Redirect to the canonical URL'|trans }}</label>
-          <div class="col-sm">
-            {{ form_errors(setUpUrlsForm.canonical_url_redirection) }}
-            {{ form_widget(setUpUrlsForm.canonical_url_redirection) }}
-          </div>
-        </div>
-
-        {% if setUpUrlsForm.disable_apache_multiview is defined %}
-          <div class="form-group row">
-            {{ ps.label_with_help(("Disable Apache's MultiViews option"|trans), ('Enable this option only if you have problems with URL rewriting.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(setUpUrlsForm.disable_apache_multiview) }}
-              {{ form_widget(setUpUrlsForm.disable_apache_multiview) }}
-            </div>
-          </div>
-        {% endif %}
-
-        {% if setUpUrlsForm.disable_apache_mod_security is defined %}
-          <div class="form-group row">
-            {{ ps.label_with_help(("Disable Apache's mod_security module"|trans), ("Some of PrestaShop's features might not work correctly with a specific configuration of Apache's mod_security module. We recommend to turn it off."|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(setUpUrlsForm.disable_apache_mod_security) }}
-              {{ form_widget(setUpUrlsForm.disable_apache_mod_security) }}
-            </div>
-          </div>
-        {% endif %}
-
-        {% block meta_set_up_urls_form_rest %}
-          {{ form_rest(setUpUrlsForm) }}
-        {% endblock %}
+          {{ form_widget(setUpUrlsForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig
@@ -33,7 +33,7 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
-          {{ form_widget(setUpUrlsForm) }}
+        {{ form_widget(setUpUrlsForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -24,15 +24,16 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% form_theme shopUrlsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block shop_urls_configuration %}
 
   {% set cardHeaderLabel = 'Set shop URL'|trans %}
   {% if isShopFeatureActive and not isHostMode %}
     <div class="card">
-      <div class="card-header">
+      <h3 class="card-header">
         <i class="material-icons">settings</i> {{ cardHeaderLabel }}
-      </div>
+      </h3>
       <div class="card-block row">
         <div class="card-text">
           <div class="row">
@@ -51,63 +52,31 @@
 
   {% if not isShopFeatureActive and not isHostMode and doesMainShopUrlExist %}
     <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">settings</i> {{ cardHeaderLabel }}
+    <h3 class="card-header">
+      <i class="material-icons">settings</i> {{ cardHeaderLabel }}
 
-        <span
-          class="help-box"
-          data-container="body"
-          data-toggle="popover"
-          data-trigger="hover"
-          data-placement="right"
-          data-content="{{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}"
-          title=""
-        >
+      <span
+        class="help-box"
+        data-container="body"
+        data-toggle="popover"
+        data-trigger="hover"
+        data-placement="right"
+        data-content="{{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}"
+        title=""
+      >
         </span>
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Shop domain'|trans }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(shopUrlsForm.domain) }}
-                {{ form_widget(shopUrlsForm.domain) }}
-              </div>
-            </div>
-
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'SSL domain'|trans }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(shopUrlsForm.domain_ssl) }}
-                {{ form_widget(shopUrlsForm.domain_ssl) }}
-              </div>
-            </div>
-
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Base URI'|trans }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(shopUrlsForm.physical_uri) }}
-                {{ form_widget(shopUrlsForm.physical_uri) }}
-              </div>
-            </div>
-
-            {% block meta_shop_urls_form_rest %}
-              {{ form_rest(shopUrlsForm) }}
-            {% endblock %}
-        </div>
-      </div>
-
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-        </div>
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(shopUrlsForm) }}
       </div>
     </div>
+
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
+  </div>
   {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
+{% form_theme urlSchemaForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block url_schema_configuration %}
   <div class="card">
@@ -43,110 +44,7 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to products'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.product_rule) }}
-            {{ form_widget(urlSchemaForm.product_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'product_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to category'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.category_rule) }}
-            {{ form_widget(urlSchemaForm.category_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'category_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to category which has the "selected_filter" attribute for the "Layered Navigation" (blocklayered) module'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.layered_rule) }}
-            {{ form_widget(urlSchemaForm.layered_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'layered_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to supplier'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.supplier_rule) }}
-            {{ form_widget(urlSchemaForm.supplier_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'supplier_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to brand'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.manufacturer_rule) }}
-            {{ form_widget(urlSchemaForm.manufacturer_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'manufacturer_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to page'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.cms_rule) }}
-            {{ form_widget(urlSchemaForm.cms_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'cms_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to page category'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.cms_category_rule) }}
-            {{ form_widget(urlSchemaForm.cms_category_rule) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'cms_category_rule'}) }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Route to modules'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(urlSchemaForm.module) }}
-            {{ form_widget(urlSchemaForm.module) }}
-            <small class="form-text">
-              {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/keyword.html.twig', {'idRoute': 'module'}) }}
-            </small>
-          </div>
-        </div>
-
+        {{ form_widget(urlSchemaForm) }}
       </div>
     </div>
     <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify traffic and seo options form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes 
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  |  Simplify Configure -> Shop Paramateres -> Traffic & SEO. Everything must look the same with two exceptions. Blue help boxes were replaced with help text under input. Also some fields now are marked as required, because they always were required.


:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by SEOOptionsType, SetUpUrlType, ShopUrlType, UrlSchemaType. This means if any module extends any of those types they will get an exception. 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20243)
<!-- Reviewable:end -->
