### PR TITLE
Simplified add language form

### DIFF
--- a/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
@@ -54,7 +54,7 @@ abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
     protected function copyNoPictureImage(IsoCode $isoCode, $noPictureImagePath)
     {
         if (!($temporaryImage = tempnam(_PS_TMP_IMG_DIR_, 'PS'))
-            || !move_uploaded_file($noPictureImagePath, $temporaryImage)
+            || !copy($noPictureImagePath, $temporaryImage)
         ) {
             return;
         }
@@ -91,6 +91,7 @@ abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
             }
         }
 
+        unlink($noPictureImagePath);
         unlink($temporaryImage);
     }
 
@@ -106,7 +107,7 @@ abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
             return;
         }
 
-        if (!move_uploaded_file($newImagePath, $temporaryImage)) {
+        if (!copy($newImagePath, $temporaryImage)) {
             return;
         }
 
@@ -129,6 +130,7 @@ abstract class AbstractLanguageHandler extends AbstractObjectModelHandler
             }
         }
 
+        unlink($newImagePath);
         unlink($temporaryImage);
     }
 

--- a/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AbstractLanguageHandler.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Adapter\Language\CommandHandler;
 
 use Configuration;

--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Language\CommandHandler;
 
 use Language;
+use PrestaShop\PrestaShop\Adapter\Image\ImageValidator;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\AddLanguageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\CommandHandler\AddLanguageHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageConstraintException;
@@ -42,11 +43,30 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 final class AddLanguageHandler extends AbstractLanguageHandler implements AddLanguageHandlerInterface
 {
     /**
+     * @var ImageValidator
+     */
+    private $imageValidator;
+
+    public function __construct(ImageValidator $imageValidator)
+    {
+        $this->imageValidator = $imageValidator;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(AddLanguageCommand $command)
     {
         $this->assertLanguageWithIsoCodeDoesNotExist($command->getIsoCode());
+        if ($command->getNoPictureImagePath()) {
+            $this->imageValidator->assertFileUploadLimits($command->getNoPictureImagePath());
+            $this->imageValidator->assertIsValidImageType($command->getNoPictureImagePath());
+        }
+
+        if ($command->getFlagImagePath()) {
+            $this->imageValidator->assertFileUploadLimits($command->getFlagImagePath());
+            $this->imageValidator->assertIsValidImageType($command->getFlagImagePath());
+        }
 
         $language = $this->createLegacyLanguageObjectFromCommand($command);
 

--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -48,7 +48,6 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
     {
         $this->assertLanguageWithIsoCodeDoesNotExist($command->getIsoCode());
 
-
         $language = $this->createLegacyLanguageObjectFromCommand($command);
 
         $this->copyNoPictureImage(

--- a/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/AddLanguageHandler.php
@@ -48,13 +48,13 @@ final class AddLanguageHandler extends AbstractLanguageHandler implements AddLan
     {
         $this->assertLanguageWithIsoCodeDoesNotExist($command->getIsoCode());
 
+
+        $language = $this->createLegacyLanguageObjectFromCommand($command);
+
         $this->copyNoPictureImage(
             $command->getIsoCode(),
             $command->getNoPictureImagePath()
         );
-
-        $language = $this->createLegacyLanguageObjectFromCommand($command);
-
         $this->uploadFlagImage($language, $command);
         $this->addShopAssociation($language, $command);
 

--- a/src/Adapter/Language/CommandHandler/BulkDeleteLanguagesHandler.php
+++ b/src/Adapter/Language/CommandHandler/BulkDeleteLanguagesHandler.php
@@ -55,7 +55,7 @@ final class BulkDeleteLanguagesHandler extends AbstractLanguageHandler implement
             $this->assertLanguageIsNotInUse($language);
 
             if (false === $language->delete()) {
-                throw new LanguageException(sprintf('Failed to delele language "%s"', $language->iso_code));
+                throw new LanguageException(sprintf('Failed to delete language "%s"', $language->iso_code));
             }
         }
     }

--- a/src/Adapter/Language/CommandHandler/BulkDeleteLanguagesHandler.php
+++ b/src/Adapter/Language/CommandHandler/BulkDeleteLanguagesHandler.php
@@ -30,6 +30,7 @@ use Context;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkDeleteLanguagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\CommandHandler\BulkDeleteLanguagesHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\DefaultLanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use Shop;
 
@@ -51,7 +52,17 @@ final class BulkDeleteLanguagesHandler extends AbstractLanguageHandler implement
         foreach ($command->getLanguageIds() as $languageId) {
             $language = $this->getLegacyLanguageObject($languageId);
 
-            $this->assertLanguageIsNotDefault($language);
+            try {
+                $this->assertLanguageIsNotDefault($language);
+            } catch (DefaultLanguageException $e) {
+                throw new DefaultLanguageException(
+                    sprintf(
+                        'Default language "%s" cannot be deleted',
+                        $language->iso_code
+                    ),
+                    DefaultLanguageException::CANNOT_DELETE_DEFAULT_ERROR
+                );
+            }
             $this->assertLanguageIsNotInUse($language);
 
             if (false === $language->delete()) {

--- a/src/Adapter/Language/CommandHandler/DeleteLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/DeleteLanguageHandler.php
@@ -54,7 +54,7 @@ final class DeleteLanguageHandler extends AbstractLanguageHandler implements Del
         Shop::setContext(Shop::CONTEXT_ALL);
 
         if (false === $language->delete()) {
-            throw new LanguageException(sprintf('Failed to delele language "%s"', $language->iso_code));
+            throw new LanguageException(sprintf('Failed to delete language "%s"', $language->iso_code));
         }
     }
 }

--- a/src/Adapter/Language/CommandHandler/DeleteLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/DeleteLanguageHandler.php
@@ -30,6 +30,7 @@ use Context;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\DeleteLanguageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\CommandHandler\DeleteLanguageHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\DefaultLanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use Shop;
 
@@ -47,7 +48,18 @@ final class DeleteLanguageHandler extends AbstractLanguageHandler implements Del
     {
         $language = $this->getLegacyLanguageObject($command->getLanguageId());
 
-        $this->assertLanguageIsNotDefault($language);
+        try {
+            $this->assertLanguageIsNotDefault($language);
+        } catch (DefaultLanguageException $e) {
+            throw new DefaultLanguageException(
+                sprintf(
+                    'Default language "%s" cannot be deleted',
+                    $language->iso_code
+                ),
+                DefaultLanguageException::CANNOT_DELETE_DEFAULT_ERROR
+            );
+        }
+
         $this->assertLanguageIsNotInUse($language);
 
         // language must be deleted in "ALL SHOPS" context

--- a/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Language\CommandHandler;
 use Configuration;
 use Db;
 use Language;
+use PrestaShop\PrestaShop\Adapter\Image\ImageValidator;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\EditLanguageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Language\CommandHandler\EditLanguageHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\CannotDisableDefaultLanguageException;
@@ -44,10 +45,30 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
 final class EditLanguageHandler extends AbstractLanguageHandler implements EditLanguageHandlerInterface
 {
     /**
+     * @var ImageValidator
+     */
+    private $imageValidator;
+
+    public function __construct(ImageValidator $imageValidator)
+    {
+        $this->imageValidator = $imageValidator;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(EditLanguageCommand $command)
     {
+        if ($command->getNoPictureImagePath()) {
+            $this->imageValidator->assertFileUploadLimits($command->getNoPictureImagePath());
+            $this->imageValidator->assertIsValidImageType($command->getNoPictureImagePath());
+        }
+
+        if ($command->getFlagImagePath()) {
+            $this->imageValidator->assertFileUploadLimits($command->getFlagImagePath());
+            $this->imageValidator->assertIsValidImageType($command->getFlagImagePath());
+        }
+
         $language = $this->getLegacyLanguageObject($command->getLanguageId());
 
         $this->assertLanguageWithIsoCodeDoesNotExist($language, $command);

--- a/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
+++ b/src/Adapter/Language/CommandHandler/EditLanguageHandler.php
@@ -53,12 +53,12 @@ final class EditLanguageHandler extends AbstractLanguageHandler implements EditL
         $this->assertLanguageWithIsoCodeDoesNotExist($language, $command);
         $this->assertDefaultLanguageIsNotDisabled($command);
 
-        $this->copyNoPictureIfChanged($language, $command);
         $this->updateEmployeeLanguage($command);
         $this->moveTranslationsIfIsoChanged($language, $command);
 
         $this->updateLanguageWithCommandData($language, $command);
         $this->updateShopAssociationIfChanged($language, $command);
+        $this->copyNoPictureIfChanged($language, $command);
         $this->uploadFlagImageIfChanged($language, $command);
     }
 

--- a/src/Core/Domain/Language/Exception/DefaultLanguageException.php
+++ b/src/Core/Domain/Language/Exception/DefaultLanguageException.php
@@ -37,7 +37,7 @@ class DefaultLanguageException extends LanguageException
     const CANNOT_DELETE_ERROR = 1;
 
     /**
-     * @var string Code is uswed when disabling default language
+     * @var string Code is used when disabling default language
      */
     const CANNOT_DISABLE_ERROR = 2;
 
@@ -45,4 +45,9 @@ class DefaultLanguageException extends LanguageException
      * @var string Code is used when deleting language that is use (e.g. as employee's default language)
      */
     const CANNOT_DELETE_IN_USE_ERROR = 3;
+
+    /**
+     * @var string Code is used when deleting default language
+     */
+    const CANNOT_DELETE_DEFAULT_ERROR = 4;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundExcepti
 use PrestaShop\PrestaShop\Core\Domain\Language\Query\GetLanguageForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Language\QueryResult\EditableLanguage;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\LanguageFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -317,6 +318,8 @@ class LanguageController extends FrameworkBundleAdminController
      */
     private function getErrorMessages(Exception $e)
     {
+        $iniConfig = $this->get('prestashop.core.configuration.ini_configuration');
+
         return [
             LanguageNotFoundException::class => $this->trans(
                 'The object cannot be loaded (or found)',
@@ -326,6 +329,16 @@ class LanguageController extends FrameworkBundleAdminController
                 'You cannot change the status of the default language.',
                 'Admin.International.Notification'
             ),
+            UploadedImageConstraintException::class => [
+                UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
+                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error', [
+                    $iniConfig->getUploadMaxSizeInBytes(),
+                ]),
+                UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
+                    'Image format not recognized, allowed formats are: .gif, .jpg, .png',
+                    'Admin.Notifications.Error'
+                ),
+            ],
             CopyingNoPictureException::class => [
                 CopyingNoPictureException::PRODUCT_IMAGE_COPY_ERROR => $this->trans(
                     'An error occurred while copying "No Picture" image to your product folder.',

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -332,8 +332,8 @@ class LanguageController extends FrameworkBundleAdminController
             UploadedImageConstraintException::class => [
                 UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
                     'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error', [
-                    $iniConfig->getUploadMaxSizeInBytes(),
-                ]),
+                        $iniConfig->getUploadMaxSizeInBytes(),
+                    ]),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
                     'Image format not recognized, allowed formats are: .gif, .jpg, .png',
                     'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -392,6 +392,10 @@ class LanguageController extends FrameworkBundleAdminController
                     'You cannot change the status of the default language.',
                     'Admin.International.Notification'
                 ),
+                DefaultLanguageException::CANNOT_DELETE_DEFAULT_ERROR => $this->trans(
+                    'You cannot delete default language.',
+                    'Admin.International.Notification'
+                ),
                 DefaultLanguageException::CANNOT_DELETE_IN_USE_ERROR => $this->trans(
                     'You cannot delete the language currently in use. Please select a different language.',
                     'Admin.International.Notification'

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -393,7 +393,7 @@ class LanguageController extends FrameworkBundleAdminController
                     'Admin.International.Notification'
                 ),
                 DefaultLanguageException::CANNOT_DELETE_DEFAULT_ERROR => $this->trans(
-                    'You cannot delete default language.',
+                    'You cannot delete the default language.',
                     'Admin.International.Notification'
                 ),
                 DefaultLanguageException::CANNOT_DELETE_IN_USE_ERROR => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -54,7 +54,7 @@ class LanguageType extends TranslatorAwareType
      *
      * @param TranslatorInterface $translator
      * @param array $locales
-     * @param $isMultistoreFeatureActive
+     * @param bool $isMultistoreFeatureActive
      */
     public function __construct(TranslatorInterface $translator, array $locales, $isMultistoreFeatureActive)
     {

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -72,7 +72,7 @@ class LanguageType extends TranslatorAwareType
                 'label' => $this->trans('Name', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
                         'type' => 'generic_name',
@@ -87,7 +87,7 @@ class LanguageType extends TranslatorAwareType
                 'help' => $this->trans('Two-letter ISO code (e.g. FR, EN, DE).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
                         'type' => 'language_iso_code',
@@ -102,7 +102,7 @@ class LanguageType extends TranslatorAwareType
                 'help' => $this->trans('IETF language tag (e.g. en-US, pt-BR).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
                         'type' => 'language_code',
@@ -114,14 +114,14 @@ class LanguageType extends TranslatorAwareType
                 'help' => $this->trans('Short date format (e.g., Y-m-d).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new Regex([
                         // We can't really check if this is valid or not,
                         // because this is a string and you can write whatever you want in it.
                         // That's why only < et > are forbidden (HTML).
                         'pattern' => '/^[^<>]+$/',
-                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
@@ -130,11 +130,11 @@ class LanguageType extends TranslatorAwareType
                 'help' => $this->trans('Full date format (e.g., Y-m-d H:i:s).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                     new Regex([
                         'pattern' => '/^[^<>]+$/',
-                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
@@ -147,22 +147,22 @@ class LanguageType extends TranslatorAwareType
                 'required' => !$options['is_for_editing'],
                 'constraints' => [
                     new Image([
-                        'mimeTypesMessage' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                        'mimeTypesMessage' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('no_picture_image', FileType::class, [
                 'label' => $this->trans('"No-picture" image', 'Admin.International.Feature'),
-                'help' => $this->trans('Image is displayed when "no picture is found".', 'Admin.International.Help'),
+                'help' => $this->trans('Image is displayed when no picture is found.', 'Admin.International.Help'),
                 'required' => !$options['is_for_editing'],
                 'constraints' => [
                     new Image([
-                        'mimeTypesMessage' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                        'mimeTypesMessage' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('is_rtl', SwitchType::class, [
-                'label' => $this->trans('Is RTL language', 'Admin.International.Feature'),
+                'label' => $this->trans('RTL language', 'Admin.International.Feature'),
                 'help' => $this->trans(
                     'Enable if this language is read from right to left.',
                     'Admin.International.Help'
@@ -185,7 +185,7 @@ class LanguageType extends TranslatorAwareType
                 'required' => false,
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -29,12 +29,12 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Language;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
@@ -42,20 +42,23 @@ use Symfony\Component\Validator\Constraints\Regex;
 /**
  * Builds language's add/edit form
  */
-class LanguageType extends AbstractType
+class LanguageType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var bool
      */
     private $isMultistoreFeatureActive;
 
     /**
-     * @param bool $isMultistoreFeatureActive
+     * LanguageType constructor.
+     *
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param $isMultistoreFeatureActive
      */
-    public function __construct($isMultistoreFeatureActive)
+    public function __construct(TranslatorInterface $translator, array $locales, $isMultistoreFeatureActive)
     {
+        parent::__construct($translator, $locales);
         $this->isMultistoreFeatureActive = $isMultistoreFeatureActive;
     }
 
@@ -66,9 +69,10 @@ class LanguageType extends AbstractType
     {
         $builder
             ->add('name', TextType::class, [
+                'label' => $this->trans('Name', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
                         'type' => 'generic_name',
@@ -76,9 +80,14 @@ class LanguageType extends AbstractType
                 ],
             ])
             ->add('iso_code', TextType::class, [
+                'attr' => [
+                    'maxLength' => 2,
+                ],
+                'label' => $this->trans('ISO code', 'Admin.International.Feature'),
+                'help' => $this->trans('Two-letter ISO code (e.g. FR, EN, DE).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
                         'type' => 'language_iso_code',
@@ -86,9 +95,14 @@ class LanguageType extends AbstractType
                 ],
             ])
             ->add('tag_ietf', TextType::class, [
+                'attr' => [
+                    'maxLength' => 5,
+                ],
+                'label' => $this->trans('Language code', 'Admin.International.Feature'),
+                'help' => $this->trans('IETF language tag (e.g. en-US, pt-BR).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new TypedRegex([
                         'type' => 'language_code',
@@ -96,60 +110,82 @@ class LanguageType extends AbstractType
                 ],
             ])
             ->add('short_date_format', TextType::class, [
+                'label' => $this->trans('Date format', 'Admin.International.Feature'),
+                'help' => $this->trans('Short date format (e.g., Y-m-d).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new Regex([
                         // We can't really check if this is valid or not,
                         // because this is a string and you can write whatever you want in it.
                         // That's why only < et > are forbidden (HTML).
                         'pattern' => '/^[^<>]+$/',
-                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('full_date_format', TextType::class, [
+                'label' => $this->trans('Date format (full)', 'Admin.International.Feature'),
+                'help' => $this->trans('Full date format (e.g., Y-m-d H:i:s).', 'Admin.International.Help'),
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                     new Regex([
                         'pattern' => '/^[^<>]+$/',
-                        'message' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('flag_image', FileType::class, [
+                'attr' => [
+                    'class' => 'type-file',
+                ],
+                'label' => $this->trans('Flag', 'Admin.International.Feature'),
+                'help' => $this->trans('Upload the country flag from your computer.', 'Admin.International.Help'),
                 'required' => !$options['is_for_editing'],
                 'constraints' => [
                     new Image([
-                        'mimeTypesMessage' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                        'mimeTypesMessage' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('no_picture_image', FileType::class, [
+                'label' => $this->trans('"No-picture" image', 'Admin.International.Feature'),
+                'help' => $this->trans('Image is displayed when "no picture is found".', 'Admin.International.Help'),
                 'required' => !$options['is_for_editing'],
                 'constraints' => [
                     new Image([
-                        'mimeTypesMessage' => $this->trans('This field is invalid', [], 'Admin.Notifications.Error'),
+                        'mimeTypesMessage' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])
             ->add('is_rtl', SwitchType::class, [
+                'label' => $this->trans('Is RTL language', 'Admin.International.Feature'),
+                'help' => $this->trans(
+                    'Enable if this language is read from right to left.',
+                    'Admin.International.Help'
+                ) . $this->trans(
+                    '(Experimental: your theme must be compliant with RTL languages).',
+                    'Admin.International.Help'
+                ),
                 'required' => false,
             ])
             ->add('is_active', SwitchType::class, [
+                'label' => $this->trans('Status', 'Admin.Global'),
+                'help' => $this->trans('Activate this language.', 'Admin.International.Help'),
                 'required' => false,
             ])
         ;
 
         if ($this->isMultistoreFeatureActive) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global'),
                 'required' => false,
                 'constraints' => [
                     new NotBlank([
-                        'message' => $this->trans('This field cannot be empty', [], 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field cannot be empty', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -44,6 +44,8 @@ use Symfony\Component\Validator\Constraints\Regex;
  */
 class LanguageType extends TranslatorAwareType
 {
+    private const MAX_NAME_LENGTH = 32;
+
     /**
      * @var bool
      */
@@ -70,6 +72,9 @@ class LanguageType extends TranslatorAwareType
         $builder
             ->add('name', TextType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
+                'attr' => [
+                    'maxLength' => self::MAX_NAME_LENGTH,
+                ],
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Language/LanguageType.php
@@ -56,7 +56,7 @@ class LanguageType extends TranslatorAwareType
      * @param array $locales
      * @param bool $isMultistoreFeatureActive
      */
-    public function __construct(TranslatorInterface $translator, array $locales, $isMultistoreFeatureActive)
+    public function __construct(TranslatorInterface $translator, array $locales, bool $isMultistoreFeatureActive)
     {
         parent::__construct($translator, $locales);
         $this->isMultistoreFeatureActive = $isMultistoreFeatureActive;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/language.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/language.yml
@@ -23,12 +23,16 @@ services:
 
   prestashop.adapter.language.command_handler.add_language_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Language\CommandHandler\AddLanguageHandler'
+    arguments:
+      - '@prestashop.adapter.image.image_validator'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Language\Command\AddLanguageCommand'
 
   prestashop.adapter.language.command_handler.edit_language_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Language\CommandHandler\EditLanguageHandler'
+    arguments:
+        - '@prestashop.adapter.image.image_validator'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Language\Command\EditLanguageCommand'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -821,10 +821,10 @@ services:
 
     form.type.international.language:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Language\LanguageType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.adapter.multistore_feature").isActive()'
-        calls:
-            - { method: setTranslator, arguments: ['@translator'] }
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme languageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(languageForm) }}
 <div class="card">
@@ -33,69 +33,7 @@
   </h3>
   <div class="card-block row">
     <div class="card-text">
-      {{ form_errors(languageForm) }}
-
-      {{ ps.form_group_row(languageForm.name, {}, {
-        'label': 'Name'|trans({}, 'Admin.Global')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.iso_code, {
-        'attr': {
-          'maxlength': 2
-        }
-      }, {
-        'label': 'ISO code'|trans({}, 'Admin.International.Feature'),
-        'help': 'Two-letter ISO code (e.g. FR, EN, DE).'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.tag_ietf, {
-        'attr': {
-          'maxlength': 5
-        }
-      }, {
-        'label': 'Language code'|trans({}, 'Admin.International.Feature'),
-        'help': 'IETF language tag (e.g. en-US, pt-BR).'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.short_date_format, {}, {
-        'label': 'Date format'|trans({}, 'Admin.International.Feature'),
-        'help': 'Short date format (e.g., Y-m-d).'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.full_date_format, {}, {
-        'label': 'Date format (full)'|trans({}, 'Admin.International.Feature'),
-        'help': 'Full date format (e.g., Y-m-d H:i:s).'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.flag_image, {}, {
-        'label': 'Flag'|trans({}, 'Admin.International.Feature'),
-        'help': 'Upload the country flag from your computer.'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.no_picture_image, {}, {
-        'label': '"No-picture" image'|trans({}, 'Admin.International.Feature'),
-        'help': 'Image is displayed when "no picture is found".'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.is_rtl, {}, {
-        'label': 'Is RTL language'|trans({}, 'Admin.International.Feature'),
-        'help': 'Enable if this language is read from right to left.'|trans({}, 'Admin.International.Help') ~ '(Experimental: your theme must be compliant with RTL languages).'|trans({}, 'Admin.International.Help')
-      }) }}
-
-      {{ ps.form_group_row(languageForm.is_active, {}, {
-        'label': 'Status'|trans({}, 'Admin.Global'),
-        'help': 'Activate this language.'|trans({}, 'Admin.International.Feature')
-      }) }}
-
-      {% if languageForm.shop_association is defined %}
-        {{ ps.form_group_row(languageForm.shop_association, {}, {
-          'label': 'Shop association'|trans({}, 'Admin.Global')
-        }) }}
-      {% endif %}
-
-      {% block language_form_rest %}
-        {{ form_rest(languageForm) }}
-      {% endblock %}
+      {{ form_widget(languageForm) }}
     </div>
   </div>
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -818,14 +818,14 @@
         class: attr.class ~ ' disabled'
       }) %}
     {% endif %}
-
-    {{ form_widget(form, {'attr': attr}) }}
+    {{- block('form_widget_simple') -}}
 
     <label class="custom-file-label" for="{{ form.vars.id }}">
       {% set attributes = form.vars.attr %}
       {{ attributes.placeholder is defined ?  attributes.placeholder : 'Choose file(s)'|trans({}, 'Admin.Actions') }}
     </label>
   </div>
+  {{- block('form_help') -}}
 {% endblock file_widget %}
 
 {% block shop_restriction_checkbox_widget %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies language add/edit form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying International -> Localization -> Languages edit and add form. Everything must look and work exactly the same/

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by LanguageType. This means if any module extends any of this type they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
