### PR TITLE
Prevent page freeze because off multiple add to cart clicks

### DIFF
--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -80,67 +80,63 @@ $(document).ready(() => {
 
   $body.on('click', '[data-button-action="add-to-cart"]', (event) => {
     event.preventDefault();
-    if (
-      $(prestashop.selectors.quantityWanted).val() > $('[data-stock]').data('stock') &&
-      $('[data-allow-oosp]').data('allow-oosp').length === 0
-    ) {
-      $('[data-button-action="add-to-cart"]').attr('disabled', 'disabled');
-    } else {
-      const $form = $(event.target.form);
-      const query = `${$form.serialize()}&add=1&action=update`;
-      const actionURL = $form.attr('action');
+    
+    $('[data-button-action="add-to-cart"]').prop('disabled', true);
+    
+    const $form = $(event.target.form);
+    const query = `${$form.serialize()}&add=1&action=update`;
+    const actionURL = $form.attr('action');
 
-      const isQuantityInputValid = ($input) => {
-        let validInput = true;
+    const isQuantityInputValid = ($input) => {
+      let validInput = true;
 
-        $input.each((index, input) => {
-          const $input = $(input);
-          const minimalValue = parseInt($input.attr('min'), 10);
-          if (minimalValue && $input.val() < minimalValue) {
-            onInvalidQuantity($input);
-            validInput = false;
-          }
-        });
+      $input.each((index, input) => {
+        const $input = $(input);
+        const minimalValue = parseInt($input.attr('min'), 10);
+        if (minimalValue && $input.val() < minimalValue) {
+          onInvalidQuantity($input);
+          validInput = false;
+        }
+      });
 
-        return validInput;
-      };
+      return validInput;
+    };
 
-      let onInvalidQuantity = ($input) => {
-        $input
-          .parents(prestashop.selectors.product.addToCart)
-          .first()
-          .find(prestashop.selectors.product.minimalQuantity)
-          .addClass('error');
-        $input.parent().find('label').addClass('error');
-      };
+    let onInvalidQuantity = ($input) => {
+      $input
+        .parents(prestashop.selectors.product.addToCart)
+        .first()
+        .find(prestashop.selectors.product.minimalQuantity)
+        .addClass('error');
+      $input.parent().find('label').addClass('error');
+    };
 
-      const $quantityInput = $form.find('input[min]');
-      if (!isQuantityInputValid($quantityInput)) {
-        onInvalidQuantity($quantityInput);
+    const $quantityInput = $form.find('input[min]');
+    if (!isQuantityInputValid($quantityInput)) {
+      onInvalidQuantity($quantityInput);
 
-        return;
-      }
-
-      $.post(actionURL, query, null, 'json')
-        .then((resp) => {
-          prestashop.emit('updateCart', {
-            reason: {
-              idProduct: resp.id_product,
-              idProductAttribute: resp.id_product_attribute,
-              idCustomization: resp.id_customization,
-              linkAction: 'add-to-cart',
-              cart: resp.cart,
-            },
-            resp,
-          });
-        })
-        .fail((resp) => {
-          prestashop.emit('handleError', {
-            eventType: 'addProductToCart',
-            resp,
-          });
-        });
+      return;
     }
+
+    $.post(actionURL, query, null, 'json')
+      .then((resp) => {
+        prestashop.emit('updateCart', {
+          reason: {
+            idProduct: resp.id_product,
+            idProductAttribute: resp.id_product_attribute,
+            idCustomization: resp.id_customization,
+            linkAction: 'add-to-cart',
+            cart: resp.cart,
+          },
+          resp,
+        });
+      })
+      .fail((resp) => {
+        prestashop.emit('handleError', {
+          eventType: 'addProductToCart',
+          resp,
+        });
+      });
   });
 
   $body.on('submit', '[data-link-action="add-voucher"]', (event) => {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  develop
| Description?  | This PR fixes double click issue and delete useless checking for stock and allow oosp, those checks are not working in quick view and when we don't allow to see stocks on front-office, also it's controller who decide whether we can or not add product to cart, button is no longer blocked after adding to cart thanks to ajax reload
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | yno
| Deprecations? | no
| Fixed ticket? | Fixes #9634 
| How to test?  | Follow scenarios below
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

## Before PR:

- [ ] page should freeze after clicking add to cart multiple times on product page

## After PR:

- [ ] page shouldn't be blocked after clicking add to cart multiple times

## QA
- [ ] we shouldn't be able to add more products than we can to cart
- [ ] add to cart should work as before on quick view and product page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21485)
<!-- Reviewable:end -->
