### PR TITLE
Remove useless logic Product customization images in Order Page and handle exotic chars in name

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -73,7 +73,6 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderPreview;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPreview;
-use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductCustomizationForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderProductForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
@@ -1567,17 +1566,15 @@ class OrderController extends FrameworkBundleAdminController
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param int $orderId
-     * @param int $type
      * @param string $name
      * @param string $value
      *
      * @return BinaryFileResponse|RedirectResponse
      */
-    public function displayCustomizationImageAction(int $orderId, int $type, string $name, string $value)
+    public function displayCustomizationImageAction(int $orderId, string $name, string $value)
     {
         $uploadDir = $this->get('prestashop.adapter.legacy.context')->getUploadDirectory();
-        $customizationForViewing = new OrderProductCustomizationForViewing($type, $name, $value);
-        $filePath = $uploadDir . $customizationForViewing->getValue();
+        $filePath = $uploadDir . $value;
         $filesystem = new Filesystem();
 
         try {

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
@@ -345,14 +345,13 @@ admin_orders_configure_product_pagination:
     expose: true
 
 admin_orders_display_customization_image:
-  path: /display-customization-image/{orderId}/{type}/{name}/{value}
+  path: /display-customization-image/{orderId}/{name}/{value}
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/Order/Order:displayCustomizationImage
     _legacy_controller: AdminOrders
   requirements:
     orderId: \d+
-    type: \d+
     name: \w+
     value: \w+
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -159,7 +159,7 @@
               <div class="mr-4">
                 <p><strong>{{ customization.name }}</strong></p>
                 <p>
-                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'type': customization.type, "name": customization.name|replace({' ': '_'}), "value": customization.value})}}" download>
+                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'name': customization.name|url_encode|replace({'%': '_'}), "value": customization.value})}}" download>
                     <img src="{{ customization.image }}" alt="{{ customization.name }}">
                   </a>
                 </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -159,7 +159,7 @@
               <div class="mr-4">
                 <p><strong>{{ customization.name }}</strong></p>
                 <p>
-                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'type': customization.type, "name": customization.name, "value": customization.value})}}" download>
+                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'type': customization.type, "name": customization.name|replace({' ': ''}), "value": customization.value})}}" download>
                     <img src="{{ customization.image }}" alt="{{ customization.name }}">
                   </a>
                 </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -159,7 +159,7 @@
               <div class="mr-4">
                 <p><strong>{{ customization.name }}</strong></p>
                 <p>
-                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'type': customization.type, "name": customization.name|replace({' ': ''}), "value": customization.value})}}" download>
+                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'type': customization.type, "name": customization.name|replace({' ': '_'}), "value": customization.value})}}" download>
                     <img src="{{ customization.image }}" alt="{{ customization.name }}">
                   </a>
                 </p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Remove useless logic Product customization images in Order Page and handle exotic chars in name.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21815
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21816)
<!-- Reviewable:end -->
