### PR TITLE
Fix webservice accessory xlink href

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -615,7 +615,7 @@ class ProductCore extends ObjectModel
                 'fields' => [
                     'id' => [
                         'required' => true,
-                        'xlink_resource' => 'product', ],
+                        'xlink_resource' => 'products', ],
                 ],
             ],
             'product_bundle' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix the wrong accessory xlink href on webservice product responses
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? |o
| How to test?  | Old xlink is 404, new one is correct

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21613)
<!-- Reviewable:end -->
