### PR TITLE
Fix help text not displayed in form_row

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -54,6 +54,7 @@
             <div class="{{ block('form_group_class') }}">
                 {{ form_widget(form) }}
                 {{ form_errors(form) }}
+                {{ block('form_help') }}
             </div>
         </div>
     {% endspaceless %}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -273,6 +273,10 @@
           <span class="text-danger">*</span>
         {% endif %}
         {{ extraVars.label }}
+
+        {% if form.vars.label_attr and form.vars.label_attr['popover'] %}
+          {{ include('@Common/HelpBox/helpbox.html.twig', {'content': form.vars.label_attr['popover']}) }}
+        {% endif %}
       </label>
     {% endif %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Help text are not displayed on twig forms
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19540.
| How to test?  | See issues, download the module and check help labels, also try to see if it doesn't break anything on migrated BO pages form

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21623)
<!-- Reviewable:end -->
