### PR TITLE
FO: fix wrong redirection after address edition in checkout process

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -189,7 +189,6 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
             if (!$this->getCheckoutProcess()->hasErrors()) {
                 $this->setNextStepAsCurrent();
                 $this->setComplete(
-                    !isset($requestParams['saveAddress']) &&
                     $this->getCheckoutSession()->getIdAddressInvoice() &&
                     $this->getCheckoutSession()->getIdAddressDelivery()
                 );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | FO - Checkout: After filling the address, we have the Address card displayed instead of being sent to the delivery choice step
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21807
| How to test?  | See issue #21807, also check that issue #11595 is still fixed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21814)
<!-- Reviewable:end -->
