### PR TITLE
Fix alert of compromised page and center window

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_compromised.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_compromised.scss
@@ -1,0 +1,21 @@
+#security-compromised-page {
+  .fake-button {
+    height: 40px;
+    line-height: 30px;
+  }
+
+  h1 {
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+
+  #csrf-white-container {
+    min-height: 100vh;
+    align-items: center;
+
+    > div:first-child {
+      background: white;
+      padding: 50px;
+    }
+  }
+}

--- a/admin-dev/themes/new-theme/scss/pages/_compromised.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_compromised.scss
@@ -10,12 +10,12 @@
   }
 
   #csrf-white-container {
-    min-height: 100vh;
     align-items: center;
+    min-height: 100vh;
 
     > div:first-child {
-      background: white;
       padding: 50px;
+      background: #fff;
     }
   }
 }

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -68,6 +68,7 @@
 @import "pages/attribute";
 @import "pages/customer_thread";
 @import "pages/customer";
+@import "pages/compromised";
 
 // Main Layout
 @import "pages/modules";

--- a/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
@@ -26,22 +26,6 @@
 
 {% block stylesheets %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
-  <style>
-    .fake-button {
-      height: 40px;
-      line-height: 30px;
-    }
-
-    #csrf-white-container div:first-child {
-      background: white;
-      padding: 50px;
-    }
-
-    #security-compromised-page h1 {
-      padding-top: 40px;
-      padding-bottom: 40px;
-    }
-  </style>
 {% endblock %}
 
 {% block title %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Compromised page layout was wrong, the alert was badly stylised dure to a selector mistake, and the window was not centered
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21827.
| How to test?  | Build assets, then copy a page link with a token, paste it to another browser and see if the layout is fine

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21849)
<!-- Reviewable:end -->
