### PR TITLE
Add inputpattern on quantity fields of product and cart

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/themes/classic/templates/catalog/_partials/product-add-to-cart.tpl
@@ -33,6 +33,8 @@
             type="number"
             name="qty"
             id="quantity_wanted"
+            inputmode="numeric"
+            pattern="[0-9]*"
             {if $product.quantity_wanted}
               value="{$product.quantity_wanted}"
               min="{$product.minimal_quantity}"

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -132,6 +132,8 @@
                 data-update-url="{$product.update_quantity_url}"
                 data-product-id="{$product.id_product}"
                 type="number"
+                inputmode="numeric"
+                pattern="[0-9]*"
                 value="{$product.quantity}"
                 name="product-quantity-spin"
               />


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Quantity inputs were opening a keyboard on mobile with multiple caracters instead of number only as it's the only thing valid
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14496.
| How to test?  | Open the PR on browserstack on iPhone for example, try the quantity input on product page and on cart page, they should open a numeric only keyboard
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21642)
<!-- Reviewable:end -->
