### PR TITLE
Remove transformation traits from behats and implement contexts instead

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Configuration/CommonConfigurationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Configuration/CommonConfigurationFeatureContext.php
@@ -28,13 +28,10 @@ namespace Tests\Integration\Behaviour\Features\Context\Configuration;
 
 use Configuration;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
-use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
 use Tools;
 
 class CommonConfigurationFeatureContext extends AbstractConfigurationFeatureContext
 {
-    use StringToBooleanTransform;
-
     /**
      * @Given /^shop configuration for "(.+)" is set to (.+)$/
      */

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -60,12 +60,9 @@ use Product;
 use RuntimeException;
 use State;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
-use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
 
 class CartFeatureContext extends AbstractDomainFeatureContext
 {
-    use StringToBooleanTransform;
-
     /**
      * @Given the current currency is :currencyIsoCode
      */

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartRuleFeatureContext.php
@@ -55,14 +55,9 @@ use PrestaShop\PrestaShop\Core\Domain\ValueObject\Money;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
-use Tests\Integration\Behaviour\Features\Transform\SharedStorageTransform;
-use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
 
 class CartRuleFeatureContext extends AbstractDomainFeatureContext
 {
-    use SharedStorageTransform;
-    use StringToBooleanTransform;
-
     private $cartRuleStorageProperty = 'add_cart_rule';
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartRuleFeatureContext.php
@@ -55,7 +55,6 @@ use PrestaShop\PrestaShop\Core\Domain\ValueObject\Money;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
-use Tests\Integration\Behaviour\Features\Transform\CurrencyTransform;
 use Tests\Integration\Behaviour\Features\Transform\SharedStorageTransform;
 use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
 
@@ -63,7 +62,6 @@ class CartRuleFeatureContext extends AbstractDomainFeatureContext
 {
     use SharedStorageTransform;
     use StringToBooleanTransform;
-    use CurrencyTransform;
 
     private $cartRuleStorageProperty = 'add_cart_rule';
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateAttachmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateAttachmentFeatureContext.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\AssociateProductAttachment
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductAttachmentsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductAttachmentsCommand;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+use Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext;
 
 class UpdateAttachmentFeatureContext extends AbstractProductFeatureContext
 {
@@ -54,21 +54,22 @@ class UpdateAttachmentFeatureContext extends AbstractProductFeatureContext
     /**
      * @Then product :productReference should have following attachments associated: :attachmentReferences
      *
+     * attachmentReferences transformation handled by @see StringToArrayTransformContext
+     *
      * @param string $productReference
-     * @param string $attachmentReferences
+     * @param string[] $attachmentReferences
      */
-    public function assertProductAttachments(string $productReference, string $attachmentReferences): void
+    public function assertProductAttachments(string $productReference, array $attachmentReferences): void
     {
         $attachmentIds = $this->getProductForEditing($productReference)->getAssociatedAttachmentIds();
-        $expectedReferences = PrimitiveUtils::castStringArrayIntoArray($attachmentReferences);
 
         Assert::assertEquals(
             count($attachmentIds),
-            count($expectedReferences),
+            count($attachmentReferences),
             'Unexpected associated product attachments count'
         );
 
-        foreach ($expectedReferences as $key => $expectedReference) {
+        foreach ($attachmentReferences as $key => $expectedReference) {
             if ($attachmentIds[$key] === $this->getSharedStorage()->get($expectedReference)) {
                 continue;
             }
@@ -93,14 +94,16 @@ class UpdateAttachmentFeatureContext extends AbstractProductFeatureContext
     /**
      * @When I associate product :productReference with following attachments: :attachmentReferences
      *
+     * attachmentReferences transformation handled by @see StringToArrayTransformContext
+     *
      * @param string $productReference
-     * @param string $attachmentReferences
+     * @param string[] $attachmentReferences
      */
-    public function setAssociatedProductAttachments(string $productReference, string $attachmentReferences): void
+    public function setAssociatedProductAttachments(string $productReference, array $attachmentReferences): void
     {
         $attachmentIds = [];
 
-        foreach (PrimitiveUtils::castStringArrayIntoArray($attachmentReferences) as $attachmentReference) {
+        foreach ($attachmentReferences as $attachmentReference) {
             $attachmentIds[] = $this->getSharedStorage()->get($attachmentReference);
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateOptionsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateOptionsFeatureContext.php
@@ -84,6 +84,59 @@ class UpdateOptionsFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @Then product :productReference should have following options information:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function assertOptionsInformation(string $productReference, TableNode $table)
+    {
+        $productForEditing = $this->getProductForEditing($productReference);
+        $data = $table->getRowsHash();
+
+        $this->assertBoolProperty($productForEditing, $data, 'available_for_order');
+        $this->assertBoolProperty($productForEditing, $data, 'online_only');
+        $this->assertBoolProperty($productForEditing, $data, 'show_price');
+        $this->assertStringProperty($productForEditing, $data, 'visibility');
+        $this->assertStringProperty($productForEditing, $data, 'condition');
+        $this->assertStringProperty($productForEditing, $data, 'isbn');
+        $this->assertStringProperty($productForEditing, $data, 'upc');
+        $this->assertStringProperty($productForEditing, $data, 'ean13');
+        $this->assertStringProperty($productForEditing, $data, 'mpn');
+        $this->assertStringProperty($productForEditing, $data, 'reference');
+
+        // Assertions checking isset() can hide some errors if it doesn't find array key,
+        // to make sure all provided fields were checked we need to unset every asserted field
+        // and finally, if provided data is not empty, it means there are some unnasserted values left
+        Assert::assertEmpty($data, sprintf('Some provided product options fields haven\'t been asserted: %s', var_export($data, true)));
+    }
+
+    /**
+     * @Then manufacturer :manufacturerReference should be assigned to product :productReference
+     *
+     * @param string $manufacturerReference
+     * @param string $productReference
+     */
+    public function assertManufacturerId(string $manufacturerReference, string $productReference): void
+    {
+        $expectedId = $this->getSharedStorage()->get($manufacturerReference);
+        $actualId = $this->getProductForEditing($productReference)->getOptions()->getManufacturerId();
+
+        Assert::assertEquals($expectedId, $actualId, 'Unexpected product manufacturer id');
+    }
+
+    /**
+     * @Then product :productReference should have no manufacturer assigned
+     *
+     * @param string $productReference
+     */
+    public function assertProductHasNoManufacturer(string $productReference): void
+    {
+        $manufacturerId = $this->getProductForEditing($productReference)->getOptions()->getManufacturerId();
+        Assert::assertEmpty($manufacturerId, sprintf('Expected product "%s" to have no manufacturer assigned', $productReference));
+    }
+
+    /**
      * @param array $data
      * @param UpdateProductOptionsCommand $command
      */
@@ -150,58 +203,5 @@ class UpdateOptionsFeatureContext extends AbstractProductFeatureContext
             }
             $command->setManufacturerId($manufacturerId);
         }
-    }
-
-    /**
-     * @Then product :productReference should have following options information:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function assertOptionsInformation(string $productReference, TableNode $table)
-    {
-        $productForEditing = $this->getProductForEditing($productReference);
-        $data = $table->getRowsHash();
-
-        $this->assertBoolProperty($productForEditing, $data, 'available_for_order');
-        $this->assertBoolProperty($productForEditing, $data, 'online_only');
-        $this->assertBoolProperty($productForEditing, $data, 'show_price');
-        $this->assertStringProperty($productForEditing, $data, 'visibility');
-        $this->assertStringProperty($productForEditing, $data, 'condition');
-        $this->assertStringProperty($productForEditing, $data, 'isbn');
-        $this->assertStringProperty($productForEditing, $data, 'upc');
-        $this->assertStringProperty($productForEditing, $data, 'ean13');
-        $this->assertStringProperty($productForEditing, $data, 'mpn');
-        $this->assertStringProperty($productForEditing, $data, 'reference');
-
-        // Assertions checking isset() can hide some errors if it doesn't find array key,
-        // to make sure all provided fields were checked we need to unset every asserted field
-        // and finally, if provided data is not empty, it means there are some unnasserted values left
-        Assert::assertEmpty($data, sprintf('Some provided product options fields haven\'t been asserted: %s', var_export($data, true)));
-    }
-
-    /**
-     * @Then manufacturer :manufacturerReference should be assigned to product :productReference
-     *
-     * @param string $manufacturerReference
-     * @param string $productReference
-     */
-    public function assertManufacturerId(string $manufacturerReference, string $productReference): void
-    {
-        $expectedId = $this->getSharedStorage()->get($manufacturerReference);
-        $actualId = $this->getProductForEditing($productReference)->getOptions()->getManufacturerId();
-
-        Assert::assertEquals($expectedId, $actualId, 'Unexpected product manufacturer id');
-    }
-
-    /**
-     * @Then product :productReference should have no manufacturer assigned
-     *
-     * @param string $productReference
-     */
-    public function assertProductHasNoManufacturer(string $productReference): void
-    {
-        $manufacturerId = $this->getProductForEditing($productReference)->getOptions()->getManufacturerId();
-        Assert::assertEmpty($manufacturerId, sprintf('Expected product "%s" to have no manufacturer assigned', $productReference));
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -47,7 +47,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
      * @param string $packReference
      * @param TableNode $table
      */
-    public function updateProductPack(string $packReference, TableNode $table)
+    public function updateProductPack(string $packReference, TableNode $table): void
     {
         $data = $table->getColumnsHash();
 
@@ -73,7 +73,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
      *
      * @param string $packReference
      */
-    public function removeAllProductsFromPack(string $packReference)
+    public function removeAllProductsFromPack(string $packReference): void
     {
         $packId = $this->getSharedStorage()->get($packReference);
 
@@ -90,7 +90,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
      * @param string $packReference
      * @param TableNode $table
      */
-    public function assertPackContents(string $packReference, TableNode $table)
+    public function assertPackContents(string $packReference, TableNode $table): void
     {
         $data = $table->getColumnsHash();
         $packId = $this->getSharedStorage()->get($packReference);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
@@ -48,7 +48,7 @@ class UpdatePricesFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateProductPrices(string $productReference, TableNode $table)
+    public function updateProductPrices(string $productReference, TableNode $table): void
     {
         $data = $table->getRowsHash();
         $command = new UpdateProductPricesCommand($this->getSharedStorage()->get($productReference));
@@ -131,7 +131,7 @@ class UpdatePricesFeatureContext extends AbstractProductFeatureContext
      * @param array $data
      * @param ProductPricesInformation $pricesInfo
      */
-    private function assertTaxRulesGroup(array &$data, ProductPricesInformation $pricesInfo)
+    private function assertTaxRulesGroup(array &$data, ProductPricesInformation $pricesInfo): void
     {
         if (!isset($data['tax rules group'])) {
             return;

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductSuppliersFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductSuppliersFeatureContext.php
@@ -48,7 +48,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
      *
      * @param string $productReference
      */
-    public function deleteAllProductSuppliers(string $productReference)
+    public function deleteAllProductSuppliers(string $productReference): void
     {
         try {
             $this->getCommandBus()->handle(new RemoveAllAssociatedProductSuppliersCommand(
@@ -125,7 +125,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param TableNode $table
      */
-    public function assertProductSuppliers(string $productReference, TableNode $table)
+    public function assertProductSuppliers(string $productReference, TableNode $table): void
     {
         $expectedProductSuppliers = $table->getColumnsHash();
         $actualProductSupplierOptions = $this->getProductSupplierOptions($productReference);
@@ -163,7 +163,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
      *
      * @param string $productReference
      */
-    public function assertProductDefaultSupplierReferenceIsEmpty(string $productReference)
+    public function assertProductDefaultSupplierReferenceIsEmpty(string $productReference): void
     {
         Assert::assertEmpty(
             $this->getProductSupplierOptions($productReference)->getDefaultSupplierReference(),
@@ -176,7 +176,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
      *
      * @param string $productReference
      */
-    public function assertProductHasNoSuppliers(string $productReference)
+    public function assertProductHasNoSuppliers(string $productReference): void
     {
         Assert::assertEmpty(
             $this->getProductSupplierOptions($productReference)->getOptionsBySupplier(),
@@ -187,7 +187,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
     /**
      * @Then I should get error that supplier is not associated with product
      */
-    public function assertFailedUpdateDefaultSupplierWhichIsNotAssigned()
+    public function assertFailedUpdateDefaultSupplierWhichIsNotAssigned(): void
     {
         $this->assertLastErrorIs(ProductSupplierException::class);
     }
@@ -197,7 +197,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
      *
      * @param string $productReference
      */
-    public function assertProductHasNoDefaultSupplier(string $productReference)
+    public function assertProductHasNoDefaultSupplier(string $productReference): void
     {
         $defaultSupplierId = $this->getProductSupplierOptions($productReference)->getDefaultSupplierId();
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateSeoFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateSeoFeatureContext.php
@@ -44,7 +44,7 @@ class UpdateSeoFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param TableNode $tableNode
      */
-    public function updateSeo(string $productReference, TableNode $tableNode)
+    public function updateSeo(string $productReference, TableNode $tableNode): void
     {
         $dataRows = $tableNode->getRowsHash();
         $productId = $this->getSharedStorage()->get($productReference);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
@@ -73,7 +73,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
      *
      * @param string $productReference
      */
-    public function assertProductHasNoCarriers(string $productReference)
+    public function assertProductHasNoCarriers(string $productReference): void
     {
         $productForEditing = $this->getProductForEditing($productReference);
 
@@ -120,7 +120,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
      * @param array $expectedValues
      * @param ProductShippingInformation $actualValues
      */
-    private function assertNumberShippingFields(array &$expectedValues, ProductShippingInformation $actualValues)
+    private function assertNumberShippingFields(array &$expectedValues, ProductShippingInformation $actualValues): void
     {
         $numberShippingFields = [
             'width',
@@ -152,7 +152,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
      * @param array $data
      * @param ProductShippingInformation $productShippingInformation
      */
-    private function assertDeliveryTimeNotes(array &$data, ProductShippingInformation $productShippingInformation)
+    private function assertDeliveryTimeNotes(array &$data, ProductShippingInformation $productShippingInformation): void
     {
         $notesTypeNamedValues = [
             'none' => DeliveryTimeNotesType::TYPE_NONE,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
@@ -30,12 +30,9 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductStatusCommand;
-use Tests\Integration\Behaviour\Features\Transform\StringToBooleanTransform;
 
 class UpdateStatusFeatureContext extends AbstractProductFeatureContext
 {
-    use StringToBooleanTransform;
-
     /**
      * @When /^I (enable|disable) product "(.*)"$/
      *

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStatusFeatureContext.php
@@ -30,13 +30,14 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductStatusCommand;
+use Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext;
 
 class UpdateStatusFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @When /^I (enable|disable) product "(.*)"$/
      *
-     * @Transform(enable|disable)
+     * status transformation handled by @see StringToBoolTransformContext
      *
      * @param bool $status
      * @param string $productReference
@@ -52,7 +53,7 @@ class UpdateStatusFeatureContext extends AbstractProductFeatureContext
     /**
      * @Then /^product "(.*)" should be (enabled|disabled)$/
      *
-     * @Transform(enabled|disabled)
+     * status transformation handled by @see StringToBoolTransformContext
      *
      * @param string $productReference
      * @param bool $expectedStatus

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
@@ -45,7 +45,7 @@ class UpdateTagsFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateProductTags(string $productReference, TableNode $table)
+    public function updateProductTags(string $productReference, TableNode $table): void
     {
         $productId = $this->getSharedStorage()->get($productReference);
         $data = $table->getRowsHash();

--- a/tests/Integration/Behaviour/Features/Transform/CurrencyTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/CurrencyTransformContext.php
@@ -32,6 +32,9 @@ use Configuration;
 use Currency;
 use InvalidArgumentException;
 
+/**
+ * Currency related transformations
+ */
 class CurrencyTransformContext
 {
     /**

--- a/tests/Integration/Behaviour/Features/Transform/CurrencyTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/CurrencyTransformContext.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Transform;
 
+use Behat\Behat\Context\Context;
 use Configuration;
 use Currency;
 use InvalidArgumentException;
@@ -35,7 +36,7 @@ use InvalidArgumentException;
 /**
  * Currency related transformations
  */
-class CurrencyTransformContext
+class CurrencyTransformContext implements Context
 {
     /**
      * Transforms currency iso code to instance

--- a/tests/Integration/Behaviour/Features/Transform/CurrencyTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/CurrencyTransformContext.php
@@ -24,13 +24,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Behaviour\Features\Transform;
 
 use Configuration;
 use Currency;
 use InvalidArgumentException;
 
-trait CurrencyTransform
+class CurrencyTransformContext
 {
     /**
      * Transforms currency iso code to instance

--- a/tests/Integration/Behaviour/Features/Transform/SharedStorageTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/SharedStorageTransformContext.php
@@ -28,12 +28,13 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Transform;
 
+use Behat\Behat\Context\Context;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 /**
  * Shared storage related transformations
  */
-class SharedStorageTransformContext
+class SharedStorageTransformContext implements Context
 {
     /**
      * Helps access the latest resource that was put into storage.

--- a/tests/Integration/Behaviour/Features/Transform/SharedStorageTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/SharedStorageTransformContext.php
@@ -24,26 +24,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Behaviour\Features\Transform;
 
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+
 /**
- * Trait containing boolean transformations.
+ * Shared storage related transformations
  */
-trait StringToBooleanTransform
+class SharedStorageTransformContext
 {
     /**
-     * @Transform /^(enabled|enable|included|should|includes)$/
+     * Helps access the latest resource that was put into storage.
+     *
+     * @Transform /^(it|its)$/
      */
-    public function transformTruthyStringToBoolean(string $string)
+    public function getLatestResource()
     {
-        return true;
-    }
-
-    /**
-     * @Transform /^(disabled|disable|excluded|should not|excludes)$/
-     */
-    public function transformFalsyStringToBoolean(string $string)
-    {
-        return false;
+        return SharedStorage::getStorage()->getLatestResource();
     }
 }

--- a/tests/Integration/Behaviour/Features/Transform/StringToArrayTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/StringToArrayTransformContext.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Transform;
+
+use Behat\Behat\Context\Context;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+/**
+ * Contains string to array transformations
+ */
+class StringToArrayTransformContext implements Context
+{
+    /**
+     * @Transform /^\[.*?\]$/
+     *
+     * @param string $string
+     *
+     * @return array
+     */
+    public function transformStringArrayToArray(string $string): array
+    {
+        return PrimitiveUtils::castStringArrayIntoArray($string);
+    }
+}

--- a/tests/Integration/Behaviour/Features/Transform/StringToBoolTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/StringToBoolTransformContext.php
@@ -28,10 +28,12 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Transform;
 
+use Behat\Behat\Context\Context;
+
 /**
  * Contains string to boolean transformations
  */
-class StringToBoolTransformContext
+class StringToBoolTransformContext implements Context
 {
     /**
      * @Transform /^(enabled|enable|included|should|includes)$/

--- a/tests/Integration/Behaviour/Features/Transform/StringToBoolTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/StringToBoolTransformContext.php
@@ -24,22 +24,36 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Behaviour\Features\Transform;
 
-use Tests\Integration\Behaviour\Features\Context\SharedStorage;
-
 /**
- * Trait with common shared storage related transformations.
+ * Contains string to boolean transformations
  */
-trait SharedStorageTransform
+class StringToBoolTransformContext
 {
     /**
-     * Helps access the latest resource that was put into storage.
+     * @Transform /^(enabled|enable|included|should|includes)$/
      *
-     * @Transform /^(it|its)$/
+     * @param string $string
+     *
+     * @return bool
      */
-    public function getLatestResource()
+    public function transformTruthyStringToBoolean(string $string): bool
     {
-        return SharedStorage::getStorage()->getLatestResource();
+        return true;
+    }
+
+    /**
+     * @Transform /^(disabled|disable|excluded|should not|excludes)$/
+     *
+     * @param string $string
+     *
+     * @return bool
+     */
+    public function transformFalsyStringToBoolean(string $string): bool
+    {
+        return false;
     }
 }

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -21,6 +21,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         category:
             paths:
                 - %paths.base%/Features/Scenario/Category
@@ -55,6 +56,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\EmployeeFeatureContext
                 - Tests\Integration\Behaviour\Features\Transform\CurrencyTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\SharedStorageTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         order:
             paths:
                 - %paths.base%/Features/Scenario/Order
@@ -89,6 +92,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Transform\CurrencyTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\SharedStorageTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         currency:
             paths:
                 - %paths.base%/Features/Scenario/Currency
@@ -144,6 +149,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
                 - Tests\Integration\Behaviour\Features\Transform\CurrencyTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\SharedStorageTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         meta:
             paths:
                 - %paths.base%/Features/Scenario/Meta
@@ -154,6 +161,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\MetaFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\MetaFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         feature:
             paths:
                 - %paths.base%/Features/Scenario/Feature
@@ -234,3 +242,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\RelatedProductsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DuplicateProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -54,6 +54,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\EmployeeFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\CurrencyTransformContext
         order:
             paths:
                 - %paths.base%/Features/Scenario/Order
@@ -87,6 +88,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\CurrencyTransformContext
         currency:
             paths:
                 - %paths.base%/Features/Scenario/Currency
@@ -141,6 +143,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\CurrencyTransformContext
         meta:
             paths:
                 - %paths.base%/Features/Scenario/Meta

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -243,3 +243,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DuplicateProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Using traits as transformations in behat contexts isn't right because once you use the trait in one context it will be shared across whole Feature. That means all the other contexts will be unstable, as you are not aware if the trait is used in one or another context. So this PR provides simple yet a bit cleaner solution - instead of traits, implement Contexts with related transformations, so once we need a transformer, we add that transformer context to the feature in behat.yml and then its easier to spot when feature is dependant on transformer or not. (open to improvements, but this one was first and only idea how to reuse transformers for now)
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | travis :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21955)
<!-- Reviewable:end -->
