### PR TITLE
Fix checkbox going over label on multishop add shop

### DIFF
--- a/admin-dev/themes/default/sass/partials/_commons.sass
+++ b/admin-dev/themes/default/sass/partials/_commons.sass
@@ -204,3 +204,6 @@
 
 .pointer
 	cursor: pointer
+
+.multiple-checkboxes
+  padding-left: 25px;

--- a/admin-dev/themes/default/sass/partials/_commons.sass
+++ b/admin-dev/themes/default/sass/partials/_commons.sass
@@ -206,4 +206,4 @@
 	cursor: pointer
 
 .multiple-checkboxes
-  padding-left: 25px;
+  padding-left: 25px

--- a/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
@@ -106,7 +106,7 @@
 		{elseif $key == 'allcheckbox'}
 			<div id="data_list" {if !$checked}display:none{/if}>
 				<label class="control-label col-lg-3">{$field.label}</label>
-				<div class="col-lg-9">
+				<div class="col-lg-9 multiple-checkboxes">
 				{foreach $field.values as $key => $label}
 					<p class="checkbox"><input type="checkbox" name="importData[{$key}]" checked="checked" /> {$label}</p>
 				{/foreach}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Checkboxes were going over the label on the Add Shop view of multishop
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21671.
| How to test?  | See issue, go on multishop, add shop and look if checkboxes are fine

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21673)
<!-- Reviewable:end -->
