### PR TITLE
Make PrestaShop compatible with composer 2.0

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -32,13 +32,13 @@ class AddressFormatCore extends ObjectModel
 {
     const FORMAT_NEW_LINE = "\n";
 
-    /** @var int $id_address_format Address format */
+    /** @var int Address format */
     public $id_address_format;
 
-    /** @var int $id_country Country ID */
+    /** @var int Country ID */
     public $id_country;
 
-    /** @var string $format Format */
+    /** @var string Format */
     public $format;
 
     protected $_errorFormatList = [];

--- a/classes/Attribute.php
+++ b/classes/Attribute.php
@@ -34,9 +34,9 @@ class AttributeCore extends ObjectModel
 
     /** @var string Name */
     public $name;
-    /** @var string $color */
+    /** @var string */
     public $color;
-    /** @var int $position */
+    /** @var int */
     public $position;
     /** @todo Find type */
     public $default;
@@ -58,10 +58,10 @@ class AttributeCore extends ObjectModel
         ],
     ];
 
-    /** @var string $image_dir */
+    /** @var string */
     protected $image_dir = _PS_COL_IMG_DIR_;
 
-    /** @var array $webserviceParameters Web service parameters */
+    /** @var array Web service parameters */
     protected $webserviceParameters = [
         'objectsNodeName' => 'product_option_values',
         'objectNodeName' => 'product_option_value',

--- a/classes/AttributeGroup.php
+++ b/classes/AttributeGroup.php
@@ -31,11 +31,11 @@ class AttributeGroupCore extends ObjectModel
 {
     /** @var string Name */
     public $name;
-    /** @var bool $is_color_group Whether the attribute group is a color group */
+    /** @var bool Whether the attribute group is a color group */
     public $is_color_group;
-    /** @var int $position Position */
+    /** @var int Position */
     public $position;
-    /** @var string $group_type Group type */
+    /** @var string Group type */
     public $group_type;
 
     /** @var string Public Name */
@@ -59,7 +59,7 @@ class AttributeGroupCore extends ObjectModel
         ],
     ];
 
-    /** @var array $webserviceParameters Web service parameters */
+    /** @var array Web service parameters */
     protected $webserviceParameters = [
         'objectsNodeName' => 'product_options',
         'objectNodeName' => 'product_option',

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -140,7 +140,7 @@ class CartCore extends ObjectModel
         ],
     ];
 
-    /** @var array $webserviceParameters Web service parameters */
+    /** @var array Web service parameters */
     protected $webserviceParameters = [
         'fields' => [
             'id_address_delivery' => ['xlink_resource' => 'addresses'],

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -29,12 +29,12 @@
  */
 class CombinationCore extends ObjectModel
 {
-    /** @var int $id_product Product ID */
+    /** @var int Product ID */
     public $id_product;
 
     public $reference;
 
-    /** @var string $supplier_reference */
+    /** @var string */
     public $supplier_reference;
 
     public $location;

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -250,6 +250,7 @@ class ConfigurationTestCore
         $dir = rtrim(_PS_ROOT_DIR_, '\\/') . DIRECTORY_SEPARATOR . trim($relative_dir, '\\/');
         if (!file_exists($dir) || !$dh = @opendir($dir)) {
             $full_report = sprintf('Directory %s does not exist or is not writable', $dir); // sprintf for future translation
+
             return false;
         }
         closedir($dh);
@@ -261,6 +262,7 @@ class ConfigurationTestCore
             }
         } elseif (!is_writable($dir)) {
             $full_report = sprintf('Directory %s is not writable', $dir); // sprintf for future translation
+
             return false;
         }
 

--- a/classes/Connection.php
+++ b/classes/Connection.php
@@ -29,25 +29,25 @@
  */
 class ConnectionCore extends ObjectModel
 {
-    /** @var int $id_guest */
+    /** @var int */
     public $id_guest;
 
-    /** @var int $id_page */
+    /** @var int */
     public $id_page;
 
-    /** @var string $ip_address */
+    /** @var string */
     public $ip_address;
 
-    /** @var string $http_referer */
+    /** @var string */
     public $http_referer;
 
-    /** @var int $id_shop */
+    /** @var int */
     public $id_shop;
 
-    /** @var int $id_shop_group */
+    /** @var int */
     public $id_shop_group;
 
-    /** @var string $date_add */
+    /** @var string */
     public $date_add;
 
     /**

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -63,7 +63,7 @@ class ContextCore
     /** @var AdminController|FrontController */
     public $controller;
 
-    /** @var string $override_controller_name_for_translations */
+    /** @var string */
     public $override_controller_name_for_translations;
 
     /** @var Language */

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -31,13 +31,13 @@ use PrestaShop\PrestaShop\Adapter\ServiceLocator;
  */
 class CustomerCore extends ObjectModel
 {
-    /** @var int $id Customer ID */
+    /** @var int Customer ID */
     public $id;
 
-    /** @var int $id_shop Shop ID */
+    /** @var int Shop ID */
     public $id_shop;
 
-    /** @var int $id_shop_group ShopGroup ID */
+    /** @var int ShopGroup ID */
     public $id_shop_group;
 
     /** @var string Secure key */

--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -36,28 +36,28 @@ class CustomerMessageCore extends ObjectModel
     /** @var   */
     public $id_employee;
 
-    /** @var string $message */
+    /** @var string */
     public $message;
 
-    /** @var string $file_name */
+    /** @var string */
     public $file_name;
 
-    /** @var string $ip_address */
+    /** @var string */
     public $ip_address;
 
-    /** @var string $user_agent */
+    /** @var string */
     public $user_agent;
 
-    /** @var int $private */
+    /** @var int */
     public $private;
 
-    /** @var string $date_add */
+    /** @var string */
     public $date_add;
 
-    /** @var string $date_upd */
+    /** @var string */
     public $date_upd;
 
-    /** @var bool $read */
+    /** @var bool */
     public $read;
 
     /**
@@ -80,7 +80,7 @@ class CustomerMessageCore extends ObjectModel
         ],
     ];
 
-    /** @var array $webserviceParameters */
+    /** @var array */
     protected $webserviceParameters = [
         'fields' => [
             'id_employee' => [

--- a/classes/CustomizationField.php
+++ b/classes/CustomizationField.php
@@ -63,7 +63,7 @@ class CustomizationFieldCore extends ObjectModel
         ],
     ];
 
-    /** @var array $webserviceParameters */
+    /** @var array */
     protected $webserviceParameters = [
         'fields' => [
             'id_product' => [

--- a/classes/DateRange.php
+++ b/classes/DateRange.php
@@ -29,10 +29,10 @@
  */
 class DateRangeCore extends ObjectModel
 {
-    /** @var string $time_start */
+    /** @var string */
     public $time_start;
 
-    /** @var string $time_end */
+    /** @var string */
     public $time_end;
 
     /**

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Core\Crypto\Hashing;
  */
 class EmployeeCore extends ObjectModel
 {
-    /** @var int $id Employee ID */
+    /** @var int Employee ID */
     public $id;
 
     /** @var string Determine employee profile */

--- a/classes/Feature.php
+++ b/classes/Feature.php
@@ -32,7 +32,7 @@ class FeatureCore extends ObjectModel
     /** @var string Name */
     public $name;
 
-    /** @var int $position */
+    /** @var int */
     public $position;
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-/**
+/*
  * @deprecated 1.5.0.1
  */
 define('_CUSTOMIZE_FILE_', 0);

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-/**
+/*
  * @deprecated This const is deprecated you should use the configuration variable instead Configuration::get('PS_SEARCH_MAX_WORD_LENGTH')
  */
 define('PS_SEARCH_MAX_WORD_LENGTH', 30);

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -103,7 +103,7 @@ class AdminControllerCore extends Controller
     /** @var string "shop" or "group_shop" */
     public $shopLinkType;
 
-    /** @var string Default ORDER BY clause when $_orderBy is not defined */
+    /** @var string Default ORDER BY clause when `$_orderBy` is not defined */
     protected $_defaultOrderBy = false;
 
     /** @var string */
@@ -157,7 +157,7 @@ class AdminControllerCore extends Controller
     /** @var array Edit form to be generated */
     protected $fields_form;
 
-    /** @var array Override of $fields_form */
+    /** @var array Override of `$fields_form` */
     protected $fields_form_override;
 
     /** @var string Override form action */

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -118,7 +118,7 @@ class FrontControllerCore extends Controller
     /** @var bool If true, forces display to maintenance page. */
     protected $maintenance = false;
 
-    /** @var string[] Adds excluded $_GET keys for redirection */
+    /** @var string[] Adds excluded `$_GET` keys for redirection */
     protected $redirectionExtraExcludedKeys = [];
 
     /**

--- a/classes/helper/HelperForm.php
+++ b/classes/helper/HelperForm.php
@@ -25,7 +25,7 @@
  */
  use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 
- /**
+/**
  * @since 1.5.0
  */
 class HelperFormCore extends Helper

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -55,7 +55,7 @@ class HelperListCore extends Helper
     /** @var string ORDER BY clause determined by field/arrows in list header */
     public $orderBy;
 
-    /** @var string Default ORDER BY clause when $orderBy is not defined */
+    /** @var string Default ORDER BY clause when `$orderBy` is not defined */
     public $_defaultOrderBy = false;
 
     /** @var array : list of vars for button delete */
@@ -68,7 +68,7 @@ class HelperListCore extends Helper
 
     protected $deleted = 0;
 
-    /** @var array $cache_lang use to cache texts in current language */
+    /** @var array use to cache texts in current language */
     public static $cache_lang = [];
 
     public $is_cms = false;

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -149,7 +149,7 @@ class OrderDetailCore extends ObjectModel
      */
     public $tax_rate;
 
-    /** @var float $tax_computation_method * */
+    /** @var float */
     public $tax_computation_method;
 
     /** @var int Id tax rules group */

--- a/composer.lock
+++ b/composer.lock
@@ -8248,16 +8248,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.16.1",
+            "version": "v2.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "c8afb599858876e95e8ebfcd97812d383fa23f02"
+                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/c8afb599858876e95e8ebfcd97812d383fa23f02",
-                "reference": "c8afb599858876e95e8ebfcd97812d383fa23f02",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1023c3458137ab052f6ff1e09621a721bfdeca13",
+                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13",
                 "shasum": ""
             },
             "require": {
@@ -8289,11 +8289,12 @@
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
                 "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
                 "phpunitgoodpractices/traits": "^1.8",
-                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/phpunit-bridge": "^5.1",
                 "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
-                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters.",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
                 "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
@@ -8315,6 +8316,7 @@
                     "tests/Test/IntegrationCaseFactory.php",
                     "tests/Test/IntegrationCaseFactoryInterface.php",
                     "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/Test/IsIdenticalConstraint.php",
                     "tests/TestCase.php"
                 ]
             },
@@ -8333,7 +8335,17 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-11-25T22:10:32+00:00"
+            "support": {
+                "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-06-27T23:57:46+00:00"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/composer.lock
+++ b/composer.lock
@@ -118,28 +118,31 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.7.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "141b272484481432cda342727a427dc1e206bfa0"
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/141b272484481432cda342727a427dc1e206bfa0",
-                "reference": "141b272484481432cda342727a427dc1e206bfa0",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
@@ -175,6 +178,7 @@
                 "Kanboard",
                 "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
                 "Maya",
                 "OXID",
@@ -229,6 +233,7 @@
                 "shopware",
                 "silverstripe",
                 "sydes",
+                "sylius",
                 "symfony",
                 "typo3",
                 "wordpress",
@@ -236,7 +241,21 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2019-08-12T15:00:31+00:00"
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
         },
         {
             "name": "csa/guzzle-bundle",
@@ -8228,38 +8247,6 @@
             "time": "2019-11-06T16:40:04+00:00"
         },
         {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
-        {
             "name": "friendsofphp/php-cs-fixer",
             "version": "v2.16.1",
             "source": {
@@ -9994,5 +9981,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.3"
-    }
+    },
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Adapter/Contact/CommandHandler/EditContactHandler.php
+++ b/src/Adapter/Contact/CommandHandler/EditContactHandler.php
@@ -36,7 +36,6 @@ use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\CannotUpdateContactExcep
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactException;
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactNotFoundException;
-use PrestaShop\PrestaShop\Core\Domain\Contact\ValueObject\ContactId;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -43,7 +43,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\VoucherRefundType;
 use PrestaShopDatabaseException;
 use PrestaShopException;
-use Product;
 use StockAvailable;
 use Symfony\Component\Translation\TranslatorInterface;
 use TaxCalculator;

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -64,6 +64,7 @@ class ModulePresenter implements PresenterInterface
         $attributes['picos'] = $this->addPicos($attributes);
         $attributes['price'] = $this->getModulePrice($attributes['price']);
         $attributes['starsRate'] = str_replace('.', '', round($attributes['avgRate'] * 2) / 2); // Round to the nearest 0.5
+
         return [
             'attributes' => $attributes,
             'disk' => $module->disk->all(),

--- a/src/Core/Domain/Address/QueryResult/EditableManufacturerAddress.php
+++ b/src/Core/Domain/Address/QueryResult/EditableManufacturerAddress.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Address\QueryResult;
 
 use PrestaShop\PrestaShop\Core\Domain\Address\ValueObject\AddressId;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 
 /**
  * Transfers manufacturer address data for editing

--- a/src/Core/Hook/Generator/HookDescriptionGenerator.php
+++ b/src/Core/Hook/Generator/HookDescriptionGenerator.php
@@ -27,9 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Hook\Generator;
 
 use PrestaShop\PrestaShop\Core\Hook\HookDescription;
-use PrestaShop\PrestaShop\Core\Util\String\StringModifier;
 use PrestaShop\PrestaShop\Core\Util\String\StringModifierInterface;
-use PrestaShop\PrestaShop\Core\Util\String\StringValidator;
 use PrestaShop\PrestaShop\Core\Util\String\StringValidatorInterface;
 
 /**

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -38,7 +38,7 @@ use Tools;
  */
 class LogoUploader
 {
-    /** @var $shop the shop */
+    /** @var the shop */
     private $shop;
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -42,7 +42,6 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidEmployeeIdExcept
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\MissingShopAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeForEditing;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;

--- a/tests/Integration/Behaviour/Features/Context/Util/CategoryTreeIterator.php
+++ b/tests/Integration/Behaviour/Features/Context/Util/CategoryTreeIterator.php
@@ -26,8 +26,6 @@
 
 namespace Tests\Integration\Behaviour\Features\Context\Util;
 
-use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CategoryTreeChoiceProvider;
-
 class CategoryTreeIterator
 {
     public const ROOT_CATEGORY_ID = 1;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Now that composer 2.0 is released, we can't use it on PrestaShop because we're using an incompatible dependency ([composer/installers](https://packagist.org/packages/composer/installers)). This PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Try `composer install` with both composer 1.x & composer 2.0. You shouldn't get any error.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21609)
<!-- Reviewable:end -->
