### PR TITLE
Set jquery colorpicker option only if it is needed and loaded

### DIFF
--- a/admin-dev/themes/default/template/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/helpers/options/options.tpl
@@ -387,6 +387,8 @@
 </script>
 {/if}
 {/block}
+{if $has_color_field}
 <script type="text/javascript">
   $.fn.mColorPicker.defaults.imageFolder = baseDir + 'img/admin/';
 </script>
+{/if}

--- a/classes/helper/HelperOptions.php
+++ b/classes/helper/HelperOptions.php
@@ -53,6 +53,7 @@ class HelperOptionsCore extends Helper
             $languages = Language::getLanguages(false);
         }
 
+        $has_color_field = false;
         $use_multishop = false;
         $hide_multishop_checkbox = (Shop::getTotalShops(false, null) < 2) ? true : false;
         foreach ($option_list as $category => $category_data) {
@@ -101,6 +102,7 @@ class HelperOptionsCore extends Helper
                 $field['required'] = isset($field['required']) ? $field['required'] : $this->required;
 
                 if ($field['type'] == 'color') {
+                    $has_color_field = true;
                     $this->context->controller->addJqueryPlugin('colorpicker');
                 }
 
@@ -246,6 +248,7 @@ class HelperOptionsCore extends Helper
             'currency_left_sign' => $this->context->currency->getSign('left'),
             'currency_right_sign' => $this->context->currency->getSign('right'),
             'use_multishop' => $use_multishop,
+            'has_color_field' => $has_color_field,
         ]);
 
         return parent::generate();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On the main multishop BO page, we had a console error, the jquery colorpicker had options being set without being loaded, because it is not needed in this page. This PR checks that the color picker is needed before using it.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21516
| How to test?  | See issue #21516

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21674)
<!-- Reviewable:end -->
