### PR TITLE
Fix Customer view Vouchers & Addresses tables

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/index.js
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.js
@@ -66,9 +66,11 @@ $(() => {
 
   const customerDiscountsGrid = new Grid('customer_discount');
   customerDiscountsGrid.addExtension(new SubmitRowActionExtension());
+  customerDiscountsGrid.addExtension(new LinkRowActionExtension());
 
   const customerAddressesGrid = new Grid('customer_address');
   customerAddressesGrid.addExtension(new SubmitRowActionExtension());
+  customerAddressesGrid.addExtension(new LinkRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());

--- a/src/Core/Grid/Column/Type/Common/StatusColumn.php
+++ b/src/Core/Grid/Column/Type/Common/StatusColumn.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,25 +22,42 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-<div class="card customer-discounts-card">
-  <h3 class="card-header">
-    <i class="material-icons">loyalty</i>
-    {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
-  </h3>
-  <div class="card-body">
-    {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-      </p>
-    {% endif %}
-  </div>
-</div>
+namespace PrestaShop\PrestaShop\Core\Grid\Column\Type\Common;
+
+use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class Column defines most simple column in the grid that renders raw data.
+ */
+final class StatusColumn extends AbstractColumn
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'status';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired([
+                'field',
+            ])
+            ->setDefaults([
+                'clickable' => true,
+            ])
+            ->setAllowedTypes('field', 'string')
+            ->setAllowedTypes('clickable', 'bool')
+        ;
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -135,6 +135,7 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
                                 'extra_route_params' => [
                                     'back' => $this->backUrl,
                                 ],
+                                'clickable_row' => true,
                             ])
                     )
                     ->add(

--- a/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\Customer\EditCustomerDiscoun
 use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\StatusColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 
 /**
@@ -88,7 +89,7 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ])
             )
             ->add(
-                (new DataColumn('active'))
+                (new StatusColumn('active'))
                     ->setName($this->trans('Status', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'active',

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/edit_customer_discount.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/edit_customer_discount.html.twig
@@ -36,6 +36,8 @@
     data-placement="top"
     data-original-title="{{ action.name }}"
   {% endif %}
+   data-confirm-message=""
+   data-clickable-row="1"
 >
   {% if action.icon is not empty %}
     <i class="material-icons">{{ action.icon }}</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
@@ -31,7 +31,9 @@
   <thead class="thead-default">
   {% block grid_table_head %}
     {{ include('@PrestaShop/Admin/Common/Grid/Blocks/Table/headers_row.html.twig', {'grid': grid}) }}
-    {{ include('@PrestaShop/Admin/Common/Grid/Blocks/Table/filters_row.html.twig', {'grid': grid}) }}
+    {% if grid.actions.bulk|length > 0 or grid.filter_form|length > 1 %}
+      {{ include('@PrestaShop/Admin/Common/Grid/Blocks/Table/filters_row.html.twig', {'grid': grid}) }}
+    {% endif %}
   {% endblock %}
   </thead>
   <tbody>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/status.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/status.html.twig
@@ -22,24 +22,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
+{% set isValid = record[column.id] is same as('1') %}
 
-<div class="card customer-discounts-card">
-  <h3 class="card-header">
-    <i class="material-icons">loyalty</i>
-    {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
-  </h3>
-  <div class="card-body">
-    {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-      </p>
-    {% endif %}
-  </div>
-</div>
+<i
+  class="material-icons {% if isValid == true %}text-success{% else %}text-danger{% endif %}"
+>
+  {% if isValid %}check{% else %}clear{% endif %}
+</i>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | On the customer view page, the Vouchers table & the Addresses table were not displayed as it should. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21778
| How to test?  | Please see #21778

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21793)
<!-- Reviewable:end -->
