### PR TITLE
Handle Shop context override in order editing

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2682,6 +2682,30 @@ class OrderCore extends ObjectModel
     }
 
     /**
+     * @param int $productId
+     * @param int $productAttributeId
+     *
+     * @return int|null
+     */
+    public function getProductSpecificPriceId(int $productId, int $productAttributeId): ?int
+    {
+        return SpecificPrice::exists(
+            $productId,
+            $productAttributeId,
+            0,
+            0,
+            0,
+            $this->id_currency,
+            $this->id_customer,
+            SpecificPrice::ORDER_DEFAULT_FROM_QUANTITY,
+            SpecificPrice::ORDER_DEFAULT_DATE,
+            SpecificPrice::ORDER_DEFAULT_DATE,
+            false,
+            $this->id_cart
+        );
+    }
+
+    /**
      * Re calculate shipping cost.
      *
      * @return object $order

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -537,7 +537,7 @@ class OrderDetailCore extends ObjectModel
         if ($id_order_state != Configuration::get('PS_OS_CANCELED') && $id_order_state != Configuration::get('PS_OS_ERROR')) {
             $update_quantity = true;
             if (!StockAvailable::dependsOnStock($product['id_product'])) {
-                $update_quantity = StockAvailable::updateQuantity($product['id_product'], $product['id_product_attribute'], -(int) $product['cart_quantity']);
+                $update_quantity = StockAvailable::updateQuantity($product['id_product'], $product['id_product_attribute'], -(int) $product['cart_quantity'], $product['id_shop'], true);
             }
 
             if ($update_quantity) {

--- a/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCartRuleToCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\AddCartRuleToCartHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\CartRuleValidityException;
+use Shop;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -80,7 +81,9 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setLanguage(new Language($cart->id_lang))
-            ->setCustomer(new Customer($cart->id_customer));
+            ->setCustomer(new Customer($cart->id_customer))
+            ->setShop(new Shop($cart->id_shop))
+        ;
 
         $errorMessage = $this->validateCartRule($cartRule, $cart);
 

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateCartCarrierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
+use Shop;
 use Validate;
 
 /**
@@ -68,14 +69,18 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
             ->setCurrency(new Currency($cart->id_currency))
             ->setLanguage(new Language($cart->id_lang))
             ->setCustomer(new Customer($cart->id_customer))
+            ->setShop(new Shop($cart->id_shop))
         ;
 
-        $cart->setDeliveryOption([
-            (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($command->getNewCarrierId()),
-        ]);
+        try {
+            $cart->setDeliveryOption([
+                (int) $cart->id_address_delivery => $this->formatLegacyDeliveryOptionFromCarrierId($command->getNewCarrierId()),
+            ]);
 
-        $cart->update();
-        $this->contextStateManager->restorePreviousContext();
+            $cart->update();
+        } finally {
+            $this->contextStateManager->restorePreviousContext();
+        }
     }
 
     /**

--- a/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use Product;
+use Shop;
 
 /**
  * @internal
@@ -66,7 +67,10 @@ final class UpdateProductQuantityInCartHandler extends AbstractCartHandler imple
     public function handle(UpdateProductQuantityInCartCommand $command)
     {
         $cart = $this->getCart($command->getCartId());
-        $this->contextStateManager->setCart($cart);
+        $this->contextStateManager
+            ->setCart($cart)
+            ->setShop(new Shop($cart->id_shop))
+        ;
 
         try {
             $this->updateProductQuantityInCart($cart, $command);

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -246,20 +246,28 @@ final class ContextStateManager
         // NOTE: array_key_exists important here, isset cannot be used because it would not detect if null is stored
         if (array_key_exists($fieldName, $this->contextFieldsStack[$currentStashIndex])) {
             if ('shop' === $fieldName) {
-                $shop = $this->contextFieldsStack[$currentStashIndex][$fieldName];
-                $shopId = $shop instanceof Shop ? $shop->id : null;
-                $shopContext = $this->contextFieldsStack[$currentStashIndex]['shopContext'];
-                if (null !== $shopContext) {
-                    Shop::setContext(
-                        $shopContext,
-                        $shopId
-                    );
-                }
-                unset($this->contextFieldsStack[$currentStashIndex]['shopContext']);
+                $this->restoreShopContext($currentStashIndex);
             }
             $this->context->$fieldName = $this->contextFieldsStack[$currentStashIndex][$fieldName];
             unset($this->contextFieldsStack[$currentStashIndex][$fieldName]);
         }
+    }
+
+    /**
+     * Restore the ShopContext, this is used when Shop has been overridden, we need to
+     * restore context->shop of course But also the static fields in Shop class
+     *
+     * @param int $currentStashIndex
+     */
+    private function restoreShopContext(int $currentStashIndex): void
+    {
+        $shop = $this->contextFieldsStack[$currentStashIndex]['shop'];
+        $shopId = $shop instanceof Shop ? $shop->id : null;
+        $shopContext = $this->contextFieldsStack[$currentStashIndex]['shopContext'];
+        if (null !== $shopContext) {
+            Shop::setContext($shopContext, $shopId);
+        }
+        unset($this->contextFieldsStack[$currentStashIndex]['shopContext']);
     }
 
     /**

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -34,6 +34,7 @@ use Country;
 use Currency;
 use Customer;
 use Language;
+use Shop;
 
 /**
  * Allows manipulating context state.
@@ -51,6 +52,8 @@ final class ContextStateManager
         'currency',
         'language',
         'customer',
+        'shop',
+        'shopContext',
     ];
 
     /**
@@ -155,6 +158,25 @@ final class ContextStateManager
     }
 
     /**
+     * Sets context shop and saves previous value
+     *
+     * @param Shop|null $shop
+     * @param int $shopContextType
+     *
+     * @return $this
+     *
+     * @throws \PrestaShopException
+     */
+    public function setShop(?Shop $shop, int $shopContextType = Shop::CONTEXT_SHOP): self
+    {
+        $this->saveContextField('shop');
+        $this->context->shop = $shop;
+        Shop::setContext(Shop::CONTEXT_SHOP, null !== $shop ? $shop->id : null);
+
+        return $this;
+    }
+
+    /**
      * Restores context to a state before changes
      *
      * @return self
@@ -204,7 +226,12 @@ final class ContextStateManager
         $currentStashIndex = array_key_last($this->contextFieldsStack);
         // NOTE: array_key_exists important here, isset cannot be used because it would not detect if null is stored
         if (!array_key_exists($fieldName, $this->contextFieldsStack[$currentStashIndex])) {
-            $this->contextFieldsStack[$currentStashIndex][$fieldName] = $this->context->$fieldName;
+            if ('shop' === $fieldName) {
+                $this->contextFieldsStack[$currentStashIndex]['shop'] = $this->context->$fieldName;
+                $this->contextFieldsStack[$currentStashIndex]['shopContext'] = Shop::getContext();
+            } else {
+                $this->contextFieldsStack[$currentStashIndex][$fieldName] = $this->context->$fieldName;
+            }
         }
     }
 
@@ -218,6 +245,18 @@ final class ContextStateManager
         $currentStashIndex = array_key_last($this->contextFieldsStack);
         // NOTE: array_key_exists important here, isset cannot be used because it would not detect if null is stored
         if (array_key_exists($fieldName, $this->contextFieldsStack[$currentStashIndex])) {
+            if ('shop' === $fieldName) {
+                $shop = $this->contextFieldsStack[$currentStashIndex][$fieldName];
+                $shopId = $shop instanceof Shop ? $shop->id : null;
+                $shopContext = $this->contextFieldsStack[$currentStashIndex]['shopContext'];
+                if (null !== $shopContext) {
+                    Shop::setContext(
+                        $shopContext,
+                        $shopId
+                    );
+                }
+                unset($this->contextFieldsStack[$currentStashIndex]['shopContext']);
+            }
             $this->context->$fieldName = $this->contextFieldsStack[$currentStashIndex][$fieldName];
             unset($this->contextFieldsStack[$currentStashIndex][$fieldName]);
         }

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -160,18 +160,17 @@ final class ContextStateManager
     /**
      * Sets context shop and saves previous value
      *
-     * @param Shop|null $shop
-     * @param int $shopContextType
+     * @param Shop $shop
      *
      * @return $this
      *
      * @throws \PrestaShopException
      */
-    public function setShop(?Shop $shop, int $shopContextType = Shop::CONTEXT_SHOP): self
+    public function setShop(Shop $shop): self
     {
         $this->saveContextField('shop');
         $this->context->shop = $shop;
-        Shop::setContext(Shop::CONTEXT_SHOP, null !== $shop ? $shop->id : null);
+        Shop::setContext(Shop::CONTEXT_SHOP, $shop->id);
 
         return $this;
     }

--- a/src/Adapter/Order/AbstractOrderHandler.php
+++ b/src/Adapter/Order/AbstractOrderHandler.php
@@ -290,20 +290,7 @@ abstract class AbstractOrderHandler
     ): ?SpecificPrice {
         // WARNING: DO NOT use SpecificPrice::getSpecificPrice as it filters out fields that are not in database
         // hence it ignores the customer or cart restriction and results are biased
-        $existingSpecificPriceId = SpecificPrice::exists(
-            $product->id,
-            $combination ? $combination->id : 0,
-            0,
-            0,
-            0,
-            $order->id_currency,
-            $order->id_customer,
-            SpecificPrice::ORDER_DEFAULT_FROM_QUANTITY,
-            SpecificPrice::ORDER_DEFAULT_DATE,
-            SpecificPrice::ORDER_DEFAULT_DATE,
-            false,
-            $order->id_cart
-        );
+        $existingSpecificPriceId = $order->getProductSpecificPriceId($product->id, $combination ? $combination->id : 0);
 
         if (empty($existingSpecificPriceId)) {
             return null;

--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -41,8 +41,8 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\AddCartRuleToOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderDiscountType;
-use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShopException;
+use Shop;
 use Validate;
 
 /**
@@ -79,7 +79,9 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
 
         $this->contextStateManager
             ->setCurrency(new Currency($order->id_currency))
-            ->setCustomer(new Customer($order->id_customer));
+            ->setCustomer(new Customer($order->id_customer))
+            ->setShop(new Shop($order->id_shop))
+        ;
 
         try {
             $this->addCartRuleAndUpdateOrder($command, $order);
@@ -101,10 +103,6 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
      */
     private function addCartRuleAndUpdateOrder(AddCartRuleToOrderCommand $command, Order $order): void
     {
-        $computingPrecision = new ComputingPrecision();
-        $currency = new Currency((int) $order->id_currency);
-        $precision = $computingPrecision->getPrecision($currency->precision);
-
         // If the discount is for only one invoice
         $orderInvoice = null;
         if ($order->hasInvoice() && null !== $command->getOrderInvoiceId()) {

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\AddOrderFromBackOffic
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use Shop;
 use Validate;
 
 /**
@@ -89,6 +90,7 @@ final class AddOrderFromBackOfficeHandler implements AddOrderFromBackOfficeHandl
             ->setCustomer(new Customer($cart->id_customer))
             ->setLanguage(new Language($cart->id_lang))
             ->setCountry($this->getTaxCountry($cart))
+            ->setShop(new Shop($cart->id_shop))
         ;
 
         $translator = Context::getContext()->getTranslator();

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -139,6 +139,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             ->setCurrency(new Currency($order->id_currency))
             ->setCustomer(new Customer($order->id_customer))
             ->setCart($cart)
+            ->setShop(new Shop($order->id_shop))
         ;
 
         $this->computingPrecision = $this->getPrecisionFromCart($cart);

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteCartRuleFromOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\DeleteCartRuleFromOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use Shop;
 use Validate;
 
 /**
@@ -96,7 +97,9 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
 
         $this->contextStateManager
             ->setCurrency(new Currency($order->id_currency))
-            ->setCustomer(new Customer($order->id_customer));
+            ->setCustomer(new Customer($order->id_customer))
+            ->setShop(new Shop($order->id_shop))
+        ;
 
         try {
             // Delete Order Cart Rule and update Order

--- a/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteProductFromOrderHandler.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\CommandHandler\DeleteProductFromOrderHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use Shop;
 use Validate;
 
 /**
@@ -64,6 +65,8 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
 
     /**
      * @param ContextStateManager $contextStateManager
+     * @param OrderAmountUpdater $orderAmountUpdater
+     * @param OrderProductQuantityUpdater $orderProductQuantityUpdater
      */
     public function __construct(
         ContextStateManager $contextStateManager,
@@ -90,7 +93,9 @@ final class DeleteProductFromOrderHandler extends AbstractOrderCommandHandler im
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($order->id_currency))
-            ->setCustomer(new Customer($order->id_customer));
+            ->setCustomer(new Customer($order->id_customer))
+            ->setShop(new Shop($order->id_shop))
+        ;
 
         try {
             $order = $this->orderProductQuantityUpdater->update(

--- a/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
+++ b/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DuplicateOrderCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\CommandHandler\DuplicateOrderCartHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DuplicateOrderCartException;
+use Shop;
 
 /**
  * @internal
@@ -66,6 +67,7 @@ final class DuplicateOrderCartHandler implements DuplicateOrderCartHandlerInterf
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
             ->setLanguage(new Language($cart->id_lang))
+            ->setShop(new Shop($cart->id_shop))
         ;
         $result = $cart->duplicate();
 

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -49,6 +49,7 @@ use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShopDatabaseException;
 use PrestaShopException;
 use Product;
+use Shop;
 use Tools;
 use Validate;
 
@@ -104,6 +105,7 @@ class OrderAmountUpdater
             ->setCustomer(new Customer($cart->id_customer))
             ->setLanguage(new Language($cart->id_lang))
             ->setCountry($cart->getTaxCountry())
+            ->setShop(new Shop($cart->id_shop))
         ;
 
         try {

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -112,6 +112,7 @@ class OrderProductQuantityUpdater
             ->setCustomer(new Customer($cart->id_customer))
             ->setLanguage(new Language($cart->id_lang))
             ->setCountry($cart->getTaxCountry())
+            ->setShop(new Shop($cart->id_shop))
         ;
 
         try {
@@ -287,7 +288,8 @@ class OrderProductQuantityUpdater
                 $orderDetail->product_id,
                 $orderDetail->product_attribute_id,
                 $deltaQuantity,
-                $cart->id_shop
+                $cart->id_shop,
+                true
             );
         } else {
             // Decrease product quantity. Reinject quantity in stock

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -289,7 +289,11 @@ class OrderProductQuantityUpdater
                 $orderDetail->product_attribute_id,
                 $deltaQuantity,
                 $cart->id_shop,
-                true
+                true,
+                [
+                    'id_order' => $orderDetail->id_order,
+                    'id_stock_mvt_reason' => Configuration::get('PS_STOCK_CUSTOMER_RETURN_REASON'),
+                ]
             );
         } else {
             // Decrease product quantity. Reinject quantity in stock

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
 
 use Address;
 use Configuration;
+use Currency;
 use Order;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
@@ -106,6 +107,24 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
     {
         $currency = $this->currencyDataProvider->getCurrencyByIsoCode($query->getAlphaIsoCode()->getValue());
         $this->contextStateManager->setCurrency($currency);
+
+        try {
+            $foundProducts = $this->searchProducts($query, $currency);
+        } finally {
+            $this->contextStateManager->restorePreviousContext();
+        }
+
+        return $foundProducts;
+    }
+
+    /**
+     * @param SearchProducts $query
+     * @param Currency $currency
+     *
+     * @return array
+     */
+    private function searchProducts(SearchProducts $query, Currency $currency): array
+    {
         $computingPrecision = new ComputingPrecision();
         $currencyPrecision = $computingPrecision->getPrecision((int) $currency->precision);
 
@@ -136,8 +155,6 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
                 $foundProducts[] = $foundProduct;
             }
         }
-
-        $this->contextStateManager->restorePreviousContext();
 
         return $foundProducts;
     }

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCustomizationFi
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 use Product;
+use Shop;
 
 /**
  * Handles products search using legacy object model
@@ -109,6 +110,12 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
         $this->contextStateManager
             ->setCurrency($currency)
         ;
+        if (null !== $query->getOrderId()) {
+            $order = $this->getOrder($query->getOrderId());
+            $this->contextStateManager
+                ->setShop(new Shop($order->id_shop))
+            ;
+        }
 
         try {
             $foundProducts = $this->searchProducts($query, $currency);

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -106,7 +106,9 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
     public function handle(SearchProducts $query): array
     {
         $currency = $this->currencyDataProvider->getCurrencyByIsoCode($query->getAlphaIsoCode()->getValue());
-        $this->contextStateManager->setCurrency($currency);
+        $this->contextStateManager
+            ->setCurrency($currency)
+        ;
 
         try {
             $foundProducts = $this->searchProducts($query, $currency);

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -102,7 +102,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
         self::rebootKernel();
     }
 
-
     /**
      * Return PrestaShop Symfony services container
      *

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -83,18 +83,25 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * This hook can be used to flag a feature for kernel reboot, this is useful
-     * to force recreation of services (e.g: when you add some currencies in the
-     * database, you may need to reset the CLDR related services to use the new ones)
+     * This hook can be used to flag a feature for kernel reboot
      *
      * @BeforeFeature @reboot-kernel-before-feature
      */
     public static function rebootKernelPrepareFeature()
     {
-        $realCacheDir = self::$kernel->getContainer()->getParameter('kernel.cache_dir');
-        $warmupDir = substr($realCacheDir, 0, -1) . ('_' === substr($realCacheDir, -1) ? '-' : '_');
-        self::$kernel->reboot($warmupDir);
+        self::rebootKernel();
     }
+
+    /**
+     * This hook can be used to flag a scenario for kernel reboot
+     *
+     * @BeforeScenario @reboot-kernel-before-scenario
+     */
+    public static function rebootKernelBeforeScenario()
+    {
+        self::rebootKernel();
+    }
+
 
     /**
      * Return PrestaShop Symfony services container
@@ -160,6 +167,26 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     public function clearEntityManager()
     {
         $this::getContainer()->get('doctrine.orm.entity_manager')->clear();
+    }
+
+    /**
+     * @Given I reboot kernel
+     */
+    public function rebootKernelOnDemand()
+    {
+        self::rebootKernel();
+    }
+
+    /**
+     * This method reboots Symfony kernel, this is used to force recreation of services
+     * (e.g: when you add some currencies in the database, you may need to reset the CLDR
+     * related services to use the new ones)
+     */
+    private static function rebootKernel(): void
+    {
+        $realCacheDir = self::$kernel->getContainer()->getParameter('kernel.cache_dir');
+        $warmupDir = substr($realCacheDir, 0, -1) . ('_' === substr($realCacheDir, -1) ? '-' : '_');
+        self::$kernel->reboot($warmupDir);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -67,7 +67,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockExcepti
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
 use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\OrderStateByIdChoiceProvider;
-use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use PrestaShopCollection;
 use Product;
 use RuntimeException;
@@ -1355,18 +1354,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     {
         $order = new Order($orderId);
 
-        $specificPriceId = SpecificPrice::exists(
-            $productId,
-            $combinationId,
-            0,
-            0,
-            0,
-            $order->id_currency,
-            $order->id_customer,
-            1,
-            DateTime::NULL_VALUE,
-            DateTime::NULL_VALUE
-        );
+        $specificPriceId = $order->getProductSpecificPriceId($productId, $combinationId);
 
         return $specificPriceId ? (int) $specificPriceId : null;
     }

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Configuration;
 use RuntimeException;
 use Shop;
 
@@ -53,7 +54,7 @@ class ShopFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function singleShopContextIsLoaded()
     {
-        Shop::setContext(Shop::CONTEXT_SHOP);
+        Shop::setContext(Shop::CONTEXT_SHOP, Configuration::get('PS_SHOP_DEFAULT'));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -113,15 +113,26 @@ Feature: Order from Back Office (BO)
     Then there is duplicated cart "duplicated_dummy_cart" for cart dummy_cart
 
   Scenario: Add product to an existing Order without invoice without free shipping and new invoice
-    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Given there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock
+    And order with reference "bo_order1" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
     When I add products to order "bo_order1" with new invoice and the following products details:
-      | name          | Mug Today is a good day |
-      | amount        | 2                       |
-      | price         | 16                      |
-    Then order "bo_order1" should contain 2 products "Mug Today is a good day"
-    And product "Mug Today is a good day" in order "bo_order1" should have specific price 16.0
+      | name          | Test Added Product |
+      | amount        | 2                  |
+      | price         | 16                 |
+    Then order "bo_order1" should contain 2 products "Test Added Product"
+    And product "Test Added Product" in order "bo_order1" should have specific price 16.0
+    And the available stock for product "Test Added Product" should be 98
     And order "bo_order1" should have 4 products in total
     And order "bo_order1" should have 0 invoices
+    And product "Test Added Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_price               | 16.00 |
+      | original_product_price      | 15.00 |
+      | unit_price_tax_excl         | 16.00 |
+      | unit_price_tax_incl         | 16.96 |
+      | total_price_tax_excl        | 32.00 |
+      | total_price_tax_incl        | 33.92 |
     And order "bo_order1" should have following details:
       | total_products           | 55.80 |
       | total_products_wt        | 59.15 |
@@ -260,15 +271,26 @@ Feature: Order from Back Office (BO)
     Then order "bo_order1" should contain 0 products "Mug Today is a good day"
 
   Scenario: Delete product from order
-    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    Given there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock
+    And order with reference "bo_order1" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
     When I add products to order "bo_order1" with new invoice and the following products details:
-      | name          | Mug Today is a good day |
-      | amount        | 2                       |
-      | price         | 16                      |
-    Then order "bo_order1" should contain 2 products "Mug Today is a good day"
-    And product "Mug Today is a good day" in order "bo_order1" should have specific price 16.0
+      | name          | Test Added Product |
+      | amount        | 2                  |
+      | price         | 16                 |
+    Then order "bo_order1" should contain 2 products "Test Added Product"
+    And product "Test Added Product" in order "bo_order1" should have specific price 16.0
+    And the available stock for product "Test Added Product" should be 98
     And order "bo_order1" should have 4 products in total
     And order "bo_order1" should have 0 invoices
+    And product "Test Added Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_price               | 16.00 |
+      | original_product_price      | 15.00 |
+      | unit_price_tax_excl         | 16.00 |
+      | unit_price_tax_incl         | 16.96 |
+      | total_price_tax_excl        | 32.00 |
+      | total_price_tax_incl        | 33.92 |
     And order "bo_order1" should have following details:
       | total_products           | 55.80 |
       | total_products_wt        | 59.15 |
@@ -280,12 +302,13 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0   |
       | total_shipping_tax_excl  | 7.0   |
       | total_shipping_tax_incl  | 7.42  |
-    When I remove product "Mug Today is a good day" from order "bo_order1"
-    Then product "Mug Today is a good day" in order "bo_order1" should have no specific price
+    When I remove product "Test Added Product" from order "bo_order1"
+    Then product "Test Added Product" in order "bo_order1" should have no specific price
     And order "bo_order1" should have 2 products in total
-    And order "bo_order1" should contain 0 product "Mug Today is a good day"
-    And cart of order "bo_order1" should contain 0 product "Mug Today is a good day"
-    Then order "bo_order1" should have following details:
+    And order "bo_order1" should contain 0 product "Test Added Product"
+    And cart of order "bo_order1" should contain 0 product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 98
+    And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
       | total_discounts_tax_excl | 0.0    |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -307,7 +307,7 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have 2 products in total
     And order "bo_order1" should contain 0 product "Test Added Product"
     And cart of order "bo_order1" should contain 0 product "Test Added Product"
-    And the available stock for product "Test Added Product" should be 98
+    And the available stock for product "Test Added Product" should be 100
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -91,6 +91,17 @@ Feature: Order from Back Office (BO)
       | payment_method | Payments by check   |
       | transaction_id | test123             |
       | amount         | $6.00               |
+    And order "bo_order1" should have following details:
+      | total_products           | 23.80 |
+      | total_products_wt        | 25.23 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 30.80 |
+      | total_paid_tax_incl      | 32.65 |
+      | total_paid               | 32.65 |
+      | total_paid_real          | 6.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
 
   Scenario: Change order state to Delivered to be able to add valid invoice to new Payment
     When order "bo_order1" has 0 payments
@@ -108,7 +119,20 @@ Feature: Order from Back Office (BO)
       | amount        | 2                       |
       | price         | 16                      |
     Then order "bo_order1" should contain 2 products "Mug Today is a good day"
-    Then order "bo_order1" should have 0 invoices
+    And product "Mug Today is a good day" in order "bo_order1" should have specific price 16.0
+    And order "bo_order1" should have 4 products in total
+    And order "bo_order1" should have 0 invoices
+    And order "bo_order1" should have following details:
+      | total_products           | 55.80 |
+      | total_products_wt        | 59.15 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 62.80 |
+      | total_paid_tax_incl      | 66.57 |
+      | total_paid               | 66.57 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
 
   # This test validates the out of stock behaviour and a bug that occured when a specific price had been set
   Scenario: Add product with specific price without stock, get error, allow out of stock order and retry, it should work (no unicity error)
@@ -162,7 +186,19 @@ Feature: Order from Back Office (BO)
       | amount        | 2                       |
       | price         | 16                      |
     Then order "bo_order1" should contain 2 products "Mug Today is a good day"
-    Then order "bo_order1" should have 2 invoices
+    And product "Mug Today is a good day" in order "bo_order1" should have specific price 16.0
+    And order "bo_order1" should have 2 invoices
+    And order "bo_order1" should have following details:
+      | total_products           | 55.80 |
+      | total_products_wt        | 59.15 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 62.80 |
+      | total_paid_tax_incl      | 66.57 |
+      | total_paid               | 66.57 |
+      | total_paid_real          | 32.65 |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
 
   Scenario: Add product to an existing Order with invoice with free shipping to last invoice
     Given I update order "bo_order1" status to "Payment accepted"
@@ -173,7 +209,18 @@ Feature: Order from Back Office (BO)
       | amount        | 2                       |
       | price         | 16                      |
     Then order "bo_order1" should contain 2 products "Mug Today is a good day"
-    Then order "bo_order1" should have 1 invoice
+    And order "bo_order1" should have 1 invoice
+    And order "bo_order1" should have following details:
+      | total_products           | 55.80 |
+      | total_products_wt        | 59.15 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 62.80 |
+      | total_paid_tax_incl      | 66.57 |
+      | total_paid               | 66.57 |
+      | total_paid_real          | 32.65 |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
 
   Scenario: Add product with negative quantity is forbidden
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
@@ -215,15 +262,27 @@ Feature: Order from Back Office (BO)
   Scenario: Update product in order
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
       | amount        | 3                       |
-      | price         | 12                      |
+      | price         | 11.90                   |
     Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" should have no specific price
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 3  |
-      | product_price               | 12 |
-      | unit_price_tax_incl         | 12.72 |
-      | unit_price_tax_excl         | 12 |
-      | total_price_tax_incl        | 38.16 |
-      | total_price_tax_excl        | 36 |
+      | product_quantity            | 3      |
+      | product_price               | 11.90  |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.90  |
+      | total_price_tax_incl        | 37.84  |
+      | total_price_tax_excl        | 35.70  |
+    Then order "bo_order1" should have following details:
+      | total_products           | 35.700 |
+      | total_products_wt        | 37.840 |
+      | total_discounts_tax_excl | 0.0000 |
+      | total_discounts_tax_incl | 0.0000 |
+      | total_paid_tax_excl      | 42.7   |
+      | total_paid_tax_incl      | 45.260 |
+      | total_paid               | 45.260 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
 
   Scenario: Update product in order with zero quantity is forbidden
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
@@ -238,6 +297,17 @@ Feature: Order from Back Office (BO)
       | unit_price_tax_excl         | 11.9   |
       | total_price_tax_incl        | 25.230000 |
       | total_price_tax_excl        | 23.8   |
+    And order "bo_order1" should have following details:
+      | total_products           | 23.80 |
+      | total_products_wt        | 25.23 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 30.80 |
+      | total_paid_tax_incl      | 32.65 |
+      | total_paid               | 32.65 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
 
   Scenario: Update product in order with negative quantity is forbidden
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
@@ -250,8 +320,19 @@ Feature: Order from Back Office (BO)
       | product_price               | 11.9   |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.9   |
-      | total_price_tax_incl        | 25.230000 |
+      | total_price_tax_incl        | 25.23  |
       | total_price_tax_excl        | 23.8   |
+    And order "bo_order1" should have following details:
+      | total_products           | 23.80 |
+      | total_products_wt        | 25.23 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 30.80 |
+      | total_paid_tax_incl      | 32.65 |
+      | total_paid               | 32.65 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
 
   Scenario: Add different combinations of the same product
     Given there is a product in the catalog named "My Product" with a price of 10.00 and 200 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -112,7 +112,7 @@ Feature: Order from Back Office (BO)
     When I duplicate order "bo_order1" cart "dummy_cart" with reference "duplicated_dummy_cart"
     Then there is duplicated cart "duplicated_dummy_cart" for cart dummy_cart
 
-  Scenario: Add product to an existing Order without invoice with free shipping and new invoice
+  Scenario: Add product to an existing Order without invoice without free shipping and new invoice
     Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Mug Today is a good day |
@@ -177,7 +177,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
-  Scenario: Add product to an existing Order with invoice with free shipping to new invoice
+  Scenario: Add product to an existing Order with invoice without free shipping to new invoice
     Given I update order "bo_order1" status to "Payment accepted"
     And order "bo_order1" should have 1 invoice
     And order with reference "bo_order1" does not contain product "Mug Today is a good day"
@@ -200,7 +200,7 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0   |
       | total_shipping_tax_incl  | 7.42  |
 
-  Scenario: Add product to an existing Order with invoice with free shipping to last invoice
+  Scenario: Add product to an existing Order with invoice without free shipping to last invoice
     Given I update order "bo_order1" status to "Payment accepted"
     And order "bo_order1" should have 1 invoice
     And order with reference "bo_order1" does not contain product "Mug Today is a good day"
@@ -258,6 +258,44 @@ Feature: Order from Back Office (BO)
       | price         | 16                      |
     Then I should get error that product is out of stock
     Then order "bo_order1" should contain 0 products "Mug Today is a good day"
+
+  Scenario: Delete product from order
+    Given order with reference "bo_order1" does not contain product "Mug Today is a good day"
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Mug Today is a good day |
+      | amount        | 2                       |
+      | price         | 16                      |
+    Then order "bo_order1" should contain 2 products "Mug Today is a good day"
+    And product "Mug Today is a good day" in order "bo_order1" should have specific price 16.0
+    And order "bo_order1" should have 4 products in total
+    And order "bo_order1" should have 0 invoices
+    And order "bo_order1" should have following details:
+      | total_products           | 55.80 |
+      | total_products_wt        | 59.15 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 62.80 |
+      | total_paid_tax_incl      | 66.57 |
+      | total_paid               | 66.57 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
+    When I remove product "Mug Today is a good day" from order "bo_order1"
+    Then product "Mug Today is a good day" in order "bo_order1" should have no specific price
+    And order "bo_order1" should have 2 products in total
+    And order "bo_order1" should contain 0 product "Mug Today is a good day"
+    And cart of order "bo_order1" should contain 0 product "Mug Today is a good day"
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
 
   Scenario: Update product in order
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
@@ -359,7 +397,7 @@ Feature: Order from Back Office (BO)
     When I generate invoice for "bo_order1" order
     Then order "bo_order1" should have invoice
 
-  Scenario: Add gift order from Back Office with free shipping
+  Scenario: Add gift order from Back Office without free shipping
     And I create an empty cart "dummy_cart2" for customer "testCustomer"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart2"
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart2"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -1,0 +1,140 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-multi-shop
+@reset-database-before-feature
+@clear-cache-before-feature
+@order-multi-shop
+Feature: Order from Back Office (BO)
+  In order to manage orders for FO customers
+  As a BO user
+  I need to be able to customize orders from the BO even when it has multi shops
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    # These tests were initially created to ensure the quantity can be updated even in multishop all context,
+    # because StockManagementRepository cannot work in a multi shop context, but it is required to create a new
+    # product So we force single shop context create the product, then we need to reboot the kernel so that
+    # StockManagementRepository is created again in the following steps of the scenario
+    And single shop context is loaded
+    And there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock
+    And I reboot kernel
+    And multiple shop context is loaded
+
+  Scenario: Update product in order
+    When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
+      | amount        | 3                       |
+      | price         | 11.90                   |
+    Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" should have no specific price
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 3      |
+      | product_price               | 11.90  |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.90  |
+      | total_price_tax_incl        | 37.84  |
+      | total_price_tax_excl        | 35.70  |
+    Then order "bo_order1" should have following details:
+      | total_products           | 35.700 |
+      | total_products_wt        | 37.840 |
+      | total_discounts_tax_excl | 0.0000 |
+      | total_discounts_tax_incl | 0.0000 |
+      | total_paid_tax_excl      | 42.7   |
+      | total_paid_tax_incl      | 45.260 |
+      | total_paid               | 45.260 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: Add product to an existing Order without invoice without free shipping and new invoice
+    And order with reference "bo_order1" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Added Product |
+      | amount        | 2                  |
+      | price         | 16                 |
+    Then order "bo_order1" should contain 2 products "Test Added Product"
+    And product "Test Added Product" in order "bo_order1" should have specific price 16.0
+    And the available stock for product "Test Added Product" should be 98
+    And order "bo_order1" should have 4 products in total
+    And order "bo_order1" should have 0 invoices
+    And product "Test Added Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_price               | 16.00 |
+      | original_product_price      | 15.00 |
+      | unit_price_tax_excl         | 16.00 |
+      | unit_price_tax_incl         | 16.96 |
+      | total_price_tax_excl        | 32.00 |
+      | total_price_tax_incl        | 33.92 |
+    And order "bo_order1" should have following details:
+      | total_products           | 55.80 |
+      | total_products_wt        | 59.15 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 62.80 |
+      | total_paid_tax_incl      | 66.57 |
+      | total_paid               | 66.57 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
+
+  Scenario: Delete product from order
+    Given order with reference "bo_order1" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Added Product |
+      | amount        | 2                  |
+      | price         | 16                 |
+    Then order "bo_order1" should contain 2 products "Test Added Product"
+    And product "Test Added Product" in order "bo_order1" should have specific price 16.0
+    And the available stock for product "Test Added Product" should be 98
+    And order "bo_order1" should have 4 products in total
+    And order "bo_order1" should have 0 invoices
+    And product "Test Added Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_price               | 16.00 |
+      | original_product_price      | 15.00 |
+      | unit_price_tax_excl         | 16.00 |
+      | unit_price_tax_incl         | 16.96 |
+      | total_price_tax_excl        | 32.00 |
+      | total_price_tax_incl        | 33.92 |
+    And order "bo_order1" should have following details:
+      | total_products           | 55.80 |
+      | total_products_wt        | 59.15 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 62.80 |
+      | total_paid_tax_incl      | 66.57 |
+      | total_paid               | 66.57 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
+    When I remove product "Test Added Product" from order "bo_order1"
+    Then product "Test Added Product" in order "bo_order1" should have no specific price
+    And order "bo_order1" should have 2 products in total
+    And order "bo_order1" should contain 0 product "Test Added Product"
+    And cart of order "bo_order1" should contain 0 product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 98
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -126,7 +126,7 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have 2 products in total
     And order "bo_order1" should contain 0 product "Test Added Product"
     And cart of order "bo_order1" should contain 0 product "Test Added Product"
-    And the available stock for product "Test Added Product" should be 98
+    And the available stock for product "Test Added Product" should be 100
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |

--- a/tests/Integration/Behaviour/bootstrap.php
+++ b/tests/Integration/Behaviour/bootstrap.php
@@ -31,5 +31,8 @@
 $rootDirectory = __DIR__ . '/../../../';
 
 define('_PS_IN_TEST_', true);
+if (!defined('_PS_ADMIN_DIR_')) {
+    define('_PS_ADMIN_DIR_', __DIR__);
+}
 require_once $rootDirectory . 'config/config.inc.php';
 require_once $rootDirectory . 'app/AppKernel.php';

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -165,7 +165,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
         }
 
-        public function testShopStateGroup()
+        public function testShopStateAll()
         {
             $context = $this->createContextMock([
                 'shop' => $this->createContextFieldMock(Shop::class, 42),
@@ -200,6 +200,43 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(null, Shop::getContextShopID());
             $this->assertEquals(null, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
+        }
+
+        public function testShopStateGroup()
+        {
+            $context = $this->createContextMock([
+                'shop' => $this->createContextFieldMock(Shop::class, 42),
+            ]);
+            Shop::setContext(Shop::CONTEXT_GROUP, 42);
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(null, Shop::getContextShopID());
+            $this->assertEquals(42, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
+            $this->assertEquals(51, $context->shop->id);
+            $this->assertEquals(51, Shop::getContextShopID());
+            $this->assertEquals(51, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 69));
+            $this->assertEquals(69, $context->shop->id);
+            $this->assertEquals(69, Shop::getContextShopID());
+            $this->assertEquals(69, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(null, Shop::getContextShopID());
+            $this->assertEquals(42, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(null, Shop::getContextShopID());
+            $this->assertEquals(42, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
         }
 
         public function testNullField()

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -24,331 +24,416 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\Unit\Adapter;
+namespace Tests\Unit\Adapter {
+    use Cart;
+    use Context;
+    use Country;
+    use Currency;
+    use Customer;
+    use Language;
+    use PHPUnit\Framework\MockObject\MockObject;
+    use PHPUnit\Framework\TestCase;
+    use PrestaShop\PrestaShop\Adapter\ContextStateManager;
+    use Shop;
 
-use Cart;
-use Context;
-use Country;
-use Currency;
-use Customer;
-use Language;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Adapter\ContextStateManager;
-
-class ContextStateManagerTest extends TestCase
-{
-    public function testCartState()
+    class ContextStateManagerTest extends TestCase
     {
-        $context = $this->createContextMock([
-            'cart' => $this->createContextFieldMock(Cart::class, 42),
-        ]);
-        $this->assertEquals(42, $context->cart->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 51));
-        $this->assertEquals(51, $context->cart->id);
-
-        $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 69));
-        $this->assertEquals(69, $context->cart->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->cart->id);
-    }
-
-    public function testCountryState()
-    {
-        $context = $this->createContextMock([
-            'country' => $this->createContextFieldMock(Country::class, 42),
-        ]);
-        $this->assertEquals(42, $context->country->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 51));
-        $this->assertEquals(51, $context->country->id);
-
-        $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 69));
-        $this->assertEquals(69, $context->country->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->country->id);
-    }
-
-    public function testCurrencyState()
-    {
-        $context = $this->createContextMock([
-            'currency' => $this->createContextFieldMock(Currency::class, 42),
-        ]);
-        $this->assertEquals(42, $context->currency->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 51));
-        $this->assertEquals(51, $context->currency->id);
-
-        $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 69));
-        $this->assertEquals(69, $context->currency->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->currency->id);
-    }
-
-    public function testCustomerState()
-    {
-        $context = $this->createContextMock([
-            'customer' => $this->createContextFieldMock(Customer::class, 42),
-        ]);
-        $this->assertEquals(42, $context->customer->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 51));
-        $this->assertEquals(51, $context->customer->id);
-
-        $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 69));
-        $this->assertEquals(69, $context->customer->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->customer->id);
-    }
-
-    public function testLanguageState()
-    {
-        $context = $this->createContextMock([
-            'language' => $this->createContextFieldMock(Language::class, 42),
-        ]);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
-        $this->assertEquals(51, $context->language->id);
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->language->id);
-    }
-
-    public function testNullField()
-    {
-        $context = $this->createContextMock([
-            'language' => null,
-        ]);
-        $this->assertNull($context->language);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
-        $this->assertEquals(51, $context->language->id);
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertNull($context->language);
-    }
-
-    public function testMultipleFields()
-    {
-        $context = $this->createContextMock([
-            'cart' => $this->createContextFieldMock(Cart::class, 42),
-            'country' => $this->createContextFieldMock(Country::class, 42),
-            'currency' => $this->createContextFieldMock(Currency::class, 42),
-            'customer' => $this->createContextFieldMock(Customer::class, 42),
-            'language' => $this->createContextFieldMock(Language::class, 42),
-        ]);
-        $this->assertEquals(42, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(42, $context->currency->id);
-        $this->assertEquals(42, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager
-            ->setCart($this->createContextFieldMock(Cart::class, 51))
-            ->setCountry($this->createContextFieldMock(Country::class, 51))
-            ->setCurrency($this->createContextFieldMock(Currency::class, 51))
-            ->setCustomer($this->createContextFieldMock(Customer::class, 51))
-            ->setLanguage($this->createContextFieldMock(Language::class, 51))
-        ;
-
-        $this->assertEquals(51, $context->cart->id);
-        $this->assertEquals(51, $context->country->id);
-        $this->assertEquals(51, $context->currency->id);
-        $this->assertEquals(51, $context->customer->id);
-        $this->assertEquals(51, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-
-        $this->assertEquals(42, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(42, $context->currency->id);
-        $this->assertEquals(42, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-    }
-
-    public function testSavedContexts()
-    {
-        $context = $this->createContextMock([
-            'language' => $this->createContextFieldMock(Language::class, 42),
-        ]);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
-        $this->assertEquals(51, $context->language->id);
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->saveCurrentContext();
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
-        $this->assertEquals(93, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->language->id);
-
-        // If several sets have been called, the state returns to the value that was saved
-        $contextStateManager->saveCurrentContext();
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
-        $this->assertEquals(51, $context->language->id);
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->language->id);
-    }
-
-    public function testMultipleSavedContextFieds()
-    {
-        $context = $this->createContextMock([
-            'cart' => $this->createContextFieldMock(Cart::class, 42),
-            'country' => $this->createContextFieldMock(Country::class, 42),
-            'currency' => $this->createContextFieldMock(Currency::class, 42),
-            'customer' => $this->createContextFieldMock(Customer::class, 42),
-            'language' => $this->createContextFieldMock(Language::class, 42),
-        ]);
-        $this->assertEquals(42, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(42, $context->currency->id);
-        $this->assertEquals(42, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager
-            ->setCart($this->createContextFieldMock(Cart::class, 51))
-            ->setCurrency($this->createContextFieldMock(Currency::class, 51))
-            ->setCustomer($this->createContextFieldMock(Customer::class, 51))
-        ;
-
-        $this->assertEquals(51, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(51, $context->currency->id);
-        $this->assertEquals(51, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager->saveCurrentContext();
-
-        $contextStateManager
-            ->setCart($this->createContextFieldMock(Cart::class, 69))
-            ->setCurrency($this->createContextFieldMock(Currency::class, 69))
-        ;
-
-        $this->assertEquals(69, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(69, $context->currency->id);
-        $this->assertEquals(51, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-
-        $this->assertEquals(51, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(51, $context->currency->id);
-        $this->assertEquals(51, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-
-        $this->assertEquals(42, $context->cart->id);
-        $this->assertEquals(42, $context->country->id);
-        $this->assertEquals(42, $context->currency->id);
-        $this->assertEquals(42, $context->customer->id);
-        $this->assertEquals(42, $context->language->id);
-    }
-
-    public function testTooManyRestore()
-    {
-        $context = $this->createContextMock([
-            'language' => $this->createContextFieldMock(Language::class, 42),
-        ]);
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager = new ContextStateManager($context);
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
-        $this->assertEquals(51, $context->language->id);
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->saveCurrentContext();
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
-        $this->assertEquals(93, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(69, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->language->id);
-
-        // This removes all persisted states, but we always re-init one for future calls
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->language->id);
-
-        $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
-        $this->assertEquals(93, $context->language->id);
-
-        $contextStateManager->restorePreviousContext();
-        $this->assertEquals(42, $context->language->id);
-    }
-
-    /**
-     * @param string $className
-     * @param int $objectId
-     *
-     * @return MockObject|Cart|Country|Currency|Customer|Language
-     */
-    private function createContextFieldMock(string $className, int $objectId)
-    {
-        $contextField = $this->getMockBuilder($className)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $contextField->id = $objectId;
-
-        return $contextField;
-    }
-
-    /**
-     * @param array $contextFields
-     *
-     * @return MockObject|Context
-     */
-    private function createContextMock(array $contextFields)
-    {
-        $contextMock = $this->getMockBuilder(Context::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        foreach ($contextFields as $fieldName => $contextValue) {
-            $contextMock->$fieldName = $contextValue;
+        public function testCartState()
+        {
+            $context = $this->createContextMock([
+                'cart' => $this->createContextFieldMock(Cart::class, 42),
+            ]);
+            $this->assertEquals(42, $context->cart->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 51));
+            $this->assertEquals(51, $context->cart->id);
+
+            $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 69));
+            $this->assertEquals(69, $context->cart->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->cart->id);
         }
 
-        return $contextMock;
+        public function testCountryState()
+        {
+            $context = $this->createContextMock([
+                'country' => $this->createContextFieldMock(Country::class, 42),
+            ]);
+            $this->assertEquals(42, $context->country->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 51));
+            $this->assertEquals(51, $context->country->id);
+
+            $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 69));
+            $this->assertEquals(69, $context->country->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->country->id);
+        }
+
+        public function testCurrencyState()
+        {
+            $context = $this->createContextMock([
+                'currency' => $this->createContextFieldMock(Currency::class, 42),
+            ]);
+            $this->assertEquals(42, $context->currency->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 51));
+            $this->assertEquals(51, $context->currency->id);
+
+            $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 69));
+            $this->assertEquals(69, $context->currency->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->currency->id);
+        }
+
+        public function testCustomerState()
+        {
+            $context = $this->createContextMock([
+                'customer' => $this->createContextFieldMock(Customer::class, 42),
+            ]);
+            $this->assertEquals(42, $context->customer->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 51));
+            $this->assertEquals(51, $context->customer->id);
+
+            $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 69));
+            $this->assertEquals(69, $context->customer->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->customer->id);
+        }
+
+        public function testLanguageState()
+        {
+            $context = $this->createContextMock([
+                'language' => $this->createContextFieldMock(Language::class, 42),
+            ]);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+            $this->assertEquals(51, $context->language->id);
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+        }
+
+        public function testShopState()
+        {
+            $context = $this->createContextMock([
+                'shop' => $this->createContextFieldMock(Shop::class, 42),
+            ]);
+            Shop::setContext(Shop::CONTEXT_SHOP, 42);
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(42, Shop::getContextShopID());
+            $this->assertEquals(42, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
+            $this->assertEquals(51, $context->shop->id);
+            $this->assertEquals(51, Shop::getContextShopID());
+            $this->assertEquals(51, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 69));
+            $this->assertEquals(69, $context->shop->id);
+            $this->assertEquals(69, Shop::getContextShopID());
+            $this->assertEquals(69, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(42, Shop::getContextShopID());
+            $this->assertEquals(42, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(42, Shop::getContextShopID());
+            $this->assertEquals(42, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+        }
+
+        public function testShopStateGroup()
+        {
+            $context = $this->createContextMock([
+                'shop' => $this->createContextFieldMock(Shop::class, 42),
+            ]);
+            Shop::setContext(Shop::CONTEXT_ALL);
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(null, Shop::getContextShopID());
+            $this->assertEquals(null, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
+            $this->assertEquals(51, $context->shop->id);
+            $this->assertEquals(51, Shop::getContextShopID());
+            $this->assertEquals(51, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 69));
+            $this->assertEquals(69, $context->shop->id);
+            $this->assertEquals(69, Shop::getContextShopID());
+            $this->assertEquals(69, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(null, Shop::getContextShopID());
+            $this->assertEquals(null, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->shop->id);
+            $this->assertEquals(null, Shop::getContextShopID());
+            $this->assertEquals(null, Shop::getContextShopGroupID());
+            $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
+        }
+
+        public function testNullField()
+        {
+            $context = $this->createContextMock([
+                'language' => null,
+            ]);
+            $this->assertNull($context->language);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+            $this->assertEquals(51, $context->language->id);
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertNull($context->language);
+        }
+
+        public function testMultipleFields()
+        {
+            $context = $this->createContextMock([
+                'cart' => $this->createContextFieldMock(Cart::class, 42),
+                'country' => $this->createContextFieldMock(Country::class, 42),
+                'currency' => $this->createContextFieldMock(Currency::class, 42),
+                'customer' => $this->createContextFieldMock(Customer::class, 42),
+                'language' => $this->createContextFieldMock(Language::class, 42),
+            ]);
+            $this->assertEquals(42, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(42, $context->currency->id);
+            $this->assertEquals(42, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager
+                ->setCart($this->createContextFieldMock(Cart::class, 51))
+                ->setCountry($this->createContextFieldMock(Country::class, 51))
+                ->setCurrency($this->createContextFieldMock(Currency::class, 51))
+                ->setCustomer($this->createContextFieldMock(Customer::class, 51))
+                ->setLanguage($this->createContextFieldMock(Language::class, 51))
+            ;
+
+            $this->assertEquals(51, $context->cart->id);
+            $this->assertEquals(51, $context->country->id);
+            $this->assertEquals(51, $context->currency->id);
+            $this->assertEquals(51, $context->customer->id);
+            $this->assertEquals(51, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+
+            $this->assertEquals(42, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(42, $context->currency->id);
+            $this->assertEquals(42, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+        }
+
+        public function testSavedContexts()
+        {
+            $context = $this->createContextMock([
+                'language' => $this->createContextFieldMock(Language::class, 42),
+            ]);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+            $this->assertEquals(51, $context->language->id);
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->saveCurrentContext();
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
+            $this->assertEquals(93, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+
+            // If several sets have been called, the state returns to the value that was saved
+            $contextStateManager->saveCurrentContext();
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+            $this->assertEquals(51, $context->language->id);
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+        }
+
+        public function testMultipleSavedContextFieds()
+        {
+            $context = $this->createContextMock([
+                'cart' => $this->createContextFieldMock(Cart::class, 42),
+                'country' => $this->createContextFieldMock(Country::class, 42),
+                'currency' => $this->createContextFieldMock(Currency::class, 42),
+                'customer' => $this->createContextFieldMock(Customer::class, 42),
+                'language' => $this->createContextFieldMock(Language::class, 42),
+            ]);
+            $this->assertEquals(42, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(42, $context->currency->id);
+            $this->assertEquals(42, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager
+                ->setCart($this->createContextFieldMock(Cart::class, 51))
+                ->setCurrency($this->createContextFieldMock(Currency::class, 51))
+                ->setCustomer($this->createContextFieldMock(Customer::class, 51))
+            ;
+
+            $this->assertEquals(51, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(51, $context->currency->id);
+            $this->assertEquals(51, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager->saveCurrentContext();
+
+            $contextStateManager
+                ->setCart($this->createContextFieldMock(Cart::class, 69))
+                ->setCurrency($this->createContextFieldMock(Currency::class, 69))
+            ;
+
+            $this->assertEquals(69, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(69, $context->currency->id);
+            $this->assertEquals(51, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+
+            $this->assertEquals(51, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(51, $context->currency->id);
+            $this->assertEquals(51, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+
+            $this->assertEquals(42, $context->cart->id);
+            $this->assertEquals(42, $context->country->id);
+            $this->assertEquals(42, $context->currency->id);
+            $this->assertEquals(42, $context->customer->id);
+            $this->assertEquals(42, $context->language->id);
+        }
+
+        public function testTooManyRestore()
+        {
+            $context = $this->createContextMock([
+                'language' => $this->createContextFieldMock(Language::class, 42),
+            ]);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+            $this->assertEquals(51, $context->language->id);
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->saveCurrentContext();
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
+            $this->assertEquals(93, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(69, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+
+            // This removes all persisted states, but we always re-init one for future calls
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
+            $this->assertEquals(93, $context->language->id);
+
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+        }
+
+        /**
+         * @param string $className
+         * @param int $objectId
+         *
+         * @return MockObject|Cart|Country|Currency|Customer|Language|Shop
+         */
+        private function createContextFieldMock(string $className, int $objectId)
+        {
+            $contextField = $this->getMockBuilder($className)
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $contextField->id = $objectId;
+
+            return $contextField;
+        }
+
+        /**
+         * @param array $contextFields
+         *
+         * @return MockObject|Context
+         */
+        private function createContextMock(array $contextFields)
+        {
+            $contextMock = $this->getMockBuilder(Context::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            foreach ($contextFields as $fieldName => $contextValue) {
+                $contextMock->$fieldName = $contextValue;
+            }
+
+            return $contextMock;
+        }
+    }
+}
+
+namespace {
+    class Shop extends ShopCore
+    {
+        public static function getGroupFromShop($shop_id, $as_id = true)
+        {
+            return $shop_id;
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Some errors happened when stock movement needed to be added, because `StockManagementRepository` constructor checks that we are in single shop context So the ContextStateManager is now able to override the shop context which allows to perform any modif even when you are in All shops context (it forces the order's shop in the context just the time to make the changes)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21706
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21721)
<!-- Reviewable:end -->
