### PR TITLE
Improve attachment tests to check multiple languages

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_management.feature
@@ -5,13 +5,28 @@ Feature: Manage attachment from Back Office (BO)
   As an employee I want to be able to add, update and delete attachments
 
   Scenario: I add new attachment
+    Given language "language1" with locale "en-US" exists
+    And language with iso code "en" is the default one
+    And language "language2" with locale "fr-FR" exists
     When I add new attachment "att1" with following properties:
-      | description | en-US:puffin photo nr1 |
-      | name        | en-US:puffin           |
-      | file_name   | app_icon.png           |
+      | description | en-US:puffin photo nr1;fr-FR:photo de macareux |
+      | name        | en-US:puffin;fr-FR:macareux                    |
+      | file_name   | app_icon.png                                   |
     Then attachment "att1" should have following properties:
+      | description | en-US:puffin photo nr1;fr-FR:photo de macareux |
+      | name        | en-US:puffin;fr-FR:macareux                    |
+      | file_name   | app_icon.png                                   |
+      | mime        | image/png                                      |
+      | size        | 19187                                          |
+
+  Scenario: I add new attachment providing name and description only in default language
+    When I add new attachment "att2" with following properties:
       | description | en-US:puffin photo nr1 |
       | name        | en-US:puffin           |
       | file_name   | app_icon.png           |
-      | mime        | image/png              |
-      | size        | 19187                  |
+    Then attachment "att2" should have following properties:
+      | description | en-US:puffin photo nr1;fr-FR: |
+      | name        | en-US:puffin;fr-FR:puffin     |
+      | file_name   | app_icon.png                  |
+      | mime        | image/png                     |
+      | size        | 19187                         |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
@@ -6,6 +6,9 @@ Feature: Update product attachments from Back Office (BO).
   As an employee I want to be able to assign/remove existing attachments to product and add new ones.
 
   Scenario: I associate attachment with product
+    Given language "language1" with locale "en-US" exists
+    And language with iso code "en" is the default one
+    And language "language2" with locale "fr-FR" exists
     When I add product "product1" with following information:
       | name       | en-US:mug with photo |
       | is_virtual | false                |
@@ -17,21 +20,21 @@ Feature: Update product attachments from Back Office (BO).
       | name        | en-US:puffin           |
       | file_name   | app_icon.png           |
     Then attachment "att1" should have following properties:
-      | description | en-US:puffin photo nr1 |
-      | name        | en-US:puffin           |
-      | file_name   | app_icon.png           |
-      | mime        | image/png              |
-      | size        | 19187                  |
+      | description | en-US:puffin photo nr1;fr-FR: |
+      | name        | en-US:puffin;fr-FR:puffin     |
+      | file_name   | app_icon.png                  |
+      | mime        | image/png                     |
+      | size        | 19187                         |
     Given I add new attachment "att2" with following properties:
       | description | en-US:my shop logo |
       | name        | en-US:myShop       |
       | file_name   | logo.jpg           |
     Then attachment "att2" should have following properties:
-      | description | en-US:my shop logo |
-      | name        | en-US:myShop       |
-      | mime        | image/jpeg         |
-      | file_name   | logo.jpg           |
-      | size        | 2758               |
+      | description | en-US:my shop logo;fr-FR: |
+      | name        | en-US:myShop;fr-FR:myShop |
+      | mime        | image/jpeg                |
+      | file_name   | logo.jpg                  |
+      | size        | 2758                      |
     When I associate attachment "att1" with product product1
     Then product product1 should have following attachments associated: "[att1]"
 

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -197,6 +197,7 @@ default:
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttachmentFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
         product:
             paths:
                 - %paths.base%/Features/Scenario/Product


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | PR https://github.com/PrestaShop/PrestaShop/pull/21550 that is not associated with attachments is failing (update_attachments.feature) due to some recent changes in tests that are executed before. In this Pr I added some scenarios in attachment behats to assert multiple languages. This improves the test itself and also should get rid of error in another pr without expanding its scope.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | 
| How to test?  | tests :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21796)
<!-- Reviewable:end -->
