### PR TITLE
Do not use the cache when checking if data exists in the database (Part 1)

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -442,15 +442,12 @@ class AddressCore extends ObjectModel
      */
     public static function addressExists($id_address)
     {
-        $key = 'address_exists_' . (int) $id_address;
-        if (!Cache::isStored($key)) {
-            $id_address = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('SELECT `id_address` FROM ' . _DB_PREFIX_ . 'address a WHERE a.`id_address` = ' . (int) $id_address);
-            Cache::store($key, (bool) $id_address);
-
-            return (bool) $id_address;
-        }
-
-        return Cache::retrieve($key);
+        return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+            'SELECT `id_address` 
+            FROM ' . _DB_PREFIX_ . 'address a 
+            WHERE a.`id_address` = ' . (int) $id_address,
+            false
+        );
     }
 
     /**
@@ -608,7 +605,7 @@ class AddressCore extends ObjectModel
         $query->where('id_customer = ' . (int) $id_customer);
         $query->where('deleted = 0');
 
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query, false);
     }
 
     /**

--- a/classes/Alias.php
+++ b/classes/Alias.php
@@ -164,7 +164,7 @@ class AliasCore extends ObjectModel
         $sql->select('a.`id_alias`');
         $sql->from('alias', 'a');
         $sql->where('a.`id_alias` = ' . (int) $idAlias);
-        $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql);
+        $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql, false);
 
         return isset($row['id_alias']);
     }

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -587,7 +587,7 @@ class CartRuleCore extends ObjectModel
         return (bool) Db::getInstance()->getValue('
 		SELECT `id_cart_rule`
 		FROM `' . _DB_PREFIX_ . 'cart_rule`
-		WHERE `code` = \'' . pSQL($code) . '\'');
+		WHERE `code` = \'' . pSQL($code) . '\'', false);
     }
 
     /**

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1601,7 +1601,7 @@ class CategoryCore extends ObjectModel
         $row = Db::getInstance()->getRow('
 		SELECT `id_category`
 		FROM ' . _DB_PREFIX_ . 'category c
-		WHERE c.`id_category` = ' . (int) $idCategory);
+		WHERE c.`id_category` = ' . (int) $idCategory, false);
 
         return isset($row['id_category']);
     }
@@ -2438,6 +2438,6 @@ class CategoryCore extends ObjectModel
 		SELECT `id_category`
 		FROM `' . _DB_PREFIX_ . 'category_shop`
 		WHERE `id_category` = ' . (int) $this->id . '
-		AND `id_shop` = ' . (int) $idShop);
+		AND `id_shop` = ' . (int) $idShop, false);
     }
 }

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -587,7 +587,7 @@ class CustomerCore extends ObjectModel
         FROM `' . _DB_PREFIX_ . 'customer`
         WHERE `email` = \'' . pSQL($email) . '\'
         ' . Shop::addSqlRestriction(Shop::SHARE_CUSTOMER) . '
-        ' . ($ignoreGuest ? ' AND `is_guest` = 0' : ''));
+        ' . ($ignoreGuest ? ' AND `is_guest` = 0' : ''), false);
 
         return $returnId ? (int) $result : (bool) $result;
     }

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -366,7 +366,7 @@ class EmployeeCore extends ObjectModel
 		    SELECT `id_employee`
 		    FROM `' . _DB_PREFIX_ . 'employee`
 		    WHERE `email` = \'' . pSQL($email) . '\'
-        ');
+        ', false);
     }
 
     /**

--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -128,7 +128,7 @@ class ImageTypeCore extends ObjectModel
         Db::getInstance()->executeS('
 			SELECT `id_image_type`
 			FROM `' . _DB_PREFIX_ . 'image_type`
-			WHERE `name` = \'' . pSQL($typeName) . '\'');
+			WHERE `name` = \'' . pSQL($typeName) . '\'', false);
 
         return Db::getInstance()->numRows();
     }

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -543,7 +543,7 @@ class ManufacturerCore extends ObjectModel
 			SELECT `id_manufacturer`
 			FROM ' . _DB_PREFIX_ . 'manufacturer m
 			WHERE m.`id_manufacturer` = ' . (int) $idManufacturer,
-			false
+            false
         );
 
         return isset($row['id_manufacturer']);

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -542,7 +542,8 @@ class ManufacturerCore extends ObjectModel
             '
 			SELECT `id_manufacturer`
 			FROM ' . _DB_PREFIX_ . 'manufacturer m
-			WHERE m.`id_manufacturer` = ' . (int) $idManufacturer
+			WHERE m.`id_manufacturer` = ' . (int) $idManufacturer,
+			false
         );
 
         return isset($row['id_manufacturer']);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7096,7 +7096,7 @@ class ProductCore extends ObjectModel
         $row = Db::getInstance()->getRow('
         SELECT `reference`
         FROM `' . _DB_PREFIX_ . 'product` p
-        WHERE p.reference = "' . pSQL($reference) . '"');
+        WHERE p.reference = "' . pSQL($reference) . '"', false);
 
         return isset($row['reference']);
     }

--- a/classes/Store.php
+++ b/classes/Store.php
@@ -199,7 +199,8 @@ class StoreCore extends ObjectModel
             '
             SELECT `id_store`
             FROM ' . _DB_PREFIX_ . 'store a
-            WHERE a.`id_store` = ' . (int) $idStore
+            WHERE a.`id_store` = ' . (int) $idStore,
+            false
         );
 
         return isset($row['id_store']);

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -457,7 +457,7 @@ class SupplierCore extends ObjectModel
         $query->select('id_supplier');
         $query->from('supplier');
         $query->where('id_supplier = ' . (int) $idSupplier);
-        $res = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+        $res = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query, false);
 
         return $res > 0;
     }

--- a/classes/shop/ShopGroup.php
+++ b/classes/shop/ShopGroup.php
@@ -171,7 +171,8 @@ class ShopGroupCore extends ObjectModel
             FROM ' . _DB_PREFIX_ . 'shop
             WHERE name = "' . pSQL($name) . '"
             AND id_shop_group = ' . (int) $this->id . '
-            ' . ($id_shop ? 'AND id_shop != ' . (int) $id_shop : '')
+            ' . ($id_shop ? 'AND id_shop != ' . (int) $id_shop : ''),
+            false
         );
     }
 }

--- a/classes/stock/Warehouse.php
+++ b/classes/stock/Warehouse.php
@@ -232,7 +232,7 @@ class WarehouseCore extends ObjectModel
         $query->where('id_warehouse = ' . (int) $id_warehouse);
         $query->where('deleted = 0');
 
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query, false);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |  Do not use the cache when checking if data exists in the database. <<_For a critical method like this one that checks if an object exists we shouldn't cache the result If the object has been deleted during the process, the method will keep returning that it exists And we have no easy way to clear this cache on deletion either so we can't keep it consistent._>> By @jolelievre  See https://github.com/PrestaShop/PrestaShop/pull/21227#discussion_r498681706
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A.
| How to test?  | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21616)
<!-- Reviewable:end -->
