### PR TITLE
Fix categorytree not showing on mobile when mobile is enabled

### DIFF
--- a/themes/classic/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
+++ b/themes/classic/modules/ps_categorytree/views/templates/hook/ps_categorytree.tpl
@@ -59,7 +59,7 @@
   {/strip}
 {/function}
 
-<div class="block-categories hidden-sm-down">
+<div class="block-categories">
   <ul class="category-top-menu">
     <li><a class="text-uppercase h6" href="{$categories.link nofilter}">{$categories.name}</a></li>
     <li>{categories nodes=$categories.children}</li>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Category tree is not shown on mobile when mobile is enabled
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #20747.
| How to test?  | Disable mobile, see if categorytree on category page is not displayed, enable it and see if it's displayed

It's a BC Break, as every shops will now see the categorytree, shops with huge amount of categories of not wanting to see this block will need to disable it, this is the normal global behavior.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21620)
<!-- Reviewable:end -->
