### PR TITLE
Allow '+' in Base URI and show error when Base URI is invalid

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -87,9 +87,7 @@ class CookieCore
             $this->_path = '/' . $this->_path;
         }
         $this->_path = rawurlencode($this->_path);
-        $this->_path = str_replace('%2F', '/', $this->_path);
-        $this->_path = str_replace('%7E', '~', $this->_path);
-        $this->_path = str_replace('%2B', '+', $this->_path);
+        $this->_path = str_replace(['%2F', '%7E', '%2B', '%26'], ['/', '~', '+', '&'], $this->_path);
         $this->_domain = $this->getDomain($shared_urls);
         $this->_name = 'PrestaShop-' . md5(($this->_standalone ? '' : _PS_VERSION_) . $name . $this->_domain);
         $this->_allow_writing = true;

--- a/src/Adapter/Meta/ShopUrlDataConfiguration.php
+++ b/src/Adapter/Meta/ShopUrlDataConfiguration.php
@@ -89,12 +89,18 @@ final class ShopUrlDataConfiguration implements DataConfigurationInterface
 
         try {
             if ($this->validateConfiguration($configuration)) {
+                if (!$this->isValidUri($configuration['physical_uri'])) {
+                    return [
+                        [
+                            'key' => 'The Base URI is not valid.',
+                            'domain' => 'Admin.Shopparameters.Notification',
+                            'parameters' => [],
+                        ],
+                    ];
+                }
                 $this->mainShopUrl->domain = $configuration['domain'];
                 $this->mainShopUrl->domain_ssl = $configuration['domain_ssl'];
-
-                if (is_string($configuration['physical_uri'])) {
-                    $this->mainShopUrl->physical_uri = $configuration['physical_uri'];
-                }
+                $this->mainShopUrl->physical_uri = $configuration['physical_uri'];
 
                 $this->mainShopUrl->update();
 
@@ -116,8 +122,9 @@ final class ShopUrlDataConfiguration implements DataConfigurationInterface
     {
         return isset(
             $configuration['domain'],
-            $configuration['domain_ssl']
-        ) && $this->isValidUri($configuration['physical_uri']);
+            $configuration['domain_ssl'],
+            $configuration['physical_uri']
+        );
     }
 
     /**
@@ -129,6 +136,6 @@ final class ShopUrlDataConfiguration implements DataConfigurationInterface
      */
     private function isValidUri($uri)
     {
-        return preg_match('#^(?:[~\-_\/&\.]|\w|%\d+|\s)+$#', $uri);
+        return is_string($uri) && preg_match('#^(?:[~\-_\/&\.\+]|\w|%\d+|\s)+$#', $uri);
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -92,7 +92,7 @@
               </label>
               <div class="col-sm">
                 {{ form_errors(shopUrlsForm.physical_uri) }}
-                {{ form_widget(shopUrlsForm.physical_uri, {'required': false}) }}
+                {{ form_widget(shopUrlsForm.physical_uri) }}
               </div>
             </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since #20006 , it's now possible to have a "+" in the url of the shop but that change wasn't handled in the *Set shop URL* form. This PR fixes it and add an error message when the Base URI is invalid.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21560
| How to test?  | 1. Go to Configure > Shop Parameters > Traffic & SEO<br>2. In Set shop URL, change the Base URI for `/prestashop+dev/` and click Save -> It should work<br>3. Change the Base URI for `/prestashop!dev/` and click Save -> It should show an error message

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21563)
<!-- Reviewable:end -->
