### PR TITLE
Strip_tags() error when having an array in the URL

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2012,9 +2012,7 @@ class FrontControllerCore extends Controller
 
         if (!empty($url_details['query'])) {
             parse_str($url_details['query'], $query);
-            foreach ($query as $key => $value) {
-                $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
-            }
+            $params = $this->sanitizeQueryOutput($query);
         }
 
         $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
@@ -2034,6 +2032,27 @@ class FrontControllerCore extends Controller
         $sanitizedUrl = preg_replace('/^([^?]*)?.*$/', '$1', $url) . (!empty($str_params) ? '?' . $str_params : '');
 
         return $sanitizedUrl;
+    }
+
+    /**
+     * Recursively sanitize output query
+     *
+     * @param array $query URL query
+     *
+     * @return array
+     */
+    protected function sanitizeQueryOutput(array $query): array
+    {
+        $params = [];
+        foreach ($query as $key => $value) {
+            if (is_array($value)) {
+                $params[Tools::safeOutput($key)] = $this->sanitizeQueryOutput($value);
+            } else {
+                $params[Tools::safeOutput($key)] = Tools::safeOutput($value);
+            }
+        }
+
+        return $params;
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Warning: strip_tags() expects parameter 1 to be string, array given when calling a front URL with an array in the query.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | QA dev: <br> You must be connected with a Customer account, then `http://ps-develop.localhost/gb/module/productcomments/PostComment?id_product=3&criterion[1]=1&comment_title=abc&customer_name=test&comment_content=abc.` must failed with a strip_tags error without this PR

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21908)
<!-- Reviewable:end -->
