### PR TITLE
Allow ContextStateManager to stash contexts

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -5098,4 +5098,21 @@ class CartCore extends ObjectModel
 
         return $products;
     }
+
+    /**
+     * @param Cart $cart
+     *
+     * @return Country
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function getTaxCountry(): Country
+    {
+        $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
+        $taxAddressId = property_exists($this, $taxAddressType) ? $this->{$taxAddressType} : $this->id_address_delivery;
+        $taxAddress = new Address($taxAddressId);
+
+        return new Country($taxAddress->id_country);
+    }
 }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -5100,8 +5100,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * @param Cart $cart
-     *
      * @return Country
      *
      * @throws \PrestaShopDatabaseException

--- a/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
@@ -85,18 +85,18 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
         $errorMessage = $this->validateCartRule($cartRule, $cart);
 
         if ($errorMessage) {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
 
             throw new CartRuleValidityException($errorMessage);
         }
 
         if (!$cart->addCartRule($cartRule->id)) {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
 
             throw new CartException('Failed to add cart rule to cart.');
         }
 
-        $this->contextStateManager->restoreContext();
+        $this->contextStateManager->restorePreviousContext();
     }
 
     /**

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -75,7 +75,7 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
         ]);
 
         $cart->update();
-        $this->contextStateManager->restoreContext();
+        $this->contextStateManager->restorePreviousContext();
     }
 
     /**

--- a/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
@@ -71,7 +71,7 @@ final class UpdateProductQuantityInCartHandler extends AbstractCartHandler imple
         try {
             $this->updateProductQuantityInCart($cart, $command);
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
     }
 

--- a/src/Adapter/Cart/QueryHandler/GetCartInformationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartInformationHandler.php
@@ -141,7 +141,7 @@ final class GetCartInformationHandler extends AbstractCartHandler implements Get
             $addresses ? $this->extractShippingFromLegacySummary($cart, $legacySummary) : null
         );
 
-        $this->contextStateManager->restoreContext();
+        $this->contextStateManager->restorePreviousContext();
 
         return $result;
     }

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -45,7 +45,7 @@ use Language;
  */
 final class ContextStateManager
 {
-    const MANAGED_FIELDS = [
+    private const MANAGED_FIELDS = [
         'cart',
         'country',
         'currency',

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -45,7 +45,7 @@ use Language;
  */
 final class ContextStateManager
 {
-    const MANAGE_CONTEXT_FIELDS = [
+    const MANAGED_FIELDS = [
         'cart',
         'country',
         'currency',
@@ -184,7 +184,7 @@ final class ContextStateManager
     public function saveCurrentContext(): self
     {
         // Saves all the fields that have not been overridden
-        foreach (self::MANAGE_CONTEXT_FIELDS as $contextField) {
+        foreach (self::MANAGED_FIELDS as $contextField) {
             $this->saveContextField($contextField);
         }
 

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -172,12 +172,12 @@ final class ContextStateManager
 
     /**
      * Saves the current overridden fields in the context, allowing you to set new values to the
-     * current Context. Next time you call restoreContext only newly modified fields are restored
-     * so you end up in the same state as when you called stashContext.
+     * current Context. Next time you call restorePreviousContext the context will be refilled with
+     * the values that were saved during this call.
      *
      * This is useful if several services use the ContextStateManager, this way if every service
-     * stashed the context before modifying it there is no risk of removing previous modifications
-     * when you restore the context because the different states have been stacked.
+     * saved the context before modifying it there is no risk of removing previous modifications
+     * when you restore the context, because the different states have been stacked.
      *
      * @return $this
      */

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -84,7 +84,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
         try {
             $this->addCartRuleAndUpdateOrder($command, $order);
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
     }
 

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -120,7 +120,7 @@ final class AddOrderFromBackOfficeHandler implements AddOrderFromBackOfficeHandl
         } catch (Exception $e) {
             throw new OrderException('Failed to add order. ' . $e->getMessage(), 0, $e);
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
 
         if (!$paymentModule->currentOrder) {

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -191,7 +191,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             $this->orderAmountUpdater->update($order, $cart, null !== $invoice ? (int) $invoice->id : null);
             Hook::exec('actionOrderEdited', ['order' => $order]);
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
     }
 

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -38,7 +38,6 @@ use Configuration;
 use Context;
 use Currency;
 use Customer;
-use Exception;
 use Hook;
 use Order;
 use OrderCarrier;
@@ -191,12 +190,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             // Update totals amount of order
             $this->orderAmountUpdater->update($order, $cart, null !== $invoice ? (int) $invoice->id : null);
             Hook::exec('actionOrderEdited', ['order' => $order]);
-        } catch (Exception $e) {
+        } finally {
             $this->contextStateManager->restoreContext();
-            throw $e;
         }
-
-        $this->contextStateManager->restoreContext();
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -126,7 +126,7 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
                 $this->orderAmountUpdater->update($order, $cart, $orderCartRule->id_order_invoice);
             }
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
     }
 

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 use Cart;
 use Currency;
 use Customer;
-use Exception;
 use Hook;
 use Order;
 use OrderDetail;
@@ -102,12 +101,9 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
             );
 
             Hook::exec('actionOrderEdited', ['order' => $order]);
-        } catch (Exception $e) {
-            $this->contextStateManager->restoreContext();
-            throw $e;
+        } finally {
+            $this->contextStateManager->restorePreviousContext();
         }
-
-        $this->contextStateManager->restoreContext();
     }
 
     /**

--- a/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
+++ b/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
@@ -70,11 +70,11 @@ final class DuplicateOrderCartHandler implements DuplicateOrderCartHandlerInterf
         $result = $cart->duplicate();
 
         if (false === $result || !isset($result['cart'])) {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
             throw new DuplicateOrderCartException(sprintf('Cannot duplicate cart from order "%s"', $command->getOrderId()->getValue()));
         }
 
-        $this->contextStateManager->restoreContext();
+        $this->contextStateManager->restorePreviousContext();
 
         return new CartId((int) $result['cart']->id);
     }

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -34,6 +34,8 @@ use Carrier;
 use Cart;
 use CartRule;
 use Currency;
+use Customer;
+use Language;
 use Order;
 use OrderCarrier;
 use OrderCartRule;
@@ -95,15 +97,67 @@ class OrderAmountUpdater
     ): void {
         $this->cleanCaches();
 
-        // @todo: use https://github.com/PrestaShop/decimal for price computations
-        $computingPrecision = $this->getPrecisionFromCart($cart);
+        $this->contextStateManager
+            ->stashContext()
+            ->setCart($cart)
+            ->setCurrency(new Currency($cart->id_currency))
+            ->setCustomer(new Customer($cart->id_customer))
+            ->setLanguage(new Language($cart->id_lang))
+            ->setCountry($cart->getTaxCountry())
+        ;
 
-        // Update order details (if quantity or product price have been modified)
-        $this->updateOrderDetails($order, $cart, $computingPrecision);
+        try {
+            // @todo: use https://github.com/PrestaShop/decimal for price computations
+            $computingPrecision = $this->getPrecisionFromCart($cart);
 
-        // Recalculate cart rules and Fix differences between cart's cartRules and order's cartRules
-        $this->updateOrderCartRules($order, $cart, $computingPrecision, $orderInvoiceId);
+            // Update order details (if quantity or product price have been modified)
+            $this->updateOrderDetails($order, $cart, $computingPrecision);
 
+            // Recalculate cart rules and Fix differences between cart's cartRules and order's cartRules
+            $this->updateOrderCartRules($order, $cart, $computingPrecision, $orderInvoiceId);
+
+            // Update order totals
+            $this->updateOrderTotals($order, $cart, $computingPrecision);
+
+            // Update carrier weight for shipping cost
+            $this->updateOrderCarrier($order, $cart);
+
+            // Order::update is called after previous functions so that we only call it once
+            if (!$order->update()) {
+                throw new OrderException('Could not update order invoice in database.');
+            }
+
+            $this->updateOrderInvoices($order, $cart, $computingPrecision);
+        } finally {
+            $this->contextStateManager->restoreContext();
+        }
+    }
+
+    /**
+     * There are many caches among legacy classes that can store previous prices
+     * we need to clean them to make sure the price is completely up to date
+     */
+    private function cleanCaches(): void
+    {
+        // For many intermediate computations
+        Cart::resetStaticCache();
+
+        // For discount computation
+        CartRule::resetStaticCache();
+        Cache::clean('getContextualValue_*');
+
+        // For shipping costs
+        Carrier::resetStaticCache();
+        Cache::clean('getPackageShippingCost_*');
+    }
+
+    /**
+     * @param Order $order
+     * @param Cart $cart
+     * @param int $computingPrecision
+     */
+    private function updateOrderTotals(Order $order, Cart $cart, int $computingPrecision): void
+    {
         $orderProducts = $order->getCartProducts();
 
         $carrierId = $order->id_carrier;
@@ -151,33 +205,6 @@ class OrderAmountUpdater
             $order->total_paid_tax_incl -= $shippingDiffTaxIncluded;
             $order->total_paid_tax_excl -= $shippingDiffTaxExcluded;
         }
-
-        // Update carrier weight for shipping cost
-        $this->updateOrderCarrier($order, $cart);
-
-        if (!$order->update()) {
-            throw new OrderException('Could not update order invoice in database.');
-        }
-
-        $this->updateOrderInvoices($order, $cart, $computingPrecision);
-    }
-
-    /**
-     * There are many caches among legacy classes that can store previous prices
-     * we need to clean them to make sure the price is completely up to date
-     */
-    private function cleanCaches(): void
-    {
-        // For many intermediate computations
-        Cart::resetStaticCache();
-
-        // For discount computation
-        CartRule::resetStaticCache();
-        Cache::clean('getContextualValue_*');
-
-        // For shipping costs
-        Carrier::resetStaticCache();
-        Cache::clean('getPackageShippingCost_*');
     }
 
     /**
@@ -322,7 +349,6 @@ class OrderAmountUpdater
         int $computingPrecision,
         ?int $orderInvoiceId
     ): void {
-        $this->contextStateManager->setCart($cart);
         CartRule::autoAddToCart();
         CartRule::autoRemoveFromCart();
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -98,7 +98,7 @@ class OrderAmountUpdater
         $this->cleanCaches();
 
         $this->contextStateManager
-            ->stashContext()
+            ->saveCurrentContext()
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
@@ -129,7 +129,7 @@ class OrderAmountUpdater
 
             $this->updateOrderInvoices($order, $cart, $computingPrecision);
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
     }
 

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -106,7 +106,7 @@ class OrderProductQuantityUpdater
         $cart = new Cart($order->id_cart);
 
         $this->contextStateManager
-            ->stashContext()
+            ->saveCurrentContext()
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
@@ -120,7 +120,7 @@ class OrderProductQuantityUpdater
             // Update prices on the order after cart rules are recomputed
             $this->orderAmountUpdater->update($order, $cart, null !== $orderInvoice ? (int) $orderInvoice->id : null);
         } finally {
-            $this->contextStateManager->restoreContext();
+            $this->contextStateManager->restorePreviousContext();
         }
 
         return $order;

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -108,6 +108,7 @@ class OrderProductQuantityUpdater
         $cart = new Cart($order->id_cart);
 
         $this->contextStateManager
+            ->stashContext()
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -28,11 +28,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
-use Address;
 use Cart;
 use Configuration;
 use Context;
-use Country;
 use Currency;
 use Customer;
 use Customization;
@@ -113,7 +111,7 @@ class OrderProductQuantityUpdater
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
             ->setLanguage(new Language($cart->id_lang))
-            ->setCountry($this->getTaxCountry($cart))
+            ->setCountry($cart->getTaxCountry())
         ;
 
         try {
@@ -450,23 +448,6 @@ class OrderProductQuantityUpdater
         if (!Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'customization` WHERE `quantity` = 0')) {
             throw new OrderException('Could not delete customization from database.');
         }
-    }
-
-    /**
-     * @param Cart $cart
-     *
-     * @return Country
-     *
-     * @throws \PrestaShopDatabaseException
-     * @throws \PrestaShopException
-     */
-    private function getTaxCountry(Cart $cart): Country
-    {
-        $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
-        $taxAddressId = property_exists($cart, $taxAddressType) ? $cart->{$taxAddressType} : $cart->id_address_delivery;
-        $taxAddress = new Address($taxAddressId);
-
-        return new Country($taxAddress->id_country);
     }
 
     /**

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -137,7 +137,7 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
             }
         }
 
-        $this->contextStateManager->restoreContext();
+        $this->contextStateManager->restorePreviousContext();
 
         return $foundProducts;
     }

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -133,6 +133,17 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     /**
      * This hook can be used to flag a scenario for database hard reset
      *
+     * @BeforeScenario @reset-database-before-scenario
+     */
+    public static function cleanDatabaseHardPrepareScenario()
+    {
+        DatabaseCreator::restoreTestDB();
+        require_once _PS_ROOT_DIR_ . '/config/config.inc.php';
+    }
+
+    /**
+     * This hook can be used to flag a scenario for database hard reset
+     *
      * @BeforeScenario @database-scenario
      */
     public function cleanDatabaseHardPrepare()

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -52,6 +52,13 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2        |
+      | product_price               | 119.00   |
+      | unit_price_tax_incl         | 126.14   |
+      | unit_price_tax_excl         | 119.00   |
+      | total_price_tax_incl        | 252.28   |
+      | total_price_tax_excl        | 238.00   |
 
   Scenario: Add cart rule of type 'amount' to an order with secondary currency
     Given I add discount to order "bo_order1" with following details:
@@ -226,6 +233,72 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_excl | 70.00    |
       | total_shipping_tax_incl | 74.20    |
 
+  Scenario: Change delivery address
+    Given I add new address to customer "testCustomer" with following details:
+      | Address alias    | test-customer-france-address |
+      | First name       | testFirstName                |
+      | Last name        | testLastName                 |
+      | Address          | 36 Avenue des Champs Elysees |
+      | City             | Paris                        |
+      | Country          | France                       |
+      | Postal code      | 75008                        |
+    And I change order "bo_order1" shipping address to "test-customer-france-address"
+    Then order "bo_order1" should have following details:
+      | total_products           | 238.00 |
+      | total_products_wt        | 238.00 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 308.00 |
+      | total_paid_tax_incl      | 308.00 |
+      | total_paid               | 308.00 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 70.00  |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 70.00 |
+      | shipping_cost_tax_incl | 70.00 |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 119.00 |
+      | unit_price_tax_incl         | 119.00 |
+      | unit_price_tax_excl         | 119.00 |
+      | total_price_tax_incl        | 238.00 |
+      | total_price_tax_excl        | 238.00 |
+
+  Scenario: Change invoice address
+    Given I add new address to customer "testCustomer" with following details:
+      | Address alias    | test-customer-france-address |
+      | First name       | testFirstName                |
+      | Last name        | testLastName                 |
+      | Address          | 36 Avenue des Champs Elysees |
+      | City             | Paris                        |
+      | Country          | France                       |
+      | Postal code      | 75008                        |
+    And I change order "bo_order1" invoice address to "test-customer-france-address"
+    Then order "bo_order1" should have following details:
+      | total_products           | 238.00 |
+      | total_products_wt        | 252.28 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 308.00 |
+      | total_paid_tax_incl      | 326.48 |
+      | total_paid               | 326.48 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 70.00 |
+      | shipping_cost_tax_incl | 74.20 |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 119.00 |
+      | unit_price_tax_incl         | 126.14 |
+      | unit_price_tax_excl         | 119.00 |
+      | total_price_tax_incl        | 252.28 |
+      | total_price_tax_excl        | 238.00 |
+
   Scenario: Carrier change for an order with secondary currency
     Given a carrier "default_carrier" with name "My carrier" exists
     And a carrier "price_carrier" with name "My cheap carrier" exists
@@ -251,8 +324,14 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 60.00  |
       | shipping_cost_tax_incl | 63.60  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2        |
+      | product_price               | 119.00   |
+      | unit_price_tax_incl         | 126.14   |
+      | unit_price_tax_excl         | 119.00   |
+      | total_price_tax_incl        | 252.28   |
+      | total_price_tax_excl        | 238.00   |
 
-    @currency-multi-gift
     @reset-database-before-scenario
     # We reset database before this scenario to be sure only default_carrier is enabled
     Scenario: I add the product with associated gift when the order already has the gift
@@ -337,6 +416,46 @@ Feature: Multiple currencies for Order in Back Office (BO)
         | unit_price_tax_excl         | 150.00 |
         | total_price_tax_incl        | 318.00 |
         | total_price_tax_excl        | 300.00 |
+      And product "Test Product With Auto Gift" in order "bo_order1" has following details:
+        | product_quantity            | 1      |
+        | product_price               | 120.00 |
+        | unit_price_tax_incl         | 127.20 |
+        | unit_price_tax_excl         | 120.00 |
+        | total_price_tax_incl        | 127.20 |
+        | total_price_tax_excl        | 120.00 |
+      When I remove cart rule "MultiGiftAutoCartRule" from order "bo_order1"
+      Then order "bo_order1" should have 4 products in total
+      And order "bo_order1" should have 0 invoice
+      And order "bo_order1" should have 0 cart rule
+      And order "bo_order1" should have following details:
+        | total_products           | 508.00 |
+        | total_products_wt        | 538.48 |
+        | total_discounts_tax_excl | 0.00   |
+        | total_discounts_tax_incl | 0.00   |
+        | total_paid_tax_excl      | 578.00 |
+        | total_paid_tax_incl      | 612.68 |
+        | total_paid               | 612.68 |
+        | total_paid_real          | 0.0    |
+        | total_shipping_tax_excl  | 70.00  |
+        | total_shipping_tax_incl  | 74.20  |
+      And order "bo_order1" carrier should have following details:
+        | weight                 | 0.600 |
+        | shipping_cost_tax_excl | 70.00 |
+        | shipping_cost_tax_incl | 74.20 |
+      And product "Mug The best is yet to come" in order "bo_order1" has following details:
+        | product_quantity            | 2      |
+        | product_price               | 119.00 |
+        | unit_price_tax_incl         | 126.14 |
+        | unit_price_tax_excl         | 119.00 |
+        | total_price_tax_incl        | 252.28 |
+        | total_price_tax_excl        | 238.00 |
+      And product "Test Product Gifted" in order "bo_order1" has following details:
+        | product_quantity            | 1      |
+        | product_price               | 150.00 |
+        | unit_price_tax_incl         | 159.00 |
+        | unit_price_tax_excl         | 150.00 |
+        | total_price_tax_incl        | 159.00 |
+        | total_price_tax_excl        | 150.00 |
       And product "Test Product With Auto Gift" in order "bo_order1" has following details:
         | product_quantity            | 1      |
         | product_price               | 120.00 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -251,3 +251,96 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | weight                 | 0.600 |
       | shipping_cost_tax_excl | 60.00  |
       | shipping_cost_tax_incl | 63.60  |
+
+    @currency-multi-gift
+    @reset-database-before-scenario
+    # We reset database before this scenario to be sure only default_carrier is enabled
+    Scenario: I add the product with associated gift when the order already has the gift
+      Given there is a product in the catalog named "Test Product With Auto Gift" with a price of 12.0 and 100 items in stock
+      And there is a product in the catalog named "Test Product Gifted" with a price of 15.0 and 100 items in stock
+      And there is a cart rule named "MultiGiftAutoCartRule" that applies an amount discount of 1.0 with priority 1, quantity of 100 and quantity per user 100
+      And cart rule "MultiGiftAutoCartRule" has no discount code
+      And cart rule "MultiGiftAutoCartRule" is restricted to product "Test Product With Auto Gift"
+      And cart rule "MultiGiftAutoCartRule" offers free shipping
+      And cart rule "MultiGiftAutoCartRule" offers a gift product "Test Product Gifted"
+      And I add products to order "bo_order1" with new invoice and the following products details:
+        | name          | Test Product Gifted |
+        | amount        | 1                   |
+        | price         | 150.0               |
+      Then order "bo_order1" should have 3 products in total
+      And order "bo_order1" should have 0 invoice
+      And order "bo_order1" should have 0 cart rule
+      And order "bo_order1" should have "default_carrier" as a carrier
+      And order "bo_order1" should have following details:
+        | total_products           | 388.00 |
+        | total_products_wt        | 411.28 |
+        | total_discounts_tax_excl | 0.0    |
+        | total_discounts_tax_incl | 0.0    |
+        | total_paid_tax_excl      | 458.00 |
+        | total_paid_tax_incl      | 485.48 |
+        | total_paid               | 485.48 |
+        | total_paid_real          | 0.0    |
+        | total_shipping_tax_excl  | 70.00  |
+        | total_shipping_tax_incl  | 74.20  |
+      And order "bo_order1" carrier should have following details:
+        | weight                 | 0.600 |
+        | shipping_cost_tax_excl | 70.00 |
+        | shipping_cost_tax_incl | 74.20 |
+      And product "Mug The best is yet to come" in order "bo_order1" has following details:
+        | product_quantity            | 2      |
+        | product_price               | 119.00 |
+        | unit_price_tax_incl         | 126.14 |
+        | unit_price_tax_excl         | 119.00 |
+        | total_price_tax_incl        | 252.28 |
+        | total_price_tax_excl        | 238.00 |
+      And product "Test Product Gifted" in order "bo_order1" has following details:
+        | product_quantity            | 1      |
+        | product_price               | 150.00 |
+        | unit_price_tax_incl         | 159.00 |
+        | unit_price_tax_excl         | 150.00 |
+        | total_price_tax_incl        | 159.00 |
+        | total_price_tax_excl        | 150.00 |
+      When I add products to order "bo_order1" with new invoice and the following products details:
+        | name          | Test Product With Auto Gift |
+        | amount        | 1                           |
+        | price         | 120.00                      |
+      Then order "bo_order1" should have 5 products in total
+      And order "bo_order1" should have 0 invoice
+      And order "bo_order1" should have 1 cart rule
+      And order "bo_order1" should have following details:
+        | total_products           | 658.00 |
+        | total_products_wt        | 697.48 |
+        | total_discounts_tax_excl | 230.0  |
+        | total_discounts_tax_incl | 243.80 |
+        | total_paid_tax_excl      | 498.00 |
+        | total_paid_tax_incl      | 527.88 |
+        | total_paid               | 527.88 |
+        | total_paid_real          | 0.0    |
+        | total_shipping_tax_excl  | 70.00  |
+        | total_shipping_tax_incl  | 74.20  |
+      And order "bo_order1" carrier should have following details:
+        | weight                 | 0.600 |
+        | shipping_cost_tax_excl | 70.00 |
+        | shipping_cost_tax_incl | 74.20 |
+      And order "bo_order1" should have cart rule "MultiGiftAutoCartRule" with amount "€230.00"
+      And product "Mug The best is yet to come" in order "bo_order1" has following details:
+        | product_quantity            | 2      |
+        | product_price               | 119.00 |
+        | unit_price_tax_incl         | 126.14 |
+        | unit_price_tax_excl         | 119.00 |
+        | total_price_tax_incl        | 252.28 |
+        | total_price_tax_excl        | 238.00 |
+      And product "Test Product Gifted" in order "bo_order1" has following details:
+        | product_quantity            | 2      |
+        | product_price               | 150.00 |
+        | unit_price_tax_incl         | 159.00 |
+        | unit_price_tax_excl         | 150.00 |
+        | total_price_tax_incl        | 318.00 |
+        | total_price_tax_excl        | 300.00 |
+      And product "Test Product With Auto Gift" in order "bo_order1" has following details:
+        | product_quantity            | 1      |
+        | product_price               | 120.00 |
+        | unit_price_tax_incl         | 127.20 |
+        | unit_price_tax_excl         | 120.00 |
+        | total_price_tax_incl        | 127.20 |
+        | total_price_tax_excl        | 120.00 |

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -185,7 +185,7 @@ class ContextStateManagerTest extends TestCase
         $this->assertEquals(42, $context->language->id);
     }
 
-    public function testStashedState()
+    public function testSavedContexts()
     {
         $context = $this->createContextMock([
             'language' => $this->createContextFieldMock(Language::class, 42),
@@ -209,9 +209,21 @@ class ContextStateManagerTest extends TestCase
 
         $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->language->id);
+
+        // If several sets have been called, the state returns to the value that was saved
+        $contextStateManager->saveCurrentContext();
+
+        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+        $this->assertEquals(51, $context->language->id);
+
+        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+        $this->assertEquals(69, $context->language->id);
+
+        $contextStateManager->restorePreviousContext();
+        $this->assertEquals(42, $context->language->id);
     }
 
-    public function testMultipleStashedFields()
+    public function testMultipleSavedContextFieds()
     {
         $context = $this->createContextMock([
             'cart' => $this->createContextFieldMock(Cart::class, 42),
@@ -269,7 +281,7 @@ class ContextStateManagerTest extends TestCase
         $this->assertEquals(42, $context->language->id);
     }
 
-    public function testTooManyrestores()
+    public function testTooManyRestore()
     {
         $context = $this->createContextMock([
             'language' => $this->createContextFieldMock(Language::class, 42),

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -52,7 +52,7 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 69));
         $this->assertEquals(69, $context->cart->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->cart->id);
     }
 
@@ -70,7 +70,7 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 69));
         $this->assertEquals(69, $context->country->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->country->id);
     }
 
@@ -88,7 +88,7 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 69));
         $this->assertEquals(69, $context->currency->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->currency->id);
     }
 
@@ -106,7 +106,7 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 69));
         $this->assertEquals(69, $context->customer->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->customer->id);
     }
 
@@ -124,7 +124,7 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
         $this->assertEquals(69, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->language->id);
     }
 
@@ -142,7 +142,7 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
         $this->assertEquals(69, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertNull($context->language);
     }
 
@@ -176,7 +176,7 @@ class ContextStateManagerTest extends TestCase
         $this->assertEquals(51, $context->customer->id);
         $this->assertEquals(51, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
 
         $this->assertEquals(42, $context->cart->id);
         $this->assertEquals(42, $context->country->id);
@@ -199,15 +199,15 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
         $this->assertEquals(69, $context->language->id);
 
-        $contextStateManager->stashContext();
+        $contextStateManager->saveCurrentContext();
 
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
         $this->assertEquals(93, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(69, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->language->id);
     }
 
@@ -239,7 +239,7 @@ class ContextStateManagerTest extends TestCase
         $this->assertEquals(51, $context->customer->id);
         $this->assertEquals(42, $context->language->id);
 
-        $contextStateManager->stashContext();
+        $contextStateManager->saveCurrentContext();
 
         $contextStateManager
             ->setCart($this->createContextFieldMock(Cart::class, 69))
@@ -252,7 +252,7 @@ class ContextStateManagerTest extends TestCase
         $this->assertEquals(51, $context->customer->id);
         $this->assertEquals(42, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
 
         $this->assertEquals(51, $context->cart->id);
         $this->assertEquals(42, $context->country->id);
@@ -260,7 +260,7 @@ class ContextStateManagerTest extends TestCase
         $this->assertEquals(51, $context->customer->id);
         $this->assertEquals(42, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
 
         $this->assertEquals(42, $context->cart->id);
         $this->assertEquals(42, $context->country->id);
@@ -283,25 +283,25 @@ class ContextStateManagerTest extends TestCase
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
         $this->assertEquals(69, $context->language->id);
 
-        $contextStateManager->stashContext();
+        $contextStateManager->saveCurrentContext();
 
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
         $this->assertEquals(93, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(69, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->language->id);
 
         // This removes all persisted states, but we always re-init one for future calls
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->language->id);
 
         $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
         $this->assertEquals(93, $context->language->id);
 
-        $contextStateManager->restoreContext();
+        $contextStateManager->restorePreviousContext();
         $this->assertEquals(42, $context->language->id);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | This bug was due to a specific case but it could have happen in other occasions in the future. We were in a specific case where one service `OrderProductQuantityUpdater` use the `ContextStateManager` whereas it is usually only used in the handlers. The result is that when the service restored the context at the end of this method it reset the Context's fields that were previously overridden by the handler (here the currency). So in the final call from the handler the Context was no longer correctly overridden. We could have removed the `ContextStateManager` from the service and move it to the Handler layer at all times, however this meant relying on a convention, and it still didn't solve another potential issue in the future. What if two services use the `ContextStateManager` in subsequent calls, how can you prevent the context overridden by one to be reset by the latter ? The solution added here is to save the changed fields in a stack each time `stashContext` is called, this way when `restoreContext` is called it restores the context to the previous state not the initial one
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21566
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21574)
<!-- Reviewable:end -->
