### PR TITLE
Stream downloaded file for HTTP/2

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -49,6 +49,7 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\Stream;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -378,7 +379,8 @@ class SqlManagerController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_sql_requests_index');
         }
 
-        $response = new BinaryFileResponse($exportedFile->getPathname());
+        $stream  = new Stream($exportedFile->getPathname());
+        $response = new BinaryFileResponse($stream);
         $response->setCharset($sqlRequestSettings->getFileEncoding());
         $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $exportedFile->getFilename());
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -379,7 +379,7 @@ class SqlManagerController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_sql_requests_index');
         }
 
-        $stream  = new Stream($exportedFile->getPathname());
+        $stream = new Stream($exportedFile->getPathname());
         $response = new BinaryFileResponse($stream);
         $response->setCharset($sqlRequestSettings->getFileEncoding());
         $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $exportedFile->getFilename());


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | When a file reaches a certain size, I was getting some errors while downloading it with HTTP/2.<br>It's the issue described here : https://community.cloudflare.com/t/files-can-not-be-downloaded/5598/16<br><br>I was able to fix this by streaming the content as described in the HttpFoundation doc : https://symfony.com/doc/current/components/http_foundation.html#serving-files
| Type?         | bug fix
| Category?     | BO 
| BC breaks?    | no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #21629.
| How to test?  | Add a sql query in SQL manager which returns more than 100Ko of data. Download the file using HTTP/2 (Cloudflare do it by default)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21628)
<!-- Reviewable:end -->
