### PR TITLE
Make customer note TYPE_STRING instead of TYPE_HTML

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -194,7 +194,7 @@ class CustomerCore extends ObjectModel
             'max_payment_days' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'copy_post' => false],
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false],
             'deleted' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false],
-            'note' => ['type' => self::TYPE_HTML, 'validate' => 'isCleanHtml', 'size' => 65000, 'copy_post' => false],
+            'note' => ['type' => self::TYPE_HTML, 'size' => 65000, 'copy_post' => false],
             'is_guest' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false],
             'id_shop' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'copy_post' => false],
             'id_shop_group' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'copy_post' => false],

--- a/install-dev/upgrade/php/ps_1771_update_customer_note.php
+++ b/install-dev/upgrade/php/ps_1771_update_customer_note.php
@@ -34,16 +34,14 @@ function ps_1771_update_customer_note()
         WHERE note IS NOT NULL AND note != ""'
     );
 
+    $result = true;
     foreach ($notes as $note) {
-        $result = Db::getInstance()->execute(
+        $result &= Db::getInstance()->execute(
             'UPDATE ' . _DB_PREFIX_ . 'customer
             SET note = "' . html_entity_decode($note['note']) . '"
             WHERE id_customer = ' . $note['id_customer']
         );
-        if (false === $result) {
-            return false;
-        }
     }
 
-    return true;
+    return (bool) $result;
 }

--- a/install-dev/upgrade/php/ps_1771_update_customer_note.php
+++ b/install-dev/upgrade/php/ps_1771_update_customer_note.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+/*
+ * Since note is now TYPE_STRING instead of TYPE_HTML it needs to be decoded
+ */
+function ps_1771_update_customer_note()
+{
+    $notes = Db::getInstance()->executeS(
+        'SELECT id_customer, note FROM ' . _DB_PREFIX_ . 'customer
+        WHERE note IS NOT NULL AND note != ""'
+    );
+
+    foreach ($notes as $note) {
+        $result = Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'customer
+            SET note = "' . html_entity_decode($note['note']) . '"
+            WHERE id_customer = ' . $note['id_customer']
+        );
+        if (false === $result) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/install-dev/upgrade/sql/1.7.7.1.sql
+++ b/install-dev/upgrade/sql/1.7.7.1.sql
@@ -1,0 +1,1 @@
+/* PHP:ps_1771_update_customer_note(); */;


### PR DESCRIPTION
## Please don't merge before release 1.7.7.0

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | With the new Order detail page, the customer private note is showing encoded html entities instead of the real character. This PR fixes it.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21829
| How to test?  | You should be able to save customer's note both from order detail page & customer detail page containing the character `&` and it should not be transformed to `&amp;`.<br><br>You should also check that the upgrade process is working following those steps:<br>1. Add a customer's private note containing the char `&` and see that it's changed to `&amp;`<br>2. Checkout this PR<br>3. Update `_PS_INSTALL_VERSION_` constant in `install-dev/install_version.php` with `'1.7.7.1'`<br>4. Run `php install-dev/upgrade/upgrade.php`<br>5. Check that the private note is now display correctly

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21992)
<!-- Reviewable:end -->
