### PR TITLE
Fix legacy form selectors

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.js
@@ -48,7 +48,7 @@ class PositionsListHandler {
     self.handleList();
     self.handleSortable();
 
-    $('input[name="form[general][enable_tos]"]').on('change', () => self.handle());
+    $('input[name="general[enable_tos]"]').on('change', () => self.handle());
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/order-preferences/terms-and-conditions-option-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/order-preferences/terms-and-conditions-option-handler.js
@@ -29,11 +29,11 @@ class TermsAndConditionsOptionHandler {
   constructor() {
     this.handle();
 
-    $('input[name="form[general][enable_tos]"]').on('change', () => this.handle());
+    $('input[name="general[enable_tos]"]').on('change', () => this.handle());
   }
 
   handle() {
-    const tosEnabledVal = $('input[name="form[general][enable_tos]"]:checked').val();
+    const tosEnabledVal = $('input[name="general[enable_tos]"]:checked').val();
     const isTosEnabled = parseInt(tosEnabledVal, 10);
 
     this.handleTermsAndConditionsCmsSelect(isTosEnabled);

--- a/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
@@ -29,11 +29,11 @@ class StockManagementOptionHandler {
   constructor() {
     this.handle();
 
-    $('input[name="form[stock][stock_management]"]').on('change', () => this.handle());
+    $('input[name="stock[stock_management]"]').on('change', () => this.handle());
   }
 
   handle() {
-    const stockManagementVal = $('input[name="form[stock][stock_management]"]:checked').val();
+    const stockManagementVal = $('input[name="stock[stock_management]"]:checked').val();
     const isStockManagementEnabled = parseInt(stockManagementVal, 10);
 
     this.handleAllowOrderingOutOfStockOption(isStockManagementEnabled);
@@ -48,7 +48,7 @@ class StockManagementOptionHandler {
    * @param {int} isStockManagementEnabled
    */
   handleAllowOrderingOutOfStockOption(isStockManagementEnabled) {
-    const allowOrderingOosRadios = $('input[name="form[stock][allow_ordering_oos]"]');
+    const allowOrderingOosRadios = $('input[name="stock[allow_ordering_oos]"]');
 
     if (isStockManagementEnabled) {
       allowOrderingOosRadios.removeAttr('disabled');
@@ -66,7 +66,7 @@ class StockManagementOptionHandler {
    * @param {int} isStockManagementEnabled
    */
   handleDisplayAvailableQuantitiesOption(isStockManagementEnabled) {
-    const displayQuantitiesRadio = $('input[name="form[page][display_quantities]"]');
+    const displayQuantitiesRadio = $('input[name="page[display_quantities]"]');
 
     if (isStockManagementEnabled) {
       displayQuantitiesRadio.removeAttr('disabled');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | in bo new forms, field's name attributes have changed after a refactor of forms. This PR fix some JS selectors that kept the legacy name attribute.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21819
| How to test?  | First, you can test that this old issue is fixed: #21037, then you can checks that forms are working fine in shop parameters > product and shop parameters> order. Those are the only broken JS selectors I found, but it's not impossible that there are others in any new admin form...  


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21960)
<!-- Reviewable:end -->
