### PR TITLE
Add id_product_attribute to order conf  mails

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -431,6 +431,7 @@ abstract class PaymentModuleCore extends Module
 
                         $product_var_tpl = [
                             'id_product' => $product['id_product'],
+                            'id_product_attribute' => $product['id_product_attribute'],
                             'reference' => $product['reference'],
                             'name' => $product['name'] . (isset($product['attributes']) ? ' - ' . $product['attributes'] : ''),
                             'price' => Tools::getContextLocale($this->context)->formatPrice($product_price * $product['quantity'], $this->context->currency->iso_code),

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -359,6 +359,7 @@ final class MailPreviewVariablesBuilder
 
             $productTemplate = [
                 'id_product' => $product['id_product'],
+                'id_product_attribute' => $product['id_product_attribute'],
                 'reference' => $product['reference'],
                 'name' => $product['name'] . (isset($product['attributes']) ? ' - ' . $product['attributes'] : ''),
                 'price' => $this->locale->formatPrice($productPrice * $product['quantity'], $this->context->currency->iso_code),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Add id_product_attribute to order conf mails to be able to use custom hooks which rely on the $product var in the tpl file like getting attribute specific values from DB the id_product_attrbute is needed additionally to the id_product
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21518
| How to test?  | print out id_product_attrbute in order_conf email

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21491)
<!-- Reviewable:end -->
