### PR TITLE
Change product unit price color to brand primary

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -222,6 +222,7 @@
 .product-unit-price {
   margin-bottom: 0;
   font-size: $font-size-xs;
+  color: $brand-primary;
 }
 
 .tabs {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Unit price was hardly visible when a single product contain multiple products
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11632.
| How to test?  | Create a product with unit price and unit, see if it's blue on the product page (don't test it on promoted product, overwhise you'll see it's orange)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21651)
<!-- Reviewable:end -->
