### PR TITLE
Remove composer.lock from the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ npm-debug.log.*
 
 /vendor/*
 /docs/phpdoc-sf/
-/composer.lock
 *.hot-update.js
 *.hot-update.json
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Since the composer.lock file is already inside this repository, remove it from the .gitignore file.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | /
| How to test?  | /

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21777)
<!-- Reviewable:end -->
