### PR TITLE
Show gift package and message on every details tabs of order view

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/details.html.twig
@@ -108,6 +108,14 @@
         {% endblock %}
       {% endembed %}
     </div>
+
+    {% if orderForViewing.shipping.recycledPackaging %}
+      <span class="badge badge-success">{{ 'Recycled packaging'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
+    {% endif %}
+
+    {% if orderForViewing.shipping.giftWrapping %}
+      <span class="badge badge-success">{{ 'Gift wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
+    {% endif %}
   </div>
 </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -86,14 +86,6 @@
   {% if orderForViewing.shipping.carrierModuleInfo %}
     {{ orderForViewing.shipping.carrierModuleInfo|raw }}
   {% endif %}
-
-  {% if orderForViewing.shipping.recycledPackaging %}
-    <span class="badge badge-success">{{ 'Recycled packaging'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-  {% endif %}
-
-  {% if orderForViewing.shipping.giftWrapping %}
-    <span class="badge badge-success">{{ 'Gift wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-  {% endif %}
 {% else %}
   <p class="text-center mb-0">
     {{ 'Shipping does not apply to virtual orders'|trans({}, 'Admin.Orderscustomers.Feature') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Gift package and recycled is not displayed on every details pages of order view
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21562.
| How to test?  | Create an order with recycled and gift package checked, see if on Order View you see the two labels on the details panel

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21617)
<!-- Reviewable:end -->
