### PR TITLE
Fix nightly (03-11-2020) 'Sort shopping cart table by order ID'

### DIFF
--- a/tests/UI/campaigns/functional/BO/02_orders/05_shoppingCarts/02_sortAndPagination.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/05_shoppingCarts/02_sortAndPagination.js
@@ -170,7 +170,7 @@ describe('sort and pagination shopping carts', async () => {
   });
 
   // 3 - Sort table
-  describe('Sort cart rules table', async () => {
+  describe('Sort shopping cart table', async () => {
     const sortTests = [
       {
         args: {

--- a/tests/UI/campaigns/functional/BO/02_orders/05_shoppingCarts/02_sortAndPagination.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/05_shoppingCarts/02_sortAndPagination.js
@@ -179,12 +179,12 @@ describe('sort and pagination shopping carts', async () => {
       },
       {
         args: {
-          testIdentifier: 'sortByOrderIDAsc', sortBy: 'status', sortDirection: 'up',
+          testIdentifier: 'sortByOrderIDAsc', sortBy: 'status', sortDirection: 'up', isFloat: true,
         },
       },
       {
         args: {
-          testIdentifier: 'sortByOrderIDDesc', sortBy: 'status', sortDirection: 'down',
+          testIdentifier: 'sortByOrderIDDesc', sortBy: 'status', sortDirection: 'down', isFloat: true,
         },
       },
       /* Sort by carrier not working, skipping it


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fix Sort shopping cart table by order ID
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  |  TEST_PATH="functional/BO/02_orders/05_shoppingCarts/02_sortAndPagination.js" URL_FO=yourShopURL npm run specific-test

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21726)
<!-- Reviewable:end -->
