### PR TITLE
Fix theme not being enabled when creating test database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,24 @@ tests-legacy/resources/modules/ps_emailalerts/
 tests-legacy/resources/modules/ps_emailsubscription/mails/
 tests-legacy/resources/modules/referralprogram/
 
+# themes listed in the modules_to_hook section of the theme.yml
+tests-legacy/resources/modules/blockreassurance
+tests-legacy/resources/modules/ps_contactinfo
+tests-legacy/resources/modules/ps_languageselector
+tests-legacy/resources/modules/ps_currencyselector
+tests-legacy/resources/modules/ps_customersignin
+tests-legacy/resources/modules/ps_shoppingcart
+tests-legacy/resources/modules/ps_mainmenu
+tests-legacy/resources/modules/ps_searchbar
+tests-legacy/resources/modules/ps_imageslider
+tests-legacy/resources/modules/ps_customtext
+tests-legacy/resources/modules/ps_socialfollow
+tests-legacy/resources/modules/ps_linklist
+tests-legacy/resources/modules/ps_customeraccountlinks
+tests-legacy/resources/modules/ps_categorytree
+tests-legacy/resources/modules/ps_facetedsearch
+tests-legacy/resources/modules/ps_sharebuttons
+
 /admin-dev/autoupgrade/*
 !/admin-dev/autoupgrade/index.php
 !/admin-dev/autoupgrade/backup/index.php

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -196,6 +196,14 @@ class TabCore extends ObjectModel
     }
 
     /**
+     * reset static cache (eg unit testing purpose).
+     */
+    public static function resetStaticCache()
+    {
+        self::$_getIdFromClassName = null;
+    }
+
+    /**
      * Get tab id.
      *
      * @return int tab id

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -848,6 +848,7 @@ class Install extends AbstractInstall
 
                 return false;
             }
+            Context::getContext()->employee = $employee;
         } else {
             $this->setError($this->translator->trans('Cannot create admin account', [], 'Install'));
 

--- a/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
+++ b/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
@@ -31,6 +31,7 @@ use Doctrine\DBAL\DBALException;
 use PrestaShopBundle\Install\DatabaseDump;
 use PrestaShopBundle\Install\Install;
 use Symfony\Component\Process\Process;
+use Tab;
 
 class DatabaseCreator
 {
@@ -68,6 +69,7 @@ class DatabaseCreator
             'configuration_agrement' => true,
         ));
         $install->installFixtures();
+        Tab::resetStaticCache();
         $install->installTheme();
         $install->installModules();
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AddProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AddProductFeatureContext.php
@@ -31,6 +31,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 use Behat\Gherkin\Node\TableNode;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use Product;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class AddProductFeatureContext extends AbstractProductFeatureContext
@@ -55,5 +56,8 @@ class AddProductFeatureContext extends AbstractProductFeatureContext
         } catch (ProductException $e) {
             $this->setLastException($e);
         }
+        // Fix issue related to modules hooked on `actionProductSave` and calling `Product::priceCalculation()`
+        // leading to cache issues later
+        Product::resetStaticCache();
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -28,7 +28,7 @@ namespace Tests\Integration\Behaviour\Features\Context;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use Cart;
+use Cache;
 use Combination;
 use Configuration;
 use Customization;
@@ -215,6 +215,10 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
 
         // Fix issue pack cache is set when adding products.
         Pack::resetStaticCache();
+        // Fix issue related to modules hooked on `actionProductSave` and calling `Product::priceCalculation()`
+        // leading to cache issues later
+        Product::resetStaticCache();
+        Cache::clear();
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Because no `employee` was present in the context while creating the test database, the theme cannot be enabled leading to an empty `ps_image_type` table. This PR fixes it.
| Type?         | bug fix
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| How to test?  | run `composer run-script create-test-db` and check that the table `ps_image_type` is not empty in the test database

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21646)
<!-- Reviewable:end -->
