### PR TITLE
Payment > Preferences - Update message in all shops or in a group context

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig
@@ -32,7 +32,7 @@
         {% if not isSingleShopContext %}
           <div class="alert alert-warning" role="alert">
             <p class="alert-text">
-              {{ 'You have more than one shop and must select one to configure payment.'|trans({}, 'Admin.Payment.Notification') }}
+              {{ 'Note that this page is available in a single shop context only. Switch context to work on it.'|trans({}, 'Admin.Payment.Notification') }}
             </p>
           </div>
         {% elseif paymentModulesCount == 0 %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Payment > Preferences - Update message in all shops or in a group context
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes #19426
| How to test?  | Enable multistore, create a second shop, go to Payment > Preferences, select all shops context / a group context and verify if the message displayed is "Note that this page is available in a single shop context only. Switch context to work on it."

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21583)
<!-- Reviewable:end -->
