### PR TITLE
Add selected combinations value inside product page

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -26,7 +26,7 @@
   {foreach from=$groups key=id_attribute_group item=group}
     {if !empty($group.attributes)}
     <div class="clearfix product-variants-item">
-      <span class="control-label">{$group.name} : 
+      <span class="control-label">{$group.name}{l s=': ' d='Shop.Theme.Catalog'}
           {foreach from=$group.attributes key=id_attribute item=group_attribute}
             {if $group_attribute.selected}{$group_attribute.name}{/if}
           {/foreach}

--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -26,7 +26,11 @@
   {foreach from=$groups key=id_attribute_group item=group}
     {if !empty($group.attributes)}
     <div class="clearfix product-variants-item">
-      <span class="control-label">{$group.name}</span>
+      <span class="control-label">{$group.name} : 
+          {foreach from=$group.attributes key=id_attribute item=group_attribute}
+            {if $group_attribute.selected}{$group_attribute.name}{/if}
+          {/foreach}
+      </span>
       {if $group.group_type == 'select'}
         <select
           class="form-control form-control-select"

--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -26,7 +26,7 @@
   {foreach from=$groups key=id_attribute_group item=group}
     {if !empty($group.attributes)}
     <div class="clearfix product-variants-item">
-      <span class="control-label">{$group.name}{l s=': ' d='Shop.Theme.Catalog'}
+      <span class="control-label">{$group.name}{l s=': ' d='Shop.Pdf'}
           {foreach from=$group.attributes key=id_attribute item=group_attribute}
             {if $group_attribute.selected}{$group_attribute.name}{/if}
           {/foreach}

--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -26,7 +26,7 @@
   {foreach from=$groups key=id_attribute_group item=group}
     {if !empty($group.attributes)}
     <div class="clearfix product-variants-item">
-      <span class="control-label">{$group.name}{l s=': ' d='Shop.Pdf'}
+      <span class="control-label">{$group.name}{l s=': ' d='Shop.Theme.Catalog'}
           {foreach from=$group.attributes key=id_attribute item=group_attribute}
             {if $group_attribute.selected}{$group_attribute.name}{/if}
           {/foreach}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Colorblind peoples sometimes can't see which combinations they've selected, adding it as a text is a way to help them.
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21006.
| How to test?  | Go on a product page with color combination, select and more, select a color, you should see the selected text value after the label

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21612)
<!-- Reviewable:end -->
