### PR TITLE
Add behat tests for UpdateProductStatusCommand

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -134,27 +134,6 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then product :productReference should have following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     *
-     * @todo: method can be simplified if there is no more than single common field at the end of product migration
-     */
-    public function assertProductFields(string $productReference, TableNode $table)
-    {
-        $productForEditing = $this->getProductForEditing($productReference);
-        $data = $table->getRowsHash();
-
-        $this->assertBoolProperty($productForEditing, $data, 'active');
-
-        // Assertions checking isset() can hide some errors if it doesn't find array key,
-        // to make sure all provided fields were checked we need to unset every asserted field
-        // and finally, if provided data is not empty, it means there are some unnasserted values left
-        Assert::assertEmpty($data, sprintf('Some provided product fields haven\'t been asserted: %s', var_export($data, true)));
-    }
-
-    /**
      * @When I update product :productReference prices and apply non-existing tax rules group
      *
      * @param string $productReference

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
+use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductStatusCommand;
 use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
 
@@ -49,5 +50,19 @@ class UpdateStatusFeatureContext extends AbstractProductFeatureContext
             $this->getSharedStorage()->get($productReference),
             $status
         ));
+    }
+
+    /**
+     * @Then product :productReference should be :expectedStatus
+     *
+     * @Transform(enabled|disabled)
+     *
+     * @param string $productReference
+     * @param bool $expectedStatus
+     */
+    public function assertStatus(string $productReference, bool $expectedStatus): void
+    {
+        $actualStatus = $this->extractValueFromProductForEditing($this->getProductForEditing($productReference), 'active');
+        Assert::assertSame($expectedStatus, $actualStatus, 'Unexpected product status');
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductStatusCommand;
+use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
+
+class UpdateStatusFeatureContext extends AbstractProductFeatureContext
+{
+    use StringToBooleanTransform;
+
+    /**
+     * @When I :status product :productReference
+     *
+     * @Transform(enable|disable)
+     *
+     * @param bool $status
+     * @param string $productReference
+     */
+    public function updateStatus(bool $status, string $productReference): void
+    {
+        $this->getCommandBus()->handle(new UpdateProductStatusCommand(
+            $this->getSharedStorage()->get($productReference),
+            $status
+        ));
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
@@ -37,7 +37,7 @@ class UpdateStatusFeatureContext extends AbstractProductFeatureContext
     use StringToBooleanTransform;
 
     /**
-     * @When I :status product :productReference
+     * @When /^I (enable|disable) product "(.*)"$/
      *
      * @Transform(enable|disable)
      *
@@ -53,7 +53,7 @@ class UpdateStatusFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then product :productReference should be :expectedStatus
+     * @Then /^product "(.*)" should be (enabled|disabled)$/
      *
      * @Transform(enabled|disabled)
      *

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -10,8 +10,7 @@ Feature: Add basic product from Back Office (BO)
     When I add product "product1" with following information:
       | name       | en-US:bottle of beer |
       | is_virtual | false                |
-    Then product "product1" should have following values:
-      | active           | false          |
+    Then product "product1" should be disabled
     And product "product1" type should be standard
     And product "product1" localized "name" should be "en-US:bottle of beer"
     And product "product1" should be assigned to default category
@@ -20,8 +19,7 @@ Feature: Add basic product from Back Office (BO)
     When I add product "product1" with following information:
       | name       | en-US:bottle of beer |
       | is_virtual | true                 |
-    Then product "product1" should have following values:
-      | active           | false          |
+    Then product "product1" should be disabled
     Then product "product1" should have following options information:
       | condition        | new            |
     And product "product1" type should be virtual

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
@@ -12,8 +12,7 @@ Feature: Update product attachments from Back Office (BO).
     When I add product "product1" with following information:
       | name       | en-US:mug with photo |
       | is_virtual | false                |
-    Then product "product1" should have following values:
-      | active | false |
+    Then product "product1" should be disabled
     And product "product1" type should be standard
     Given I add new attachment "att1" with following properties:
       | description | en-US:puffin photo nr1 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -1,3 +1,7 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-status
+@reset-database-before-feature
+@clear-cache-before-feature
+@update-status
 Feature: Update product status from BO (Back Office)
   As an employee I must be able to update product status (enable/disable)
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -1,0 +1,63 @@
+Feature: Update product status from BO (Back Office)
+  As an employee I must be able to update product status (enable/disable)
+
+  Scenario: I update standard product status
+    Given I add product "product1" with following information:
+      | name       | en-US:Values list poster nr. 1 (paper) |
+      | is_virtual | false                                  |
+    And product product1 type should be standard
+    And product "product1" should have following values:
+      | active | false |
+    When I enable product product1
+    Then product "product1" should have following values:
+      | active | true |
+    When I disable product product1
+    Then product "product1" should have following values:
+      | active | false |
+
+  Scenario: I update virtual product status
+    And I add product "product2" with following information:
+      | name       | en-US:Values list poster nr. 2 (virtual) |
+      | is_virtual | true                                     |
+    And product product2 type should be virtual
+    And product "product2" should have following values:
+      | active | false |
+    When I enable product product2
+    And product "product2" should have following values:
+      | active | true |
+    When I disable product product2
+    Then product "product2" should have following values:
+      | active | false |
+
+  Scenario: I update combination product status
+    And I add product "product3" with following information:
+      | name       | en-US:T-Shirt with listed values |
+      | is_virtual | false                            |
+    And product "product3" has following combinations:
+      | reference | quantity | attributes         |
+      | whiteS    | 100      | Size:S;Color:White |
+      | whiteM    | 150      | Size:M;Color:White |
+      | blackM    | 130      | Size:M;Color:Black |
+    And product product3 type should be combination
+    And product "product3" should have following values:
+      | active | false |
+    When I enable product product3
+    And product "product3" should have following values:
+      | active | true |
+    When I disable product product3
+    Then product "product3" should have following values:
+      | active | false |
+
+  Scenario: I disable product which is already disabled
+    And product "product1" should have following values:
+      | active | false |
+    When I disable product product1
+    Then product "product1" should have following values:
+      | active | false |
+
+  Scenario: I enable product which is already enabled
+    And product "product1" should have following values:
+      | active | false |
+    When I enable product product1
+    Then product "product1" should have following values:
+      | active | true |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -11,9 +11,9 @@ Feature: Update product status from BO (Back Office)
       | is_virtual | false                                  |
     And product product1 type should be standard
     And product "product1" should be disabled
-    When I enable product product1
+    When I enable product "product1"
     And product "product1" should be enabled
-    When I disable product product1
+    When I disable product "product1"
     And product "product1" should be disabled
 
   Scenario: I update virtual product status
@@ -22,9 +22,9 @@ Feature: Update product status from BO (Back Office)
       | is_virtual | true                                     |
     And product product2 type should be virtual
     And product "product2" should be disabled
-    When I enable product product2
+    When I enable product "product2"
     And product "product2" should be enabled
-    When I disable product product2
+    When I disable product "product2"
     And product "product2" should be disabled
 
   Scenario: I update combination product status
@@ -38,19 +38,19 @@ Feature: Update product status from BO (Back Office)
       | blackM    | 130      | Size:M;Color:Black |
     And product product3 type should be combination
     And product "product3" should be disabled
-    When I enable product product3
+    When I enable product "product3"
     And product "product3" should be enabled
-    When I disable product product3
+    When I disable product "product3"
     Then product "product3" should be disabled
 
   Scenario: I disable product which is already disabled
     And product "product1" should be disabled
-    When I disable product product1
+    When I disable product "product1"
     And product "product1" should be disabled
 
   Scenario: I enable product which is already enabled
     And product "product1" should be disabled
-    And I enable product product1
+    And I enable product "product1"
     And product "product1" should be enabled
-    When I enable product product1
+    When I enable product "product1"
     Then product "product1" should be enabled

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -10,28 +10,22 @@ Feature: Update product status from BO (Back Office)
       | name       | en-US:Values list poster nr. 1 (paper) |
       | is_virtual | false                                  |
     And product product1 type should be standard
-    And product "product1" should have following values:
-      | active | false |
+    And product "product1" should be disabled
     When I enable product product1
-    Then product "product1" should have following values:
-      | active | true |
+    And product "product1" should be enabled
     When I disable product product1
-    Then product "product1" should have following values:
-      | active | false |
+    And product "product1" should be disabled
 
   Scenario: I update virtual product status
     And I add product "product2" with following information:
       | name       | en-US:Values list poster nr. 2 (virtual) |
       | is_virtual | true                                     |
     And product product2 type should be virtual
-    And product "product2" should have following values:
-      | active | false |
+    And product "product2" should be disabled
     When I enable product product2
-    And product "product2" should have following values:
-      | active | true |
+    And product "product2" should be enabled
     When I disable product product2
-    Then product "product2" should have following values:
-      | active | false |
+    And product "product2" should be disabled
 
   Scenario: I update combination product status
     And I add product "product3" with following information:
@@ -43,25 +37,20 @@ Feature: Update product status from BO (Back Office)
       | whiteM    | 150      | Size:M;Color:White |
       | blackM    | 130      | Size:M;Color:Black |
     And product product3 type should be combination
-    And product "product3" should have following values:
-      | active | false |
+    And product "product3" should be disabled
     When I enable product product3
-    And product "product3" should have following values:
-      | active | true |
+    And product "product3" should be enabled
     When I disable product product3
-    Then product "product3" should have following values:
-      | active | false |
+    Then product "product3" should be disabled
 
   Scenario: I disable product which is already disabled
-    And product "product1" should have following values:
-      | active | false |
+    And product "product1" should be disabled
     When I disable product product1
-    Then product "product1" should have following values:
-      | active | false |
+    And product "product1" should be disabled
 
   Scenario: I enable product which is already enabled
-    And product "product1" should have following values:
-      | active | false |
+    And product "product1" should be disabled
+    And I enable product product1
+    And product "product1" should be enabled
     When I enable product product1
-    Then product "product1" should have following values:
-      | active | true |
+    Then product "product1" should be enabled

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -229,3 +229,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttachmentFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPricePrioritiesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\RelatedProductsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | add tests for UpdateProductStatusCommand. Also move status assertion to UpdateStatusFeatureContext and remove ambigous method 'assertProductFields' from CommonProductFeatureContext
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #10632
| How to test?  | Tests :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**NOTE** 
Now to assert product status in behat use
 :heavy_check_mark:  `@Then product :productReference should be (enabled|disabled)`
instead of previously used 

:no_entry_sign: 
```   
@Then product :productReference should have following values:
      | active           | (true|false)          |
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21861)
<!-- Reviewable:end -->
