### PR TITLE
Add swipe on product images on mobile

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -796,6 +796,10 @@
       padding: 1.875rem;
     }
   }
+
+  .product-images > li.thumb-container > .thumb:not(.selected) {
+    border: none;
+  }
 }
 
 @include media-breakpoint-down(sm) {

--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -54,11 +54,42 @@ $(document).ready(function () {
   });
 
   function coverImage() {
+    const productCover = $(prestashop.themeSelectors.product.cover);
+    let thumbSelected = $(prestashop.themeSelectors.product.selected);
+
+    const swipe = (selectedThumb, thumbParent) => {
+      const newSelectedThumb = thumbParent.find(prestashop.themeSelectors.product.thumb);
+
+      $(prestashop.themeSelectors.product.modalProductCover).attr('src', newSelectedThumb.data('image-large-src'));
+      selectedThumb.removeClass('selected');
+      newSelectedThumb.addClass('selected');
+      productCover.prop('src', newSelectedThumb.data('image-large-src'));
+    };
+
     $(prestashop.themeSelectors.product.thumb).on('click', (event) => {
-      $(prestashop.themeSelectors.product.modalProductCover).attr('src', $(event.target).data('image-large-src'));
-      $(prestashop.themeSelectors.product.selected).removeClass('selected');
-      $(event.target).addClass('selected');
-      $(prestashop.themeSelectors.product.cover).prop('src', $(event.currentTarget).data('image-large-src'));
+      thumbSelected = $(prestashop.themeSelectors.product.selected);
+      swipe(thumbSelected, $(event.target).closest(prestashop.themeSelectors.product.thumbContainer));
+    });
+
+    productCover.swipe({
+      swipe: (event, direction) => {
+        thumbSelected = $(prestashop.themeSelectors.product.selected);
+        const parentThumb = thumbSelected.closest(prestashop.themeSelectors.product.thumbContainer);
+
+        if (direction === 'right') {
+          if (parentThumb.prev().length > 0) {
+            swipe(thumbSelected, parentThumb.prev());
+          } else if (parentThumb.next().length > 0) {
+            swipe(thumbSelected, parentThumb.next());
+          }
+        } else if (direction === 'left') {
+          if (parentThumb.next().length > 0) {
+            swipe(thumbSelected, parentThumb.next());
+          } else if (parentThumb.prev().length > 0) {
+            swipe(thumbSelected, parentThumb.prev());
+          }
+        }
+      },
     });
   }
 

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -30,6 +30,7 @@ prestashop.themeSelectors = {
     activeTabs: '.tabs .nav-link.active',
     imagesModal: '.js-product-images-modal',
     thumb: '.js-thumb',
+    thumbContainer: '.thumb-container',
     arrows: '.js-arrows',
     selected: '.selected',
     modalProductCover: '.js-modal-product-cover',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We wants our customers to be able to swipe between images instead of clicking on thumbnails, this is more UX
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20431.
| How to test?  | Go on product page with multiple images on mobile mode, try to swipe between images

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21611)
<!-- Reviewable:end -->
