### PR TITLE
Simplify customer form

### DIFF
--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -160,7 +160,7 @@ table.table {
 .choice-table {
   .table {
     .form-check {
-        padding-left: 0;
+      padding-left: 0;
     }
   }
 }

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -157,6 +157,7 @@ table.table {
   }
 }
 
+/// Need this in order for material choice table select boxes to be aligned correctly
 .choice-table {
   .table {
     .form-check {

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -156,3 +156,11 @@ table.table {
     width: 100%;
   }
 }
+
+.choice-table {
+  .table {
+    .form-check {
+        padding-left: 0;
+    }
+  }
+}

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -150,3 +150,9 @@ table.table {
     display: initial;
   }
 }
+
+.birthday-select-container {
+  .custom-select.form-control {
+    width: 100%;
+  }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -33,8 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -43,6 +42,7 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -51,10 +51,8 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * Type is used to created form for customer add/edit actions
  */
-class CustomerType extends AbstractType
+class CustomerType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var array
      */
@@ -88,12 +86,15 @@ class CustomerType extends AbstractType
      * @param bool $isPartnerOffersEnabled
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         array $genderChoices,
         array $groupChoices,
         array $riskChoices,
         $isB2bFeatureEnabled,
         $isPartnerOffersEnabled
     ) {
+        parent::__construct($translator, $locales);
         $this->genderChoices = $genderChoices;
         $this->groupChoices = $groupChoices;
         $this->isB2bFeatureEnabled = $isB2bFeatureEnabled;
@@ -113,89 +114,146 @@ class CustomerType extends AbstractType
                 'expanded' => true,
                 'required' => false,
                 'placeholder' => null,
+                'label' => $this->trans('Social title', 'Admin.Global')
             ])
             ->add('first_name', TextType::class, [
+                'label' => $this->trans('First name', 'First name'),
+                'help' => $this->trans(
+                    'Only letters and the dot (.) character, followed by a space, are allowed.',
+                    'Admin.Orderscustomers.Help'
+                ),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new Length([
                         'max' => FirstName::MAX_LENGTH,
                         'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => FirstName::MAX_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => FirstName::MAX_LENGTH]
                         ),
                     ]),
                     new CustomerName([
-                        'message' => $this->trans('The %s field is invalid.', [sprintf('"%s"', $this->trans('First name', [], 'Admin.Global'))], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('The %s field is invalid.',
+                            'Admin.Notifications.Error',
+                            [sprintf('"%s"', $this->trans('First name', 'Admin.Global'))]
+                        ),
                     ]),
                 ],
             ])
             ->add('last_name', TextType::class, [
+                'label' => $this->trans('Last name', 'Admin.Global'),
+                'help' => $this->trans(
+                    'Only letters and the dot (.) character, followed by a space, are allowed.',
+                    'Admin.Orderscustomers.Help'
+                ),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new Length([
                         'max' => LastName::MAX_LENGTH,
                         'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => LastName::MAX_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => LastName::MAX_LENGTH]
+
                         ),
                     ]),
                     new CustomerName([
-                        'message' => $this->trans('The %s field is invalid.', [sprintf('"%s"', $this->trans('Last name', [], 'Admin.Global'))], 'Admin.Notifications.Error'),
+                        'message' => $this->trans(
+                            'The %s field is invalid.',
+                            'Admin.Notifications.Error',
+                            [sprintf('"%s"', $this->trans('Last name', 'Admin.Global'))]
+
+                        ),
                     ]),
                 ],
             ])
             ->add('email', EmailType::class, [
+                'label' => $this->trans('Email', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new Email([
-                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('password', PasswordType::class, [
+                'label' => $this->trans('Password', 'Admin.Global'),
+                'help' => $this->trans(
+                    'Password should be at least %length% characters long.',
+                    'Admin.Notifications.Info',
+                    [
+                        '%length%' => Password::MIN_LENGTH,
+                    ]
+                ),
                 'constraints' => [
                     new Length([
                         'max' => Password::MAX_LENGTH,
                         'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
-                            ['%limit%' => Password::MAX_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => Password::MAX_LENGTH]
                         ),
                         'min' => Password::MIN_LENGTH,
                         'minMessage' => $this->trans(
                             'This field cannot be shorter than %limit% characters',
-                            ['%limit%' => Password::MIN_LENGTH],
-                            'Admin.Notifications.Error'
+                            'Admin.Notifications.Error',
+                            ['%limit%' => Password::MIN_LENGTH]
                         ),
                     ]),
                 ],
                 'required' => $options['is_password_required'],
             ])
             ->add('birthday', BirthdayType::class, [
+                'label' => $this->trans('Birthday', 'Admin.Orderscustomers.Feature'),
                 'required' => false,
                 'format' => 'yyyy MM dd',
                 'input' => 'string',
             ])
             ->add('is_enabled', SwitchType::class, [
+                'label' => $this->trans('Enabled', 'Admin.Orderscustomers.Feature'),
+                'help' => $this->trans(
+                    'Enable or disable customer login.',
+                    'Admin.Orderscustomers.Help'
+                ),
                 'required' => false,
             ])
             ->add('is_partner_offers_subscribed', SwitchType::class, [
+                'label' => $this->trans('Partner offers', 'Admin.Orderscustomers.Feature'),
+                'help' => $this->trans(
+                    'This customer will receive your ads via email.',
+                    'Admin.Orderscustomers.Help'
+                ),
                 'required' => false,
                 'disabled' => !$this->isPartnerOffersEnabled,
             ])
             ->add('group_ids', MaterialChoiceTableType::class, [
+                'label' => $this->trans('Group access', 'Admin.Orderscustomers.Feature'),
+                'help' => $this->trans(
+                    'Select all the groups that you would like to apply to this customer.',
+                    'Admin.Orderscustomers.Help'
+                ),
                 'empty_data' => [],
                 'choices' => $this->groupChoices,
             ])
             ->add('default_group_id', ChoiceType::class, [
+                'label' => $this->trans('Default customer group', 'Admin.Orderscustomers.Feature'),
+                'help' => sprintf(
+                    '%s %s',
+                    $this->trans(
+                        'This group will be the user\'s default group.',
+                        'Admin.Orderscustomers.Help'
+                    ),
+                    $this->trans(
+                        'Only the discount for the selected group will be applied to this customer.',
+                        'Admin'
+                    )
+                ),
                 'required' => false,
                 'placeholder' => null,
                 'choices' => $this->groupChoices,
@@ -205,33 +263,54 @@ class CustomerType extends AbstractType
         if ($this->isB2bFeatureEnabled) {
             $builder
                 ->add('company_name', TextType::class, [
+                    'label' => $this->trans('Company', 'Admin.Global'),
                     'required' => false,
                 ])
                 ->add('siret_code', TextType::class, [
+                    'label' => $this->trans('SIRET', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                 ])
                 ->add('ape_code', TextType::class, [
+                    'label' => $this->trans('APE', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                     'constraints' => [
                         new Type([
                             'type' => 'alnum',
-                            'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                            'message' => $this->trans('This field is invalid','Admin.Notifications.Error'),
                         ]),
                     ],
                 ])
                 ->add('website', TextType::class, [
+                    'label' => $this->trans('Website', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                 ])
                 ->add('allowed_outstanding_amount', NumberType::class, [
+                    'label' => $this->trans('Allowed outstanding amount', 'Admin.Orderscustomers.Feature'),
+                    'help' => sprintf(
+                        '%s 0-9',
+                        $this->trans(
+                            'Valid characters:',
+                            'Admin.Orderscustomers.Help'
+                        )
+                    ),
                     'scale' => 6,
                     'required' => false,
-                    'invalid_message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                    'invalid_message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                 ])
                 ->add('max_payment_days', IntegerType::class, [
+                    'label' => $this->trans('Maximum number of payment days', 'Admin.Orderscustomers.Feature'),
+                    'help' => sprintf(
+                        '%s 0-9',
+                        $this->trans(
+                            'Valid characters:',
+                            'Admin.Orderscustomers.Help'
+                        )
+                    ),
                     'required' => false,
-                    'invalid_message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                    'invalid_message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                 ])
                 ->add('risk_id', ChoiceType::class, [
+                    'label' => $this->trans('Risk rating', 'Admin.Orderscustomers.Feature'),
                     'required' => false,
                     'placeholder' => null,
                     'choices' => $this->riskChoices,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -124,7 +124,7 @@ class CustomerType extends TranslatorAwareType
                 ),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new Length([
                         'max' => FirstName::MAX_LENGTH,
@@ -150,7 +150,7 @@ class CustomerType extends TranslatorAwareType
                 ),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new Length([
                         'max' => LastName::MAX_LENGTH,
@@ -173,10 +173,10 @@ class CustomerType extends TranslatorAwareType
                 'label' => $this->trans('Email', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new Email([
-                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
@@ -274,7 +274,7 @@ class CustomerType extends TranslatorAwareType
                     'constraints' => [
                         new Type([
                             'type' => 'alnum',
-                            'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                         ]),
                     ],
                 ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -114,7 +114,7 @@ class CustomerType extends TranslatorAwareType
                 'expanded' => true,
                 'required' => false,
                 'placeholder' => null,
-                'label' => $this->trans('Social title', 'Admin.Global')
+                'label' => $this->trans('Social title', 'Admin.Global'),
             ])
             ->add('first_name', TextType::class, [
                 'label' => $this->trans('First name', 'First name'),
@@ -158,7 +158,6 @@ class CustomerType extends TranslatorAwareType
                             'This field cannot be longer than %limit% characters',
                             'Admin.Notifications.Error',
                             ['%limit%' => LastName::MAX_LENGTH]
-
                         ),
                     ]),
                     new CustomerName([
@@ -166,7 +165,6 @@ class CustomerType extends TranslatorAwareType
                             'The %s field is invalid.',
                             'Admin.Notifications.Error',
                             [sprintf('"%s"', $this->trans('Last name', 'Admin.Global'))]
-
                         ),
                     ]),
                 ],
@@ -276,7 +274,7 @@ class CustomerType extends TranslatorAwareType
                     'constraints' => [
                         new Type([
                             'type' => 'alnum',
-                            'message' => $this->trans('This field is invalid','Admin.Notifications.Error'),
+                            'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                         ]),
                     ],
                 ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -293,7 +293,7 @@ class CustomerType extends TranslatorAwareType
                     ),
                     'scale' => 6,
                     'required' => false,
-                    'invalid_message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                    'invalid_message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                 ])
                 ->add('max_payment_days', IntegerType::class, [
                     'label' => $this->trans('Maximum number of payment days', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -305,7 +305,7 @@ class CustomerType extends TranslatorAwareType
                         )
                     ),
                     'required' => false,
-                    'invalid_message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                    'invalid_message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                 ])
                 ->add('risk_id', ChoiceType::class, [
                     'label' => $this->trans('Risk rating', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -117,7 +117,7 @@ class CustomerType extends TranslatorAwareType
                 'label' => $this->trans('Social title', 'Admin.Global'),
             ])
             ->add('first_name', TextType::class, [
-                'label' => $this->trans('First name', 'First name'),
+                'label' => $this->trans('First name', 'Admin.Global'),
                 'help' => $this->trans(
                     'Only letters and the dot (.) character, followed by a space, are allowed.',
                     'Admin.Orderscustomers.Help'
@@ -214,7 +214,7 @@ class CustomerType extends TranslatorAwareType
                 'input' => 'string',
             ])
             ->add('is_enabled', SwitchType::class, [
-                'label' => $this->trans('Enabled', 'Admin.Orderscustomers.Feature'),
+                'label' => $this->trans('Enabled', 'Admin.Global'),
                 'help' => $this->trans(
                     'Enable or disable customer login.',
                     'Admin.Orderscustomers.Help'
@@ -249,7 +249,7 @@ class CustomerType extends TranslatorAwareType
                     ),
                     $this->trans(
                         'Only the discount for the selected group will be applied to this customer.',
-                        'Admin'
+                        'Admin.Orderscustomers.Help'
                     )
                 ),
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
@@ -26,15 +26,16 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Customer;
 
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * Class TransferGuestAccountType is type used to submit guest customer transformation
  * into actual customer with password.
  */
-class TransferGuestAccountType extends AbstractType
+class TransferGuestAccountType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -42,6 +43,12 @@ class TransferGuestAccountType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('id_customer', HiddenType::class);
+            ->add('id_customer', HiddenType::class)
+            ->add('transfer_guest_account', SubmitType::class, [
+                'attr' => [
+                    'class' => 'btn-sm btn-primary'
+                ],
+                'label' => $this->trans('Transform to a customer account', 'Admin.Orderscustomers.Feature'),
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/TransferGuestAccountType.php
@@ -46,9 +46,9 @@ class TransferGuestAccountType extends TranslatorAwareType
             ->add('id_customer', HiddenType::class)
             ->add('transfer_guest_account', SubmitType::class, [
                 'attr' => [
-                    'class' => 'btn-sm btn-primary'
+                    'class' => 'btn-sm btn-primary',
                 ],
                 'label' => $this->trans('Transform to a customer account', 'Admin.Orderscustomers.Feature'),
-        ]);
+            ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -749,6 +749,13 @@ services:
         tags:
             - { name: form.type }
 
+    prestashop.bundle.form.admin.sell.customer.transfer_guest_account:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Customer\TransferGuestAccountType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     prestashop.bundle.form.admin.sell.customer.customer:
         class: 'PrestaShopBundle\Form\Admin\Sell\Customer\CustomerType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -751,14 +751,14 @@ services:
 
     prestashop.bundle.form.admin.sell.customer.customer:
         class: 'PrestaShopBundle\Form\Admin\Sell\Customer\CustomerType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.adapter.form.choice_provider.gender_by_id_choice_provider").getChoices()'
             - '@=service("prestashop.adapter.form.choice_provider.group_by_id_choice_provider").getChoices()'
             - '@=service("prestashop.adapter.form.choice_provider.risk_by_id_choice_provider").getChoices()'
             - '@=service("prestashop.core.b2b.b2b_feature").isActive()'
             - '@=service("prestashop.adapter.legacy.configuration").get("PS_CUSTOMER_OPTIN")'
-        calls:
-            - { method: setTranslator, arguments: ['@translator'] }
         tags:
            - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
@@ -25,26 +25,28 @@
 {% form_theme customerRequiredFieldsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 <div class="collapse" id="customerRequiredFieldsContainer">
-  {{ form_start(customerRequiredFieldsForm, {'action': path('admin_customers_set_required_fields')}) }}
-  <div class="card" >
-    <h3 class="card-header">
-      {{ 'Required Fields'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    </h3>
-    <div class="card-body">
-      <div class="alert alert-info" role="alert">
-        <div class="alert-text">
-          <p>{{ 'Select the fields you would like to be required for this section.'|trans({}, 'Admin.Orderscustomers.Help') }}</p>
-          <p>{{ 'Please make sure you are complying with the opt-in legislation applicable in your country.'|trans({}, 'Admin.Orderscustomers.Help') }}</p>
+  {% block customer_required_fields_form %}
+    {{ form_start(customerRequiredFieldsForm, {'action': path('admin_customers_set_required_fields')}) }}
+    <div class="card" >
+      <h3 class="card-header">
+        {{ 'Required Fields'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </h3>
+      <div class="card-body">
+        <div class="alert alert-info" role="alert">
+          <div class="alert-text">
+            <p>{{ 'Select the fields you would like to be required for this section.'|trans({}, 'Admin.Orderscustomers.Help') }}</p>
+            <p>{{ 'Please make sure you are complying with the opt-in legislation applicable in your country.'|trans({}, 'Admin.Orderscustomers.Help') }}</p>
+          </div>
+        </div>
+
+        {{ form_widget(customerRequiredFieldsForm.required_fields) }}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
         </div>
       </div>
-
-      {{ form_widget(customerRequiredFieldsForm.required_fields) }}
     </div>
-    <div class="card-footer">
-      <div class="d-flex justify-content-end">
-        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-      </div>
-    </div>
-  </div>
-  {{ form_end(customerRequiredFieldsForm) }}
+    {{ form_end(customerRequiredFieldsForm) }}
+  {% endblock %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
@@ -22,6 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
+{% form_theme customerRequiredFieldsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 <div class="collapse" id="customerRequiredFieldsContainer">
   {{ form_start(customerRequiredFieldsForm, {'action': path('admin_customers_set_required_fields')}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
@@ -29,7 +29,7 @@
     {{ form_start(customerRequiredFieldsForm, {'action': path('admin_customers_set_required_fields')}) }}
     <div class="card" >
       <h3 class="card-header">
-        {{ 'Required Fields'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        {{ 'Required fields'|trans({}, 'Admin.Orderscustomers.Feature') }}
       </h3>
       <div class="card-body">
         <div class="alert alert-info" role="alert">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+
 <div class="card customer-personal-informations-card">
   <h3 class="card-header">
     <i class="material-icons">person</i>
@@ -161,6 +162,8 @@
     </div>
 
     {% if customerInformation.personalInformation.guest %}
+      {% form_theme transferGuestAccountForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+
       <div class="customer-guest-status row mb-1">
         <div class="col-4 text-right">
           {{ 'This customer is registered as a Guest.'|trans({}, 'Admin.Orderscustomers.Feature') }}
@@ -170,11 +173,11 @@
             <p>{{ 'A registered customer account using the defined email address already exists. '|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
           {% else %}
             {{ form_start(transferGuestAccountForm, {'action': path('admin_customers_transform_guest_to_customer', {'customerId': customerInformation.customerId.value})}) }}
-              <button class="btn btn-primary btn-sm">
-                {{ 'Transform to a customer account'|trans({}, 'Admin.Orderscustomers.Feature') }}
-              </button>
+            {{ form_widget(transferGuestAccountForm.transfer_guest_account) }}
 
-              <p class="small-text">{{ 'This feature generates a random password before sending an email to your customer.'|trans({}, 'Admin.Orderscustomers.Help') }}</p>
+            <p class="small-text">
+              {{ 'This feature generates a random password before sending an email to your customer.'|trans({}, 'Admin.Orderscustomers.Help') }}
+            </p>
             {{ form_end(transferGuestAccountForm) }}
           {% endif %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/delete_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/delete_modal.html.twig
@@ -36,18 +36,19 @@
   {% block content %}
     <div class="modal-body">
       <p>{{ 'There are two ways of deleting a customer. Please choose your preferred method.'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
+      {% block delete_customers_form %}
+        {{ form_start(deleteCustomersForm, {'action': path('admin_customers_index'), 'method': 'post'}) }}
 
-      {{ form_start(deleteCustomersForm, {'action': path('admin_customers_index'), 'method': 'post'}) }}
+        <div class="form-group mb-0">
+          {{ form_widget(deleteCustomersForm.delete_method) }}
+        </div>
 
-      <div class="form-group mb-0">
-        {{ form_widget(deleteCustomersForm.delete_method) }}
-      </div>
+        <div class="d-none">
+          {{ form_widget(deleteCustomersForm.customers_to_delete) }}
+        </div>
 
-      <div class="d-none">
-        {{ form_widget(deleteCustomersForm.customers_to_delete) }}
-      </div>
-
-      {{ form_end(deleteCustomersForm) }}
+        {{ form_end(deleteCustomersForm) }}
+      {% endblock %}
     </div>
   {% endblock %}
 {% endembed %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
@@ -22,8 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme customerForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% set allowedNameChars = '0-9!<>,;?=+()@#"°{}_$%:' %}
 {% set isGuest = isGuest|default(false) %}
@@ -37,91 +36,7 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          {{ form_errors(customerForm) }}
-
-          {{ ps.form_group_row(customerForm.gender_id, {}, {
-            'label': 'Social title'|trans({}, 'Admin.Global')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.first_name, {}, {
-            'label': 'First name'|trans({}, 'Admin.Global'),
-            'help': 'Only letters and the dot (.) character, followed by a space, are allowed.'|trans({}, 'Admin.Orderscustomers.Help')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.last_name, {}, {
-            'label': 'Last name'|trans({}, 'Admin.Global'),
-            'help': 'Only letters and the dot (.) character, followed by a space, are allowed.'|trans({}, 'Admin.Orderscustomers.Help')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.email, {}, {
-            'label': 'Email'|trans({}, 'Admin.Global')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.password, {}, {
-            'label': 'Password'|trans({}, 'Admin.Global'),
-            'help': 'Password should be at least %length% characters long.'|trans({'%length%': minPasswordLength}, 'Admin.Notifications.Info'),
-            'class': isGuest ? 'd-none' : ''
-          }) }}
-
-          {{ ps.form_group_row(customerForm.birthday, {}, {
-            'label': 'Birthday'|trans({}, 'Admin.Orderscustomers.Feature')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.is_enabled, {}, {
-            'label': 'Enabled'|trans({}, 'Admin.Global'),
-            'help': 'Enable or disable customer login.'|trans({}, 'Admin.Orderscustomers.Help')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.is_partner_offers_subscribed, {}, {
-            'label': 'Partner offers'|trans({}, 'Admin.Orderscustomers.Feature'),
-            'help': 'This customer will receive your ads via email.'|trans({}, 'Admin.Orderscustomers.Help')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.group_ids, {}, {
-            'label': 'Group access'|trans({}, 'Admin.Orderscustomers.Feature'),
-            'help': 'Select all the groups that you would like to apply to this customer.'|trans({}, 'Admin.Orderscustomers.Help')
-          }) }}
-
-          {{ ps.form_group_row(customerForm.default_group_id, {}, {
-            'label': 'Default customer group'|trans({}, 'Admin.Orderscustomers.Feature'),
-            'help': '%s %s'|format('This group will be the user\'s default group.'|trans({}, 'Admin.Orderscustomers.Help'), 'Only the discount for the selected group will be applied to this customer.'|trans({}, 'Admin.Orderscustomers.Help'))
-          }) }}
-
-          {% if isB2bFeatureActive %}
-            {{ ps.form_group_row(customerForm.company_name, {}, {
-              'label': 'Company'|trans({}, 'Admin.Global')
-            }) }}
-
-            {{ ps.form_group_row(customerForm.siret_code, {}, {
-              'label': 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature')
-            }) }}
-
-            {{ ps.form_group_row(customerForm.ape_code, {}, {
-              'label': 'APE'|trans({}, 'Admin.Orderscustomers.Feature')
-            }) }}
-
-            {{ ps.form_group_row(customerForm.website, {}, {
-              'label': 'Website'|trans({}, 'Admin.Orderscustomers.Feature')
-            }) }}
-
-            {{ ps.form_group_row(customerForm.allowed_outstanding_amount, {}, {
-              'label': 'Allowed outstanding amount'|trans({}, 'Admin.Orderscustomers.Feature'),
-              'help': '%s 0-9'|format('Valid characters:'|trans({}, 'Admin.Orderscustomers.Help'))
-            }) }}
-
-            {{ ps.form_group_row(customerForm.max_payment_days, {}, {
-              'label': 'Maximum number of payment days'|trans({}, 'Admin.Orderscustomers.Feature'),
-              'help': '%s 0-9'|format('Valid characters:'|trans({}, 'Admin.Orderscustomers.Help'))
-            }) }}
-
-            {{ ps.form_group_row(customerForm.risk_id, {}, {
-              'label': 'Risk rating'|trans({}, 'Admin.Orderscustomers.Feature')
-            }) }}
-          {% endif %}
-
-          {% block customer_form_rest %}
-            {{ form_rest(customerForm) }}
-          {% endblock %}
+          {{ form_widget(customerForm) }}
         </div>
       </div>
       <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -717,9 +717,9 @@
       <div {{ block('widget_container_attributes') -}}>
     {%- endif %}
 
-    {% set yearWidget = '<div class="col pl-0">' ~ form_widget(form.year) ~ '</div>'|raw %}
-    {% set monthWidget = '<div class="col">' ~ form_widget(form.month) ~ '</div>'|raw %}
-    {% set dayWidget = '<div class="col pr-0">' ~ form_widget(form.day) ~ '</div>'|raw %}
+    {% set yearWidget = '<div class="col pl-0 birthday-select-container">' ~ form_widget(form.year) ~ '</div>'|raw %}
+    {% set monthWidget = '<div class="col birthday-select-container">' ~ form_widget(form.month) ~ '</div>'|raw %}
+    {% set dayWidget = '<div class="col pr-0 birthday-select-container">' ~ form_widget(form.day) ~ '</div>'|raw %}
 
     {{- date_pattern|replace({
       '{{ year }}': yearWidget,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies import form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Sell -> Customer edit and view forms. Everything must look the same with one exception: blue help box replaced with help text under input.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by CustomerType, TransferGuestAccountType. This means if any module extends any of this types they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
