### PR TITLE
Fix invalid email template html render in tinymce

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Email\SwiftCommentDeletePlugin;
+
 /**
  * Class MailCore.
  */
@@ -559,6 +561,7 @@ class MailCore extends ObjectModel
             );
             $templateVars = array_merge($templateVars, $extraTemplateVars);
             $swift->registerPlugin(new Swift_Plugins_DecoratorPlugin([self::toPunycode($toPlugin) => $templateVars]));
+            $swift->registerPlugin(new SwiftCommentDeletePlugin());
             if ($configuration['PS_MAIL_TYPE'] == Mail::TYPE_BOTH ||
                 $configuration['PS_MAIL_TYPE'] == Mail::TYPE_TEXT
             ) {

--- a/mails/themes/classic/core/order_conf.html.twig
+++ b/mails/themes/classic/core/order_conf.html.twig
@@ -48,19 +48,32 @@
           <th bgcolor="#f8f8f8" style="border:1px solid #D6D4D4;background-color: #fbfbfb;color: #333;font-family: Arial;font-size: 13px;padding: 10px;">{{ 'Quantity'|trans({}, 'Emails.Body', locale)|raw }}</th>
           <th bgcolor="#f8f8f8" style="border:1px solid #D6D4D4;background-color: #fbfbfb;color: #333;font-family: Arial;font-size: 13px;padding: 10px;" width="17%">{{ 'Total price'|trans({}, 'Emails.Body', locale)|raw }}</th>
         </tr>
-        {% if templateType == 'html' %}
-{products}
-{% endif %}
-        {% if templateType == 'txt' %}
-{products_txt}
-{% endif %}
-
-        {% if templateType == 'html' %}
-{discounts}
-{% endif %}
-        {% if templateType == 'txt' %}
-{discounts_txt}
-{% endif %}
+        <!-- delete -->
+        <tr>
+          <td style="border:1px solid #D6D4D4;padding:7px 0;text-align:center;" colspan="5">
+            <!-- /delete -->
+            {% if templateType == 'html' %}
+              {products}
+            {% endif %}
+            {% if templateType == 'txt' %}
+              {products_txt}
+            {% endif %}
+            <!-- delete -->
+          </td>
+        </tr>
+        <tr class="conf_body">
+          <td bgcolor="#f8f8f8" colspan="5" style="border:1px solid #D6D4D4;color:#333;padding:7px 0;text-align:center;">
+            <!-- /delete -->
+            {% if templateType == 'html' %}
+              {discounts}
+            {% endif %}
+            {% if templateType == 'txt' %}
+              {discounts_txt}
+            {% endif %}
+            <!-- delete -->
+          </td>
+        </tr>
+        <!-- /delete -->
 
         <tr class="conf_body">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">

--- a/mails/themes/modern/core/order_conf.html.twig
+++ b/mails/themes/modern/core/order_conf.html.twig
@@ -246,12 +246,14 @@
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;"><span class="label">{{ 'Order:'|trans({}, 'Emails.Body', locale)|raw }}</span> {order_name} {{ 'Placed on'|trans({}, 'Emails.Body', locale)|raw }} {date}</div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;">
+<span class="label">{{ 'Order:'|trans({}, 'Emails.Body', locale)|raw }}</span> {order_name} {{ 'Placed on'|trans({}, 'Emails.Body', locale)|raw }} {date}</div>
                                       </td>
                                     </tr>
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;"><span class="label">{{ 'Payment:'|trans({}, 'Emails.Body', locale)|raw }}</span> {payment}</div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;">
+<span class="label">{{ 'Payment:'|trans({}, 'Emails.Body', locale)|raw }}</span> {payment}</div>
                                       </td>
                                     </tr>
                                   </table>
@@ -327,18 +329,32 @@
                                     <th bgcolor="#FDFDFD">{{ 'Quantity'|trans({}, 'Emails.Body', locale)|raw }}</th>
                                     <th bgcolor="#FDFDFD">{{ 'Total price'|trans({}, 'Emails.Body', locale)|raw }}</th>
                                   </tr>
-                                  {% if templateType == 'html' %}
+                                  <!-- delete -->
+                                  <tr>
+                                    <td style="border:1px solid #D6D4D4;padding:7px 0;text-align:center;" colspan="5">
+                                      <!-- /delete -->
+                                      {% if templateType == 'html' %}
 {products}
 {% endif %}
-                                  {% if templateType == 'txt' %}
+                                      {% if templateType == 'txt' %}
 {products_txt}
 {% endif %}
-                                  {% if templateType == 'html' %}
+                                      <!-- delete -->
+                                    </td>
+                                  </tr>
+                                  <tr class="conf_body">
+                                    <td bgcolor="#f8f8f8" colspan="5" style="border:1px solid #D6D4D4;color:#333;padding:7px 0;text-align:center;">
+                                      <!-- /delete -->
+                                      {% if templateType == 'html' %}
 {discounts}
 {% endif %}
-                                  {% if templateType == 'txt' %}
+                                      {% if templateType == 'txt' %}
 {discounts_txt}
 {% endif %}
+                                      <!-- delete -->
+                                    </td>
+                                  </tr>
+                                  <!-- /delete -->
                                   <tr class="order_summary">
                                     <td bgcolor="#FDFDFD" colspan="3" align="right">
                                       {{ 'Products'|trans({}, 'Emails.Body', locale)|raw }}
@@ -436,8 +452,10 @@
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;font-weight:600;line-height:25px;text-align:left;color:#363A41;"><img src="{{ mailThemesUrl }}/modern/assets/baseline-local_shipping-24px.png" style="margin-right:10px">
-                                          {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}</div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;font-weight:600;line-height:25px;text-align:left;color:#363A41;">
+<img src="{{ mailThemesUrl }}/modern/assets/baseline-local_shipping-24px.png" style="margin-right:10px">
+                                          {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}
+                                        </div>
                                       </td>
                                     </tr>
                                   </table>
@@ -502,12 +520,14 @@
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;"><span class="label">{{ 'Carrier:'|trans({}, 'Emails.Body', locale)|raw }}</span> {carrier}</div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;">
+<span class="label">{{ 'Carrier:'|trans({}, 'Emails.Body', locale)|raw }}</span> {carrier}</div>
                                       </td>
                                     </tr>
                                     <tr>
                                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
-                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;"><span class="label">{{ 'Payment:'|trans({}, 'Emails.Body', locale)|raw }}</span> {payment}</div>
+                                        <div style="font-family:Open sans, arial, sans-serif;font-size:16px;line-height:25px;text-align:left;color:#363A41;">
+<span class="label">{{ 'Payment:'|trans({}, 'Emails.Body', locale)|raw }}</span> {payment}</div>
                                       </td>
                                     </tr>
                                   </table>

--- a/src/Core/Email/SwiftCommentDeletePlugin.php
+++ b/src/Core/Email/SwiftCommentDeletePlugin.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Email;
+
+use Swift_Events_SendEvent;
+
+/**
+ * Class SwiftCommentDeletePlugin used to delete html between <!-- delete --> & <!-- /delete --> in mail template
+ */
+class SwiftCommentDeletePlugin implements \Swift_Events_SendListener
+{
+    private const DELETE_REGEX = '/<!--\s*delete\s*-->(:?\s|.)*?<!--\s*\/delete\s*-->/';
+
+    public function beforeSendPerformed(Swift_Events_SendEvent $evt)
+    {
+        $children = $evt->getMessage()->getChildren();
+        foreach ($children as &$child) {
+            if ($child->getBodyContentType() === 'text/html') {
+                $body = preg_replace(self::DELETE_REGEX, '', $child->getBody());
+                $child->setBody($body);
+            }
+        }
+    }
+
+    public function sendPerformed(Swift_Events_SendEvent $evt)
+    {
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | With the new email system introduced in 1.7.6.0, the modern & classic theme have been modified and some invalid html has been introduced, leading to a broken template when saving from the tinymce editor.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21630
| How to test?  | 1. Generate `modern` mail templates<br>2. Go to translation page for mail with `modern` template.<br>3. Go on the order_conf mail template and translate a word.<br>4. Save.<br>5. Go to mail theme page.<br>6. Select `modern` template.<br>7. Select order_conf template and send a test mail.<br>8. The template should not be broke<br>9. Repeat step 1 to 8 with the `classic` theme, should be working as well

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21798)
<!-- Reviewable:end -->
