### PR TITLE
Force lowercase email addresses to fix missing variables in templates

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -298,7 +298,7 @@ class MailCore extends ObjectModel
 
         if (is_array($to) && isset($to)) {
             foreach ($to as $key => $addr) {
-                $addr = trim($addr);
+                $addr = strtolower(trim($addr));
                 if (!Validate::isEmail($addr)) {
                     self::dieOrLog($die, 'Error: invalid e-mail address');
 
@@ -316,9 +316,10 @@ class MailCore extends ObjectModel
                           self::mimeEncode($addrName);
                 $message->addTo(self::toPunycode($addr), $addrName);
             }
-            $toPlugin = $to[0];
+            $toPlugin = strtolower($to[0]);
         } else {
             /* Simple recipient, one address */
+            $to = strtolower($to);
             $toPlugin = $to;
             $toName = (($toName == null || $toName == $to) ? '' : self::mimeEncode($toName));
             $message->addTo(self::toPunycode($to), $toName);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | If the customer gave an email address with uppercase characters (eg `foo@bar.Com` instead of `foo@bar.com`), the `templateVars` are passed to Swift in an array indexed by the given email (eg `foo@bar.Com`) here:<br><br>`$swift->registerPlugin(new \Swift_Plugins_DecoratorPlugin(array($toPlugin => $templateVars)));`<br><br>Problem is: Swift looks for the lowercase key (eg `foo@bar.com`) and doesn't find variables. We need to force lowercase on email addresses to fix this.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to pass an order with a mixed-case email address. You should receive a mail with variables no replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21763)
<!-- Reviewable:end -->
