### PR TITLE
Fixed increment button when adding a product out of stock and with allow order

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
@@ -265,7 +265,10 @@ export default class ProductManager {
     const combination = this.selectedProduct.combinations[combinationId];
 
     this.selectedCombinationId = combinationId;
-    this.productRenderer.renderStock(combination.stock);
+    this.productRenderer.renderStock(
+      combination.stock,
+      this.selectedProduct.availableOutOfStock || (combination.stock <= 0)
+    );
 
     return combination;
   }

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
@@ -157,10 +157,10 @@ export default class ProductRenderer {
   /**
    * Renders available fields related to selected product
    *
-   * @param product
+   * @param {object} product
    */
   renderProductMetadata(product) {
-    this.renderStock(product.stock, product.stock === 0 && product.availableOutOfStock ? true : false);
+    this.renderStock(product.stock, product.availableOutOfStock ? true : (product.stock <= 0));
     this._renderCombinations(product.combinations);
     this._renderCustomizations(product.customizationFields);
   }
@@ -168,7 +168,8 @@ export default class ProductRenderer {
   /**
    * Updates stock text helper value
    *
-   * @param stock
+   * @param {number} stock
+   * @param {boolean} infinitMax
    */
   renderStock(stock, infinitMax) {
     $(createOrderMap.inStockCounter).text(stock);

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
@@ -160,7 +160,7 @@ export default class ProductRenderer {
    * @param {object} product
    */
   renderProductMetadata(product) {
-    this.renderStock(product.stock, product.availableOutOfStock ? true : (product.stock <= 0));
+    this.renderStock(product.stock, product.availableOutOfStock || (product.stock <= 0));
     this._renderCombinations(product.combinations);
     this._renderCustomizations(product.customizationFields);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fixed increment button when adding a product out of stock and with allow order
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21529 
| How to test?  | 0. Build assets<br>1. Go to BO => Catalog => Products page<br>2. Add a product with quantity **<** 0 with allow order selected<br>3. Go to BO => Orders => New Order page<br>4. Add the last product created<br>5. check the increment/decrement button<br>6. **BEFORE**see error => we can't increment the product quantity<br>6. **AFTER** We can increment the product quantity
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21555)
<!-- Reviewable:end -->
