### PR TITLE
Select first payment method if only one is available

### DIFF
--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -30,7 +30,7 @@
                 name="payment-option"
                 type="radio"
                 required
-                {if $selected_payment_option == $option.id || $is_free} checked {/if}
+                {if ($selected_payment_option == $option.id || $is_free) || $payment_options|@count === 1} checked {/if}
               >
               <span></span>
             </span>

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -30,7 +30,7 @@
                 name="payment-option"
                 type="radio"
                 required
-                {if ($selected_payment_option == $option.id || $is_free) || $payment_options|@count === 1} checked {/if}
+                {if ($selected_payment_option == $option.id || $is_free) || ($payment_options|@count === 1 && $module_options|@count === 1)} checked {/if}
               >
               <span></span>
             </span>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Select first payment method if only one is available to gain 1 click
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11435.
| How to test?  | Activate only one payment method, go to checkout on FO, it should be selected, activate at least 2 payment method, none should be selected 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21654)
<!-- Reviewable:end -->
