### PR TITLE
Add itemprop properties from schema.org

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -35,6 +35,7 @@
               alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
               loading="lazy"
               data-full-size-image-url="{$product.cover.large.url}"
+              itemprop="image"
               />
           </a>
         {else}
@@ -73,6 +74,8 @@
               <div itemprop="offers" itemscope itemtype="http://schema.org/Offer" class="invisible">
                 <meta itemprop="priceCurrency" content="{$currency.iso_code}" />
                 <meta itemprop="price" content="{$product.price_amount}" />
+                <meta itemprop="url" content="{$product.url}" />
+                <link itemprop="availability" href="{$product.seo_availability}" />
               </div>
 
               {hook h='displayProductPriceBlock' product=$product type='unit_price'}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |  Fixing some of the Google Search Console warnings for products listing pages.
| Type?         |  Bug
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #15554 and some of the #15764
| How to test?  | Go to product warnings in Google Search Console. Then push button VALIDATE FIX for corresponding warning (in product listing look for missing field image and in offers look for missing url or availability). After Google crawl your pages, these warnings will disappear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21786)
<!-- Reviewable:end -->
