### PR TITLE
Webservice - Enable key by hosts name or IP

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/webservice/index.js
+++ b/admin-dev/themes/new-theme/js/pages/webservice/index.js
@@ -37,6 +37,7 @@ import GeneratableInput from '../../components/generatable-input';
 import MultipleChoiceTable from '../../components/multiple-choice-table';
 import PermissionsRowSelector from './permissions-row-selector';
 import LinkRowActionExtension from '../../components/grid/extension/link-row-action-extension';
+import ToggleHostsAllowedReadonly from './toggle-hostsallowed-readonly';
 
 const {$} = window;
 
@@ -64,4 +65,5 @@ $(() => {
   generatableInput.attachOn('.js-generator-btn');
 
   new PermissionsRowSelector();
+  new ToggleHostsAllowedReadonly();
 });

--- a/admin-dev/themes/new-theme/js/pages/webservice/toggle-hostsallowed-readonly.js
+++ b/admin-dev/themes/new-theme/js/pages/webservice/toggle-hostsallowed-readonly.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+const {$} = window;
+
+/**
+ * In Add/Edit page of Webservice key
+ * When hostsCheck is disabled not being able to modify hostsAllowed
+ */
+export default class ToggleHostsAllowedReadonly {
+  constructor() {
+    const self = this;
+    self.$hostsCheck = $('input[id^="webservice_key_hosts_check"]');
+    self.$hostsAllowed = $('#webservice_key_hosts_allowed');
+    self.$hostsCheckIsEnable = Boolean(Number(self.$hostsCheck.filter(':checked').val()));
+    self.$hostsAllowed.prop('readonly', !self.$hostsCheckIsEnable);
+    
+    self.$hostsCheck.on('change', (event) => {
+		self.$hostsCheckIsEnable = Boolean(Number($(event.currentTarget).val()));
+		self.$hostsAllowed.prop('readonly', !self.$hostsCheckIsEnable);
+    });
+
+    return {};
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/webservice/toggle-hostsallowed-readonly.js
+++ b/admin-dev/themes/new-theme/js/pages/webservice/toggle-hostsallowed-readonly.js
@@ -36,10 +36,10 @@ export default class ToggleHostsAllowedReadonly {
     self.$hostsAllowed = $('#webservice_key_hosts_allowed');
     self.$hostsCheckIsEnable = Boolean(Number(self.$hostsCheck.filter(':checked').val()));
     self.$hostsAllowed.prop('readonly', !self.$hostsCheckIsEnable);
-    
+
     self.$hostsCheck.on('change', (event) => {
-		self.$hostsCheckIsEnable = Boolean(Number($(event.currentTarget).val()));
-		self.$hostsAllowed.prop('readonly', !self.$hostsCheckIsEnable);
+      self.$hostsCheckIsEnable = Boolean(Number($(event.currentTarget).val()));
+      self.$hostsAllowed.prop('readonly', !self.$hostsCheckIsEnable);
     });
 
     return {};

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -197,7 +197,7 @@ class WebserviceKeyCore extends ObjectModel
      *
      * @return WebserviceKey|null
      */
-    public static function getWebServiceObjectFromKey($auth_key)
+    public static function getWebServiceObjectFromKey(string $auth_key): ?WebserviceKey
     {
         $id_account = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             (new DbQuery())

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -37,7 +37,7 @@ class WebserviceKeyCore extends ObjectModel
     /** @var string Webservice Account hosts allowed */
     public $hosts_allowed;
 
-    /** @var string Webservice Account enable/disable hosts check */
+    /** @var bool Webservice Account enable/disable hosts check */
     public $hosts_check;
 
     /**

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -33,6 +33,12 @@ class WebserviceKeyCore extends ObjectModel
 
     /** @var string Webservice Account description */
     public $description;
+    
+    /** @var string Webservice Account hosts allowed */
+    public $hosts_allowed;
+    
+    /** @var string Webservice Account enable/disable hosts check */
+    public $hosts_check;
 
     /**
      * @see ObjectModel::$definition
@@ -44,6 +50,8 @@ class WebserviceKeyCore extends ObjectModel
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'key' => ['type' => self::TYPE_STRING, 'required' => true, 'size' => 32],
             'description' => ['type' => self::TYPE_STRING],
+            'hosts_allowed' => ['type' => self::TYPE_STRING],
+            'hosts_check' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
         ],
     ];
 
@@ -182,5 +190,26 @@ class WebserviceKeyCore extends ObjectModel
         }
 
         return $ok;
+    }
+    
+    /**
+     * @param string $auth_key
+     *
+     * @return WebserviceKey|null
+     */
+    public static function getWebServiceObjectFromKey($auth_key)
+    {
+        $id_account = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+			(new DbQuery())
+			  ->select('w.id_webservice_account')
+			  ->from('webservice_account', 'w')
+			  ->where('w.key = "' . pSQL($auth_key) . '"'),
+			  false
+        );
+        
+        $WebServiceObject =  new WebserviceKey((int) $id_account);
+        
+        return Validate::isLoadedObject($WebServiceObject) ? $WebServiceObject : null;
+        
     }
 }

--- a/classes/webservice/WebserviceKey.php
+++ b/classes/webservice/WebserviceKey.php
@@ -33,10 +33,10 @@ class WebserviceKeyCore extends ObjectModel
 
     /** @var string Webservice Account description */
     public $description;
-    
+
     /** @var string Webservice Account hosts allowed */
     public $hosts_allowed;
-    
+
     /** @var string Webservice Account enable/disable hosts check */
     public $hosts_check;
 
@@ -191,7 +191,7 @@ class WebserviceKeyCore extends ObjectModel
 
         return $ok;
     }
-    
+
     /**
      * @param string $auth_key
      *
@@ -200,16 +200,15 @@ class WebserviceKeyCore extends ObjectModel
     public static function getWebServiceObjectFromKey($auth_key)
     {
         $id_account = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
-			(new DbQuery())
-			  ->select('w.id_webservice_account')
-			  ->from('webservice_account', 'w')
-			  ->where('w.key = "' . pSQL($auth_key) . '"'),
-			  false
+            (new DbQuery())
+                ->select('w.id_webservice_account')
+                ->from('webservice_account', 'w')
+                ->where('w.key = "' . pSQL($auth_key) . '"'),
+              false
         );
-        
-        $WebServiceObject =  new WebserviceKey((int) $id_account);
-        
+
+        $WebServiceObject = new WebserviceKey((int) $id_account);
+
         return Validate::isLoadedObject($WebServiceObject) ? $WebServiceObject : null;
-        
     }
 }

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -812,7 +812,7 @@ class WebserviceRequestCore
                     if (!$this->keyPermissions) {
                         $this->setError(401, 'No permission for this authentication key', 21);
                     }
-                    
+
                     if (!$this->checkHostAllowed($this->_key)) {
                         $this->setError(503, 'No permission for this host authentication', 666);
                     }
@@ -1891,7 +1891,7 @@ class WebserviceRequestCore
 
         return $retarr;
     }
-    
+
     /**
      * Check if client hostname/ip is allowed.
      *
@@ -1899,21 +1899,20 @@ class WebserviceRequestCore
      */
     protected function checkHostAllowed($key)
     {
-		$WebServiceObject = WebserviceKey::getWebServiceObjectFromKey($key);
-		
-		if (!$WebServiceObject) {
-			return false;
-		}
-		
-		if (!$WebServiceObject->hosts_check) {
-			return true;
-		}
-		
-		$hostsAllowed = array_map('trim', explode(',', $WebServiceObject->hosts_allowed));
-		$hostIp = Tools::getRemoteAddr();
-		$hostName = gethostbyaddr($hostIp);
-		
-		 return in_array($hostIp, $hostsAllowed) || in_array($hostName, $hostsAllowed) ;
-		
-	}
+        $WebServiceObject = WebserviceKey::getWebServiceObjectFromKey($key);
+
+        if (!$WebServiceObject) {
+            return false;
+        }
+
+        if (!$WebServiceObject->hosts_check) {
+            return true;
+        }
+
+        $hostsAllowed = array_map('trim', explode(',', $WebServiceObject->hosts_allowed));
+        $hostIp = Tools::getRemoteAddr();
+        $hostName = gethostbyaddr($hostIp);
+
+        return in_array($hostIp, $hostsAllowed) || in_array($hostName, $hostsAllowed);
+    }
 }

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -812,6 +812,10 @@ class WebserviceRequestCore
                     if (!$this->keyPermissions) {
                         $this->setError(401, 'No permission for this authentication key', 21);
                     }
+                    
+                    if (!$this->checkHostAllowed($this->_key)) {
+                        $this->setError(503, 'No permission for this host authentication', 666);
+                    }
                 }
             }
             if ($this->hasErrors()) {
@@ -1887,4 +1891,29 @@ class WebserviceRequestCore
 
         return $retarr;
     }
+    
+    /**
+     * Check if client hostname/ip is allowed.
+     *
+     * @return bool
+     */
+    protected function checkHostAllowed($key)
+    {
+		$WebServiceObject = WebserviceKey::getWebServiceObjectFromKey($key);
+		
+		if (!$WebServiceObject) {
+			return false;
+		}
+		
+		if (!$WebServiceObject->hosts_check) {
+			return true;
+		}
+		
+		$hostsAllowed = array_map('trim', explode(',', $WebServiceObject->hosts_allowed));
+		$hostIp = Tools::getRemoteAddr();
+		$hostName = gethostbyaddr($hostIp);
+		
+		 return in_array($hostIp, $hostsAllowed) || in_array($hostName, $hostsAllowed) ;
+		
+	}
 }

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1895,6 +1895,8 @@ class WebserviceRequestCore
     /**
      * Check if client hostname/ip is allowed.
      *
+     * @param string $key
+     *
      * @return bool
      */
     protected function checkHostAllowed(string $key): bool

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1897,7 +1897,7 @@ class WebserviceRequestCore
      *
      * @return bool
      */
-    protected function checkHostAllowed($key)
+    protected function checkHostAllowed(string $key): bool
     {
         $WebServiceObject = WebserviceKey::getWebServiceObjectFromKey($key);
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2185,6 +2185,8 @@ CREATE TABLE `PREFIX_webservice_account` (
   `is_module` TINYINT(2) NOT NULL DEFAULT '0',
   `module_name` VARCHAR(50) NULL DEFAULT NULL,
   `active` tinyint(2) NOT NULL,
+  `hosts_allowed` TEXT NULL DEFAULT NULL,
+  `hosts_check` TINYINT(2) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_webservice_account`),
   KEY `key` (`key`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -30,3 +30,6 @@ ALTER TABLE `PREFIX_hook` ADD `active` TINYINT(1) UNSIGNED DEFAULT 1 NOT NULL AF
 ALTER TABLE `PREFIX_orders` ADD COLUMN `note` TEXT AFTER `date_upd`;
 
 ALTER TABLE `PREFIX_currency` CHANGE `numeric_iso_code` `numeric_iso_code` varchar(3) NULL DEFAULT NULL;
+
+ALTER TABLE `PREFIX_webservice_account` ADD `hosts_allowed` TEXT NULL DEFAULT NULL AFTER `active`;
+ALTER TABLE `PREFIX_webservice_account` ADD `hosts_check` TINYINT(2) NOT NULL DEFAULT '0' AFTER `hosts_allowed`;

--- a/src/Adapter/Webservice/CommandHandler/AddWebserviceKeyHandler.php
+++ b/src/Adapter/Webservice/CommandHandler/AddWebserviceKeyHandler.php
@@ -80,6 +80,8 @@ final class AddWebserviceKeyHandler extends AbstractWebserviceKeyHandler impleme
         $webserviceKey->key = $command->getKey()->getValue();
         $webserviceKey->description = $command->getDescription();
         $webserviceKey->active = $command->getStatus();
+        $webserviceKey->hosts_allowed = $command->getHostsAllowed();
+        $webserviceKey->hosts_check = (bool) $command->getHostsCheck();
 
         if (false === $webserviceKey->validateFields(false)) {
             throw new WebserviceConstraintException('One or more fields are invalid in WebserviceKey');

--- a/src/Adapter/Webservice/CommandHandler/AddWebserviceKeyHandler.php
+++ b/src/Adapter/Webservice/CommandHandler/AddWebserviceKeyHandler.php
@@ -81,7 +81,7 @@ final class AddWebserviceKeyHandler extends AbstractWebserviceKeyHandler impleme
         $webserviceKey->description = $command->getDescription();
         $webserviceKey->active = $command->getStatus();
         $webserviceKey->hosts_allowed = $command->getHostsAllowed();
-        $webserviceKey->hosts_check = (bool) $command->getHostsCheck();
+        $webserviceKey->hosts_check = $command->getHostsCheck();
 
         if (false === $webserviceKey->validateFields(false)) {
             throw new WebserviceConstraintException('One or more fields are invalid in WebserviceKey');

--- a/src/Adapter/Webservice/CommandHandler/EditWebserviceKeyHandler.php
+++ b/src/Adapter/Webservice/CommandHandler/EditWebserviceKeyHandler.php
@@ -88,7 +88,7 @@ final class EditWebserviceKeyHandler extends AbstractWebserviceKeyHandler implem
         }
 
         $webserviceKey->hosts_allowed = $command->getHostsAllowed();
-        $webserviceKey->hosts_check = (bool) $command->getHostsCheck();
+        $webserviceKey->hosts_check = $command->getHostsCheck();
 
         if (false === $webserviceKey->validateFields(false)) {
             throw new WebserviceConstraintException('One or more fields are invalid in WebserviceKey');

--- a/src/Adapter/Webservice/CommandHandler/EditWebserviceKeyHandler.php
+++ b/src/Adapter/Webservice/CommandHandler/EditWebserviceKeyHandler.php
@@ -87,6 +87,9 @@ final class EditWebserviceKeyHandler extends AbstractWebserviceKeyHandler implem
             $webserviceKey->active = $command->getStatus();
         }
 
+        $webserviceKey->hosts_allowed = $command->getHostsAllowed();
+        $webserviceKey->hosts_check = (bool) $command->getHostsCheck();
+
         if (false === $webserviceKey->validateFields(false)) {
             throw new WebserviceConstraintException('One or more fields are invalid in WebserviceKey');
         }

--- a/src/Adapter/Webservice/QueryHandler/GetWebserviceKeyForEditingHandler.php
+++ b/src/Adapter/Webservice/QueryHandler/GetWebserviceKeyForEditingHandler.php
@@ -53,7 +53,9 @@ final class GetWebserviceKeyForEditingHandler implements GetWebserviceKeyForEdit
             $webserviceKey->description,
             $webserviceKey->active,
             WebserviceKey::getPermissionForAccount($webserviceKey->key),
-            $webserviceKey->getAssociatedShops()
+            $webserviceKey->getAssociatedShops(),
+            $webserviceKey->hosts_allowed,
+            $webserviceKey->hosts_check
         );
     }
 

--- a/src/Adapter/Webservice/WebserviceKeyHostsCheckModifier.php
+++ b/src/Adapter/Webservice/WebserviceKeyHostsCheckModifier.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Webservice;
+
+use Symfony\Component\Translation\TranslatorInterface;
+use Validate;
+use WebserviceKey;
+
+/**
+ * Class WebserviceKeyHostsCheckModifier is responsible for modifying webservice account hosts check.
+ */
+final class WebserviceKeyHostsCheckModifier
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * WebserviceKeyHostsCheckModifier constructor.
+     *
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * Toggles host check for webservice key entity.
+     *
+     * @param int $columnId - an id which identifies the required entity to be modified
+     *
+     * @return string[] - if empty when process of hosts check change was successful
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function toggleHostsCheck($columnId)
+    {
+        $webserviceKey = new WebserviceKey($columnId);
+        $webserviceKey->hosts_check = !$webserviceKey->hosts_check;
+        if (!Validate::isLoadedObject($webserviceKey)) {
+            $error = $this->translator
+                ->trans(
+                    'An error occurred while updating the object.',
+                    [],
+                    'Admin.Notifications.Error'
+                ) .
+                WebserviceKey::$definition['table'] .
+                $this->translator->trans('(cannot load object)', [], 'Admin.Notifications.Error');
+
+            return [$error];
+        }
+
+        if (!$webserviceKey->save()) {
+            $error = $this->translator
+                ->trans('An error occurred while performing this action.', [], 'Admin.Notifications.Error');
+
+            return [$error];
+        }
+
+        return [];
+    }
+}

--- a/src/Adapter/Webservice/WebserviceKeyHostsCheckModifier.php
+++ b/src/Adapter/Webservice/WebserviceKeyHostsCheckModifier.php
@@ -23,6 +23,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+ 
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Webservice;
 

--- a/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
@@ -57,7 +57,7 @@ class AddWebserviceKeyCommand
      * @var array
      */
     private $associatedShops;
-    
+
     /**
      * @var string
      */
@@ -134,7 +134,7 @@ class AddWebserviceKeyCommand
     {
         return $this->associatedShops;
     }
-    
+
     /**
      * @return string
      */

--- a/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
@@ -138,7 +138,7 @@ class AddWebserviceKeyCommand
     /**
      * @return string
      */
-    public function getHostsAllowed()
+    public function getHostsAllowed(): string
     {
         return $this->hosts_allowed;
     }

--- a/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
@@ -57,6 +57,16 @@ class AddWebserviceKeyCommand
      * @var array
      */
     private $associatedShops;
+    
+    /**
+     * @var string
+     */
+    private $hosts_allowed;
+
+    /**
+     * @var bool
+     */
+    private $hosts_check;
 
     /**
      * @param string $key
@@ -64,19 +74,25 @@ class AddWebserviceKeyCommand
      * @param bool $status
      * @param array $permissions
      * @param int[] $associatedShops
+     * @param string $hosts_allowed
+     * @param bool $hosts_check
      */
     public function __construct(
         $key,
         $description,
         $status,
         array $permissions,
-        array $associatedShops
+        array $associatedShops,
+        string $hosts_allowed = null,
+        bool $hosts_check = false
     ) {
         $this->key = new Key($key);
         $this->description = $description;
         $this->status = $status;
         $this->permissions = $permissions;
         $this->associatedShops = $associatedShops;
+        $this->hosts_allowed = $hosts_allowed;
+        $this->hosts_check = $hosts_check;
     }
 
     /**
@@ -117,5 +133,21 @@ class AddWebserviceKeyCommand
     public function getAssociatedShops()
     {
         return $this->associatedShops;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getHostsAllowed()
+    {
+        return $this->hosts_allowed;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHostsCheck()
+    {
+        return $this->hosts_check;
     }
 }

--- a/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
@@ -83,7 +83,7 @@ class AddWebserviceKeyCommand
         $status,
         array $permissions,
         array $associatedShops,
-        string $hosts_allowed = null,
+        string $hosts_allowed = '',
         bool $hosts_check = false
     ) {
         $this->key = new Key($key);

--- a/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/AddWebserviceKeyCommand.php
@@ -146,7 +146,7 @@ class AddWebserviceKeyCommand
     /**
      * @return bool
      */
-    public function getHostsCheck()
+    public function getHostsCheck(): bool
     {
         return $this->hosts_check;
     }

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -211,9 +211,9 @@ class EditWebserviceKeyCommand
     }
 
     /**
-     * @return bool|null
+     * @return bool
      */
-    public function getHostsCheck()
+    public function getHostsCheck(): bool
     {
         return $this->hosts_check;
     }

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -191,9 +191,9 @@ class EditWebserviceKeyCommand
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getHostsAllowed()
+    public function getHostsAllowed(): string
     {
         return $this->hosts_allowed;
     }

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -203,7 +203,7 @@ class EditWebserviceKeyCommand
      *
      * @return self
      */
-    public function setHostsAllowed($hosts_allowed)
+    public function setHostsAllowed(string $hosts_allowed): self
     {
         $this->hosts_allowed = $hosts_allowed;
 

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -65,14 +65,14 @@ class EditWebserviceKeyCommand
     private $shopAssociation;
 
     /**
-     * @var string|null
+     * @var string
      */
-    private $hosts_allowed;
+    private $hosts_allowed = '';
 
     /**
-     * @var bool|null
+     * @var bool
      */
-    private $hosts_check;
+    private $hosts_check = false;
 
     /**
      * @param int $webserviceKeyId

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -63,7 +63,7 @@ class EditWebserviceKeyCommand
      * @var int[]|null
      */
     private $shopAssociation;
-    
+
     /**
      * @var string|null
      */
@@ -189,7 +189,7 @@ class EditWebserviceKeyCommand
 
         return $this;
     }
-    
+
     /**
      * @return string|null
      */

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -223,7 +223,7 @@ class EditWebserviceKeyCommand
      *
      * @return self
      */
-    public function setHostsCheck($hosts_check)
+    public function setHostsCheck(bool $hosts_check): self
     {
         $this->hosts_check = $hosts_check;
 

--- a/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
+++ b/src/Core/Domain/Webservice/Command/EditWebserviceKeyCommand.php
@@ -63,6 +63,16 @@ class EditWebserviceKeyCommand
      * @var int[]|null
      */
     private $shopAssociation;
+    
+    /**
+     * @var string|null
+     */
+    private $hosts_allowed;
+
+    /**
+     * @var bool|null
+     */
+    private $hosts_check;
 
     /**
      * @param int $webserviceKeyId
@@ -176,6 +186,46 @@ class EditWebserviceKeyCommand
     public function setShopAssociation(array $shopAssociation)
     {
         $this->shopAssociation = $shopAssociation;
+
+        return $this;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getHostsAllowed()
+    {
+        return $this->hosts_allowed;
+    }
+
+    /**
+     * @param string $hosts_allowed
+     *
+     * @return self
+     */
+    public function setHostsAllowed($hosts_allowed)
+    {
+        $this->hosts_allowed = $hosts_allowed;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getHostsCheck()
+    {
+        return $this->hosts_check;
+    }
+
+    /**
+     * @param bool $hosts_check
+     *
+     * @return self
+     */
+    public function setHostsCheck($hosts_check)
+    {
+        $this->hosts_check = $hosts_check;
 
         return $this;
     }

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -162,7 +162,7 @@ class EditableWebserviceKey
     /**
      * @return bool
      */
-    public function getHostsCheck()
+    public function getHostsCheck(): bool
     {
         return $this->hosts_check;
     }

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -154,7 +154,7 @@ class EditableWebserviceKey
     /**
      * @return string|null
      */
-    public function getHostsAllowed()
+    public function getHostsAllowed(): string
     {
         return $this->hosts_allowed;
     }

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -62,7 +62,7 @@ class EditableWebserviceKey
      * @var int[]
      */
     private $associatedShops;
-    
+
     /**
      * @var string
      */
@@ -150,7 +150,7 @@ class EditableWebserviceKey
     {
         return $this->associatedShops;
     }
-    
+
     /**
      * @return string|null
      */

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -152,7 +152,7 @@ class EditableWebserviceKey
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     public function getHostsAllowed(): string
     {

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -90,7 +90,7 @@ class EditableWebserviceKey
         $status,
         array $resourcePermissions,
         array $associatedShops,
-        string $hosts_allowed = null,
+        string $hosts_allowed = '',
         bool $hosts_check = false
     ) {
         $this->webserviceKeyId = $webserviceKeyId;

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -62,6 +62,16 @@ class EditableWebserviceKey
      * @var int[]
      */
     private $associatedShops;
+    
+    /**
+     * @var string
+     */
+    private $hosts_allowed;
+
+    /**
+     * @var bool
+     */
+    private $hosts_check;
 
     /**
      * @param WebserviceKeyId $webserviceKeyId
@@ -70,6 +80,8 @@ class EditableWebserviceKey
      * @param bool $status
      * @param array $resourcePermissions
      * @param array $associatedShops
+     * @param string $hosts_allowed
+     * @param bool $hosts_check
      */
     public function __construct(
         WebserviceKeyId $webserviceKeyId,
@@ -77,7 +89,9 @@ class EditableWebserviceKey
         $description,
         $status,
         array $resourcePermissions,
-        array $associatedShops
+        array $associatedShops,
+        string $hosts_allowed = null,
+        bool $hosts_check = false
     ) {
         $this->webserviceKeyId = $webserviceKeyId;
         $this->key = $key;
@@ -85,6 +99,8 @@ class EditableWebserviceKey
         $this->status = $status;
         $this->resourcePermissions = $resourcePermissions;
         $this->associatedShops = $associatedShops;
+        $this->hosts_allowed = $hosts_allowed;
+        $this->hosts_check = $hosts_check;
     }
 
     /**
@@ -133,5 +149,21 @@ class EditableWebserviceKey
     public function getAssociatedShops()
     {
         return $this->associatedShops;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getHostsAllowed()
+    {
+        return $this->hosts_allowed;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getHostsCheck()
+    {
+        return $this->hosts_check;
     }
 }

--- a/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
+++ b/src/Core/Domain/Webservice/QueryResult/EditableWebserviceKey.php
@@ -160,7 +160,7 @@ class EditableWebserviceKey
     }
 
     /**
-     * @return bool|null
+     * @return bool
      */
     public function getHostsCheck()
     {

--- a/src/Core/Form/IdentifiableObject/DataHandler/WebserviceKeyFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/WebserviceKeyFormDataHandler.php
@@ -71,7 +71,9 @@ final class WebserviceKeyFormDataHandler implements FormDataHandlerInterface
             $data['description'],
             $data['status'],
             $data['permissions'],
-            $data['shop_association']
+            $data['shop_association'],
+            $data['hosts_allowed'],
+            $data['hosts_check']
         ));
 
         return $webserviceKeyId->getValue();
@@ -88,6 +90,8 @@ final class WebserviceKeyFormDataHandler implements FormDataHandlerInterface
             ->setDescription($data['description'])
             ->setStatus($data['status'])
             ->setPermissions($data['permissions'])
+            ->setHostsAllowed($data['hosts_allowed'])
+            ->setHostsCheck($data['hosts_check'])
         ;
 
         if (isset($data['shop_association'])) {

--- a/src/Core/Form/IdentifiableObject/DataProvider/WebserviceKeyFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/WebserviceKeyFormDataProvider.php
@@ -71,6 +71,8 @@ final class WebserviceKeyFormDataProvider implements FormDataProviderInterface
                 $editableWebserviceKey->getResourcePermissions()
             ),
             'shop_association' => $editableWebserviceKey->getAssociatedShops(),
+            'hosts_allowed' => $editableWebserviceKey->getHostsAllowed(),
+            'hosts_check' => $editableWebserviceKey->getHostsCheck(),
         ];
     }
 

--- a/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/WebserviceKeyDefinitionFactory.php
@@ -141,6 +141,16 @@ final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
+                (new ToggleColumn('hosts_check'))
+                    ->setName($this->trans('Hosts check', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'hosts_check',
+                        'primary_field' => 'id_webservice_account',
+                        'route' => 'admin_webservice_keys_toggle_hostscheck',
+                        'route_param_name' => 'webserviceKeyId',
+                    ])
+            )
+            ->add(
                 (new ActionColumn('actions'))
                     ->setName($this->trans('Actions', [], 'Admin.Global'))
                     ->setOptions([
@@ -201,6 +211,15 @@ final class WebserviceKeyDefinitionFactory extends AbstractGridDefinitionFactory
                         'choice_translation_domain' => false,
                     ])
                     ->setAssociatedColumn('active')
+            )
+            ->add(
+                (new Filter('hosts_check', ChoiceType::class))
+                    ->setTypeOptions([
+                        'required' => false,
+                        'choices' => $this->statusChoices,
+                        'choice_translation_domain' => false,
+                    ])
+                    ->setAssociatedColumn('hosts_check')
             )
             ->add(
                 (new Filter('actions', SearchAndResetType::class))

--- a/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
+++ b/src/Core/Grid/Query/WebserviceKeyQueryBuilder.php
@@ -81,7 +81,7 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
-        $qb->select('wa.`id_webservice_account`, wa.`key`, wa.`description`, wa.`active`')
+        $qb->select('wa.`id_webservice_account`, wa.`key`, wa.`description`, wa.`active`, wa.hosts_check')
             ->orderBy(
                 $this->getModifiedOrderBy($searchCriteria->getOrderBy()),
                 $searchCriteria->getOrderWay()
@@ -129,6 +129,7 @@ final class WebserviceKeyQueryBuilder extends AbstractDoctrineQueryBuilder
         $sqlFilters = (new SqlFilters())
             ->addFilter('key', 'wa.key', SqlFilters::WHERE_LIKE)
             ->addFilter('active', 'wa.active', SqlFilters::WHERE_STRICT)
+            ->addFilter('hosts_check', 'wa.hosts_check', SqlFilters::WHERE_STRICT)
             ->addFilter('description', 'wa.description', SqlFilters::WHERE_LIKE)
         ;
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -303,6 +303,33 @@ class WebserviceController extends FrameworkBundleAdminController
     }
 
     /**
+     * Enable/Disable hosts check.
+     *
+     * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
+     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     *
+     * @param int $webserviceKeyId
+     *
+     * @return RedirectResponse
+     */
+    public function toggleHostsCheckAction($webserviceKeyId)
+    {
+        $hostsCheckModifier = $this->get('prestashop.adapter.webservice.webservice_key_hostscheck_modifier');
+        $errors = $hostsCheckModifier->toggleHostsCheck($webserviceKeyId);
+
+        if (!empty($errors)) {
+            $this->flashErrors($errors);
+        } else {
+            $this->addFlash(
+                'success',
+                $this->trans('Update successful', 'Admin.Notifications.Success')
+            );
+        }
+
+        return $this->redirectToRoute('admin_webservice_keys_index');
+    }
+
+    /**
      * Process the Webservice configuration form.
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -118,7 +118,7 @@ class WebserviceKeyType extends AbstractType
                 'empty_data' => '',
                 'attr' => [
                     'rows' => 5,
-                    'placeholder' => 'www.prestashop.com, 42.24.4.2,127.0.0.1,99.98.97.96',
+                    'placeholder' => 'www.prestashop.com,42.24.4.2,127.0.0.1,99.98.97.96',
                 ],
             ])
             ->add('hosts_check', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -113,6 +113,17 @@ class WebserviceKeyType extends AbstractType
                 'scrollable' => false,
                 'headers_to_disable' => ['all'],
             ])
+            ->add('hosts_allowed', TextareaType::class, [
+                'required' => false,
+                'empty_data' => '',
+                'attr' => array(
+                  'rows' => 5,
+                  'placeholder' => 'www.prestashop.com, 42.24.4.2,127.0.0.1,99.98.97.96',
+				)
+            ])
+            ->add('hosts_check', SwitchType::class, [
+                'required' => false,
+            ])
         ;
 
         // remove "all" configuration since it's not an actual permission

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -113,16 +113,20 @@ class WebserviceKeyType extends AbstractType
                 'scrollable' => false,
                 'headers_to_disable' => ['all'],
             ])
+            ->add('hosts_check', SwitchType::class, [
+                'required' => false,
+            ])
             ->add('hosts_allowed', TextareaType::class, [
                 'required' => false,
                 'empty_data' => '',
                 'attr' => [
                     'rows' => 5,
-                    'placeholder' => 'www.prestashop.com,42.24.4.2,127.0.0.1,99.98.97.96',
+                    'placeholder' => $this->trans(
+                        'www.prestashop.com,42.24.4.2,127.0.0.1,99.98.97.96',
+                        [],
+                        'Admin.Advparameters.Help'
+                    ),
                 ],
-            ])
-            ->add('hosts_check', SwitchType::class, [
-                'required' => false,
             ])
         ;
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -116,10 +116,10 @@ class WebserviceKeyType extends AbstractType
             ->add('hosts_allowed', TextareaType::class, [
                 'required' => false,
                 'empty_data' => '',
-                'attr' => array(
-                  'rows' => 5,
-                  'placeholder' => 'www.prestashop.com, 42.24.4.2,127.0.0.1,99.98.97.96',
-				)
+                'attr' => [
+                    'rows' => 5,
+                    'placeholder' => 'www.prestashop.com, 42.24.4.2,127.0.0.1,99.98.97.96',
+                ],
             ])
             ->add('hosts_check', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/webservice.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/webservice.yml
@@ -74,6 +74,17 @@ admin_webservice_keys_toggle_status:
     requirements:
         webserviceKeyId: \d+
 
+admin_webservice_keys_toggle_hostscheck:
+    path: /{webserviceKeyId}/toggle-hostscheck
+    methods: POST
+    defaults:
+        _controller: 'PrestaShopBundle:Admin\Configure\AdvancedParameters\Webservice:toggleHostsCheck'
+        _legacy_controller: AdminWebservice
+        _legacy_parameters:
+            id_webservice_account: webserviceKeyId
+    requirements:
+        webserviceKeyId: \d+
+
 admin_webservice_keys_bulk_enable:
     path: /bulk-enable
     methods: POST

--- a/src/PrestaShopBundle/Resources/config/services/adapter/webservice.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/webservice.yml
@@ -10,6 +10,11 @@ services:
       arguments:
           - '@translator'
 
+    prestashop.adapter.webservice.webservice_key_hostscheck_modifier:
+      class: 'PrestaShop\PrestaShop\Adapter\Webservice\WebserviceKeyHostsCheckModifier'
+      arguments:
+          - '@translator'
+
     prestashop.adapter.webservice.query_handler.get_webservice_key_for_editing_handler:
       class: 'PrestaShop\PrestaShop\Adapter\Webservice\QueryHandler\GetWebserviceKeyForEditingHandler'
       tags:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
@@ -69,6 +69,15 @@
             'label': 'Shop association'|trans({}, 'Admin.Global')
           }) }}
         {% endif %}
+        
+        {{ ps.form_group_row(webserviceKeyForm.hosts_allowed, {}, {
+          'label': 'Hosts allowed'|trans({}, 'Admin.Advparameters.Feature'),
+          'help': 'Hosts allowed to access this webservice key. Please use a comma to separate them (e.g. www.prestashop.com,127.0.0.1).'|trans({}, 'Admin.Advparameters.Help')
+        }) }}
+
+        {{ ps.form_group_row(webserviceKeyForm.hosts_check, {}, {
+          'label': 'Enable hosts check'|trans({}, 'Admin.Global')
+        }) }}
 
         {% block webservice_key_form_rest %}
           {{ form_rest(webserviceKeyForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
@@ -69,14 +69,14 @@
             'label': 'Shop association'|trans({}, 'Admin.Global')
           }) }}
         {% endif %}
-        
-        {{ ps.form_group_row(webserviceKeyForm.hosts_allowed, {}, {
-          'label': 'Hosts allowed'|trans({}, 'Admin.Advparameters.Feature'),
-          'help': 'Hosts allowed to access this webservice key. Please use a comma to separate them (e.g. www.prestashop.com,127.0.0.1).'|trans({}, 'Admin.Advparameters.Help')
-        }) }}
 
         {{ ps.form_group_row(webserviceKeyForm.hosts_check, {}, {
           'label': 'Enable hosts check'|trans({}, 'Admin.Global')
+        }) }}
+
+        {{ ps.form_group_row(webserviceKeyForm.hosts_allowed, {}, {
+          'label': 'Hosts allowed'|trans({}, 'Admin.Advparameters.Feature'),
+          'help': 'Hosts allowed to access this webservice key. Please use a comma to separate them (e.g. www.prestashop.com,127.0.0.1).'|trans({}, 'Admin.Advparameters.Help')
         }) }}
 
         {% block webservice_key_form_rest %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improve the security of Web Services. In some cases a key is not enough to secure access to the API. It would be interesting to have the possibility of limiting accesses by IP address or Domain name.
| Type?         | improvement 
| Category?     | WS 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21493
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/21493

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21494)
<!-- Reviewable:end -->
