### PR TITLE
Fix customer addresses edit/delete redirection

### DIFF
--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 
 /**
  * Class CustomerAddressGridDefinitionFactory defines customer's addresses grid structure.
@@ -43,6 +44,17 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
     use DeleteActionTrait;
 
     const GRID_ID = 'customer_address';
+
+    /**
+     * @var string
+     */
+    private $backUrl;
+
+    public function __construct(HookDispatcherInterface $hookDispatcher, string $backUrl)
+    {
+        parent::__construct($hookDispatcher);
+        $this->backUrl = $backUrl;
+    }
 
     /**
      * {@inheritdoc}
@@ -120,13 +132,18 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
                                 'route' => 'admin_addresses_edit',
                                 'route_param_name' => 'addressId',
                                 'route_param_field' => 'id_address',
+                                'extra_route_params' => [
+                                    'back' => $this->backUrl,
+                                ],
                             ])
                     )
                     ->add(
                         $this->buildDeleteAction(
                             'admin_addresses_delete',
                             'addressId',
-                            'id_address'
+                            'id_address',
+                            'POST',
+                            ['back' => $this->backUrl]
                         )
                     ),
             ])

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -97,6 +97,8 @@ services:
     prestashop.core.grid.definition.factory.customer.address:
         class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerAddressGridDefinitionFactory'
         parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+        arguments:
+            - '@=service("request_stack").getCurrentRequest().getUri()'
         public: true
 
     prestashop.core.grid.definition.factory.language:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/addresses.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/addresses.html.twig
@@ -44,7 +44,7 @@
     {% if customerAddressGrid.data.records_total > 0 %}
       <div class="row">
         <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerAddressGrid} %}
+          {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerAddressGrid} %}
         </div>
       </div>
     {% else %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since #20261 has been merged, when editing/deleting an address from the customer's details page, the redirection was wrong. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #19912 
| How to test?  | 1. Go to Customers => Customers<br>2. Select any customer and go to the customer detail page<br>3. Scroll down to the bottom of the page and in the address block click on the "edit" action button<br>4. Save the form<br>5. **You should be redirected back to the customer detail page**.<br>6. In the same address block, try to delete an address<br>7. **You should be redirected back to the customer detail page too**.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21684)
<!-- Reviewable:end -->
