### PR TITLE
Simplified contact form

### DIFF
--- a/classes/Contact.php
+++ b/classes/Contact.php
@@ -70,9 +70,9 @@ class ContactCore extends ObjectModel
                 'size' => 255,
             ],
             'description' => [
-                'type' => self::TYPE_HTML,
+                'type' => self::TYPE_STRING,
                 'lang' => true,
-                'validate' => 'isCleanHtml',
+                'validate' => 'isString',
             ],
         ],
     ];

--- a/classes/Contact.php
+++ b/classes/Contact.php
@@ -70,7 +70,7 @@ class ContactCore extends ObjectModel
                 'size' => 255,
             ],
             'description' => [
-                'type' => self::TYPE_STRING,
+                'type' => self::TYPE_HTML,
                 'lang' => true,
                 'validate' => 'isCleanHtml',
             ],

--- a/src/Core/ConstraintValidator/Constraints/NoTags.php
+++ b/src/Core/ConstraintValidator/Constraints/NoTags.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\NoTagsValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validation constraint for making sure there are no HTML or PHP tags to be removed by strip_tags
+ */
+class NoTags extends Constraint
+{
+    public $message = 'Field must not contain HTML or PHP tags';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return NoTagsValidator::class;
+    }
+}

--- a/src/Core/ConstraintValidator/NoTagsValidator.php
+++ b/src/Core/ConstraintValidator/NoTagsValidator.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\NoTags;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validation constraint for making sure there are no HTML or PHP tags to be removed by strip_tags
+ */
+class NoTagsValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof NoTags) {
+            throw new UnexpectedTypeException($constraint, NoTags::class);
+        }
+
+        if ($value === '' || $value === null) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if ($value !== strip_tags($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setTranslationDomain('Admin.Notifications.Error')
+                ->setParameter('%s', $this->formatValue($value))
+                ->addViolation()
+            ;
+        }
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/ContactFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ContactFormDataProvider.php
@@ -96,6 +96,7 @@ final class ContactFormDataProvider implements FormDataProviderInterface
 
         return [
             'shop_association' => $shopIds,
+            'is_messages_saving_enabled' => false,
         ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -144,7 +144,9 @@ class ContactsController extends FrameworkBundleAdminController
         }
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/create.html.twig', [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'contactForm' => $contactForm->createView(),
+            'enableSidebar' => true,
         ]);
     }
 
@@ -186,7 +188,9 @@ class ContactsController extends FrameworkBundleAdminController
         }
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/edit.html.twig', [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'contactForm' => $contactForm->createView(),
+            'enableSidebar' => true,
         ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -134,7 +134,7 @@ class ContactType extends TranslatorAwareType
                     'constraints' => [
                         new NoTags([
                             'message' => $this->trans(
-                                'The field %s is invalid. HTML tags are not allowed.',
+                                'The "%s" field is invalid. HTML tags are not allowed.',
                                 'Admin.Notifications.Error'
                             ),
                         ]),

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -32,11 +32,13 @@ use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
@@ -44,10 +46,8 @@ use Symfony\Component\Validator\Constraints\Regex;
 /**
  * Class ContactType
  */
-class ContactType extends AbstractType
+class ContactType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var bool
      */
@@ -59,13 +59,18 @@ class ContactType extends AbstractType
     private $singleDefaultLanguageArrayToFilledArrayDataTransformer;
 
     /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
      * @param DataTransformerInterface $singleDefaultLanguageArrayToFilledArrayDataTransformer
      * @param bool $isShopFeatureEnabled
      */
     public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
         DataTransformerInterface $singleDefaultLanguageArrayToFilledArrayDataTransformer,
         $isShopFeatureEnabled
     ) {
+        parent::__construct($translator, $locales);
         $this->isShopFeatureEnabled = $isShopFeatureEnabled;
         $this->singleDefaultLanguageArrayToFilledArrayDataTransformer = $singleDefaultLanguageArrayToFilledArrayDataTransformer;
     }
@@ -77,6 +82,8 @@ class ContactType extends AbstractType
     {
         $builder
             ->add('title', TranslatableType::class, [
+                'label' => $this->trans('Title', 'Admin.Global'),
+                'help' => $this->trans('Contact name (e.g. Customer Support).', 'Admin.Shopparameters.Help'),
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
@@ -86,7 +93,6 @@ class ContactType extends AbstractType
                             'pattern' => '/^[^<>={}]*$/u',
                             'message' => $this->trans(
                                 '%s is invalid.',
-                                [],
                                 'Admin.Notifications.Error'
                             ),
                         ]
@@ -95,19 +101,24 @@ class ContactType extends AbstractType
                 ],
             ])
             ->add('email', EmailType::class, [
+                'label' => $this->trans('Email address', 'Admin.Global'),
+                'help' => $this->trans('Emails will be sent to this address.', 'Admin.Shopparameters.Help'),
                 'required' => false,
                 'constraints' => [
                     new Email([
                         'message' => $this->trans(
                             '%s is invalid.',
-                            [],
                             'Admin.Notifications.Error'
                         ),
                     ]),
                 ],
             ])
-            ->add('is_messages_saving_enabled', SwitchType::class)
+            ->add('is_messages_saving_enabled', SwitchType::class, [
+                'label' => $this->trans('Save messages?', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('If enabled, all messages will be saved in the "Customer Service" page under the "Customer" menu.', 'Admin.Shopparameters.Help'),
+            ])
             ->add('description', TranslatableType::class, [
+                'label' => $this->trans('Description', 'Admin.Global'),
                 'type' => TextareaType::class,
                 'required' => false,
                 'options' => [
@@ -115,7 +126,6 @@ class ContactType extends AbstractType
                         new CleanHtml([
                             'message' => $this->trans(
                                 '%s is invalid.',
-                                [],
                                 'Admin.Notifications.Error'
                             ),
                         ]),
@@ -128,14 +138,15 @@ class ContactType extends AbstractType
 
         if ($this->isShopFeatureEnabled) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
                             'The %s field is required.',
+                            'Admin.Notifications.Error',
                             [
-                                sprintf('"%s"', $this->trans('Shop association', [], 'Admin.Global')),
-                            ],
-                            'Admin.Notifications.Error'
+                                sprintf('"%s"', $this->trans('Shop association','Admin.Global')),
+                            ]
                         ),
                     ]),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -123,7 +123,7 @@ class ContactType extends TranslatorAwareType
                     'constraints' => [
                         new NoTags([
                             'message' => $this->trans(
-                                'Field %s is invalid. Field must not contain HTML tags.',
+                                'The field %s is invalid. HTML tags are not allowed.',
                                 'Admin.Notifications.Error'
                             ),
                         ]),

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -33,8 +33,6 @@ use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -145,7 +143,7 @@ class ContactType extends TranslatorAwareType
                             'The %s field is required.',
                             'Admin.Notifications.Error',
                             [
-                                sprintf('"%s"', $this->trans('Shop association','Admin.Global')),
+                                sprintf('"%s"', $this->trans('Shop association', 'Admin.Global')),
                             ]
                         ),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -38,6 +38,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 
@@ -46,6 +47,8 @@ use Symfony\Component\Validator\Constraints\Regex;
  */
 class ContactType extends TranslatorAwareType
 {
+    public const MAX_TITLE_LENGTH = 255;
+
     /**
      * @var bool
      */
@@ -95,6 +98,14 @@ class ContactType extends TranslatorAwareType
                             ),
                         ]
                         ),
+                        new Length([
+                            'max' => static::MAX_TITLE_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => static::MAX_TITLE_LENGTH]
+                            ),
+                        ]),
                     ],
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/Contact/ContactType.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\Contact;
 
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\NoTags;
 use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -121,9 +121,9 @@ class ContactType extends TranslatorAwareType
                 'required' => false,
                 'options' => [
                     'constraints' => [
-                        new CleanHtml([
+                        new NoTags([
                             'message' => $this->trans(
-                                '%s is invalid.',
+                                'Field %s is invalid. Field must not contain HTML tags.',
                                 'Admin.Notifications.Error'
                             ),
                         ]),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -874,11 +874,11 @@ services:
 
     form.type.contact:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\Contact\ContactType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
           - '@prestashop.bundle.form.data_transformer.default_language_to_filled_array'
           - '@=service("prestashop.adapter.multistore_feature").isUsed()'
-        calls:
-            - { method: setTranslator, arguments: ['@translator'] }
         tags:
           - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme contactForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block contact_form %}
   {{ form_start(contactForm) }}
@@ -34,36 +34,7 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          {{ form_errors(contactForm) }}
-
-          {{ ps.form_group_row(contactForm.title, {}, {
-            'label': 'Title'|trans({}, 'Admin.Global'),
-            'help': 'Contact name (e.g. Customer Support).'|trans({}, 'Admin.Shopparameters.Help')
-          }) }}
-
-          {{ ps.form_group_row(contactForm.email, {}, {
-            'label': 'Email address'|trans({}, 'Admin.Global'),
-            'help': 'Emails will be sent to this address.'|trans({}, 'Admin.Shopparameters.Help')
-          }) }}
-
-          {{ ps.form_group_row(contactForm.is_messages_saving_enabled, {}, {
-            'label': 'Save messages?'|trans({}, 'Admin.Shopparameters.Feature'),
-            'help': 'If enabled, all messages will be saved in the "Customer Service" page under the "Customer" menu.'|trans({}, 'Admin.Shopparameters.Help')
-          }) }}
-
-          {{ ps.form_group_row(contactForm.description, {}, {
-            'label': 'Description'|trans({}, 'Admin.Global')
-          }) }}
-
-          {% if contactForm.shop_association is defined %}
-            {{ ps.form_group_row(contactForm.shop_association, {}, {
-              'label': 'Shop association'|trans({}, 'Admin.Global')
-            }) }}
-          {% endif %}
-
-          {% block contact_form_rest %}
-            {{ form_rest(contactForm) }}
-          {% endblock %}
+          {{ form_widget(contactForm) }}
         </div>
       </div>
       <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -193,6 +193,12 @@
   {% endif %}
 {%- endblock time_widget %}
 
+{%- block email_widget -%}
+  {%- set type = type|default('email') -%}
+  {{ block('form_widget_simple') }}
+  {{ block('form_help') }}
+{%- endblock email_widget -%}
+
 {% block button_widget -%}
   {% set attr = attr|merge({class: (attr.class|default('btn-default') ~ ' btn')|trim}) %}
   {{- parent() -}}

--- a/tests/Unit/Core/ConstraintValidator/NoTagsValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/NoTagsValidatorTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\Core\ConstraintValidator;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\NoTags;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\NoTagsValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class NoTagsValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testItFailsWhenScriptTagsAreGiven()
+    {
+        $scriptTag = '<script></script>';
+
+        $this->validator->validate($scriptTag, new NoTags());
+
+        $this->buildViolation((new NoTags())->message)
+            ->setParameter('%s', '"' . $scriptTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    public function testItFailsWhenHTMLTagsGiven()
+    {
+        $htmlTag = '<div class="btn">Button</div>';
+
+        $this->validator->validate($htmlTag, new NoTags());
+
+        $this->buildViolation((new NoTags())->message)
+            ->setParameter('%s', '"' . $htmlTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    public function testItFailsWhenPHPTagsGiven()
+    {
+        $phpTag = '<?php $_SERVER = "crash"; ?>';
+
+        $this->validator->validate($phpTag, new NoTags());
+
+        $this->buildViolation((new NoTags())->message)
+            ->setParameter('%s', '"' . $phpTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    protected function createValidator(): NoTagsValidator
+    {
+        return new NoTagsValidator();
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies contact form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Shop Parameters -> Contact add/edit form. Everything must look the same.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by ContactType. This means if any module extends this type they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
