### PR TITLE
Made switch type not required

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -52,6 +52,7 @@ class SwitchType extends AbstractType
             'multiple' => false,
             'expanded' => false,
             'disabled' => false,
+            'required' => false,
             'choice_translation_domain' => self::TRANS_DOMAIN,
         ]);
         $resolver->setAllowedTypes('disabled', 'bool');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | With new form theme if form is required you can see the red * next to it. There is no reason for SwitchType to be required by default and it makes form simplfyng simplier for not have to write required => false for every SwitchType. Based on Symfonys description https://symfony.com/doc/current/reference/forms/types/form.html#required required mostly meant for HTML. I don't see how it's additional uses regarding empty data would impact SwitchType. I couldn't find how PrestaShop uses required param in any other way so I think it's safe to change default to false. 
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below.

## How to test ?

Switch type works same as before, shouldn't impact **non simplified forms** in any way. Any simplified form that has SwitchType should no longer have red * next to it. 

Please check, in particular:
- 1 BO **not simplified** form that does use SwitchType => we should see no differenc

Configure -> Advanced Parameters -> Performance and Improve -> International -> Localization -> Geolocation.

- 1 BO **simplified** form that does use SwitchType (if it exists) => we should see the difference

Category, Advanced Parameters -> E-Mail, Advanced Parameters -> Webservice. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21672)
<!-- Reviewable:end -->
