### PR TITLE
Add test 'View raw html and text' in email themes page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
@@ -85,11 +85,11 @@
                           </a>
 
                           <div class="dropdown-menu dropdown-menu-right">
-                            <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ rawUrl }}">
+                            <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
                               <i class="material-icons">code</i>
                               {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
                             </a>
-                            <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ txtUrl }}">
+                            <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
                               <i class="material-icons">subject</i>
                               {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
                             </a>

--- a/tests/UI/campaigns/functional/BO/08_design/03_emailThemes/03_viewRawHtmlAndText.js
+++ b/tests/UI/campaigns/functional/BO/08_design/03_emailThemes/03_viewRawHtmlAndText.js
@@ -69,25 +69,54 @@ describe('View raw html and text and check result', async () => {
     );
   });
 
-  describe('View raw html and text', async () => {
+  describe('View raw html', async () => {
+    let newPage;
     it('should view raw html and check its URL', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'viewRawHtml', baseContext);
 
-      const newPage = await previewEmailThemesPage.viewRawHtml(page, 1);
+      newPage = await previewEmailThemesPage.viewRawHtml(page, 1);
       await expect(newPage.url())
         .to.contain(emailThemeName)
         .and.to.contain('raw')
         .and.to.contain('.html');
     });
 
+    it('should get text from page and check email format', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkRawHtmlText', baseContext);
+
+      const pageText = await previewEmailThemesPage.getTextFromViewLayoutPage(newPage);
+      await expect(pageText)
+        .to.contain(global.FO.URL)
+        .and.to.contain('<html')
+        .and.to.contain('<body')
+        .and.to.contain('</body>')
+        .and.to.contain('</html>');
+    });
+
+    after(() => newPage.close());
+  });
+
+  describe('View raw text', async () => {
+    let newPage;
     it('should view raw text and check its URL', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'viewRawText', baseContext);
 
-      const newPage = await previewEmailThemesPage.viewRawText(page, 1);
+      newPage = await previewEmailThemesPage.viewRawText(page, 1);
       await expect(newPage.url())
         .to.contain(emailThemeName)
         .and.to.contain('raw')
         .and.to.contain('.txt');
     });
+
+    it('should get text from page and check format', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkRawTextPage', baseContext);
+
+      const pageText = await previewEmailThemesPage.getTextFromViewLayoutPage(newPage);
+      await expect(pageText)
+        .to.contain(global.FO.URL)
+        .and.to.contain('Hi');
+    });
+
+    after(() => newPage.close());
   });
 });

--- a/tests/UI/campaigns/functional/BO/08_design/03_emailThemes/03_viewRawHtmlAndText.js
+++ b/tests/UI/campaigns/functional/BO/08_design/03_emailThemes/03_viewRawHtmlAndText.js
@@ -1,0 +1,93 @@
+require('module-alias/register');
+
+const {expect} = require('chai');
+
+// Import utils
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+
+// Import pages
+const dashboardPage = require('@pages/BO/dashboard');
+const emailThemesPage = require('@pages/BO/design/emailThemes');
+const previewEmailThemesPage = require('@pages/BO/design/emailThemes/preview');
+
+// Import test context
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_design_emailThemes_viewRawHtmlAndText';
+
+const emailThemeName = 'classic';
+
+let browserContext;
+let page;
+
+/*
+Go to design > email themes page
+Preview classic theme
+View email as raw html
+View email as text
+ */
+describe('View raw html and text and check result', async () => {
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await loginCommon.loginBO(this, page);
+  });
+
+  it('should go to design > email themes page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToEmailThemesPage', baseContext);
+
+    await dashboardPage.goToSubMenu(
+      page,
+      dashboardPage.designParentLink,
+      dashboardPage.emailThemeLink,
+    );
+
+    await emailThemesPage.closeSfToolBar(page);
+
+    const pageTitle = await emailThemesPage.getPageTitle(page);
+    await expect(pageTitle).to.contains(emailThemesPage.pageTitle);
+  });
+
+  it('should preview classic email theme', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'previewEmailTheme', baseContext);
+
+    await emailThemesPage.previewEmailTheme(page, emailThemeName);
+
+    const pageTitle = await previewEmailThemesPage.getPageTitle(page);
+
+    await expect(pageTitle).to.contains(
+      `${previewEmailThemesPage.pageTitle} ${emailThemeName}`,
+    );
+  });
+
+  describe('View raw html and text', async () => {
+    it('should view raw html and check its URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'viewRawHtml', baseContext);
+
+      const newPage = await previewEmailThemesPage.viewRawHtml(page, 1);
+      await expect(newPage.url())
+        .to.contain(emailThemeName)
+        .and.to.contain('raw')
+        .and.to.contain('.html');
+    });
+
+    it('should view raw text and check its URL', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'viewRawText', baseContext);
+
+      const newPage = await previewEmailThemesPage.viewRawText(page, 1);
+      await expect(newPage.url())
+        .to.contain(emailThemeName)
+        .and.to.contain('raw')
+        .and.to.contain('.txt');
+    });
+  });
+});

--- a/tests/UI/pages/BO/design/emailThemes/preview.js
+++ b/tests/UI/pages/BO/design/emailThemes/preview.js
@@ -8,6 +8,7 @@ class PreviewEmailTheme extends BOBasePage {
     this.pageTitle = 'Preview Theme';
 
     // Selectors
+    this.layoutBody = 'body pre';
     this.emailThemeTable = 'table.grid-table';
     this.tableBody = `${this.emailThemeTable} tbody`;
     this.tableRows = `${this.tableBody} tr`;
@@ -76,6 +77,15 @@ class PreviewEmailTheme extends BOBasePage {
     ]);
 
     return newPage;
+  }
+
+  /**
+   * Get text from view layout page
+   * @param page
+   * @return {Promise<string>}
+   */
+  getTextFromViewLayoutPage(page) {
+    return this.getTextContent(page, this.layoutBody);
   }
 }
 

--- a/tests/UI/pages/BO/design/emailThemes/preview.js
+++ b/tests/UI/pages/BO/design/emailThemes/preview.js
@@ -11,6 +11,12 @@ class PreviewEmailTheme extends BOBasePage {
     this.emailThemeTable = 'table.grid-table';
     this.tableBody = `${this.emailThemeTable} tbody`;
     this.tableRows = `${this.tableBody} tr`;
+    this.tableRow = row => `${this.tableRows}:nth-child(${row}`;
+    this.tableColumns = row => `${this.tableRow(row)} td`;
+    this.tableActionColumn = row => `${this.tableColumns(row)}.action-type`;
+    this.tableActionColumnDropDownLink = row => `${this.tableActionColumn(row)} .dropdown-toggle`;
+    this.tableActionColumnRawHtmlLink = row => `${this.tableActionColumn(row)} .raw-html-link`;
+    this.tableActionColumnRawTextLink = row => `${this.tableActionColumn(row)} .raw-text-link`;
     this.backToConfigurationLink = '#back-to-configuration-link';
   }
 
@@ -32,6 +38,44 @@ class PreviewEmailTheme extends BOBasePage {
    */
   async goBackToEmailThemesPage(page) {
     await this.clickAndWaitForNavigation(page, this.backToConfigurationLink);
+  }
+
+  /**
+   * View raw html
+   * @param page
+   * @param row
+   * @return {Promise<Page>}
+   */
+  async viewRawHtml(page, row) {
+    // Click on dropdown
+    await page.click(this.tableActionColumnDropDownLink(row));
+
+    // Open link in new target and return URL
+    const [newPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.click(this.tableActionColumnRawHtmlLink(row)),
+    ]);
+
+    return newPage;
+  }
+
+  /**
+   * View raw text
+   * @param page
+   * @param row
+   * @return {Promise<*>}
+   */
+  async viewRawText(page, row) {
+    // Click on dropdown
+    await page.click(this.tableActionColumnDropDownLink(row));
+
+    // Open link in new target and return URL
+    const [newPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.click(this.tableActionColumnRawTextLink(row)),
+    ]);
+
+    return newPage;
   }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add test 'View raw html and text' in email themes page
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/08_design/03_emailThemes/03_03_viewRawHtmlAndText" URL_FO=shopUrl/ npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21669)
<!-- Reviewable:end -->
