### PR TITLE
Handle '+' sign in url when using 'back' parameter to redirect

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1282,7 +1282,7 @@ class AdminControllerCore extends Controller
                         $parent_id = (int) Tools::getValue('id_parent', 1);
                         // Specific back redirect
                         if ($back = Tools::getValue('back')) {
-                            $this->redirect_after = urldecode($back) . '&conf=4';
+                            $this->redirect_after = urldecode(str_replace('+', '%2B', $back)) . '&conf=4';
                         }
                         // Save and stay on same form
                         // @todo on the to following if, we may prefer to avoid override redirect_after previous value
@@ -2521,7 +2521,7 @@ class AdminControllerCore extends Controller
             $helper->tpl_vars = $this->getTemplateFormVars();
             $helper->show_cancel_button = (isset($this->show_form_cancel_button)) ? $this->show_form_cancel_button : ($this->display == 'add' || $this->display == 'edit');
 
-            $back = urldecode(Tools::getValue('back', ''));
+            $back = urldecode(str_replace('+', '%2B', Tools::getValue('back', '')));
             if (empty($back)) {
                 $back = self::$currentIndex . '&token=' . $this->token;
             }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1282,7 +1282,7 @@ class AdminControllerCore extends Controller
                         $parent_id = (int) Tools::getValue('id_parent', 1);
                         // Specific back redirect
                         if ($back = Tools::getValue('back')) {
-                            $this->redirect_after = urldecode(str_replace('+', '%2B', $back)) . '&conf=4';
+                            $this->redirect_after = rawurldecode($back) . '&conf=4';
                         }
                         // Save and stay on same form
                         // @todo on the to following if, we may prefer to avoid override redirect_after previous value
@@ -2521,7 +2521,7 @@ class AdminControllerCore extends Controller
             $helper->tpl_vars = $this->getTemplateFormVars();
             $helper->show_cancel_button = (isset($this->show_form_cancel_button)) ? $this->show_form_cancel_button : ($this->display == 'add' || $this->display == 'edit');
 
-            $back = urldecode(str_replace('+', '%2B', Tools::getValue('back', '')));
+            $back = rawurldecode(Tools::getValue('back', ''));
             if (empty($back)) {
                 $back = self::$currentIndex . '&token=' . $this->token;
             }

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -239,7 +239,7 @@ class AdminCartRulesControllerCore extends AdminController
     {
         $res = parent::processDelete();
         if (Tools::isSubmit('delete' . $this->table)) {
-            $back = urldecode(str_replace('+', '%2B', Tools::getValue('back', '')));
+            $back = rawurldecode(Tools::getValue('back', ''));
             if (!empty($back)) {
                 $this->redirect_after = $back;
             }

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -239,7 +239,7 @@ class AdminCartRulesControllerCore extends AdminController
     {
         $res = parent::processDelete();
         if (Tools::isSubmit('delete' . $this->table)) {
-            $back = urldecode(Tools::getValue('back', ''));
+            $back = urldecode(str_replace('+', '%2B', Tools::getValue('back', '')));
             if (!empty($back)) {
                 $this->redirect_after = $back;
             }

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -87,7 +87,7 @@ class AuthControllerCore extends FrontController
         parent::initContent();
 
         if ($should_redirect && !$this->ajax) {
-            $back = urldecode(str_replace('+', '%2B', Tools::getValue('back')));
+            $back = rawurldecode(Tools::getValue('back'));
 
             if (Tools::urlBelongsToShop($back)) {
                 // Checks to see if "back" is a fully qualified

--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -87,7 +87,7 @@ class AuthControllerCore extends FrontController
         parent::initContent();
 
         if ($should_redirect && !$this->ajax) {
-            $back = urldecode(Tools::getValue('back'));
+            $back = urldecode(str_replace('+', '%2B', Tools::getValue('back')));
 
             if (Tools::urlBelongsToShop($back)) {
                 // Checks to see if "back" is a fully qualified

--- a/src/Core/Util/Url/BackUrlProvider.php
+++ b/src/Core/Util/Url/BackUrlProvider.php
@@ -42,7 +42,6 @@ class BackUrlProvider
     {
         $backUrl = $request->query->get('back');
 
-        // convert '+' to its url code so it doesn't get decoded as a space character
-        return urldecode(str_replace('+', '%2B', $backUrl));
+        return rawurldecode($backUrl);
     }
 }

--- a/src/Core/Util/Url/BackUrlProvider.php
+++ b/src/Core/Util/Url/BackUrlProvider.php
@@ -42,6 +42,7 @@ class BackUrlProvider
     {
         $backUrl = $request->query->get('back');
 
-        return urldecode($backUrl);
+        // convert '+' to its url code so it doesn't get decoded as a space character
+        return urldecode(str_replace('+', '%2B', $backUrl));
     }
 }

--- a/src/PrestaShopBundle/EventListener/BackUrlRedirectResponseListener.php
+++ b/src/PrestaShopBundle/EventListener/BackUrlRedirectResponseListener.php
@@ -79,7 +79,7 @@ final class BackUrlRedirectResponseListener
         $backUrl = $this->backUrlProvider->getBackUrl($currentRequest);
 
         if ($backUrl && !$this->isRequestUrlEqualToResponseUrl($currentRequest, $originalResponse)) {
-            $backUrlResponse = $originalResponse->setTargetUrl(urldecode($backUrl));
+            $backUrlResponse = $originalResponse->setTargetUrl($backUrl);
             $event->setResponse($backUrlResponse);
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since PR #20006 we allow '+' sign in urls but it was converted to a space character when redirecting from the `back` url parameter. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 1. Install PrestaShop in a subfolder containing the '+' sign (e.g. `http://locahost/prestashop+dev/`).<br>2. Go to Customers > Customers<br>3. Select any customer and go to the customer detail page<br>4. Scroll down to the bottom of the page and in the address block click on the + icon to add a new address<br>5. Fill all the required fields and click on save<br>6. You should be redirected correctly

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21690)
<!-- Reviewable:end -->
