### PR TITLE
Undefined index: _route

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -118,7 +118,7 @@ class CommonController extends FrameworkBundleAdminController
                 unset($callerParameters[$k]);
             }
         }
-        $routeName = $request->attributes->get('caller_route', $request->attributes->get('caller_parameters', ['_route' => false])['_route']);
+        $routeName = $request->attributes->get('caller_route', $request->attributes->get('caller_parameters', ['_route' => false])['_route'] ?? false);
         $nextPageUrl = (!$routeName || ($offset + $limit >= $total)) ? false : $this->generateUrl($routeName, array_merge(
             $callerParameters,
             array(


### PR DESCRIPTION
Undefined index: _route in CommonController.php 121
Affected all PS1.7.X up to (incl.) 1.7.9 with PHP 7.2/7.3 with Nginx/Apache running with PHP-FPM
Reproduction (Apache24 example):
Configure web server with mpm_event + php-fpm mode
Turn on full error reporting in php.ini (full means really full)
```error_reporting = E_ALL```
Navigate to "Traffic & SEO / SEO & URLs" Click Save in different page sections.
Look at error/notice messages in log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21967)
<!-- Reviewable:end -->
