### PR TITLE
Get proper cover for product in cart and cart modal

### DIFF
--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -48,7 +48,8 @@
                   >
                 {else}
                   <img
-                    src="{$urls.no_picture_image.medium.url}"
+                    src="{$urls.no_picture_image.bySize.medium_default.url}"
+                    loading="lazy"
                     class="product-image"
                   />
                 {/if}

--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -36,10 +36,21 @@
           <div class="col-md-5 divide-right">
             <div class="row">
               <div class="col-md-6">
-                {if $product.cover}
-                  <img class="product-image" src="{$product.cover.medium.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" itemprop="image" loading="lazy">
+                {if $product.default_image}
+                  <img
+                    src="{$product.default_image.medium.url}"
+                    data-full-size-image-url="{$product.default_image.large.url}"
+                    title="{$product.default_image.legend}"
+                    alt="{$product.default_image.legend}"
+                    itemprop="image"
+                    loading="lazy"
+                    class="product-image"
+                  >
                 {else}
-                  <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
+                  <img
+                    src="{$urls.no_picture_image.medium.url}"
+                    class="product-image"
+                  />
                 {/if}
               </div>
               <div class="col-md-6">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Get proper cover for product with variant
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21775 
| How to test?  | Add variants with different images to cart, check for proper covers in display and in cart
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

I don't like this fix tbh, this will create n+1 query for products with cart, the problem is that with changes to covers introduced some time ago I don't see any other way to split getting products with **real** cover based on attribute selection, with those where we need to get products on listings and force **selected cover from BO**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21782)
<!-- Reviewable:end -->
