### PR TITLE
Fix for #9664: makes use of the getContextListShopID method to get the correct shop it instead of the legacyContextService

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -611,7 +611,7 @@ class ProductController extends FrameworkBundleAdminController
 
         $doctrine = $this->getDoctrine()->getManager();
         $language = empty($languages[0]) ? ['id_lang' => 1, 'id_shop' => 1] : $languages[0];
-        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int) $language['id_lang'], (int) $language['id_shop']);
+        $attributeGroups = $doctrine->getRepository('PrestaShopBundle:Attribute')->findByLangAndShop((int) $language['id_lang'], $shopContext->getContextListShopID()[0]);
 
         $drawerModules = (new HookFinder())->setHookName('displayProductPageDrawer')
             ->setParams(['product' => $product])


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | 1.7.6.x
| Description  | Suggested fix for #9664: makes use of the getContextListShopID method to get the correct shop it instead of the legacyContextService
| Type         | bug fix 
| Category     | BO
| BC breaks    | yes / no
| Deprecations | yes / no
| Fixed ticket | Fixes #9664 
| How to test  |

In my case, when adding/editing combinations of a product in shop 2, Prestashop was showing the available attributes
for shop 1 on the right-hand side. 

Analysis showed that this was causing by $legacyContextService->getLanguages() returning incorrect shop id. 
Using $shopContext->getContextListShopID() instead resolved this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21545)
<!-- Reviewable:end -->
