### PR TITLE
Fix order detail total amount update when rounding is per item

### DIFF
--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -282,7 +282,7 @@ class OrderAmountUpdater
                     $orderDetail->product_price = $orderDetail->unit_price_tax_excl = Tools::ps_round($unitPriceTaxExcl, $computingPrecision);
                     $orderDetail->unit_price_tax_incl = Tools::ps_round($unitPriceTaxIncl, $computingPrecision);
                     $orderDetail->total_price_tax_excl = $orderDetail->unit_price_tax_excl * $orderDetail->product_quantity;
-                    $orderDetail->total_price_tax_incl = $orderDetail->total_price_tax_incl * $orderDetail->product_quantity;
+                    $orderDetail->total_price_tax_incl = $orderDetail->unit_price_tax_incl * $orderDetail->product_quantity;
 
                     break;
             }

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -713,7 +713,7 @@ Feature: Order from Back Office (BO)
 
   Scenario: I use and address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
     Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
-    Given I enable carrier "price_carrier"
+    And I enable carrier "price_carrier"
     And I select carrier "price_carrier" for cart "dummy_cart"
     Then cart "dummy_cart" should have "price_carrier" as a carrier
     Then I add new address to customer "testCustomer" with following details:
@@ -845,6 +845,147 @@ Feature: Order from Back Office (BO)
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
+      | total_price_tax_excl        | 23.800 |
+    And order "bo_order1" should have no tax details
+    And the first invoice from order "bo_order1" should have following shipping tax details:
+      | total_tax_excl | rate | total_amount |
+      | 5.0            | 0.00 | 0.00         |
+
+  Scenario: In rounding per item mode, I use and address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
+    Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
+    Given specific shop configuration for "rounding type" is set to round each article
+    And I enable carrier "price_carrier"
+    And I select carrier "price_carrier" for cart "dummy_cart"
+    Then cart "dummy_cart" should have "price_carrier" as a carrier
+    Then I add new address to customer "testCustomer" with following details:
+      | Address alias    | test-customer-france-address |
+      | First name       | testFirstName                |
+      | Last name        | testLastName                 |
+      | Address          | 36 Avenue des Champs Elysees |
+      | City             | Paris                        |
+      | Country          | France                       |
+      | Postal code      | 75008                        |
+    And I select "FR" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And I update order "bo_order1" status to "Payment accepted"
+    Then order "bo_order1" should have 1 invoice
+    And order "bo_order1" should have 2 products in total
+    And order "bo_order1" should have "price_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 23.800 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 28.800 |
+      | total_paid_tax_incl      | 28.800 |
+      | total_paid               | 28.800 |
+      | total_paid_real          | 28.800 |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.0    |
+      | carrier_tax_rate         | 0.0    |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 5.00  |
+      | shipping_cost_tax_incl | 5.00  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 11.900 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 23.800 |
+      | total_price_tax_excl        | 23.800 |
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 23.800 |
+      | total_products_wt       | 23.800 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 28.800 |
+      | total_paid_tax_incl     | 28.800 |
+      | total_shipping_tax_excl | 5.0    |
+      | total_shipping_tax_incl | 5.00   |
+    And order "bo_order1" should have no tax details
+    And the first invoice from order "bo_order1" should have following shipping tax details:
+      | total_tax_excl | rate | total_amount |
+      | 5.0            | 0.00 | 0.0          |
+    Given I add new address to customer "testCustomer" with following details:
+      | Address alias    | test-customer-states-address |
+      | First name       | testFirstName                |
+      | Last name        | testLastName                 |
+      | Address          | 36 Avenue des Champs Elysees |
+      | City             | Miami                        |
+      | Country          | United States                |
+      | State            | Florida                      |
+      | Postal code      | 33133                        |
+    And I change order "bo_order1" shipping address to "test-customer-states-address"
+    Then order "bo_order1" shipping address should be "test-customer-states-address"
+    # Shipping cost changes because we are not in the same zone but the tax is still the one from invoice address
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.220000 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 29.800 |
+      | total_paid_tax_incl      | 31.580000 |
+      | total_paid               | 31.580000 |
+      | total_paid_real          | 28.800 |
+      | total_shipping_tax_excl  | 6.0    |
+      | total_shipping_tax_incl  | 6.36   |
+      | carrier_tax_rate         | 6.0    |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 6.00  |
+      | shipping_cost_tax_incl | 6.36  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 12.610000 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 25.220000 |
+      | total_price_tax_excl        | 23.800 |
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 23.800 |
+      | total_products_wt       | 25.220000 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 29.800 |
+      | total_paid_tax_incl     | 31.580000 |
+      | total_shipping_tax_excl | 6.0    |
+      | total_shipping_tax_incl | 6.36   |
+    And order "bo_order1" should have following tax details:
+      | unit_tax_base | total_tax_base | unit_amount | total_amount |
+      | 11.900        | 23.800         | 0.714       | 1.42        |
+    And the first invoice from order "bo_order1" should have following shipping tax details:
+      | total_tax_excl | rate | total_amount |
+      | 6.0            | 6.00 | 0.36         |
+    # If I switch back the order_detail_tax are cleaned
+    And I change order "bo_order1" shipping address to "test-customer-france-address"
+    Then order "bo_order1" shipping address should be "test-customer-france-address"
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800000 |
+      | total_products_wt        | 23.800000 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 28.800 |
+      | total_paid_tax_incl      | 28.800 |
+      | total_paid               | 28.800 |
+      | total_paid_real          | 28.800 |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.0    |
+      | carrier_tax_rate         | 0.0    |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 5.00  |
+      | shipping_cost_tax_incl | 5.00  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2      |
+      | product_price               | 11.900 |
+      | unit_price_tax_incl         | 11.900 |
+      | unit_price_tax_excl         | 11.900 |
+      | total_price_tax_incl        | 23.800000 |
       | total_price_tax_excl        | 23.800 |
     And order "bo_order1" should have no tax details
     And the first invoice from order "bo_order1" should have following shipping tax details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -851,7 +851,7 @@ Feature: Order from Back Office (BO)
       | total_tax_excl | rate | total_amount |
       | 5.0            | 0.00 | 0.00         |
 
-  Scenario: In rounding per item mode, I use and address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
+  Scenario: In rounding per item mode, I use an address without taxes (no order_detail_tax created), then I change to a country with taxes all is correctly computed
     Given shop configuration for "PS_TAX_ADDRESS_TYPE" is set to id_address_delivery
     Given specific shop configuration for "rounding type" is set to round each article
     And I enable carrier "price_carrier"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -73,6 +73,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Configuration\RoundingTypeConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderPaymentFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderShippingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderCartFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In the `OrderAmountUpdater` service, the `total_price_tax_incl` amount per order detail was not calculated correctly
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21717
| How to test?  | See steps in issue #21717

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21988)
<!-- Reviewable:end -->
