### PR TITLE
Simplified currency form

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/currency/form/index.js
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/index.js
@@ -23,16 +23,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTree from '@components/form/choice-tree';
-import TranslatableInput from '@components/translatable-input';
 import currencyFormMap from './currency-form-map';
 import CurrencyForm from './currency-form';
 
 const {$} = window;
 
 $(() => {
-  new TranslatableInput();
-  const choiceTree = new ChoiceTree(currencyFormMap.shopAssociationTree);
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
+  const choiceTree = new window.prestashop.component.ChoiceTree(currencyFormMap.shopAssociationTree);
   choiceTree.enableAutoCheckChildren();
   const currencyForm = new CurrencyForm(currencyFormMap);
   currencyForm.init();

--- a/src/Core/Form/IdentifiableObject/DataProvider/CurrencyFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CurrencyFormDataProvider.php
@@ -87,6 +87,7 @@ final class CurrencyFormDataProvider implements FormDataProviderInterface
             'precision' => Precision::DEFAULT_PRECISION,
             'exchange_rate' => ExchangeRate::DEFAULT_RATE,
             'shop_association' => $this->contextShopIds,
+            'active' => true
         ];
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/CurrencyFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CurrencyFormDataProvider.php
@@ -87,7 +87,7 @@ final class CurrencyFormDataProvider implements FormDataProviderInterface
             'precision' => Precision::DEFAULT_PRECISION,
             'exchange_rate' => ExchangeRate::DEFAULT_RATE,
             'shop_association' => $this->contextShopIds,
-            'active' => true
+            'active' => true,
         ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -188,8 +188,6 @@ class CurrencyController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_currencies_index');
             }
-
-
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -55,7 +55,6 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterf
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CurrencyGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
-use PrestaShop\PrestaShop\Core\Localization\CLDR\Currency;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository as CldrLocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
@@ -189,15 +188,25 @@ class CurrencyController extends FrameworkBundleAdminController
 
                 return $this->redirectToRoute('admin_currencies_index');
             }
+
+
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
-        return $this->render('@PrestaShop/Admin/Improve/International/Currency/edit.html.twig', [
+        $templateVars = [
             'isShopFeatureEnabled' => $multiStoreFeature->isUsed(),
             'currencyForm' => $currencyForm->createView(),
-            'languages' => $this->getLanguagesData($currencyForm->getData()['iso_code']),
-        ]);
+        ];
+        try {
+            $languageData = $this->getLanguagesData($currencyForm->getData()['iso_code']);
+            $templateVars['languages'] = $languageData;
+        } catch (Exception $e) {
+            $templateVars['languageDataError'] = $e->getMessage();
+            $templateVars['languages'] = [];
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/International/Currency/edit.html.twig', $templateVars);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Currencies;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Service\Routing\Router;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -76,8 +75,8 @@ class CurrencyExchangeRateType extends TranslatorAwareType
                 'label' => $this->trans('Live exchange rates', 'Admin.International.Feature'),
                 'attr' => [
                     'class' => 'js-live-exchange-rate',
-                    'data-url' => $this->router->generate('admin_currencies_update_live_exchange_rates')
-                ]
+                    'data-url' => $this->router->generate('admin_currencies_update_live_exchange_rates'),
+                ],
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
@@ -27,13 +27,16 @@
 namespace PrestaShopBundle\Form\Admin\Improve\International\Currencies;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use PrestaShopBundle\Service\Routing\Router;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class CurrencyExchangeRateType
  */
-class CurrencyExchangeRateType extends AbstractType
+class CurrencyExchangeRateType extends TranslatorAwareType
 {
     /**
      * @var bool
@@ -41,11 +44,25 @@ class CurrencyExchangeRateType extends AbstractType
     private $isCronModuleInstalled;
 
     /**
-     * @param bool $isCronModuleInstalled
+     * @var Router
      */
-    public function __construct($isCronModuleInstalled)
-    {
+    private $router;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param bool $isCronModuleInstalled
+     * @param Router $router
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        $isCronModuleInstalled,
+        Router $router
+    ) {
+        parent::__construct($translator, $locales);
         $this->isCronModuleInstalled = $isCronModuleInstalled;
+        $this->router = $router;
     }
 
     /**
@@ -56,6 +73,11 @@ class CurrencyExchangeRateType extends AbstractType
         $builder
             ->add('live_exchange_rate', SwitchType::class, [
                 'disabled' => !$this->isCronModuleInstalled,
+                'label' => $this->trans('Live exchange rates', 'Admin.International.Feature'),
+                'attr' => [
+                    'class' => 'js-live-exchange-rate',
+                    'data-url' => $this->router->generate('admin_currencies_update_live_exchange_rates')
+                ]
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyExchangeRateType.php
@@ -56,7 +56,7 @@ class CurrencyExchangeRateType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        $isCronModuleInstalled,
+        bool $isCronModuleInstalled,
         Router $router
     ) {
         parent::__construct($translator, $locales);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -252,7 +252,7 @@ class CurrencyType extends TranslatorAwareType
                     new LessThanOrEqual([
                         'value' => 20,
                         'message' => $this->trans(
-                            'This value should be less than or equal to %value%',
+                            'This value should be less than or equal to %value%.',
                             'Admin.Notifications.Error',
                             [
                                 '%value%' => 20,

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -244,7 +244,7 @@ class CurrencyType extends TranslatorAwareType
                             ]
                         ),
                     ]),
-                    /**
+                    /*
                      * I added this constraint because if range is too big it causes an "out of range" error in Vue.
                      * I chose maximum precision based on this
                      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Precision_range

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -43,6 +43,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -88,6 +89,11 @@ class CurrencyType extends TranslatorAwareType
         if ($newCurrency) {
             $builder
                 ->add('selected_iso_code', ChoiceType::class, [
+                    'label' => $this->trans('Select a currency', 'Admin.International.Feature'),
+                    'help' => $this->trans(
+                        'By default, PrestaShop comes with a list of official currencies. If you want to use a local currency, you will have to add it manually. For example, to accept the Iranian Toman on your store, you need to create it before.',
+                        'Admin.International.Help'
+                    ),
                     'choices' => $this->allCurrencies,
                     'choice_translation_domain' => false,
                     'required' => false,
@@ -119,6 +125,7 @@ class CurrencyType extends TranslatorAwareType
 
         $builder
             ->add('names', TranslatableType::class, [
+                'label' => $this->trans('Currency name', 'Admin.International.Feature'),
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
@@ -137,6 +144,10 @@ class CurrencyType extends TranslatorAwareType
                 ],
             ])
             ->add('symbols', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Symbol',
+                    'Admin.International.Feature'
+                ),
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
@@ -154,6 +165,14 @@ class CurrencyType extends TranslatorAwareType
             ])
             ->add('iso_code', TextType::class, [
                 'attr' => $isoCodeAttrs,
+                'label' => $this->trans(
+                  'ISO code',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'ISO 4217 code (e.g. USD for Dollars, EUR for Euros, etc.)',
+                    'Admin.International.Help'
+                ),
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
@@ -170,6 +189,14 @@ class CurrencyType extends TranslatorAwareType
                 ],
             ])
             ->add('exchange_rate', NumberType::class, [
+                'label' => $this->trans(
+                    'Exchange rate',
+                    'Admin.International.Feature'
+                ),
+                'help' => $this->trans(
+                    'Exchange rates are calculated from one unit of your shop\'s default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1&euro; = $1.20).',
+                    'Admin.International.Help'
+                ),
                 'scale' => 6,
                 'constraints' => [
                     new NotBlank([
@@ -198,6 +225,10 @@ class CurrencyType extends TranslatorAwareType
                 ),
             ])
             ->add('precision', IntegerType::class, [
+                'label' => $this->trans(
+                    'Decimals',
+                    'Admin.International.Feature'
+                ),
                 'constraints' => [
                     new Type([
                         'type' => 'integer',
@@ -213,6 +244,21 @@ class CurrencyType extends TranslatorAwareType
                             ]
                         ),
                     ]),
+                    /**
+                     * I added this constraint because if range is too big it causes an "out of range" error in Vue.
+                     * I chose maximum precision based on this
+                     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Precision_range
+                     */
+                    new LessThanOrEqual([
+                        'value' => 20,
+                        'message' => $this->trans(
+                            'This value should be lesser than or equal to %value%',
+                            'Admin.Notifications.Error',
+                            [
+                                '%value%' => 20,
+                            ]
+                        ),
+                    ]),
                 ],
                 'invalid_message' => $this->trans(
                     'Please enter a positive value',
@@ -220,15 +266,26 @@ class CurrencyType extends TranslatorAwareType
                 ),
             ])
             ->add('active', SwitchType::class, [
+                'label' => $this->trans(
+                    'Status',
+                    'Admin.Global'
+                ),
                 'required' => false,
             ])
             ->add('transformations', TranslatableType::class, [
+                'row_attr' => [
+                    'class' => 'd-none',
+                ],
                 'type' => HiddenType::class,
             ])
         ;
 
         if ($this->isShopFeatureEnabled) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans(
+                    'Shop association',
+                    'Admin.Global'
+                ),
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php
@@ -252,7 +252,7 @@ class CurrencyType extends TranslatorAwareType
                     new LessThanOrEqual([
                         'value' => 20,
                         'message' => $this->trans(
-                            'This value should be lesser than or equal to %value%',
+                            'This value should be less than or equal to %value%',
                             'Admin.Notifications.Error',
                             [
                                 '%value%' => 20,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -830,8 +830,11 @@ services:
 
     form.type.currency_exchange_rate:
         class: 'PrestaShopBundle\Form\Admin\Improve\International\Currencies\CurrencyExchangeRateType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.adapter.data_provider.module").isInstalled("cronjobs")'
+            - '@prestashop.router'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/exchange_rates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/exchange_rates.html.twig
@@ -22,6 +22,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
+
+{% form_theme exchangeRatesForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+
 {{ form_start(exchangeRatesForm, {'action': path('admin_currencies_refresh_exchange_rates') }) }}
   <div class="card">
     <h3 class="card-header">
@@ -31,7 +34,7 @@
       <div class="card-text">
         <div class="form-group row">
           <label class="form-control-label" for="{{ exchangeRatesForm.live_exchange_rate.vars.id }}">
-            {{ 'Live exchange rates'|trans({}, 'Admin.International.Feature') }}
+            {{ form_label(exchangeRatesForm.live_exchange_rate) }}
           </label>
           <div class="col-sm">
             {{ form_widget(exchangeRatesForm.live_exchange_rate, {'attr': {'class': 'js-live-exchange-rate', 'data-url': path('admin_currencies_update_live_exchange_rates')}}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -102,7 +102,7 @@
     <div class="card">
       <div class="card-body">
         <div class="alert alert-danger">
-          {{ 'Could not display symbol and format customization:'|trans({}, 'Admin.International.Feature') }} {{ languageDataError }}
+          {{ 'Could not display symbol and format customization:'|trans({}, 'Admin.International.Notification') }} {{ languageDataError }}
         </div>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -106,22 +106,22 @@
         </div>
       </div>
     </div>
-{% else %}
-  <!-- Modal -->
-  <div class="modal fade" id="currency_loading_data_modal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLongTitle">{{ 'Loading currency data'|trans({}, 'Admin.International.Feature') }}</h5>
-        </div>
-        <div class="modal-body">
-          {{ 'Please wait while currency data is being loaded'|trans({}, 'Admin.International.Feature') }}
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary spinner">{{ 'Close'|trans({}, 'Admin.Actions') }}</button>
+  {% else %}
+    <!-- Modal -->
+    <div class="modal fade" id="currency_loading_data_modal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="exampleModalLongTitle">{{ 'Loading currency data'|trans({}, 'Admin.International.Feature') }}</h5>
+          </div>
+          <div class="modal-body">
+            {{ 'Please wait while currency data is being loaded'|trans({}, 'Admin.International.Feature') }}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary spinner">{{ 'Close'|trans({}, 'Admin.Actions') }}</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
   {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -98,6 +98,15 @@
     </div>
   {{ form_end(currencyForm) }}
 
+  {% if languageDataError is defined and languageDataError %}
+    <div class="card">
+      <div class="card-body">
+        <div class="alert alert-danger">
+          {{ 'Could not display symbol and format customization:'|trans({}, 'Admin.International.Feature') }} {{ languageDataError }}
+        </div>
+      </div>
+    </div>
+{% else %}
   <!-- Modal -->
   <div class="modal fade" id="currency_loading_data_modal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static">
     <div class="modal-dialog modal-dialog-centered" role="document">
@@ -114,4 +123,5 @@
       </div>
     </div>
   </div>
+  {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme currencyForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block form %}
   {{ form_start(currencyForm, {
@@ -61,62 +61,21 @@
           {{ form_errors(currencyForm) }}
 
           {% if not currencyForm.vars.data.id is defined %}
-            {% set selectIsoCodeHelp %}
-            {{ 'By default, PrestaShop comes with a list of official currencies. If you want to use a local currency, you will have to add it manually. For example, to accept the Iranian Toman on your store, you need to create it before.'|trans({}, 'Admin.International.Help') }}
-          {% endset %}
-          {{ ps.form_group_row(currencyForm.selected_iso_code, {}, {
-            'label': 'Select a currency'|trans({}, 'Admin.International.Feature'),
-            'help': selectIsoCodeHelp
-            }) }}
 
-          {{ ps.form_group_row(currencyForm.unofficial, {}, {
-            'label': 'or'|trans({}, 'Admin.Global'),
-            }) }}
+            {{ form_row(currencyForm.selected_iso_code) }}
+            <div class="form-group row type-checkbox ">
+              <label for="currency_unofficial" class="form-control-label ">
+                {{ 'or'|trans({}, 'Admin.Global') }}
+              </label>
+              {{ form_widget(currencyForm.unofficial) }}
+            </div>
           {% endif %}
 
-          {{ ps.form_group_row(currencyForm.names, {}, {
-            'label': 'Currency name'|trans({}, 'Admin.International.Feature'),
-            }) }}
+          {{ form_row(currencyForm.names) }}
 
           {% set symbolsClass = currencyForm.symbols.vars.errors|length ? '' : 'd-none' %}
-          {{ ps.form_group_row(currencyForm.symbols, {}, {
-            'label': 'Symbol'|trans({}, 'Admin.International.Feature'),
-            'class': symbolsClass
-            }) }}
-
-          {{ ps.form_group_row(currencyForm.iso_code, {}, {
-            'label': 'ISO code'|trans({}, 'Admin.International.Feature'),
-            'help': 'ISO 4217 code (e.g. USD for Dollars, EUR for Euros, etc.)'|trans({}, 'Admin.International.Help')
-            }) }}
-
-          {% set exchangeRateHelp %}
-          {{ 'Exchange rates are calculated from one unit of your shop\'s default currency. For example, if the default currency is euros and your chosen currency is dollars, type "1.20" (1&euro; = $1.20).'|trans({}, 'Admin.International.Help') }}
-        {% endset %}
-
-        {{ ps.form_group_row(currencyForm.exchange_rate, {}, {
-          'label': 'Exchange rate'|trans({}, 'Admin.International.Feature'),
-          'help': exchangeRateHelp
-          }) }}
-
-        {{ ps.form_group_row(currencyForm.precision, {}, {
-          'label': 'Decimals'|trans({}, 'Admin.International.Feature')
-          }) }}
-
-        {{ ps.form_group_row(currencyForm.active, {}, {
-          'label': 'Status'|trans({}, 'Admin.Global'),
-          }) }}
-
-        {{ ps.form_group_row(currencyForm.transformations, {}, {'class': 'd-none'}) }}
-
-        {% if isShopFeatureEnabled %}
-          {{ ps.form_group_row(currencyForm.shop_association, {}, {
-            'label': 'Shop association'|trans({}, 'Admin.Global'),
-            }) }}
-        {% endif %}
-
-        {% block currency_form_rest %}
-          {{ form_rest(currencyForm) }}
-        {% endblock %}
+          {{ form_row(currencyForm.symbols, {'row_attr': {'class': symbolsClass}}) }}
+          {{ form_widget(currencyForm) }}
         </div>
       </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -901,6 +901,12 @@
   {{ form_widget(form['max_field'], { attr: {class: 'max-field'}}) }}
 {% endblock %}
 
+{%- block number_widget -%}
+  {%- set type = type|default('text') -%}
+  {{ block('form_widget_simple') }}
+  {{- block('form_help') -}}
+{%- endblock number_widget -%}
+
 {% block form_help %}
   {% if help %}
     <small class="form-text">{{ help|raw }}</small>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies currency form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying International -> Localization -> Currency add/edit and options forms. Everything must look the same.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by CurrencyExchangeRateType. This means if any module extends this type they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
