### PR TITLE
Adjust modal position when wrong used with a form

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -25,7 +25,6 @@
  */
 
 .form-horizontal {
-
   .card-block {
     justify-content: center;
     padding: 1.875rem $card-spacer-x;
@@ -78,4 +77,14 @@
 
 .invalid-feedback-container {
   padding-top: 8px;
+}
+
+.modal {
+  > form {
+    display: initial;
+
+    .modal-dialog {
+      top: 45%;
+    }
+  }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Modals are mostly wrong used as the form occures before modal-dialog, while it should be inside, but it can be fixed with CSS
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21943.
| How to test?  | Check issue, it's modal issue
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21947)
<!-- Reviewable:end -->
