### PR TITLE
No alert displayed when changing the status with bulk action in legacy controllers

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4176,10 +4176,10 @@ class AdminControllerCore extends Controller
                 /** @var ObjectModel $object */
                 $object = new $this->className((int) $id);
                 $object->active = (int) $status;
-                $update_ok = $object->update();
-                $result &= $update_ok;
+                $isUpdated = (bool) $object->update();
+                $result &= $isUpdated;
 
-                if (!$update_ok) {
+                if (!$isUpdated) {
                     $this->errors[] = $this->trans('Can\'t update #%id% status', ['%id%' => (int) $id], 'Admin.Notifications.Error');
                 }
             }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4190,7 +4190,7 @@ class AdminControllerCore extends Controller
                 $this->errors[] = $this->trans('An error occurred while updating the status.', [], 'Admin.Notifications.Error');
             }
         } else {
-            $this->errors[] = $this->trans('You must select at least one element to perform a bulk action.', [], 'Admin.Notifications.Error');
+            $this->errors[] = $this->trans('You need to select at least one item to use the bulk action.', [], 'Admin.Notifications.Error');
         }
 
         return $result;

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4186,9 +4186,9 @@ class AdminControllerCore extends Controller
 
             if ($result) {
                 $this->redirect_after = self::$currentIndex . '&conf=5&token=' . $this->token;
+            } else {
+                $this->errors[] = $this->trans('An error occurred while updating the status.', [], 'Admin.Notifications.Error');
             }
-
-            $this->errors[] = $this->trans('An error occurred while updating the status.', [], 'Admin.Notifications.Error');
         } else {
             $this->errors[] = $this->trans('You must select at least one element to perform a bulk action.', [], 'Admin.Notifications.Error');
         }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4176,8 +4176,21 @@ class AdminControllerCore extends Controller
                 /** @var ObjectModel $object */
                 $object = new $this->className((int) $id);
                 $object->active = (int) $status;
-                $result &= $object->update();
+                $update_ok = $object->update();
+                $result &= $update_ok;
+
+                if (!$update_ok) {
+                    $this->errors[] = $this->trans('Can\'t update #%id% status', ['%id%' => (int) $id], 'Admin.Notifications.Error');
+                }
             }
+
+            if ($result) {
+                $this->redirect_after = self::$currentIndex . '&conf=5&token=' . $this->token;
+            }
+
+            $this->errors[] = $this->trans('An error occurred while updating the status.', [], 'Admin.Notifications.Error');
+        } else {
+            $this->errors[] = $this->trans('You must select at least one element to perform a bulk action.', [], 'Admin.Notifications.Error');
         }
 
         return $result;

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -530,7 +530,7 @@ class AdminCarriersControllerCore extends AdminController
         if (!$carrier->update()) {
             $this->errors[] = $this->trans('An error occurred while updating carrier information.', [], 'Admin.Shipping.Notification');
         }
-        Tools::redirectAdmin(self::$currentIndex . '&token=' . $this->token);
+        Tools::redirectAdmin(self::$currentIndex . '&conf=5&token=' . $this->token);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | No alert displayed when changing the status with bulk action in legacy controllers.
| Type?         | bug fix
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21571
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/21571 by @khouloudbelguith .

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21576)
<!-- Reviewable:end -->
