### PR TITLE
Made sure getErrorsByLocale doesn't return empty

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -199,7 +199,7 @@ class TranslatableType extends TranslatorAwareType
     private function getErrorsByLocale(FormView $view, FormInterface $form, array $locales)
     {
         if (count($locales) <= 1) {
-            return;
+            return null;
         }
 
         $formErrors = $form->getErrors(true);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Made sure getErrorsByLocale doesn't return empty (and by extension fixes PHPStan error. )
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? |  no
| How to test?  | Q&A probably is not required

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21776)
<!-- Reviewable:end -->
