### PR TITLE
Use language_code when locale is empty to get CLDR data

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -1134,13 +1134,9 @@ class CurrencyCore extends ObjectModel
         $symbolsByLang = $namesByLang = [];
         foreach ($languages as $languageData) {
             $language = new Language($languageData['id_lang']);
-            if (empty($language->locale)) {
-                // Language doesn't have locale we can't install this language
-                continue;
-            }
 
             // CLDR locale give us the CLDR reference specification
-            $cldrLocale = $localeRepoCLDR->getLocale($language->locale);
+            $cldrLocale = $localeRepoCLDR->getLocale($language->getLocale());
             // CLDR currency gives data from CLDR reference, for the given language
             $cldrCurrency = $cldrLocale->getCurrency($this->iso_code);
 

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -783,7 +783,12 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     {
         $key = 'Language::getIdByLocale_' . $locale;
         if ($noCache || !Cache::isStored($key)) {
-            $idLang = Db::getInstance()->getValue('SELECT `id_lang` FROM `' . _DB_PREFIX_ . 'lang` WHERE `locale` = \'' . pSQL(strtolower($locale)) . '\'');
+            $idLang = Db::getInstance()
+                ->getValue(
+                    'SELECT `id_lang` FROM `' . _DB_PREFIX_ . 'lang`
+                    WHERE `locale` = \'' . pSQL(strtolower($locale)) . '\'
+                    OR `language_code` = \'' . pSQL(strtolower($locale)) . '\''
+                );
 
             Cache::store($key, $idLang);
 

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -619,6 +619,16 @@ class LocalizationPackCore
         return $this->_errors;
     }
 
+    /**
+     * Return a currency (that can be soft deleted) if presents in the DB
+     * or a new one if not.
+     *
+     * @param string $isoCode
+     *
+     * @return Currency
+     *
+     * @throws PrestaShopDatabaseException
+     */
     private function getSoftDeletedByIsoCodeOrCreate(string $isoCode): Currency
     {
         $currencies = Currency::findAllInstalled();

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -329,7 +329,7 @@ class LocalizationPackCore
                 /** @var Language $defaultLang */
                 $defaultLang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
 
-                $currency = new Currency();
+                $currency = $this->getSoftDeletedByIsoCodeOrCreate((string) $attributes['iso_code']);
                 $currency->name = (string) $attributes['name'];
                 $currency->iso_code = (string) $attributes['iso_code'];
                 $currency->iso_code_num = (int) $attributes['iso_code_num'];
@@ -339,13 +339,14 @@ class LocalizationPackCore
                 $currency->format = (int) $attributes['format'];
                 $currency->decimals = (int) $attributes['decimals'];
                 $currency->active = true;
+                $currency->deleted = false;
                 if (!$currency->validateFields()) {
                     $this->_errors[] = Context::getContext()->getTranslator()->trans('Invalid currency properties.', [], 'Admin.International.Notification');
 
                     return false;
                 }
                 if (!Currency::exists($currency->iso_code)) {
-                    if (!$currency->add()) {
+                    if (!$currency->save()) {
                         $this->_errors[] = Context::getContext()->getTranslator()->trans('An error occurred while importing the currency: %s', [(string) ($attributes['name'])], 'Admin.International.Notification');
 
                         return false;
@@ -403,7 +404,7 @@ class LocalizationPackCore
     protected function setCurrencyCldrData(Currency $currency, Language $defaultLang)
     {
         $localeRepoCLDR = $this->getCldrLocaleRepository();
-        $cldrLocale = $localeRepoCLDR->getLocale($defaultLang->locale);
+        $cldrLocale = $localeRepoCLDR->getLocale($defaultLang->getLocale());
         $cldrCurrency = $cldrLocale->getCurrency($currency->iso_code);
 
         $symbol = (string) $cldrCurrency->getSymbol();
@@ -616,5 +617,17 @@ class LocalizationPackCore
     public function getErrors()
     {
         return $this->_errors;
+    }
+
+    private function getSoftDeletedByIsoCodeOrCreate(string $isoCode)
+    {
+        $currencies = Currency::findAllInstalled();
+        foreach ($currencies as $currency) {
+            if ($currency['iso_code'] === $isoCode) {
+                return new Currency($currency['id_currency']);
+            }
+        }
+
+        return new Currency();
     }
 }

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -329,7 +329,7 @@ class LocalizationPackCore
                 /** @var Language $defaultLang */
                 $defaultLang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
 
-                $currency = $this->getSoftDeletedByIsoCodeOrCreate((string) $attributes['iso_code']);
+                $currency = $this->getExistingByIsoCodeOrCreate((string) $attributes['iso_code']);
                 $currency->name = (string) $attributes['name'];
                 $currency->iso_code = (string) $attributes['iso_code'];
                 $currency->iso_code_num = (int) $attributes['iso_code_num'];
@@ -629,7 +629,7 @@ class LocalizationPackCore
      *
      * @throws PrestaShopDatabaseException
      */
-    private function getSoftDeletedByIsoCodeOrCreate(string $isoCode): Currency
+    private function getExistingByIsoCodeOrCreate(string $isoCode): Currency
     {
         $currencies = Currency::findAllInstalled();
         foreach ($currencies as $currency) {

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -619,7 +619,7 @@ class LocalizationPackCore
         return $this->_errors;
     }
 
-    private function getSoftDeletedByIsoCodeOrCreate(string $isoCode)
+    private function getSoftDeletedByIsoCodeOrCreate(string $isoCode): Currency
     {
         $currencies = Currency::findAllInstalled();
         foreach ($currencies as $currency) {

--- a/src/PrestaShopBundle/Entity/Lang.php
+++ b/src/PrestaShopBundle/Entity/Lang.php
@@ -314,7 +314,7 @@ class Lang implements LanguageInterface
      */
     public function getLocale()
     {
-        return $this->locale;
+        return !empty($this->locale) ? $this->locale : $this->getLanguageCode();
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because on custom languages, the key `locale` of the `ps_lang` table is empty, when trying to access the cache data, an exception is thown because the key is empty. This PR fixes it by using the key `language_code` when `locale` is empty.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21891
| How to test?  | Please see #21891

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21912)
<!-- Reviewable:end -->
