### PR TITLE
Fix layout breaking on order when discount name is way too long

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -531,3 +531,9 @@ input#partial_refund_shipping {
 .discountList .btn:hover {
   color: $primary;
 }
+
+.discountList {
+  &-name {
+    max-width: 400px;
+  }
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig
@@ -33,7 +33,7 @@
   <tbody>
   {% for discount in discounts %}
     <tr>
-      <td>{{ discount.name }}</td>
+      <td class="discountList-name">{{ discount.name }}</td>
       <td>
         {% if discount.amountRaw.greaterThan(number(0)) %}-{% endif %}
         {{ discount.amountFormatted }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Discount name is not limited, this breaks the UI layout, now it can't go over 400px
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20631 .
| How to test?  | Check the issue, but go in order page, add a discount with a very big name and the UI should be fine

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21554)
<!-- Reviewable:end -->
