### PR TITLE
Get page title respecting dedicated meta title and combination information

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -469,7 +469,9 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
             // We use the meta_title key because product_title is used for the title of the page
-            'product_title' => $product['meta_title'],
+            'product_title' => $this->getProductPageTitle(
+                $this->getTemplateVarPage()['meta'] ?? []
+            ),
             'is_quick_view' => $isQuickView,
         ]));
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -468,7 +468,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
-            // We use the meta_title key because product_title is used for the title of the page
             'product_title' => $this->getProductPageTitle(
                 $this->getTemplateVarPage()['meta'] ?? []
             ),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This is follow up for https://github.com/PrestaShop/PrestaShop/issues/21391
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21391 
| How to test?  | Detailed instruction below.
| Sponsor company | impSolutions

<!-- Click the form's "Preview" button to make sure the tabe is functional in GitHub. Thank you! -->

Previous version fixed an issue with not correctly displayed `meta_title` after changing combination, but it was not working properly with setting from Shop Parameters -> Traffic & SEO -> Display attributes in the product meta title  -> YES

## How to test?

0. Set "Display attributes in the product meta title" to "YES"
1. Edit product ID 1
2. Set meta title to: Dedicated meta title
3. Go to product page, see that the current title is:
> Dedicated meta title Size S Color White
4. Now change combination, see that title is:
> Dedicated meta title

NOK

Point 4 should change meta title to:
> Dedicated meta title Size S Color Black

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21783)
<!-- Reviewable:end -->
