### PR TITLE
Prevent a store from displaying categories that are not active

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -85,7 +85,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
         parent::init();
 
-        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
+        if (!Validate::isLoadedObject($this->category) || !$this->category->active || !$this->category->inShop() || !$this->category->isAssociatedToShop()) {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans('This category does not exist.', [], 'Shop.Notifications.Error');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Reuse of controls present in 1.6 and absent from 1.7 to prevent a store from displaying categories that are not active
| Fixes | #13468
| Type?         | bug fix
| Category?     | FO
| How to test?  | Attempt to access a category in another store (in multi-shop mode) and you will see an empty page, however as it is displayed it disturbs the SEO. Detailed steps in  #13468
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21877)
<!-- Reviewable:end -->
