### PR TITLE
put back dashtrends module at its former position

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -864,9 +864,9 @@ class Install extends AbstractInstall
             $modules = [
                 'contactform',
                 'dashactivity',
+                'dashtrends',
                 'dashgoals',
                 'dashproducts',
-                'dashtrends',
                 'graphnvd3',
                 'gridhtml',
                 'gsitemap',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The order of modules at installation was changed, this PR puts back dashtrends at its original place, so that its position doesn't change in the dashboard
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21649
| How to test?  | Make a fresh install with this PR, the stat modules in the middle column should appear in the same order as in 1.7.6 (see issue for more information)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21655)
<!-- Reviewable:end -->
