### PR TITLE
Detect click but not drag and drop on grid

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/link-row-action-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/link-row-action-extension.js
@@ -67,13 +67,26 @@ export default class LinkRowActionExtension {
         const $rowAction = $(this);
         const $parentCell = $rowAction.closest('td');
 
-        const clickableCells = $('td.clickable', $parentRow)
-          .not($parentCell);
-        clickableCells.addClass('cursor-pointer').click(() => {
-          const confirmMessage = $rowAction.data('confirm-message');
+        const clickableCells = $('td.clickable', $parentRow).not($parentCell);
+        let isDragging = false;
+        clickableCells.addClass('cursor-pointer').mousedown(() => {
+          $(window).mousemove(() => {
+            isDragging = true;
+            $(window).unbind('mousemove');
+          });
+        });
 
-          if (!confirmMessage.length || window.confirm(confirmMessage)) {
-            document.location = $rowAction.attr('href');
+        clickableCells.mouseup(() => {
+          const wasDragging = isDragging;
+          isDragging = false;
+          $(window).unbind('mousemove');
+
+          if (!wasDragging) {
+            const confirmMessage = $rowAction.data('confirm-message');
+
+            if (!confirmMessage.length || window.confirm(confirmMessage)) {
+              document.location = $rowAction.attr('href');
+            }
           }
         });
       });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | You couldn't copy informations on grids without clicking on it, this is annoying when you cant to copy a reference for example without going to order page
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #10317.
| How to test?  | Go on order page, then try to select the reference, you should be able to select it without going to the order page view (also try to check if grids are working properly on some other pages)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21656)
<!-- Reviewable:end -->
