### PR TITLE
Simplify webservices forms

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -28,6 +28,9 @@ import TranslatableInput from '@js/components/translatable-input.js';
 import TinyMCEEditor from '@js/components/tinymce-editor.js';
 import TaggableField from '@js/components/taggable-field.js';
 import ChoiceTable from '@js/components/choice-table.js';
+import ChoiceTree from '@js/components/form/choice-tree.js';
+import MultipleChoiceTable from '@js/components/multiple-choice-table.js';
+import GeneratableInput from '@js/components/generatable-input.js';
 import {EventEmitter} from '@components/event-emitter';
 
 const initPrestashopComponents = () => {
@@ -69,6 +72,9 @@ const initPrestashopComponents = () => {
     TaggableField,
     ChoiceTable,
     EventEmitter,
+    ChoiceTree,
+    MultipleChoiceTable,
+    GeneratableInput,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/pages/webservice/index.js
+++ b/admin-dev/themes/new-theme/js/pages/webservice/index.js
@@ -32,9 +32,6 @@ import SubmitBulkActionExtension from '../../components/grid/extension/submit-bu
 import SortingExtension from '../../components/grid/extension/sorting-extension';
 import SubmitRowActionExtension from '../../components/grid/extension/action/row/submit-row-action-extension';
 import ColumnTogglingExtension from '../../components/grid/extension/column-toggling-extension';
-import ChoiceTree from '../../components/form/choice-tree';
-import GeneratableInput from '../../components/generatable-input';
-import MultipleChoiceTable from '../../components/multiple-choice-table';
 import PermissionsRowSelector from './permissions-row-selector';
 import LinkRowActionExtension from '../../components/grid/extension/link-row-action-extension';
 

--- a/admin-dev/themes/new-theme/js/pages/webservice/index.js
+++ b/admin-dev/themes/new-theme/js/pages/webservice/index.js
@@ -54,14 +54,10 @@ $(() => {
   webserviceGrid.addExtension(new LinkRowActionExtension());
 
   // needed for shop association input in form
-  new ChoiceTree('#webservice_key_shop_association').enableAutoCheckChildren();
-
-  // needed for permissions input in form
-  new MultipleChoiceTable();
-
+  new window.prestashop.component.ChoiceTree('#webservice_key_shop_association').enableAutoCheckChildren();
+  window.prestashop.component.initComponents(['MultipleChoiceTable', 'GeneratableInput']);
   // needed for key input in form
-  const generatableInput = new GeneratableInput();
-  generatableInput.attachOn('.js-generator-btn');
+  window.prestashop.instance.generatableInput.attachOn('.js-generator-btn');
 
   new PermissionsRowSelector();
 });

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
@@ -48,7 +48,7 @@ class WebserviceConfigurationType extends TranslatorAwareType
         $enableWebservicesHelp .= '<br/> 1. ';
         $enableWebservicesHelp .= $this->trans(
             'Check that URL rewriting is available on this server.',
-            'Check that URL rewriting is available on this server.'
+            'Admin.Advparameters.Help'
         );
         $enableWebservicesHelp .= '<br/> 2. ';
         $enableWebservicesHelp .= $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceConfigurationType.php
@@ -27,25 +27,53 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This form class generates the "Webservice configuration" form in Webservice page.
  */
-class WebserviceConfigurationType extends AbstractType
+class WebserviceConfigurationType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $enableWebservicesHelp = $this->trans(
+            'Before activating the webservice, you must be sure to: ',
+            'Admin.Advparameters.Help'
+        );
+        $enableWebservicesHelp .= '<br/> 1. ';
+        $enableWebservicesHelp .= $this->trans(
+            'Check that URL rewriting is available on this server.',
+            'Check that URL rewriting is available on this server.'
+        );
+        $enableWebservicesHelp .= '<br/> 2. ';
+        $enableWebservicesHelp .= $this->trans(
+            'Check that the five methods GET, POST, PUT, DELETE and HEAD are supported by this server.',
+            'Admin.Advparameters.Help'
+        );
+
         $builder
             ->add('enable_webservice', SwitchType::class, [
+                'label' => $this->trans(
+                    'Enable PrestaShop\'s webservice',
+                    'Admin.Advparameters.Feature'
+                ),
+                'help' => $enableWebservicesHelp,
                 'required' => true,
             ])
             ->add('enable_cgi', SwitchType::class, [
+                'label' => $this->trans(
+                    'Enable CGI mode for PHP',
+                    'Admin.Advparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Before choosing "Yes", check that PHP is not configured as an Apache module on your server.',
+                    'Admin.Advparameters.Help'
+                ),
                 'required' => true,
             ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -91,7 +91,7 @@ class WebserviceKeyType extends TranslatorAwareType
                 'generated_value_length' => Key::LENGTH,
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field is required', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is required.', 'Admin.Notifications.Error'),
                     ]),
                     new Length([
                         'min' => Key::LENGTH,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -143,7 +143,7 @@ class WebserviceKeyType extends TranslatorAwareType
 
         if ($this->isMultistoreFeatureUsed) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
-                'label' => $this->trans('Shop association', 'Admin.Global')
+                'label' => $this->trans('Shop association', 'Admin.Global'),
             ]);
 
             $builder->get('shop_association')->addModelTransformer(new CallbackTransformer(

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -113,7 +113,7 @@ class WebserviceKeyType extends TranslatorAwareType
                 'empty_data' => '',
             ])
             ->add('status', SwitchType::class, [
-                'label' => $this->trans('Status', 'Admin.Global'),
+                'label' => $this->trans('Enable webservice key', 'Admin.Global'),
                 'required' => false,
             ])
             ->add('permissions', MaterialMultipleChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -118,7 +118,7 @@ class WebserviceKeyType extends TranslatorAwareType
             ])
             ->add('permissions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Permissions', 'Admin.Advparameters.Feature'),
-                'table_label' => $this->trans('Resource', 'Admin.Advparameters.Feature'),
+                'table_label' => $this->trans('Resource', 'Admin.Global'),
                 'required' => false,
                 'choices' => $this->resourceChoices,
                 'multiple_choices' => $this->getPermissionChoicesForResources(),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -113,7 +113,7 @@ class WebserviceKeyType extends TranslatorAwareType
                 'empty_data' => '',
             ])
             ->add('status', SwitchType::class, [
-                'label' => $this->trans('Enable webservice key', 'Admin.Global'),
+                'label' => $this->trans('Enable webservice key', 'Admin.Advparameters.Feature'),
                 'required' => false,
             ])
             ->add('permissions', MaterialMultipleChoiceTableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -31,21 +31,19 @@ use PrestaShopBundle\Form\Admin\Type\GeneratableTextType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialMultipleChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * Is used to create form for adding/editing Webservice Key
  */
-class WebserviceKeyType extends AbstractType
+class WebserviceKeyType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var bool
      */
@@ -62,15 +60,20 @@ class WebserviceKeyType extends AbstractType
     private $permissionChoices;
 
     /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
      * @param bool $isMultistoreFeatureUsed
      * @param array $resourceChoices
      * @param array $permissionChoices
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         $isMultistoreFeatureUsed,
         array $resourceChoices,
         array $permissionChoices
     ) {
+        parent::__construct($translator, $locales);
         $this->isMultistoreFeatureUsed = $isMultistoreFeatureUsed;
         $this->resourceChoices = $resourceChoices;
         $this->permissionChoices = $permissionChoices;
@@ -83,30 +86,39 @@ class WebserviceKeyType extends AbstractType
     {
         $builder
             ->add('key', GeneratableTextType::class, [
+                'label' => $this->trans('Key', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('Webservice account key.', 'Admin.Advparameters.Feature'),
                 'generated_value_length' => Key::LENGTH,
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field is required', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is required', 'Admin.Notifications.Error'),
                     ]),
                     new Length([
                         'min' => Key::LENGTH,
                         'max' => Key::LENGTH,
                         'exactMessage' => $this->trans(
                             'Key length must be 32 character long.',
-                            [],
                             'Admin.Advparameters.Notification'
                         ),
                     ]),
                 ],
             ])
             ->add('description', TextareaType::class, [
+                'label' => $this->trans('Key description', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans(
+                    'Quick description of the key: who it is for, what permissions it has, etc.',
+                    'Admin.Advparameters.Help'
+                ),
                 'required' => false,
                 'empty_data' => '',
             ])
             ->add('status', SwitchType::class, [
+                'label' => $this->trans('Status', 'Admin.Global'),
                 'required' => false,
             ])
             ->add('permissions', MaterialMultipleChoiceTableType::class, [
+                'label' => $this->trans('Permissions', 'Admin.Advparameters.Feature'),
+                'table_label' => $this->trans('Resource', 'Admin.Advparameters.Feature'),
                 'required' => false,
                 'choices' => $this->resourceChoices,
                 'multiple_choices' => $this->getPermissionChoicesForResources(),
@@ -130,7 +142,9 @@ class WebserviceKeyType extends AbstractType
         ));
 
         if ($this->isMultistoreFeatureUsed) {
-            $builder->add('shop_association', ShopChoiceTreeType::class);
+            $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global')
+            ]);
 
             $builder->get('shop_association')->addModelTransformer(new CallbackTransformer(
                 function ($value) {

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
@@ -74,6 +74,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
         $view->vars['choices'] = $options['choices'];
         $view->vars['scrollable'] = $options['scrollable'];
         $view->vars['headers_to_disable'] = $options['headers_to_disable'];
+        $view->vars['table_label'] = $options['table_label'];
     }
 
     /**
@@ -108,6 +109,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
             ->setDefaults([
                 'scrollable' => true,
                 'headers_to_disable' => [],
+                'table_label' => false,
             ])
         ;
 
@@ -115,6 +117,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
         $resolver->setAllowedTypes('multiple_choices', 'array');
         $resolver->setAllowedTypes('scrollable', 'bool');
         $resolver->setAllowedTypes('headers_to_disable', 'array');
+        $resolver->setAllowedTypes('table_label', ['bool', 'string']);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -831,6 +831,13 @@ services:
       tags:
         - { name: form.type }
 
+    form.type.webservice_configuration:
+        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice\WebserviceConfigurationType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.contact:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\Contact\ContactType'
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type/webservice.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type/webservice.yml
@@ -4,11 +4,11 @@ services:
 
   form.type.webservice.webservice_key_type:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice\WebserviceKeyType'
+    parent: 'form.type.translatable.aware'
+    public: true
     arguments:
       - '@=service("prestashop.adapter.multistore_feature").isUsed()'
       - '@=service("prestashop.adapter.form.choice_provider.resources_choice_provider").getChoices()'
       - '@=service("prestashop.core.form.choice_provider.permissions_choice_provider").getChoices()'
-    calls:
-      - { method: setTranslator, arguments: ['@translator'] }
     tags:
       - { name: form.type }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme webserviceKeyForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block webservice_key_form %}
   {{ form_start(webserviceKeyForm) }}
@@ -33,46 +33,7 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
-        {{ form_errors(webserviceKeyForm) }}
-
-        {{ ps.form_group_row(webserviceKeyForm.key, {}, {
-          'label': 'Key'|trans({}, 'Admin.Advparameters.Feature'),
-          'help': 'Webservice account key.'|trans({}, 'Admin.Advparameters.Feature')
-        }) }}
-
-        {{ ps.form_group_row(webserviceKeyForm.description, {}, {
-          'label': 'Key description'|trans({}, 'Admin.Advparameters.Feature'),
-          'help': 'Quick description of the key: who it is for, what permissions it has, etc.'|trans({}, 'Admin.Advparameters.Help')
-        }) }}
-
-        {{ ps.form_group_row(webserviceKeyForm.status, {}, {
-          'label': 'Status'|trans({}, 'Admin.Global')
-        }) }}
-
-        <div class="form-group row mb-0">
-          <label class="form-control-label"></label>
-          <div class="col-sm mb-0">
-            <div class="alert alert-info" role="alert">
-              <p class="alert-text">{{ 'Set the resource permissions for this key:'|trans({}, 'Admin.Advparameters.Feature') }}</p>
-            </div>
-          </div>
-        </div>
-
-        {{ ps.form_group_row(webserviceKeyForm.permissions, {
-          'label': 'Resource'|trans({}, 'Admin.Global')
-        }, {
-          'label': 'Permissions'|trans({}, 'Admin.Advparameters.Feature')
-        }) }}
-
-        {% if webserviceKeyForm.shop_association is defined %}
-          {{ ps.form_group_row(webserviceKeyForm.shop_association, {}, {
-            'label': 'Shop association'|trans({}, 'Admin.Global')
-          }) }}
-        {% endif %}
-
-        {% block webservice_key_form_rest %}
-          {{ form_rest(webserviceKeyForm) }}
-        {% endblock %}
+        {{ form_widget(webserviceKeyForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
@@ -33,6 +33,17 @@
     </h3>
     <div class="card-block row">
       <div class="card-text">
+        {{ form_row(webserviceKeyForm.key) }}
+        {{ form_row(webserviceKeyForm.description) }}
+        {{ form_row(webserviceKeyForm.status) }}
+        <div class="form-group row mb-0">
+        <label class="form-control-label"></label>
+        <div class="col-sm mb-0">
+          <div class="alert alert-info" role="alert">
+            <p class="alert-text">{{ 'Set the resource permissions for this key:'|trans({}, 'Admin.Advparameters.Feature') }}</p>
+          </div>
+        </div>
+      </div>
         {{ form_widget(webserviceKeyForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
@@ -24,6 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Advparameters.Feature" %}
+{% form_theme webserviceConfigurationForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block webservice_form_configuration %}
   <div class="card">
@@ -33,39 +34,7 @@
 
     <div class="card-block row">
       <div class="card-text">
-        <div class="form-group row">
-          <label class="form-control-label">{{ 'Enable PrestaShop\'s webservice'|trans }}</label>
-
-          <div class="col-sm">
-            {{ form_errors(webserviceConfigurationForm.enable_webservice) }}
-            {{ form_widget(webserviceConfigurationForm.enable_webservice) }}
-
-            <small class="form-text">
-              {{ 'Before activating the webservice, you must be sure to: '|trans({}, 'Admin.Advparameters.Help') }}
-              <br/>
-              1. {{ 'Check that URL rewriting is available on this server.'|trans({}, 'Admin.Advparameters.Help') }}
-              <br/>
-              2. {{ 'Check that the five methods GET, POST, PUT, DELETE and HEAD are supported by this server.'|trans({}, 'Admin.Advparameters.Help') }}
-            </small>
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">{{ 'Enable CGI mode for PHP'|trans }}</label>
-
-          <div class="col-sm">
-            {{ form_errors(webserviceConfigurationForm.enable_cgi) }}
-            {{ form_widget(webserviceConfigurationForm.enable_cgi) }}
-
-            <small class="form-text">
-              {{ 'Before choosing "Yes", check that PHP is not configured as an Apache module on your server.'|trans({}, 'Admin.Advparameters.Help') }}
-            </small>
-          </div>
-        </div>
-
-        {% block webservice_configuration_form_rest %}
-          {{ form_rest(webserviceConfigurationForm) }}
-        {% endblock %}
+        {{ form_widget(webserviceConfigurationForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -814,7 +814,11 @@
 
 {% block generatable_text_widget %}
   <div class="input-group">
-    {{- block('form_widget') -}}
+    {% if compound %}
+      {{- block('form_widget_compound') -}}
+    {% else %}
+      {{- block('form_widget_simple') -}}
+    {% endif %}
     <span class="input-group-btn ml-1">
       <button class="btn btn-outline-secondary js-generator-btn"
               type="button"
@@ -825,6 +829,7 @@
       </button>
    </span>
   </div>
+  {{ block('form_help') }}
 {% endblock generatable_text_widget %}
 
 {% block text_with_recommended_length_widget %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -658,7 +658,7 @@
       <table class="table">
         <thead>
         <tr>
-          <th>{{ label }}</th>
+          <th>{{ table_label }}</th>
           {% for child_choice in form %}
             <th class="text-center">
               {% if child_choice.vars.multiple and child_choice.vars.name not in headers_to_disable %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies webservices forms
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Advanced Parameters > Webservice, Advanced Parameters > Webservice > Add new webservice key. Everything must look the same with 2 exceptions: blue help box replaced with help text under input and fields that actually were required before now have red * next to them.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by WebserviceConfigurationType, WebserviceKeyType. This means if any module extends any of tose types they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
