### PR TITLE
Simplify translations form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
@@ -65,7 +65,7 @@ class AddUpdateLanguageType extends TranslatorAwareType
             'label' => $this->trans('Please select the language you want to add or update', 'Admin.International.Feature'),
             'attr' => [
                 'data-minimumResultsForSearch' => '7',
-                'data-toggle' => 'select2'
+                'data-toggle' => 'select2',
             ],
             'choices' => [
                 $this->trans('Update a language', 'Admin.International.Feature') => $this->getLocaleChoices(),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/AddUpdateLanguageType.php
@@ -62,6 +62,11 @@ class AddUpdateLanguageType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('iso_localization_pack', ChoiceType::class, [
+            'label' => $this->trans('Please select the language you want to add or update', 'Admin.International.Feature'),
+            'attr' => [
+                'data-minimumResultsForSearch' => '7',
+                'data-toggle' => 'select2'
+            ],
             'choices' => [
                 $this->trans('Update a language', 'Admin.International.Feature') => $this->getLocaleChoices(),
                 $this->trans('Add a language', 'Admin.International.Feature') => $this->nonInstalledLocalizationChoices,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
@@ -65,18 +65,40 @@ class CopyLanguageType extends TranslatorAwareType
 
         $builder
             ->add('from_language', ChoiceType::class, [
+                'label' => $this->trans(
+                    'From (Language and theme)',
+                    'Admin.Global'
+                ),
+                'help' => $this->trans(
+                    'Language files must be complete to allow copying of translations.',
+                    'Admin.International.Notification'
+                ),
                 'choices' => $localeChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('from_theme', ChoiceType::class, [
+                'label' => false,
+                'help' => $this->trans(
+                    'Theme from which translations will be copied',
+                    'Admin.International.Notification'
+                ),
                 'choices' => $this->themeChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('to_language', ChoiceType::class, [
+                'label' => $this->trans(
+                    'To',
+                    'Admin.Global'
+                ),
                 'choices' => $localeChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('to_theme', ChoiceType::class, [
+                'label' => false,
+                'help' => $this->trans(
+                    'Theme to which translations will be copied',
+                    'Admin.International.Notification'
+                ),
                 'choices' => $this->themeChoices,
                 'choice_translation_domain' => false,
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
@@ -69,19 +69,11 @@ class CopyLanguageType extends TranslatorAwareType
                     'From',
                     'Admin.Global'
                 ),
-                'help' => $this->trans(
-                    'Language files must be complete to allow copying of translations.',
-                    'Admin.International.Notification'
-                ),
                 'choices' => $localeChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('from_theme', ChoiceType::class, [
                 'label' => false,
-                'help' => $this->trans(
-                    'Theme from which translations will be copied.',
-                    'Admin.International.Notification'
-                ),
                 'choices' => $this->themeChoices,
                 'choice_translation_domain' => false,
             ])
@@ -95,10 +87,6 @@ class CopyLanguageType extends TranslatorAwareType
             ])
             ->add('to_theme', ChoiceType::class, [
                 'label' => false,
-                'help' => $this->trans(
-                    'Theme to which translations will be copied.',
-                    'Admin.International.Notification'
-                ),
                 'choices' => $this->themeChoices,
                 'choice_translation_domain' => false,
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/CopyLanguageType.php
@@ -66,7 +66,7 @@ class CopyLanguageType extends TranslatorAwareType
         $builder
             ->add('from_language', ChoiceType::class, [
                 'label' => $this->trans(
-                    'From (Language and theme)',
+                    'From',
                     'Admin.Global'
                 ),
                 'help' => $this->trans(
@@ -79,7 +79,7 @@ class CopyLanguageType extends TranslatorAwareType
             ->add('from_theme', ChoiceType::class, [
                 'label' => false,
                 'help' => $this->trans(
-                    'Theme from which translations will be copied',
+                    'Theme from which translations will be copied.',
                     'Admin.International.Notification'
                 ),
                 'choices' => $this->themeChoices,
@@ -96,7 +96,7 @@ class CopyLanguageType extends TranslatorAwareType
             ->add('to_theme', ChoiceType::class, [
                 'label' => false,
                 'help' => $this->trans(
-                    'Theme to which translations will be copied',
+                    'Theme to which translations will be copied.',
                     'Admin.International.Notification'
                 ),
                 'choices' => $this->themeChoices,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
@@ -63,10 +63,18 @@ class ExportThemeLanguageType extends TranslatorAwareType
     {
         $builder
             ->add('iso_code', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Language',
+                    'Admin.International.Feature'
+                ),
                 'choices' => $this->getLocaleChoices(),
                 'choice_translation_domain' => false,
             ])
             ->add('theme_name', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Select your theme',
+                    'Admin.International.Feature'
+                ),
                 'choices' => $this->themeChoices,
                 'choice_translation_domain' => false,
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportThemeLanguageType.php
@@ -65,7 +65,7 @@ class ExportThemeLanguageType extends TranslatorAwareType
             ->add('iso_code', ChoiceType::class, [
                 'label' => $this->trans(
                     'Language',
-                    'Admin.International.Feature'
+                    'Admin.Global'
                 ),
                 'choices' => $this->getLocaleChoices(),
                 'choice_translation_domain' => false,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -89,16 +89,30 @@ class ModifyTranslationsType extends TranslatorAwareType
 
         $builder
             ->add('translation_type', ChoiceType::class, [
+                'label' => $this->trans('Type of translation', 'Admin.International.Feature'),
+                'attr' => [
+                    'class' => 'js-translation-type'
+                ],
                 'choices' => $this->translationTypeChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('email_content_type', ChoiceType::class, [
+                'label' => $this->trans('Select the type of email content', 'Admin.International.Feature'),
+                'row_attr' => [
+                    'class' => 'js-email-form-group d-none',
+                ],
+                'attr' => [
+                    'class' => 'js-email-content-type'
+                ],
                 'choices' => $this->emailContentTypeChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('theme', ChoiceType::class, [
-                'choices' => [$noTheme => 0] +
-                $this->themeChoices,
+                'label' => $this->trans('Select your theme', 'Admin.International.Feature'),
+                'row_attr' => [
+                    'class' => 'js-theme-form-group d-none',
+                ],
+                'choices' => [$noTheme => 0] + $this->themeChoices,
                 'choice_attr' => [
                     $noTheme => [
                         'class' => 'js-no-theme',
@@ -107,11 +121,20 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'choice_translation_domain' => false,
             ])
             ->add('module', ChoiceType::class, [
+                'label' => $this->trans('Select your module', 'Admin.International.Feature'),
+                'row_attr' => [
+                    'class' => 'js-module-form-group d-none',
+                ],
                 'placeholder' => '---',
+                'attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => 'select2',
+                ],
                 'choices' => $this->moduleChoices,
                 'choice_translation_domain' => false,
             ])
             ->add('language', ChoiceType::class, [
+                'label' => $this->trans('Select your language', 'Admin.International.Feature'),
                 'placeholder' => $this->trans('Language', 'Admin.Global'),
                 'choices' => $this->getLocaleChoices(),
                 'choice_translation_domain' => false,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -91,7 +91,7 @@ class ModifyTranslationsType extends TranslatorAwareType
             ->add('translation_type', ChoiceType::class, [
                 'label' => $this->trans('Type of translation', 'Admin.International.Feature'),
                 'attr' => [
-                    'class' => 'js-translation-type'
+                    'class' => 'js-translation-type',
                 ],
                 'choices' => $this->translationTypeChoices,
                 'choice_translation_domain' => false,
@@ -102,7 +102,7 @@ class ModifyTranslationsType extends TranslatorAwareType
                     'class' => 'js-email-form-group d-none',
                 ],
                 'attr' => [
-                    'class' => 'js-email-content-type'
+                    'class' => 'js-email-content-type',
                 ],
                 'choices' => $this->emailContentTypeChoices,
                 'choice_translation_domain' => false,

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme addUpdateLanguageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {{ form_start(addUpdateLanguageForm, {action: path('admin_international_translations_add_update_language')}) }}
@@ -45,16 +46,7 @@
 
   <div class="card-block row">
     <div class="card-text">
-      <div class="form-group row">
-        <label class="form-control-label">
-          {{ 'Please select the language you want to add or update'|trans }}
-        </label>
-        <div class="col-sm">
-          {{ form_errors(addUpdateLanguageForm.iso_localization_pack) }}
-          {{ form_widget(addUpdateLanguageForm.iso_localization_pack, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-        </div>
-      </div>
-      {{ form_rest(addUpdateLanguageForm) }}
+      {{ form_widget(addUpdateLanguageForm) }}
     </div>
   </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -47,9 +47,41 @@
             </div>
           </div>
         </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ form_label(copyLanguageForm.from_language) }}
+          </label>
+          <div class="col-sm">
+            <div class="input-group">
+              {{ form_errors(copyLanguageForm.from_language) }}
+              {{ form_widget(copyLanguageForm.from_language) }}
 
-        {{ form_widget(copyLanguageForm) }}
+              {{ form_errors(copyLanguageForm.from_theme) }}
+              {{ form_widget(copyLanguageForm.from_theme) }}
+            </div>
+            <small class="form-text">
+              {{ 'Language files must be complete to allow copying of translations.'|trans({}, 'Admin.International.Notification') }}
+            </small>
+          </div>
+        </div>
 
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ form_label(copyLanguageForm.to_language) }}
+          </label>
+          <div class="col-sm">
+            <div class="input-group">
+              {{ form_errors(copyLanguageForm.to_language) }}
+              {{ form_widget(copyLanguageForm.to_language) }}
+
+              {{ form_errors(copyLanguageForm.to_theme) }}
+              {{ form_widget(copyLanguageForm.to_theme) }}
+            </div>
+          </div>
+        </div>
+        {{ form_rest(copyLanguageForm) }}
+      </div>
+    </div>
         <div class="card-footer">
       <div class="d-flex justify-content-end">
         <button class="btn btn-primary">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain 'Admin.International.Feature' %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme copyLanguageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block copy_language %}
   {{ form_start(copyLanguageForm, {action: path('admin_international_translations_copy_language')}) }}
@@ -48,40 +48,9 @@
           </div>
         </div>
 
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ ps.label_with_help('From'|trans({}, 'Admin.Global'), 'Language files must be complete to allow copying of translations.'|trans({}, 'Admin.International.Notification')) }}
-          </label>
-          <div class="col-sm">
-            <div class="input-group">
-              {{ form_errors(copyLanguageForm.from_language) }}
-              {{ form_widget(copyLanguageForm.from_language) }}
+        {{ form_widget(copyLanguageForm) }}
 
-              {{ form_errors(copyLanguageForm.from_theme) }}
-              {{ form_widget(copyLanguageForm.from_theme) }}
-            </div>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'To'|trans({}, 'Admin.Global') }}
-          </label>
-          <div class="col-sm">
-            <div class="input-group">
-              {{ form_errors(copyLanguageForm.to_language) }}
-              {{ form_widget(copyLanguageForm.to_language) }}
-
-              {{ form_errors(copyLanguageForm.to_theme) }}
-              {{ form_widget(copyLanguageForm.to_theme) }}
-            </div>
-          </div>
-        </div>
-        {{ form_rest(copyLanguageForm) }}
-      </div>
-    </div>
-
-    <div class="card-footer">
+        <div class="card-footer">
       <div class="d-flex justify-content-end">
         <button class="btn btn-primary">
           <i class="material-icons">file_copy</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -82,7 +82,7 @@
         {{ form_rest(copyLanguageForm) }}
       </div>
     </div>
-        <div class="card-footer">
+    <div class="card-footer">
       <div class="d-flex justify-content-end">
         <button class="btn btn-primary">
           <i class="material-icons">file_copy</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -44,25 +44,6 @@
   </h3>
   <div class="card-block row">
     <div class="card-text">
-      <div class="form-group row">
-        <label class="form-control-label">
-          {{ 'Language'|trans({}, 'Admin.Global') }}
-        </label>
-        <div class="col-sm">
-          {{ form_errors(exportLanguageForm.iso_code) }}
-          {{ form_widget(exportLanguageForm.iso_code) }}
-        </div>
-      </div>
-
-      <div class="form-group row">
-        <label class="form-control-label">
-          {{ 'Select your theme'|trans }}
-        </label>
-        <div class="col-sm">
-          {{ form_errors(exportLanguageForm.theme_name) }}
-          {{ form_widget(exportLanguageForm.theme_name) }}
-        </div>
-      </div>
       {{ form_rest(exportLanguageForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme modifyTranslationsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block modify_translations %}
@@ -46,52 +47,7 @@
 
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Type of translation'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(modifyTranslationsForm.translation_type) }}
-            {{ form_widget(modifyTranslationsForm.translation_type, {'attr': {'class': 'js-translation-type'}}) }}
-          </div>
-        </div>
-        <div class="form-group row js-email-form-group d-none">
-          <label class="form-control-label">
-            {{ 'Select the type of email content'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(modifyTranslationsForm.email_content_type) }}
-            {{ form_widget(modifyTranslationsForm.email_content_type, {'attr': {'class': 'js-email-content-type'}}) }}
-          </div>
-        </div>
-        <div class="form-group row js-theme-form-group d-none">
-          <label class="form-control-label">
-            {{ 'Select your theme'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(modifyTranslationsForm.theme) }}
-            {{ form_widget(modifyTranslationsForm.theme) }}
-          </div>
-        </div>
-        <div class="form-group row js-module-form-group d-none">
-          <label class="form-control-label">
-            {{ 'Select your module'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(modifyTranslationsForm.module) }}
-            {{ form_widget(modifyTranslationsForm.module, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Select your language'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(modifyTranslationsForm.language) }}
-            {{ form_widget(modifyTranslationsForm.language) }}
-          </div>
-        </div>
-        {{ form_rest(modifyTranslationsForm) }}
+        {{ form_widget(modifyTranslationsForm) }}
       </div>
     </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify translations form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes 
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  |  Simplify Configure -> International -> Translations. Everything must look the same with 2 exceptions, blue boxes were replaced by help text under and majority of params now are required. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/20243)
<!-- Reviewable:end -->
