### PR TITLE
Improved Error message in New Order Page when adding a minimal product

### DIFF
--- a/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCo
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateProductQuantityInCartHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
@@ -132,7 +133,7 @@ final class UpdateProductQuantityInCartHandler extends AbstractCartHandler imple
                 Attribute::getAttributeMinimalQty($combinationIdValue) :
                 $product->minimal_quantity;
 
-            throw new CartException(sprintf('Minimum quantity of %d must be added to cart.', $minQuantity));
+            throw new MinimalQuantityException('Minimum quantity of %d must be added to cart.', $minQuantity);
         }
     }
 

--- a/src/Core/Domain/Cart/Exception/MinimalQuantityException.php
+++ b/src/Core/Domain/Cart/Exception/MinimalQuantityException.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Cart\Exception;
+
+use Throwable;
+
+/**
+ * Thrown when minimal product
+ */
+class MinimalQuantityException extends CartException
+{
+    /**
+     * @var int
+     */
+    protected $minimalQuantity;
+
+    /**
+     * @param string $message
+     * @param int $minimalQuantity
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $message, int $minimalQuantity, int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->minimalQuantity = $minimalQuantity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMinimalQuantity(): int
+    {
+        return $this->minimalQuantity;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCo
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\InvalidGiftMessageException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartInformation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartInformation;
@@ -593,6 +594,13 @@ class CartController extends FrameworkBundleAdminController
             InvalidGiftMessageException::class => $this->trans(
                 'Gift message not valid',
                 'Admin.Notifications.Error'
+            ),
+            MinimalQuantityException::class => $this->trans(
+                'You must add a minimum quantity of %d',
+                'Admin.Orderscustomers.Notification',
+                [
+                    $e->getMinimalQuantity(),
+                ]
             ),
         ];
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -49,6 +49,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartDeliverySettingsCom
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartInformation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartInformation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
@@ -146,17 +147,22 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     {
         $productId = $this->getProductIdByName($productName);
 
-        $this->getCommandBus()->handle(
-            new UpdateProductQuantityInCartCommand(
-                SharedStorage::getStorage()->get($cartReference),
-                $productId,
-                $quantity
-            )
-        );
-        SharedStorage::getStorage()->set($productName, $productId);
+        $this->lastException = null;
+        try {
+            $this->getCommandBus()->handle(
+                new UpdateProductQuantityInCartCommand(
+                    SharedStorage::getStorage()->get($cartReference),
+                    $productId,
+                    $quantity
+                )
+            );
+            SharedStorage::getStorage()->set($productName, $productId);
 
-        // Clear cart static cache or it will have no products in next calls
-        Cart::resetStaticCache();
+            // Clear cart static cache or it will have no products in next calls
+            Cart::resetStaticCache();
+        } catch (MinimalQuantityException $e) {
+            $this->lastException = $e;
+        }
     }
 
     /**
@@ -814,6 +820,25 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     {
         if (!$cartRule->add()) {
             throw new RuntimeException('Cannot add cart rule to database');
+        }
+    }
+
+    /**
+     * @Then I should get error that minimum quantity of :minQuantity must be added to cart
+     *
+     * @param int $minQuantity
+     */
+    public function assertLastErrorIsMinimumQuantityWhichMustBeAddedToCart(int $minQuantity)
+    {
+        $this->assertLastErrorIs(
+            MinimalQuantityException::class
+        );
+        if ($minQuantity !== $this->lastException->getMinimalQuantity()) {
+            throw new RuntimeException(sprintf(
+                'Minimal quantity in exception, expected %s but got %s',
+                $minQuantity,
+                $this->lastException->getMinimalQuantity()
+            ));
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -257,6 +257,19 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^the product "(.+)" minimal quantity is (\d+)$/
+     *
+     * @param string $productName
+     * @param int $minimalQty
+     */
+    public function setProductMinimalQuantity(string $productName, int $minimalQty)
+    {
+        $this->checkProductWithNameExists($productName);
+        $this->products[$productName]->minimal_quantity = $minimalQty;
+        $this->products[$productName]->save();
+    }
+
+    /**
      * @Given /^product "(.+)" can be ordered out of stock$/
      *
      * @param string $productName

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_standard_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_standard_product.feature
@@ -1,4 +1,7 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags add-standard-product
+
 @reset-database-before-feature
+@add-standard-product
 Feature: Add product in cart
   As a customer
   I must be able to correctly add products in my cart
@@ -18,6 +21,16 @@ Feature: Add product in cart
     Then my cart should contain 0 units of product "product1", excluding items in pack
     Then the remaining available stock for product "product1" should be 1000
 
+  Scenario: Cannot add product in cart with minimal quantity enabled
+    Given there is customer "testCustomer" with email "pub@prestashop.com"
+    And  I create an empty cart "dummy_cart" for customer "testCustomer"
+    And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    And the product "product1" minimal quantity is 10
+    When I add 5 products "product1" to the cart "dummy_cart"
+    Then I should get error that minimum quantity of 10 must be added to cart
+    Then my cart should contain 0 units of product "product1", excluding items in pack
+    Then the remaining available stock for product "product1" should be 1000
+
   Scenario: Be able to add out of stock product if configuration allows it
     Given order out of stock products is allowed
     Given I have an empty default cart
@@ -26,7 +39,7 @@ Feature: Add product in cart
     Then my cart should contain 1100 units of product "product1", excluding items in pack
     Then the remaining available stock for product "product1" should be -100
 
-  Scenario: change product quantity
+  Scenario: Change product quantity
     Given I have an empty default cart
     Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
     When I change quantity of product "product1" in my cart with quantity 1 and operator up, result of change is OK


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Improved Error message in New Order Page when adding a minimal product
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21525
| How to test?  | Cf. @khouloudbelguith Scenario in #21525


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21526)
<!-- Reviewable:end -->
