### PR TITLE
Adjust behats localized fields assertion and add LocalizedArrayTransformContext 

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -153,27 +153,6 @@ abstract class AbstractDomainFeatureContext implements Context
     }
 
     /**
-     * Parse a localized string into a localized array, the expected format can be:
-     *   fr-FR:valueFr;en-EN:valueEn:{localeCode}:{localeValue}
-     *   1:valueFr;2:valueEn:{langId}:{localeValue}
-     * and will be converted into an array indexed by language id
-     *
-     * @param string $localizedString
-     *
-     * @return array
-     */
-    protected function parseLocalizedArray(string $localizedString): array
-    {
-        $valuesByLocale = json_decode($localizedString, true);
-        $localizedArray = [];
-        foreach ($valuesByLocale as $locale => $value) {
-            $localizedArray[(int) Language::getIdByLocale($locale, true)] = $value;
-        }
-
-        return $localizedArray;
-    }
-
-    /**
      * @param TableNode $tableNode
      *
      * @return array

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -28,6 +28,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Behat\Testwork\Tester\Result\TestResult;
 use Configuration;
@@ -157,26 +158,49 @@ abstract class AbstractDomainFeatureContext implements Context
      *   1:valueFr;2:valueEn:{langId}:{localeValue}
      * and will be converted into an array indexed by language id
      *
-     * @param string $parsedArray
+     * @param string $localizedString
      *
      * @return array
      */
-    protected function parseLocalizedArray(string $parsedArray): array
+    protected function parseLocalizedArray(string $localizedString): array
     {
-        $arrayValues = array_map('trim', explode(';', $parsedArray));
+        $valuesByLocale = json_decode($localizedString, true);
         $localizedArray = [];
-        foreach ($arrayValues as $arrayValue) {
-            $data = explode(':', $arrayValue);
-            $langKey = $data[0];
-            $langValue = $data[1];
-            if (ctype_digit($langKey)) {
-                $localizedArray[$langKey] = $langValue;
-            } else {
-                $localizedArray[Language::getIdByLocale($langKey, true)] = $langValue;
-            }
+        foreach ($valuesByLocale as $locale => $value) {
+            $localizedArray[(int) Language::getIdByLocale($locale, true)] = $value;
         }
 
         return $localizedArray;
+    }
+
+    /**
+     * @param TableNode $tableNode
+     *
+     * @return array
+     */
+    protected function localizeByRows(TableNode $tableNode): array
+    {
+        return $this->parseLocalizedRow($tableNode->getRowsHash());
+    }
+
+    /**
+     * @param TableNode $table
+     *
+     * @return array
+     */
+    protected function localizeByColumns(TableNode $table): array
+    {
+        $rows = [];
+        foreach ($table->getColumnsHash() as $key => $column) {
+            $row = [];
+            foreach ($column as $columnName => $value) {
+                $row[$columnName] = $value;
+            }
+
+            $rows[] = $this->parseLocalizedRow($row);
+        }
+
+        return $rows;
     }
 
     /**
@@ -185,5 +209,36 @@ abstract class AbstractDomainFeatureContext implements Context
     protected function getDefaultLangId(): int
     {
         return (int) Configuration::get('PS_LANG_DEFAULT');
+    }
+
+    /**
+     * @param array $row
+     *
+     * @return array
+     */
+    private function parseLocalizedRow(array $row): array
+    {
+        $parsedRow = [];
+        foreach ($row as $key => $value) {
+            $localeMatch = preg_match('/\[.*?\]/', $key, $matches) ? reset($matches) : null;
+
+            if (!$localeMatch) {
+                $parsedRow[$key] = $value;
+                continue;
+            }
+
+            $propertyName = str_replace($localeMatch, '', $key);
+            $locale = str_replace(['[', ']'], '', $localeMatch);
+
+            $langId = (int) Language::getIdByLocale($locale, true);
+
+            if (!$langId) {
+                throw new RuntimeException(sprintf('Language by locale "%s" was not found', $locale));
+            }
+
+            $parsedRow[$propertyName][$langId] = $value;
+        }
+
+        return $parsedRow;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/AttachmentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AttachmentFeatureContext.php
@@ -45,14 +45,14 @@ class AttachmentFeatureContext extends AbstractDomainFeatureContext
      */
     public function addAttachment(string $reference, TableNode $tableNode): void
     {
-        $data = $tableNode->getRowsHash();
+        $data = $this->localizeByRows($tableNode);
         $fileName = $data['file_name'];
 
         $destination = $this->uploadDummyFile($fileName);
 
         $attachment = new Attachment();
-        $attachment->description = $this->parseLocalizedArray($data['description']);
-        $attachment->name = $this->parseLocalizedArray($data['name']);
+        $attachment->description = $data['description'];
+        $attachment->name = $data['name'];
         $attachment->file_name = $fileName;
         $attachment->mime = mime_content_type($destination);
         $attachment->file = pathinfo($destination, PATHINFO_BASENAME);
@@ -71,10 +71,10 @@ class AttachmentFeatureContext extends AbstractDomainFeatureContext
     public function assertAttachmentProperties(string $reference, TableNode $tableNode): void
     {
         $attachment = $this->getAttachment($reference);
-        $data = $tableNode->getRowsHash();
+        $data = $this->localizeByRows($tableNode);
 
-        Assert::assertEquals($this->parseLocalizedArray($data['description']), $attachment->description);
-        Assert::assertEquals($this->parseLocalizedArray($data['name']), $attachment->name);
+        Assert::assertEquals($data['description'], $attachment->description);
+        Assert::assertEquals($data['name'], $attachment->name);
         Assert::assertEquals($data['file_name'], $attachment->file_name);
         Assert::assertEquals($data['mime'], $attachment->mime);
         Assert::assertEquals($data['size'], $attachment->file_size);

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -62,7 +62,7 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
     {
         $defaultLangId = Configuration::get('PS_LANG_DEFAULT');
 
-        $data = $node->getRowsHash();
+        $data = $this->localizeByRows($node);
         /** @var \Shop $shop */
         $shop = SharedStorage::getStorage()->get($data['shop_association']);
 
@@ -93,7 +93,7 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         }
 
         if (isset($data['transformations'])) {
-            $command->setLocalizedTransformations($this->parseLocalizedArray($data['transformations']));
+            $command->setLocalizedTransformations($data['transformations']);
         }
 
         $command->setShopIds([
@@ -117,7 +117,7 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
     {
         $defaultLangId = Configuration::get('PS_LANG_DEFAULT');
 
-        $data = $node->getRowsHash();
+        $data = $this->localizeByRows($node);
         /** @var Currency $currency */
         $currency = SharedStorage::getStorage()->get($reference);
 
@@ -155,7 +155,7 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
         }
 
         if (isset($data['transformations'])) {
-            $command->setLocalizedTransformations($this->parseLocalizedArray($data['transformations']));
+            $command->setLocalizedTransformations($data['transformations']);
         }
 
         try {
@@ -222,10 +222,10 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
             'symbols' => $this->currencyData->getSymbols(),
             'patterns' => $this->currencyData->getPatterns(),
         ];
-        $expectedData = $node->getRowsHash();
-        $expectedData['names'] = $this->parseLocalizedArray($expectedData['names']);
-        $expectedData['symbols'] = $this->parseLocalizedArray($expectedData['symbols']);
-        $expectedData['patterns'] = $this->parseLocalizedArray($expectedData['patterns']);
+        $expectedData = $this->localizeByRows($node);
+        $expectedData['names'] = $expectedData['names'];
+        $expectedData['symbols'] = $expectedData['symbols'];
+        $expectedData['patterns'] = $expectedData['patterns'];
 
         foreach ($expectedData as $key => $expectedValue) {
             if ($expectedValue === 'null') {

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AddProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AddProductFeatureContext.php
@@ -44,11 +44,11 @@ class AddProductFeatureContext extends AbstractProductFeatureContext
      */
     public function addProduct(string $productReference, TableNode $table): void
     {
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
 
         try {
             $productId = $this->getCommandBus()->handle(new AddProductCommand(
-                $this->parseLocalizedArray($data['name']),
+                $data['name'],
                 PrimitiveUtils::castStringBooleanIntoBoolean($data['is_virtual'])
             ));
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
 use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
-use Tests\Integration\Behaviour\Features\Transform\StringToLocalizedArrayTransformContext;
+use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext;
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
@@ -70,10 +70,12 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then /^product "(.+)" localized "(.+)" should be "(.*)"$/
-     * @Given /^product "(.+)" localized "(.+)" is "(.*)"$/
+     * @Then /^product "(.+)" localized "(.+)" should be:$/
+     * @Given /^product "(.+)" localized "(.+)" is:$/
      *
-     * localizedValues transformation handled by @see StringToLocalizedArrayTransformContext
+     * localizedValues transformation handled by
+     *
+     * @see LocalizedArrayTransformContext
      *
      * @param string $productReference
      * @param string $fieldName

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
@@ -34,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
 use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
+use Tests\Integration\Behaviour\Features\Transform\StringToLocalizedArrayTransformContext;
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
@@ -67,17 +70,18 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then /^product "(.+)" localized "(.+)" should be "(.+)"$/
-     * @Given /^product "(.+)" localized "(.+)" is "(.+)"$/
+     * @Then /^product "(.+)" localized "(.+)" should be "(.*)"$/
+     * @Given /^product "(.+)" localized "(.+)" is "(.*)"$/
+     *
+     * localizedValues transformation handled by @see StringToLocalizedArrayTransformContext
      *
      * @param string $productReference
      * @param string $fieldName
-     * @param string $localizedValues
+     * @param array $expectedLocalizedValues
      */
-    public function assertLocalizedProperty(string $productReference, string $fieldName, string $localizedValues)
+    public function assertLocalizedProperty(string $productReference, string $fieldName, array $expectedLocalizedValues)
     {
         $productForEditing = $this->getProductForEditing($productReference);
-        $expectedLocalizedValues = $this->parseLocalizedArray($localizedValues);
 
         if ('tags' === $fieldName) {
             UpdateTagsFeatureContext::assertLocalizedTags(

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -162,7 +162,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
     public function assertProductImages(string $productReference, TableNode $tableNode): void
     {
         $images = $this->getProductImages($productReference);
-        $dataRows = $tableNode->getColumnsHash();
+        $dataRows = $this->localizeByColumns($tableNode);
 
         Assert::assertEquals(
             count($images),
@@ -179,7 +179,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
                 'Unexpected cover image'
             );
             Assert::assertEquals(
-                $this->parseLocalizedArray($dataRow['legend']),
+                $dataRow['legend'],
                 $actualImage->getLocalizedLegends(),
                 'Unexpected image legend'
             );

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
@@ -43,12 +43,12 @@ class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
      */
     public function updateProductBasicInfo(string $productReference, TableNode $table): void
     {
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
         $productId = $this->getSharedStorage()->get($productReference);
         $command = new UpdateProductBasicInformationCommand($productId);
 
         if (isset($data['name'])) {
-            $command->setLocalizedNames($this->parseLocalizedArray($data['name']));
+            $command->setLocalizedNames($data['name']);
         }
 
         if (isset($data['is_virtual'])) {
@@ -56,11 +56,11 @@ class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
         }
 
         if (isset($data['description'])) {
-            $command->setLocalizedDescriptions($this->parseLocalizedArray($data['description']));
+            $command->setLocalizedDescriptions($data['description']);
         }
 
         if (isset($data['description_short'])) {
-            $command->setLocalizedShortDescriptions($this->parseLocalizedArray($data['description_short']));
+            $command->setLocalizedShortDescriptions($data['description_short']);
         }
 
         try {

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -51,15 +51,14 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      */
     public function updateCustomizationFields(string $productReference, TableNode $table)
     {
-        $customizationFields = $table->getColumnsHash();
+        $customizationFields = $this->localizeByColumns($table);
         $fieldsForUpdate = [];
         $fieldReferences = [];
 
         foreach ($customizationFields as $customizationField) {
             $addedByModule = isset($customizationField['added by module']) ?
                 PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['added by module']) :
-                false
-            ;
+                false;
             $fieldReference = $customizationField['reference'];
             $id = $this->getSharedStorage()->exists($fieldReference) ? $this->getSharedStorage()->get($fieldReference) : null;
 
@@ -67,7 +66,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
             $fieldsForUpdate[] = [
                 'id' => $id,
                 'type' => $customizationField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT,
-                'localized_names' => $this->parseLocalizedArray($customizationField['name']),
+                'localized_names' => $customizationField['name'],
                 'is_required' => PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['is required']),
                 'added_by_module' => $addedByModule,
             ];
@@ -170,7 +169,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      */
     public function assertCustomizationFields(string $productReference, TableNode $table)
     {
-        $data = $table->getColumnsHash();
+        $data = $this->localizeByColumns($table);
         /** @var CustomizationField[] $actualFields */
         $actualFields = $this->getProductCustomizationFields($productReference);
         $notFoundExpectedFields = [];
@@ -183,11 +182,10 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
                 if ($expectedId === $actualField->getCustomizationFieldId()) {
                     $foundExpectedField = true;
                     $expectedType = $expectedField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT;
-                    $expectedLocalizedNames = $this->parseLocalizedArray($expectedField['name']);
                     $expectedRequired = PrimitiveUtils::castStringBooleanIntoBoolean($expectedField['is required']);
                     Assert::assertEquals($expectedType, $actualField->getType(), 'Unexpected customization type');
                     Assert::assertEquals(
-                        $expectedLocalizedNames,
+                        $expectedField['name'],
                         $actualField->getLocalizedNames(),
                         sprintf('Unexpected product "%s" customization field name', $productReference)
                     );

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateSeoFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateSeoFeatureContext.php
@@ -46,7 +46,7 @@ class UpdateSeoFeatureContext extends AbstractProductFeatureContext
      */
     public function updateSeo(string $productReference, TableNode $tableNode): void
     {
-        $dataRows = $tableNode->getRowsHash();
+        $dataRows = $this->localizeByRows($tableNode);
         $productId = $this->getSharedStorage()->get($productReference);
 
         try {
@@ -158,17 +158,17 @@ class UpdateSeoFeatureContext extends AbstractProductFeatureContext
     private function fillUpdateSeoCommand(array $dataRows, UpdateProductSeoCommand $command): array
     {
         if (isset($dataRows['meta_title'])) {
-            $command->setLocalizedMetaTitles($this->parseLocalizedArray($dataRows['meta_title']));
+            $command->setLocalizedMetaTitles($dataRows['meta_title']);
             unset($dataRows['meta_title']);
         }
 
         if (isset($dataRows['meta_description'])) {
-            $command->setLocalizedMetaDescriptions($this->parseLocalizedArray($dataRows['meta_description']));
+            $command->setLocalizedMetaDescriptions($dataRows['meta_description']);
             unset($dataRows['meta_description']);
         }
 
         if (isset($dataRows['link_rewrite'])) {
-            $command->setLocalizedLinkRewrites($this->parseLocalizedArray($dataRows['link_rewrite']));
+            $command->setLocalizedLinkRewrites($dataRows['link_rewrite']);
             unset($dataRows['link_rewrite']);
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
@@ -50,7 +50,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
      */
     public function updateProductShipping(string $productReference, TableNode $table): void
     {
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
         $productId = $this->getSharedStorage()->get($productReference);
 
         try {
@@ -59,7 +59,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
 
             Assert::assertEmpty(
                 $unhandledData,
-                sprintf('Not all provided values handled in scenario. %s', var_export($unhandledData))
+                sprintf('Not all provided values handled in scenario. %s', var_export($unhandledData, true))
             );
 
             $this->getCommandBus()->handle($command);
@@ -91,7 +91,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
      */
     public function assertShippingInformation(string $productReference, TableNode $tableNode): void
     {
-        $data = $tableNode->getRowsHash();
+        $data = $this->localizeByRows($tableNode);
         $productShippingInformation = $this->getProductForEditing($productReference)->getShippingInformation();
 
         if (isset($data['carriers'])) {
@@ -169,10 +169,9 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
         }
 
         if (isset($data['delivery time in stock notes'])) {
-            $expectedLocalizedOutOfStockNotes = $this->parseLocalizedArray($data['delivery time in stock notes']);
             $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeInStockNotes();
             Assert::assertEquals(
-                $expectedLocalizedOutOfStockNotes,
+                $data['delivery time in stock notes'],
                 $actualLocalizedOutOfStockNotes,
                 'Unexpected product delivery time in stock notes'
             );
@@ -181,10 +180,9 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
         }
 
         if (isset($data['delivery time out of stock notes'])) {
-            $expectedLocalizedOutOfStockNotes = $this->parseLocalizedArray($data['delivery time out of stock notes']);
             $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeOutOfStockNotes();
             Assert::assertEquals(
-                $expectedLocalizedOutOfStockNotes,
+                $data['delivery time out of stock notes'],
                 $actualLocalizedOutOfStockNotes,
                 'Unexpected product delivery time out of stock notes'
             );
@@ -234,16 +232,12 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
         }
 
         if (isset($data['delivery time in stock notes'])) {
-            $command->setLocalizedDeliveryTimeInStockNotes(
-                $this->parseLocalizedArray($data['delivery time in stock notes'])
-            );
+            $command->setLocalizedDeliveryTimeInStockNotes($data['delivery time in stock notes']);
             unset($unhandledValues['delivery time in stock notes']);
         }
 
         if (isset($data['delivery time out of stock notes'])) {
-            $command->setLocalizedDeliveryTimeOutOfStockNotes(
-                $this->parseLocalizedArray($data['delivery time out of stock notes'])
-            );
+            $command->setLocalizedDeliveryTimeOutOfStockNotes($data['delivery time out of stock notes']);
             unset($unhandledValues['delivery time out of stock notes']);
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
@@ -53,7 +53,7 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
      */
     public function updateProductStock(string $productReference, TableNode $table): void
     {
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
         $productId = $this->getSharedStorage()->get($productReference);
 
         $this->cleanLastException();
@@ -285,12 +285,12 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
         }
 
         if (isset($data['available_now_labels'])) {
-            $command->setLocalizedAvailableNowLabels($this->parseLocalizedArray($data['available_now_labels']));
+            $command->setLocalizedAvailableNowLabels($data['available_now_labels']);
             unset($data['available_now_labels']);
         }
 
         if (isset($data['available_later_labels'])) {
-            $command->setLocalizedAvailableLaterLabels($this->parseLocalizedArray($data['available_later_labels']));
+            $command->setLocalizedAvailableLaterLabels($data['available_later_labels']);
             unset($data['available_later_labels']);
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateTagsFeatureContext.php
@@ -48,12 +48,10 @@ class UpdateTagsFeatureContext extends AbstractProductFeatureContext
     public function updateProductTags(string $productReference, TableNode $table): void
     {
         $productId = $this->getSharedStorage()->get($productReference);
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
 
-        $localizedTagStrings = $this->parseLocalizedArray($data['tags']);
         $localizedTagsList = [];
-
-        foreach ($localizedTagStrings as $langId => $localizedTagString) {
+        foreach ($data['tags'] as $langId => $localizedTagString) {
             $localizedTagsList[$langId] = explode(',', $localizedTagString);
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
@@ -87,7 +87,7 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     public function assertSupplierProperties(string $supplierReference, TableNode $table)
     {
         $editableSupplier = $this->getEditableSupplier($supplierReference);
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
 
         Assert::assertEquals($data['name'], $editableSupplier->getName(), 'Unexpected supplier name');
         Assert::assertEquals($data['address'], $editableSupplier->getAddress(), 'Unexpected supplier address');
@@ -104,22 +104,22 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
             sprintf('Expected supplier to be %s', $expectedEnabled ? 'enabled' : 'disabled')
         );
         Assert::assertEquals(
-            $this->parseLocalizedArray($data['description']),
+            $data['description'],
             $editableSupplier->getLocalizedDescriptions(),
             'Unexpected supplier localized descriptions'
         );
         Assert::assertEquals(
-            $this->parseLocalizedArray($data['meta title']),
+            $data['meta title'],
             $editableSupplier->getLocalizedMetaTitles(),
             'Unexpected supplier localized meta titles'
         );
         Assert::assertEquals(
-            $this->parseLocalizedArray($data['meta description']),
+            $data['meta description'],
             $editableSupplier->getLocalizedMetaDescriptions(),
             'Unexpected supplier localized meta descriptions'
         );
         Assert::assertEquals(
-            $this->parseLocalizedArray($data['meta keywords']),
+            $data['meta keywords'],
             $editableSupplier->getLocalizedMetaKeywords(),
             'Unexpected supplier localized meta keywords'
         );

--- a/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
@@ -48,7 +48,7 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
      */
     public function createSupplier(string $supplierReference, TableNode $table)
     {
-        $data = $table->getRowsHash();
+        $data = $this->localizeByRows($table);
 
         try {
             /** @var SupplierId $supplierId */
@@ -58,10 +58,10 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
                 $data['city'],
                 $this->getCountryIdByName($data['country']),
                 PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']),
-                $this->parseLocalizedArray($data['description']),
-                $this->parseLocalizedArray($data['meta title']),
-                $this->parseLocalizedArray($data['meta description']),
-                $this->parseLocalizedArray($data['meta keywords']),
+                $data['description'],
+                $data['meta title'],
+                $data['meta description'],
+                $data['meta keywords'],
                 $this->getShopIdsByReferences($data['shops']),
                 $data['address2'] ?? null,
                 $data['post code'] ?? null,

--- a/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_management.feature
@@ -10,24 +10,30 @@ Feature: Manage attachment from Back Office (BO)
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
     When I add new attachment "att1" with following properties:
-      | description | en-US:puffin photo nr1;fr-FR:photo de macareux |
-      | name        | en-US:puffin;fr-FR:macareux                    |
-      | file_name   | app_icon.png                                   |
+      | description[en-US] | puffin photo nr1  |
+      | description[fr-FR] | photo de macareux |
+      | name[en-US]        | puffin            |
+      | name[fr-FR]        | macareux          |
+      | file_name          | app_icon.png      |
     Then attachment "att1" should have following properties:
-      | description | en-US:puffin photo nr1;fr-FR:photo de macareux |
-      | name        | en-US:puffin;fr-FR:macareux                    |
-      | file_name   | app_icon.png                                   |
-      | mime        | image/png                                      |
-      | size        | 19187                                          |
+      | description[en-US] | puffin photo nr1  |
+      | description[fr-FR] | photo de macareux |
+      | name[en-US]        | puffin            |
+      | name[fr-FR]        | macareux          |
+      | file_name          | app_icon.png      |
+      | mime               | image/png         |
+      | size               | 19187             |
 
   Scenario: I add new attachment providing name and description only in default language
     When I add new attachment "att2" with following properties:
-      | description | en-US:puffin photo nr1 |
-      | name        | en-US:puffin           |
-      | file_name   | app_icon.png           |
+      | description[en-US] | puffin photo nr1 |
+      | name[en-US]        | puffin           |
+      | file_name          | app_icon.png     |
     Then attachment "att2" should have following properties:
-      | description | en-US:puffin photo nr1;fr-FR: |
-      | name        | en-US:puffin;fr-FR:puffin     |
-      | file_name   | app_icon.png                  |
-      | mime        | image/png                     |
-      | size        | 19187                         |
+      | description[en-US] | puffin photo nr1                        |
+      | description[fr-FR] |                                         |
+      | name[en-US]        | puffin                                  |
+      | name[fr-FR]        | puffin                                  |
+      | file_name          | app_icon.png                            |
+      | mime               | image/png                               |
+      | size               | 19187                                   |

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -15,45 +15,51 @@ Feature: Currency Data
     When I request reference data for "EUR"
     Then I should get no currency error
     And I should get currency data:
-      | iso_code         | EUR                                        |
-      | numeric_iso_code | 978                                        |
-      | precision        | 2                                          |
-      | names            | {"en-US":"Euro","fr-FR":"euro"}            |
-      | symbols          | {"en-US":"€","fr-FR":"€"}                  |
-      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"} |
+      | iso_code         | EUR        |
+      | numeric_iso_code | 978        |
+      | precision        | 2          |
+      | names[en-US]     | Euro       |
+      | names[fr-FR]     | euro       |
+      | symbols[en-US]   | €          |
+      | symbols[fr-FR]   | €          |
+      | patterns[en-US]  | ¤#,##0.00  |
+      | patterns[fr-FR]  | #,##0.00 ¤ |
 
   @currency-data
   Scenario: Get data from an unofficial currency
     When I request reference data for "BTC"
     Then I should get error that currency was not found
     When I add new currency "currency1" with following properties:
-      | iso_code         | BTC                   |
-      | name             | Bitcoin               |
-      | symbol           | ₿                     |
-      | exchange_rate    | 0.42                  |
-      | is_enabled       | 1                     |
-      | is_unofficial    | 1                     |
-      | shop_association | shop1                 |
-      | patterns         | {"fr-FR":"¤#,##0.00"} |
+      | iso_code         | BTC       |
+      | name             | Bitcoin   |
+      | symbol           | ₿         |
+      | exchange_rate    | 0.42      |
+      | is_enabled       | 1         |
+      | is_unofficial    | 1         |
+      | shop_association | shop1     |
+      | patterns[fr-FR]  | ¤#,##0.00 |
     When I request reference data for "BTC"
     Then I should get error that currency was not found
 
   @currency-data
   Scenario: Get data from a customized currency
     When I add new currency "currency1" with following properties:
-      | iso_code         | JPY                    |
-      | name             | Custom Yen             |
-      | symbol           | YY                     |
-      | exchange_rate    | 0.08                   |
-      | is_enabled       | 1                      |
-      | is_unofficial    | 0                      |
-      | shop_association | shop1                  |
-      | patterns         | {"fr-FR":"¤ #,##0.00"} |
+      | iso_code         | JPY        |
+      | name             | Custom Yen |
+      | symbol           | YY         |
+      | exchange_rate    | 0.08       |
+      | is_enabled       | 1          |
+      | is_unofficial    | 0          |
+      | shop_association | shop1      |
+      | patterns[fr-FR]  | ¤ #,##0.00 |
     When I request reference data for "JPY"
     Then I should get currency data:
-      | iso_code         | JPY                                           |
-      | numeric_iso_code | 392                                           |
-      | precision        | 0                                             |
-      | names            | {"en-US":"Japanese Yen","fr-FR":"yen japonais"} |
-      | symbols          | {"en-US":"¥","fr-FR":"¥"}                     |
-      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"}    |
+      | iso_code         | JPY          |
+      | numeric_iso_code | 392          |
+      | precision        | 0            |
+      | names[en-US]     | Japanese Yen |
+      | names[fr-FR]     | yen japonais |
+      | symbols[en-US]   | ¥            |
+      | symbols[fr-FR]   | ¥            |
+      | patterns[en-US]  | ¤#,##0.00    |
+      | patterns[fr-FR]  | #,##0.00 ¤   |

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -7,53 +7,53 @@ Feature: Currency Data
 
   Background:
     Given shop "shop1" with name "test_shop" exists
-      And language "language1" with locale "en-US" exists
-      And language "language2" with locale "fr-FR" exists
+    And language "language1" with locale "en-US" exists
+    And language "language2" with locale "fr-FR" exists
 
   @currency-data
   Scenario: Get data from an official currency
     When I request reference data for "EUR"
     Then I should get no currency error
     And I should get currency data:
-      | iso_code         | EUR                   |
-      | numeric_iso_code | 978                   |
-      | precision        | 2                     |
-      | names            | en-US:Euro;fr-FR:euro |
-      | symbols          | en-US:€;fr-FR:€       |
-      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤ |
+      | iso_code         | EUR                                        |
+      | numeric_iso_code | 978                                        |
+      | precision        | 2                                          |
+      | names            | {"en-US":"Euro","fr-FR":"euro"}            |
+      | symbols          | {"en-US":"€","fr-FR":"€"}                  |
+      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"} |
 
   @currency-data
   Scenario: Get data from an unofficial currency
     When I request reference data for "BTC"
     Then I should get error that currency was not found
     When I add new currency "currency1" with following properties:
-      | iso_code         | BTC              |
-      | name             | Bitcoin          |
-      | symbol           | ₿                |
-      | exchange_rate    | 0.42             |
-      | is_enabled       | 1                |
-      | is_unofficial    | 1                |
-      | shop_association | shop1            |
-      | patterns         | fr-FR:¤#,##0.00  |
+      | iso_code         | BTC                   |
+      | name             | Bitcoin               |
+      | symbol           | ₿                     |
+      | exchange_rate    | 0.42                  |
+      | is_enabled       | 1                     |
+      | is_unofficial    | 1                     |
+      | shop_association | shop1                 |
+      | patterns         | {"fr-FR":"¤#,##0.00"} |
     When I request reference data for "BTC"
     Then I should get error that currency was not found
 
   @currency-data
   Scenario: Get data from a customized currency
     When I add new currency "currency1" with following properties:
-      | iso_code         | JPY                 |
-      | name             | Custom Yen          |
-      | symbol           | YY                  |
-      | exchange_rate    | 0.08                |
-      | is_enabled       | 1                   |
-      | is_unofficial    | 0                   |
-      | shop_association | shop1               |
-      | patterns         | fr-FR:¤ #,##0.00    |
+      | iso_code         | JPY                    |
+      | name             | Custom Yen             |
+      | symbol           | YY                     |
+      | exchange_rate    | 0.08                   |
+      | is_enabled       | 1                      |
+      | is_unofficial    | 0                      |
+      | shop_association | shop1                  |
+      | patterns         | {"fr-FR":"¤ #,##0.00"} |
     When I request reference data for "JPY"
     Then I should get currency data:
-      | iso_code         | JPY                                   |
-      | numeric_iso_code | 392                                   |
-      | precision        | 0                                     |
-      | names            | en-US:Japanese Yen;fr-FR:yen japonais |
-      | symbols          | en-US:¥;fr-FR:¥                       |
-      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤      |
+      | iso_code         | JPY                                           |
+      | numeric_iso_code | 392                                           |
+      | precision        | 0                                             |
+      | names            | {"en-US":"Japanese Yen","fr-FR":"yen japonais"} |
+      | symbols          | {"en-US":"¥","fr-FR":"¥"}                     |
+      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"}    |

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -12,13 +12,13 @@ Feature: Currency Management
 
   Scenario: Adding and editing currency
     When I add new currency "currency1" with following properties:
-      | iso_code         | EUR       |
-      | exchange_rate    | 0.88      |
-      | name             | My Euros  |
-      | symbol           | €€        |
-      | is_enabled       | 1         |
-      | is_unofficial    | 0         |
-      | shop_association | shop1     |
+      | iso_code         | EUR      |
+      | exchange_rate    | 0.88     |
+      | name             | My Euros |
+      | symbol           | €€       |
+      | is_enabled       | 1        |
+      | is_unofficial    | 0        |
+      | shop_association | shop1    |
     Then I should get no currency error
     And currency "currency1" should be "EUR"
     And currency "currency1" exchange rate should be 0.88
@@ -32,13 +32,13 @@ Feature: Currency Management
     And currency "currency1" should be available in shop "shop1"
     And database contains 1 rows of currency "EUR"
     When I edit currency "currency1" with following properties:
-      | iso_code         | EUR       |
-      | exchange_rate    | 1.0       |
-      | name             | Euro      |
-      | symbol           | €         |
-      | is_enabled       | 0         |
-      | is_unofficial    | 0         |
-      | shop_association | shop1     |
+      | iso_code         | EUR   |
+      | exchange_rate    | 1.0   |
+      | name             | Euro  |
+      | symbol           | €     |
+      | is_enabled       | 0     |
+      | is_unofficial    | 0     |
+      | shop_association | shop1 |
     Then currency "currency1" should be "EUR"
     And currency "currency1" exchange rate should be 1
     And currency "currency1" numeric iso code should be 978
@@ -74,14 +74,14 @@ Feature: Currency Management
 
   Scenario: Deleting non default currency should be allowed
     When I add new currency "currency4" with following properties:
-      | iso_code         | GBP                    |
-      | exchange_rate    | 0.88                   |
-      | name             | Pound                  |
-      | symbol           | ££                     |
-      | is_enabled       | 1                      |
-      | is_unofficial    | 0                      |
-      | shop_association | shop1                  |
-      | transformations  | fr-FR:leftWithoutSpace |
+      | iso_code         | GBP                          |
+      | exchange_rate    | 0.88                         |
+      | name             | Pound                        |
+      | symbol           | ££                           |
+      | is_enabled       | 1                            |
+      | is_unofficial    | 0                            |
+      | shop_association | shop1                        |
+      | transformations  | {"fr-FR":"leftWithoutSpace"} |
     And database contains 1 rows of currency "GBP"
     And currency "currency4" should have pattern "¤#,##0.00" for language "fr-FR"
     And currency "currency4" should have modified true
@@ -93,12 +93,12 @@ Feature: Currency Management
     Given currency with "GBP" has been deleted
     And database contains 1 rows of currency "GBP"
     When I add new currency "currency5" with following properties:
-      | iso_code         | GBP           |
-      | exchange_rate    | 0.66          |
-      | precision        | 2             |
-      | is_enabled       | 0             |
-      | is_unofficial    | 0             |
-      | shop_association | shop1         |
+      | iso_code         | GBP   |
+      | exchange_rate    | 0.66  |
+      | precision        | 2     |
+      | is_enabled       | 0     |
+      | is_unofficial    | 0     |
+      | shop_association | shop1 |
     Then I should get no currency error
     And database contains 1 rows of currency "GBP"
     And currency with "GBP" is not deleted
@@ -116,13 +116,13 @@ Feature: Currency Management
 
   Scenario: Adding invalid unofficial currency
     When I add new currency "currency6" with following properties:
-      | iso_code         | EUR       |
-      | exchange_rate    | 0.88      |
-      | name             | My Euros  |
-      | symbol           | €         |
-      | is_enabled       | 1         |
-      | is_unofficial    | 1         |
-      | shop_association | shop1     |
+      | iso_code         | EUR      |
+      | exchange_rate    | 0.88     |
+      | name             | My Euros |
+      | symbol           | €        |
+      | is_enabled       | 1        |
+      | is_unofficial    | 1        |
+      | shop_association | shop1    |
     Then I should get error that unofficial currency is invalid
 
   Scenario: Adding and editing unofficial currency
@@ -147,12 +147,12 @@ Feature: Currency Management
     And currency "currency7" should have status enabled
     And currency "currency7" should be available in shop "shop1"
     When I edit currency "currency7" with following properties:
-      | iso_code         | CUS           |
-      | exchange_rate    | 0.66          |
-      | precision        | 2             |
-      | is_enabled       | 0             |
-      | is_unofficial    | 1             |
-      | shop_association | shop1         |
+      | iso_code         | CUS   |
+      | exchange_rate    | 0.66  |
+      | precision        | 2     |
+      | is_enabled       | 0     |
+      | is_unofficial    | 1     |
+      | shop_association | shop1 |
     Then I should get no currency error
     And database contains 0 rows of currency "CST"
     And database contains 1 rows of currency "CUS"
@@ -167,12 +167,12 @@ Feature: Currency Management
     And currency "currency7" should have status disabled
     And currency "currency7" should be available in shop "shop1"
     When I edit currency "currency7" with following properties:
-      | iso_code         | CUS           |
-      | exchange_rate    | 0.88          |
-      | precision        | 3             |
-      | is_enabled       | 1             |
-      | is_unofficial    | 1             |
-      | shop_association | shop1         |
+      | iso_code         | CUS   |
+      | exchange_rate    | 0.88  |
+      | precision        | 3     |
+      | is_enabled       | 1     |
+      | is_unofficial    | 1     |
+      | shop_association | shop1 |
     Then I should get no currency error
     And currency "currency7" should be "CUS"
     And currency "currency7" exchange rate should be 0.88
@@ -208,11 +208,11 @@ Feature: Currency Management
     And currency "currency8" should have status enabled
     And currency "currency8" should be available in shop "shop1"
     When I edit currency "currency8" with following properties:
-      | iso_code         | EUR           |
-      | exchange_rate    | 0.66          |
-      | is_enabled       | 0             |
-      | is_unofficial    | 1             |
-      | shop_association | shop1         |
+      | iso_code         | EUR   |
+      | exchange_rate    | 0.66  |
+      | is_enabled       | 0     |
+      | is_unofficial    | 1     |
+      | shop_association | shop1 |
     Then I should get error that unofficial currency is invalid
 
   Scenario: Adding existing currency should not be allowed
@@ -237,22 +237,22 @@ Feature: Currency Management
     And database contains 1 rows of currency "CST"
     And database contains 1 rows of currency "CUS"
     When I edit currency "currency11" with following properties:
-      | iso_code         | CUS           |
-      | exchange_rate    | 0.66          |
-      | is_enabled       | 0             |
-      | is_unofficial    | 1             |
-      | shop_association | shop1         |
+      | iso_code         | CUS   |
+      | exchange_rate    | 0.66  |
+      | is_enabled       | 0     |
+      | is_unofficial    | 1     |
+      | shop_association | shop1 |
     Then I should get error that currency already exists
     And database contains 1 rows of currency "CST"
     And database contains 1 rows of currency "CUS"
 
   Scenario: Adding real currency with basic input is automatically filled
     When I add new currency "currency14" with following properties:
-      | iso_code         | AUD       |
-      | exchange_rate    | 0.88      |
-      | is_enabled       | 1         |
-      | is_unofficial    | 0         |
-      | shop_association | shop1     |
+      | iso_code         | AUD   |
+      | exchange_rate    | 0.88  |
+      | is_enabled       | 1     |
+      | is_unofficial    | 0     |
+      | shop_association | shop1 |
     Then I should get no currency error
     And currency "currency14" should be "AUD"
     And currency "currency14" exchange rate should be 0.88
@@ -267,11 +267,11 @@ Feature: Currency Management
 
   Scenario: Adding unofficial currency with basic input
     When I add new currency "currency15" with following properties:
-      | iso_code         | BTC       |
-      | exchange_rate    | 0.88      |
-      | is_enabled       | 1         |
-      | is_unofficial    | 1         |
-      | shop_association | shop1     |
+      | iso_code         | BTC   |
+      | exchange_rate    | 0.88  |
+      | is_enabled       | 1     |
+      | is_unofficial    | 1     |
+      | shop_association | shop1 |
     Then I should get no currency error
     And currency "currency15" should be "BTC"
     And currency "currency15" exchange rate should be 0.88
@@ -286,12 +286,12 @@ Feature: Currency Management
 
   Scenario: Adding and edit official currency with custom pattern
     When I add new currency "currency16" with following properties:
-      | iso_code         | JPY                 |
-      | exchange_rate    | 0.08                |
-      | is_enabled       | 1                   |
-      | is_unofficial    | 0                   |
-      | shop_association | shop1               |
-      | transformations  | fr-FR:leftWithSpace |
+      | iso_code         | JPY                       |
+      | exchange_rate    | 0.08                      |
+      | is_enabled       | 1                         |
+      | is_unofficial    | 0                         |
+      | shop_association | shop1                     |
+      | transformations  | {"fr-FR":"leftWithSpace"} |
     Then I should get no currency error
     And currency "currency16" should be "JPY"
     And currency "currency16" exchange rate should be 0.08
@@ -307,12 +307,12 @@ Feature: Currency Management
     And currency "currency16" should have pattern empty for language "en-EN"
     And database contains 1 rows of currency "JPY"
     When I edit currency "currency16" with following properties:
-      | iso_code         | JPY                  |
-      | exchange_rate    | 0.08                 |
-      | is_enabled       | 1                    |
-      | is_unofficial    | 0                    |
-      | shop_association | shop1                |
-      | transformations  | en-US:rightWithSpace |
+      | iso_code         | JPY                        |
+      | exchange_rate    | 0.08                       |
+      | is_enabled       | 1                          |
+      | is_unofficial    | 0                          |
+      | shop_association | shop1                      |
+      | transformations  | {"en-US":"rightWithSpace"} |
     And currency "currency16" should be "JPY"
     And currency "currency16" exchange rate should be 0.08
     And currency "currency16" numeric iso code should be 392
@@ -328,14 +328,14 @@ Feature: Currency Management
 
   Scenario: Adding and edit unofficial currency with custom pattern
     When I add new currency "currency17" with following properties:
-      | iso_code         | JPP                    |
-      | name             | Japan Private Yen      |
-      | symbol           | Yen                    |
-      | exchange_rate    | 0.8                    |
-      | is_enabled       | 1                      |
-      | is_unofficial    | 1                      |
-      | shop_association | shop1                  |
-      | transformations  | fr-FR:leftWithoutSpace |
+      | iso_code         | JPP                          |
+      | name             | Japan Private Yen            |
+      | symbol           | Yen                          |
+      | exchange_rate    | 0.8                          |
+      | is_enabled       | 1                            |
+      | is_unofficial    | 1                            |
+      | shop_association | shop1                        |
+      | transformations  | {"fr-FR":"leftWithoutSpace"} |
     Then I should get no currency error
     And currency "currency17" should be "JPP"
     And currency "currency17" exchange rate should be 0.8
@@ -351,12 +351,12 @@ Feature: Currency Management
     And currency "currency17" should have pattern empty for language "en-EN"
     And database contains 1 rows of currency "JPP"
     When I edit currency "currency17" with following properties:
-      | iso_code         | JPP                     |
-      | exchange_rate    | 0.8                     |
-      | is_enabled       | 1                       |
-      | is_unofficial    | 1                       |
-      | shop_association | shop1                   |
-      | transformations  | en-US:rightWithoutSpace |
+      | iso_code         | JPP                           |
+      | exchange_rate    | 0.8                           |
+      | is_enabled       | 1                             |
+      | is_unofficial    | 1                             |
+      | shop_association | shop1                         |
+      | transformations  | {"en-US":"rightWithoutSpace"} |
     And currency "currency17" should be "JPP"
     And currency "currency17" exchange rate should be 0.8
     And currency "currency17" numeric iso code should be null
@@ -375,12 +375,12 @@ Feature: Currency Management
     And currency with "JPP" has been deleted
     And database contains 1 rows of currency "JPP"
     When I add new currency "currency18" with following properties:
-      | iso_code         | JPP           |
-      | exchange_rate    | 0.66          |
-      | precision        | 2             |
-      | is_enabled       | 0             |
-      | is_unofficial    | 1             |
-      | shop_association | shop1         |
+      | iso_code         | JPP   |
+      | exchange_rate    | 0.66  |
+      | precision        | 2     |
+      | is_enabled       | 0     |
+      | is_unofficial    | 1     |
+      | shop_association | shop1 |
     Then I should get no currency error
     And database contains 1 rows of currency "JPP"
     And currency with "JPP" is not deleted

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -74,14 +74,14 @@ Feature: Currency Management
 
   Scenario: Deleting non default currency should be allowed
     When I add new currency "currency4" with following properties:
-      | iso_code         | GBP                          |
-      | exchange_rate    | 0.88                         |
-      | name             | Pound                        |
-      | symbol           | ££                           |
-      | is_enabled       | 1                            |
-      | is_unofficial    | 0                            |
-      | shop_association | shop1                        |
-      | transformations  | {"fr-FR":"leftWithoutSpace"} |
+      | iso_code               | GBP              |
+      | exchange_rate          | 0.88             |
+      | name                   | Pound            |
+      | symbol                 | ££               |
+      | is_enabled             | 1                |
+      | is_unofficial          | 0                |
+      | shop_association       | shop1            |
+      | transformations[fr-FR] | leftWithoutSpace |
     And database contains 1 rows of currency "GBP"
     And currency "currency4" should have pattern "¤#,##0.00" for language "fr-FR"
     And currency "currency4" should have modified true
@@ -286,12 +286,12 @@ Feature: Currency Management
 
   Scenario: Adding and edit official currency with custom pattern
     When I add new currency "currency16" with following properties:
-      | iso_code         | JPY                       |
-      | exchange_rate    | 0.08                      |
-      | is_enabled       | 1                         |
-      | is_unofficial    | 0                         |
-      | shop_association | shop1                     |
-      | transformations  | {"fr-FR":"leftWithSpace"} |
+      | iso_code               | JPY           |
+      | exchange_rate          | 0.08          |
+      | is_enabled             | 1             |
+      | is_unofficial          | 0             |
+      | shop_association       | shop1         |
+      | transformations[fr-FR] | leftWithSpace |
     Then I should get no currency error
     And currency "currency16" should be "JPY"
     And currency "currency16" exchange rate should be 0.08
@@ -307,12 +307,12 @@ Feature: Currency Management
     And currency "currency16" should have pattern empty for language "en-EN"
     And database contains 1 rows of currency "JPY"
     When I edit currency "currency16" with following properties:
-      | iso_code         | JPY                        |
-      | exchange_rate    | 0.08                       |
-      | is_enabled       | 1                          |
-      | is_unofficial    | 0                          |
-      | shop_association | shop1                      |
-      | transformations  | {"en-US":"rightWithSpace"} |
+      | iso_code               | JPY            |
+      | exchange_rate          | 0.08           |
+      | is_enabled             | 1              |
+      | is_unofficial          | 0              |
+      | shop_association       | shop1          |
+      | transformations[en-US] | rightWithSpace |
     And currency "currency16" should be "JPY"
     And currency "currency16" exchange rate should be 0.08
     And currency "currency16" numeric iso code should be 392
@@ -328,14 +328,14 @@ Feature: Currency Management
 
   Scenario: Adding and edit unofficial currency with custom pattern
     When I add new currency "currency17" with following properties:
-      | iso_code         | JPP                          |
-      | name             | Japan Private Yen            |
-      | symbol           | Yen                          |
-      | exchange_rate    | 0.8                          |
-      | is_enabled       | 1                            |
-      | is_unofficial    | 1                            |
-      | shop_association | shop1                        |
-      | transformations  | {"fr-FR":"leftWithoutSpace"} |
+      | iso_code               | JPP               |
+      | name                   | Japan Private Yen |
+      | symbol                 | Yen               |
+      | exchange_rate          | 0.8               |
+      | is_enabled             | 1                 |
+      | is_unofficial          | 1                 |
+      | shop_association       | shop1             |
+      | transformations[fr-FR] | leftWithoutSpace  |
     Then I should get no currency error
     And currency "currency17" should be "JPP"
     And currency "currency17" exchange rate should be 0.8
@@ -351,12 +351,12 @@ Feature: Currency Management
     And currency "currency17" should have pattern empty for language "en-EN"
     And database contains 1 rows of currency "JPP"
     When I edit currency "currency17" with following properties:
-      | iso_code         | JPP                           |
-      | exchange_rate    | 0.8                           |
-      | is_enabled       | 1                             |
-      | is_unofficial    | 1                             |
-      | shop_association | shop1                         |
-      | transformations  | {"en-US":"rightWithoutSpace"} |
+      | iso_code               | JPP               |
+      | exchange_rate          | 0.8               |
+      | is_enabled             | 1                 |
+      | is_unofficial          | 1                 |
+      | shop_association       | shop1             |
+      | transformations[en-US] | rightWithoutSpace |
     And currency "currency17" should be "JPP"
     And currency "currency17" exchange rate should be 0.8
     And currency "currency17" numeric iso code should be null

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
@@ -15,23 +15,27 @@ Feature: Add payment to Order from Back Office (BO)
     And country "FR" is enabled
     And language "French" with locale "fr-FR" exists
     And I add new currency "currency2" with following properties:
-      | iso_code         | EUR                              |
-      | exchange_rate    | 0.88                             |
-      | name             | My Euros                         |
-      | symbols          | {"en-US":"€","fr-FR":"€"}                  |
-      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"} |
-      | is_enabled       | 1                                |
-      | is_unofficial    | 0                                |
-      | shop_association | shop1                            |
+      | iso_code         | EUR        |
+      | exchange_rate    | 0.88       |
+      | name             | My Euros   |
+      | symbols[en-US]   | €          |
+      | symbols[fr-FR]   | €          |
+      | patterns[en-US]  | ¤#,##0.00  |
+      | patterns[fr-FR]  | #,##0.00 ¤ |
+      | is_enabled       | 1          |
+      | is_unofficial    | 0          |
+      | shop_association | shop1      |
     And I add new currency "currency3" with following properties:
-      | iso_code         | JPY                                   |
-      | exchange_rate    | 107.52                                |
-      | name             | My Japanese Yen                       |
-      | symbols          | {"en-US":"¥","fr-FR":"¥"}                       |
-      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"}      |
-      | is_enabled       | 1                                     |
-      | is_unofficial    | 0                                     |
-      | shop_association | shop1                                 |
+      | iso_code         | JPY             |
+      | exchange_rate    | 107.52          |
+      | name             | My Japanese Yen |
+      | symbols[en-US]   | ¥               |
+      | symbols[fr-FR]   | ¥               |
+      | patterns[en-US]  | ¤#,##0.00       |
+      | patterns[fr-FR]  | #,##0.00 ¤      |
+      | is_enabled       | 1               |
+      | is_unofficial    | 0               |
+      | shop_association | shop1           |
     And the module "dummy_payment" is installed
     And I am logged in as "test@prestashop.com" employee
     And there is customer "testCustomer" with email "pub@prestashop.com"
@@ -75,7 +79,7 @@ Feature: Add payment to Order from Back Office (BO)
       | transaction_id | test123             |
       | amount         | $6.00               |
     And order "bo_order1" should have the following details:
-      | total_paid_real           | 6.000000 |
+      | total_paid_real | 6.000000 |
 
   Scenario: Add a payment when Order is in default_currency and Payment is NOT in Order currency
     When order "bo_order1" has 0 payments
@@ -91,7 +95,7 @@ Feature: Add payment to Order from Back Office (BO)
       | transaction_id | test123             |
       | amount         | €6.00               |
     And order "bo_order1" should have the following details:
-      | total_paid_real           | 6.820000 |
+      | total_paid_real | 6.820000 |
 
 #  Scenario: Add a payment when Order is NOT in default_currency and Payment is in Order currency
 #    Given I update the cart "dummy_cart" currency to "currency2"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
@@ -18,8 +18,8 @@ Feature: Add payment to Order from Back Office (BO)
       | iso_code         | EUR                              |
       | exchange_rate    | 0.88                             |
       | name             | My Euros                         |
-      | symbols          | en-US:€;fr-FR:€                  |
-      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤ |
+      | symbols          | {"en-US":"€","fr-FR":"€"}                  |
+      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"} |
       | is_enabled       | 1                                |
       | is_unofficial    | 0                                |
       | shop_association | shop1                            |
@@ -27,8 +27,8 @@ Feature: Add payment to Order from Back Office (BO)
       | iso_code         | JPY                                   |
       | exchange_rate    | 107.52                                |
       | name             | My Japanese Yen                       |
-      | symbols          | en-US:¥;fr-FR:¥                       |
-      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤      |
+      | symbols          | {"en-US":"¥","fr-FR":"¥"}                       |
+      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"}      |
       | is_enabled       | 1                                     |
       | is_unofficial    | 0                                     |
       | shop_association | shop1                                 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -19,8 +19,8 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | iso_code         | EUR                              |
       | exchange_rate    | 10.00                            |
       | name             | My Euros                         |
-      | symbols          | en-US:€;fr-FR:€                  |
-      | patterns         | en-US:¤#,##0.00;fr-FR:#,##0.00 ¤ |
+      | symbols          | {"en-US":"€","fr-FR":"€"}                  |
+      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"} |
       | is_enabled       | 1                                |
       | is_unofficial    | 0                                |
       | shop_association | shop1                            |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -16,14 +16,16 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And country "FR" is enabled
     And language "French" with locale "fr-FR" exists
     And I add new currency "currency2" with following properties:
-      | iso_code         | EUR                              |
-      | exchange_rate    | 10.00                            |
-      | name             | My Euros                         |
-      | symbols          | {"en-US":"€","fr-FR":"€"}                  |
-      | patterns         | {"en-US":"¤#,##0.00","fr-FR":"#,##0.00 ¤"} |
-      | is_enabled       | 1                                |
-      | is_unofficial    | 0                                |
-      | shop_association | shop1                            |
+      | iso_code         | EUR        |
+      | exchange_rate    | 10.00      |
+      | name             | My Euros   |
+      | symbols[en-US]   | €          |
+      | symbols[fr-FR]   | €          |
+      | patterns[en-US]  | ¤#,##0.00  |
+      | patterns[fr-FR]  | #,##0.00 ¤ |
+      | is_enabled       | 1          |
+      | is_unofficial    | 0          |
+      | shop_association | shop1      |
     And the module "dummy_payment" is installed
     And I am logged in as "test@prestashop.com" employee
     And there is customer "testCustomer" with email "pub@prestashop.com"
@@ -53,18 +55,18 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 2        |
-      | product_price               | 119.00   |
-      | unit_price_tax_incl         | 126.14   |
-      | unit_price_tax_excl         | 119.00   |
-      | total_price_tax_incl        | 252.28   |
-      | total_price_tax_excl        | 238.00   |
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
 
   Scenario: Add cart rule of type 'amount' to an order with secondary currency
     Given I add discount to order "bo_order1" with following details:
-      | name      | discount ten-euros    |
-      | type      | amount                |
-      | value     | 10                    |
+      | name  | discount ten-euros |
+      | type  | amount             |
+      | value | 10                 |
     Then order "bo_order1" should have 1 cart rule
     Then order "bo_order1" should have cart rule "discount ten-euros" with amount "€9.43"
     Then order "bo_order1" should have following details:
@@ -81,9 +83,9 @@ Feature: Multiple currencies for Order in Back Office (BO)
 
   Scenario: Add cart rule of type 'percent' to an order with secondary currency
     Given I add discount to order "bo_order1" with following details:
-      | name      | discount ten-percents |
-      | type      | percent               |
-      | value     | 10                    |
+      | name  | discount ten-percents |
+      | type  | percent               |
+      | value | 10                    |
     Then order "bo_order1" should have 1 cart rule
     Then order "bo_order1" should have cart rule "discount ten-percents" with amount "€23.80"
     Then order "bo_order1" should have following details:
@@ -100,8 +102,8 @@ Feature: Multiple currencies for Order in Back Office (BO)
 
   Scenario: Add cart rule of type 'free-shipping' to an order with secondary currency
     Given I add discount to order "bo_order1" with following details:
-      | name      | discount free-shipping |
-      | type      | free_shipping          |
+      | name | discount free-shipping |
+      | type | free_shipping          |
     Then order "bo_order1" should have 1 cart rule
     Then order "bo_order1" should have cart rule "discount free-shipping" with amount "€70.00"
     Then order "bo_order1" should have following details:
@@ -113,8 +115,8 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_paid_tax_incl      | 252.28 |
       | total_paid               | 252.28 |
       | total_paid_real          | 0.00   |
-      | total_shipping_tax_excl  | 70.00   |
-      | total_shipping_tax_incl  | 74.20   |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
 
   Scenario: Add cart rule of type 'amount' to an order with secondary currency and a product with specific price
     Given there is a product in the catalog named "Test Product With Discount and SpecificPrice" with a price of 16.0 and 100 items in stock
@@ -129,9 +131,9 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And cart rule "CartRuleAmountOnSelectedProduct" has no discount code
     And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product With Discount and SpecificPrice"
     When I add products to order "bo_order1" with new invoice and the following products details:
-      | name          | Test Product With Discount and SpecificPrice |
-      | amount        | 2                                     |
-      | price         | 120                                   |
+      | name   | Test Product With Discount and SpecificPrice |
+      | amount | 2                                            |
+      | price  | 120                                          |
     Then product "Test Product With Discount and SpecificPrice" in order "bo_order1" should have no specific price
 #    For product "Test Product With Discount and SpecificPrice"
 #    Due to the specific price 25% of €160, the customer have to pay 75% of the product price : €120
@@ -151,25 +153,25 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 2        |
-      | product_price               | 119.00   |
-      | unit_price_tax_incl         | 126.14   |
-      | unit_price_tax_excl         | 119.00   |
-      | total_price_tax_incl        | 252.28   |
-      | total_price_tax_excl        | 238.00   |
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
     And product "Test Product With Discount and SpecificPrice" in order "bo_order1" has following details:
-      | product_quantity            | 2        |
-      | product_price               | 120.00   |
-      | unit_price_tax_incl         | 127.20   |
-      | unit_price_tax_excl         | 120.00   |
-      | total_price_tax_incl        | 254.40   |
-      | total_price_tax_excl        | 240.00   |
+      | product_quantity     | 2      |
+      | product_price        | 120.00 |
+      | unit_price_tax_incl  | 127.20 |
+      | unit_price_tax_excl  | 120.00 |
+      | total_price_tax_incl | 254.40 |
+      | total_price_tax_excl | 240.00 |
 
   Scenario: Add product to an order with secondary currency
     When I add products to order "bo_order1" without invoice and the following products details:
-      | name          | Mug Today is a good day  |
-      | amount        | 5                      |
-      | price         | 15                      |
+      | name   | Mug Today is a good day |
+      | amount | 5                       |
+      | price  | 15                      |
     Then order "bo_order1" should have 0 cart rule
     Then order "bo_order1" should have following details:
       | total_products           | 313.00 |
@@ -183,29 +185,29 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 2     |
-      | product_price               | 119.00 |
-      | unit_price_tax_incl         | 126.14 |
-      | unit_price_tax_excl         | 119.00 |
-      | total_price_tax_incl        | 252.28 |
-      | total_price_tax_excl        | 238.00 |
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
 
   Scenario: Update product in order with secondary currency
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
-      | amount        | 3                       |
-      | price         | 12.00                   |
+      | amount | 3     |
+      | price  | 12.00 |
     Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 3     |
-      | product_price               | 12.00 |
-      | unit_price_tax_incl         | 12.72 |
-      | unit_price_tax_excl         | 12.00 |
-      | total_price_tax_incl        | 38.16 |
-      | total_price_tax_excl        | 36.00 |
+      | product_quantity     | 3     |
+      | product_price        | 12.00 |
+      | unit_price_tax_incl  | 12.72 |
+      | unit_price_tax_excl  | 12.00 |
+      | total_price_tax_incl | 38.16 |
+      | total_price_tax_excl | 36.00 |
     And product "Mug The best is yet to come" in order "bo_order1" should have specific price 12.00
     And order "bo_order1" should have following details:
-      | total_products           | 36.00 |
-      | total_products_wt        | 38.16 |
+      | total_products           | 36.00  |
+      | total_products_wt        | 38.16  |
       | total_discounts_tax_excl | 0.00   |
       | total_discounts_tax_incl | 0.00   |
       | total_paid_tax_excl      | 106.00 |
@@ -217,31 +219,31 @@ Feature: Multiple currencies for Order in Back Office (BO)
 
   Scenario: Check invoice for an order with secondary currency and discount
     Given I add discount to order "bo_order1" with following details:
-      | name      | discount ten-euros    |
-      | type      | amount                |
-      | value     | 10                    |
+      | name  | discount ten-euros |
+      | type  | amount             |
+      | value | 10                 |
     When I generate invoice for "bo_order1" order
     Then order "bo_order1" should have 1 invoice
     And the first invoice from order "bo_order1" should contain 2 products "Mug The best is yet to come"
     And the first invoice from order "bo_order1" should have following details:
-      | total_products          | 238.00   |
-      | total_products_wt       | 252.28   |
-      | total_discount_tax_excl | 9.43     |
-      | total_discount_tax_incl | 10.0     |
-      | total_paid_tax_excl     | 298.57   |
-      | total_paid_tax_incl     | 316.48   |
-      | total_shipping_tax_excl | 70.00    |
-      | total_shipping_tax_incl | 74.20    |
+      | total_products          | 238.00 |
+      | total_products_wt       | 252.28 |
+      | total_discount_tax_excl | 9.43   |
+      | total_discount_tax_incl | 10.0   |
+      | total_paid_tax_excl     | 298.57 |
+      | total_paid_tax_incl     | 316.48 |
+      | total_shipping_tax_excl | 70.00  |
+      | total_shipping_tax_incl | 74.20  |
 
   Scenario: Change delivery address
     Given I add new address to customer "testCustomer" with following details:
-      | Address alias    | test-customer-france-address |
-      | First name       | testFirstName                |
-      | Last name        | testLastName                 |
-      | Address          | 36 Avenue des Champs Elysees |
-      | City             | Paris                        |
-      | Country          | France                       |
-      | Postal code      | 75008                        |
+      | Address alias | test-customer-france-address |
+      | First name    | testFirstName                |
+      | Last name     | testLastName                 |
+      | Address       | 36 Avenue des Champs Elysees |
+      | City          | Paris                        |
+      | Country       | France                       |
+      | Postal code   | 75008                        |
     And I change order "bo_order1" shipping address to "test-customer-france-address"
     Then order "bo_order1" should have following details:
       | total_products           | 238.00 |
@@ -259,22 +261,22 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | shipping_cost_tax_excl | 70.00 |
       | shipping_cost_tax_incl | 70.00 |
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 2      |
-      | product_price               | 119.00 |
-      | unit_price_tax_incl         | 119.00 |
-      | unit_price_tax_excl         | 119.00 |
-      | total_price_tax_incl        | 238.00 |
-      | total_price_tax_excl        | 238.00 |
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 119.00 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 238.00 |
+      | total_price_tax_excl | 238.00 |
 
   Scenario: Change invoice address
     Given I add new address to customer "testCustomer" with following details:
-      | Address alias    | test-customer-france-address |
-      | First name       | testFirstName                |
-      | Last name        | testLastName                 |
-      | Address          | 36 Avenue des Champs Elysees |
-      | City             | Paris                        |
-      | Country          | France                       |
-      | Postal code      | 75008                        |
+      | Address alias | test-customer-france-address |
+      | First name    | testFirstName                |
+      | Last name     | testLastName                 |
+      | Address       | 36 Avenue des Champs Elysees |
+      | City          | Paris                        |
+      | Country       | France                       |
+      | Postal code   | 75008                        |
     And I change order "bo_order1" invoice address to "test-customer-france-address"
     Then order "bo_order1" should have following details:
       | total_products           | 238.00 |
@@ -292,12 +294,12 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | shipping_cost_tax_excl | 70.00 |
       | shipping_cost_tax_incl | 74.20 |
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 2      |
-      | product_price               | 119.00 |
-      | unit_price_tax_incl         | 126.14 |
-      | unit_price_tax_excl         | 119.00 |
-      | total_price_tax_incl        | 252.28 |
-      | total_price_tax_excl        | 238.00 |
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
 
   Scenario: Carrier change for an order with secondary currency
     Given a carrier "default_carrier" with name "My carrier" exists
@@ -306,8 +308,8 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And order "bo_order1" should have "default_carrier" as a carrier
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
-      | shipping_cost_tax_excl | 70.00  |
-      | shipping_cost_tax_incl | 74.20  |
+      | shipping_cost_tax_excl | 70.00 |
+      | shipping_cost_tax_incl | 74.20 |
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "price_carrier"
     Then order "bo_order1" should have following details:
       | total_products           | 238.00 |
@@ -322,144 +324,144 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_incl  | 63.60  |
     And order "bo_order1" carrier should have following details:
       | weight                 | 0.600 |
-      | shipping_cost_tax_excl | 60.00  |
-      | shipping_cost_tax_incl | 63.60  |
+      | shipping_cost_tax_excl | 60.00 |
+      | shipping_cost_tax_incl | 63.60 |
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 2        |
-      | product_price               | 119.00   |
-      | unit_price_tax_incl         | 126.14   |
-      | unit_price_tax_excl         | 119.00   |
-      | total_price_tax_incl        | 252.28   |
-      | total_price_tax_excl        | 238.00   |
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
 
-    @reset-database-before-scenario
+  @reset-database-before-scenario
     # We reset database before this scenario to be sure only default_carrier is enabled
-    Scenario: I add the product with associated gift when the order already has the gift
-      Given there is a product in the catalog named "Test Product With Auto Gift" with a price of 12.0 and 100 items in stock
-      And there is a product in the catalog named "Test Product Gifted" with a price of 15.0 and 100 items in stock
-      And there is a cart rule named "MultiGiftAutoCartRule" that applies an amount discount of 1.0 with priority 1, quantity of 100 and quantity per user 100
-      And cart rule "MultiGiftAutoCartRule" has no discount code
-      And cart rule "MultiGiftAutoCartRule" is restricted to product "Test Product With Auto Gift"
-      And cart rule "MultiGiftAutoCartRule" offers free shipping
-      And cart rule "MultiGiftAutoCartRule" offers a gift product "Test Product Gifted"
-      And I add products to order "bo_order1" with new invoice and the following products details:
-        | name          | Test Product Gifted |
-        | amount        | 1                   |
-        | price         | 150.0               |
-      Then order "bo_order1" should have 3 products in total
-      And order "bo_order1" should have 0 invoice
-      And order "bo_order1" should have 0 cart rule
-      And order "bo_order1" should have "default_carrier" as a carrier
-      And order "bo_order1" should have following details:
-        | total_products           | 388.00 |
-        | total_products_wt        | 411.28 |
-        | total_discounts_tax_excl | 0.0    |
-        | total_discounts_tax_incl | 0.0    |
-        | total_paid_tax_excl      | 458.00 |
-        | total_paid_tax_incl      | 485.48 |
-        | total_paid               | 485.48 |
-        | total_paid_real          | 0.0    |
-        | total_shipping_tax_excl  | 70.00  |
-        | total_shipping_tax_incl  | 74.20  |
-      And order "bo_order1" carrier should have following details:
-        | weight                 | 0.600 |
-        | shipping_cost_tax_excl | 70.00 |
-        | shipping_cost_tax_incl | 74.20 |
-      And product "Mug The best is yet to come" in order "bo_order1" has following details:
-        | product_quantity            | 2      |
-        | product_price               | 119.00 |
-        | unit_price_tax_incl         | 126.14 |
-        | unit_price_tax_excl         | 119.00 |
-        | total_price_tax_incl        | 252.28 |
-        | total_price_tax_excl        | 238.00 |
-      And product "Test Product Gifted" in order "bo_order1" has following details:
-        | product_quantity            | 1      |
-        | product_price               | 150.00 |
-        | unit_price_tax_incl         | 159.00 |
-        | unit_price_tax_excl         | 150.00 |
-        | total_price_tax_incl        | 159.00 |
-        | total_price_tax_excl        | 150.00 |
-      When I add products to order "bo_order1" with new invoice and the following products details:
-        | name          | Test Product With Auto Gift |
-        | amount        | 1                           |
-        | price         | 120.00                      |
-      Then order "bo_order1" should have 5 products in total
-      And order "bo_order1" should have 0 invoice
-      And order "bo_order1" should have 1 cart rule
-      And order "bo_order1" should have following details:
-        | total_products           | 658.00 |
-        | total_products_wt        | 697.48 |
-        | total_discounts_tax_excl | 230.0  |
-        | total_discounts_tax_incl | 243.80 |
-        | total_paid_tax_excl      | 498.00 |
-        | total_paid_tax_incl      | 527.88 |
-        | total_paid               | 527.88 |
-        | total_paid_real          | 0.0    |
-        | total_shipping_tax_excl  | 70.00  |
-        | total_shipping_tax_incl  | 74.20  |
-      And order "bo_order1" carrier should have following details:
-        | weight                 | 0.600 |
-        | shipping_cost_tax_excl | 70.00 |
-        | shipping_cost_tax_incl | 74.20 |
-      And order "bo_order1" should have cart rule "MultiGiftAutoCartRule" with amount "€230.00"
-      And product "Mug The best is yet to come" in order "bo_order1" has following details:
-        | product_quantity            | 2      |
-        | product_price               | 119.00 |
-        | unit_price_tax_incl         | 126.14 |
-        | unit_price_tax_excl         | 119.00 |
-        | total_price_tax_incl        | 252.28 |
-        | total_price_tax_excl        | 238.00 |
-      And product "Test Product Gifted" in order "bo_order1" has following details:
-        | product_quantity            | 2      |
-        | product_price               | 150.00 |
-        | unit_price_tax_incl         | 159.00 |
-        | unit_price_tax_excl         | 150.00 |
-        | total_price_tax_incl        | 318.00 |
-        | total_price_tax_excl        | 300.00 |
-      And product "Test Product With Auto Gift" in order "bo_order1" has following details:
-        | product_quantity            | 1      |
-        | product_price               | 120.00 |
-        | unit_price_tax_incl         | 127.20 |
-        | unit_price_tax_excl         | 120.00 |
-        | total_price_tax_incl        | 127.20 |
-        | total_price_tax_excl        | 120.00 |
-      When I remove cart rule "MultiGiftAutoCartRule" from order "bo_order1"
-      Then order "bo_order1" should have 4 products in total
-      And order "bo_order1" should have 0 invoice
-      And order "bo_order1" should have 0 cart rule
-      And order "bo_order1" should have following details:
-        | total_products           | 508.00 |
-        | total_products_wt        | 538.48 |
-        | total_discounts_tax_excl | 0.00   |
-        | total_discounts_tax_incl | 0.00   |
-        | total_paid_tax_excl      | 578.00 |
-        | total_paid_tax_incl      | 612.68 |
-        | total_paid               | 612.68 |
-        | total_paid_real          | 0.0    |
-        | total_shipping_tax_excl  | 70.00  |
-        | total_shipping_tax_incl  | 74.20  |
-      And order "bo_order1" carrier should have following details:
-        | weight                 | 0.600 |
-        | shipping_cost_tax_excl | 70.00 |
-        | shipping_cost_tax_incl | 74.20 |
-      And product "Mug The best is yet to come" in order "bo_order1" has following details:
-        | product_quantity            | 2      |
-        | product_price               | 119.00 |
-        | unit_price_tax_incl         | 126.14 |
-        | unit_price_tax_excl         | 119.00 |
-        | total_price_tax_incl        | 252.28 |
-        | total_price_tax_excl        | 238.00 |
-      And product "Test Product Gifted" in order "bo_order1" has following details:
-        | product_quantity            | 1      |
-        | product_price               | 150.00 |
-        | unit_price_tax_incl         | 159.00 |
-        | unit_price_tax_excl         | 150.00 |
-        | total_price_tax_incl        | 159.00 |
-        | total_price_tax_excl        | 150.00 |
-      And product "Test Product With Auto Gift" in order "bo_order1" has following details:
-        | product_quantity            | 1      |
-        | product_price               | 120.00 |
-        | unit_price_tax_incl         | 127.20 |
-        | unit_price_tax_excl         | 120.00 |
-        | total_price_tax_incl        | 127.20 |
-        | total_price_tax_excl        | 120.00 |
+  Scenario: I add the product with associated gift when the order already has the gift
+    Given there is a product in the catalog named "Test Product With Auto Gift" with a price of 12.0 and 100 items in stock
+    And there is a product in the catalog named "Test Product Gifted" with a price of 15.0 and 100 items in stock
+    And there is a cart rule named "MultiGiftAutoCartRule" that applies an amount discount of 1.0 with priority 1, quantity of 100 and quantity per user 100
+    And cart rule "MultiGiftAutoCartRule" has no discount code
+    And cart rule "MultiGiftAutoCartRule" is restricted to product "Test Product With Auto Gift"
+    And cart rule "MultiGiftAutoCartRule" offers free shipping
+    And cart rule "MultiGiftAutoCartRule" offers a gift product "Test Product Gifted"
+    And I add products to order "bo_order1" with new invoice and the following products details:
+      | name   | Test Product Gifted |
+      | amount | 1                   |
+      | price  | 150.0               |
+    Then order "bo_order1" should have 3 products in total
+    And order "bo_order1" should have 0 invoice
+    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have "default_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 388.00 |
+      | total_products_wt        | 411.28 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 458.00 |
+      | total_paid_tax_incl      | 485.48 |
+      | total_paid               | 485.48 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 70.00 |
+      | shipping_cost_tax_incl | 74.20 |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
+    And product "Test Product Gifted" in order "bo_order1" has following details:
+      | product_quantity     | 1      |
+      | product_price        | 150.00 |
+      | unit_price_tax_incl  | 159.00 |
+      | unit_price_tax_excl  | 150.00 |
+      | total_price_tax_incl | 159.00 |
+      | total_price_tax_excl | 150.00 |
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name   | Test Product With Auto Gift |
+      | amount | 1                           |
+      | price  | 120.00                      |
+    Then order "bo_order1" should have 5 products in total
+    And order "bo_order1" should have 0 invoice
+    And order "bo_order1" should have 1 cart rule
+    And order "bo_order1" should have following details:
+      | total_products           | 658.00 |
+      | total_products_wt        | 697.48 |
+      | total_discounts_tax_excl | 230.0  |
+      | total_discounts_tax_incl | 243.80 |
+      | total_paid_tax_excl      | 498.00 |
+      | total_paid_tax_incl      | 527.88 |
+      | total_paid               | 527.88 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 70.00 |
+      | shipping_cost_tax_incl | 74.20 |
+    And order "bo_order1" should have cart rule "MultiGiftAutoCartRule" with amount "€230.00"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
+    And product "Test Product Gifted" in order "bo_order1" has following details:
+      | product_quantity     | 2      |
+      | product_price        | 150.00 |
+      | unit_price_tax_incl  | 159.00 |
+      | unit_price_tax_excl  | 150.00 |
+      | total_price_tax_incl | 318.00 |
+      | total_price_tax_excl | 300.00 |
+    And product "Test Product With Auto Gift" in order "bo_order1" has following details:
+      | product_quantity     | 1      |
+      | product_price        | 120.00 |
+      | unit_price_tax_incl  | 127.20 |
+      | unit_price_tax_excl  | 120.00 |
+      | total_price_tax_incl | 127.20 |
+      | total_price_tax_excl | 120.00 |
+    When I remove cart rule "MultiGiftAutoCartRule" from order "bo_order1"
+    Then order "bo_order1" should have 4 products in total
+    And order "bo_order1" should have 0 invoice
+    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have following details:
+      | total_products           | 508.00 |
+      | total_products_wt        | 538.48 |
+      | total_discounts_tax_excl | 0.00   |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 578.00 |
+      | total_paid_tax_incl      | 612.68 |
+      | total_paid               | 612.68 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
+    And order "bo_order1" carrier should have following details:
+      | weight                 | 0.600 |
+      | shipping_cost_tax_excl | 70.00 |
+      | shipping_cost_tax_incl | 74.20 |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity     | 2      |
+      | product_price        | 119.00 |
+      | unit_price_tax_incl  | 126.14 |
+      | unit_price_tax_excl  | 119.00 |
+      | total_price_tax_incl | 252.28 |
+      | total_price_tax_excl | 238.00 |
+    And product "Test Product Gifted" in order "bo_order1" has following details:
+      | product_quantity     | 1      |
+      | product_price        | 150.00 |
+      | unit_price_tax_incl  | 159.00 |
+      | unit_price_tax_excl  | 150.00 |
+      | total_price_tax_incl | 159.00 |
+      | total_price_tax_excl | 150.00 |
+    And product "Test Product With Auto Gift" in order "bo_order1" has following details:
+      | product_quantity     | 1      |
+      | product_price        | 120.00 |
+      | unit_price_tax_incl  | 127.20 |
+      | unit_price_tax_excl  | 120.00 |
+      | total_price_tax_incl | 127.20 |
+      | total_price_tax_excl | 120.00 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_image.feature
@@ -15,19 +15,19 @@ Feature: Add product image from Back Office (BO)
       | mediumDefault | medium_default | 452   | 452    |
       | smallDefault  | small_default  | 98    | 98     |
     And I add product "product1" with following information:
-      | name       | en-US:bottle of beer |
-      | is_virtual | false                |
+      | name[en-US] | bottle of beer |
+      | is_virtual  | false          |
     And product "product1" type should be standard
     And product "product1" should have no images
     When I add new image "image1" named "app_icon.png" to product "product1"
     Then product "product1" should have following images:
-      | image reference | is cover | legend | position |
-      | image1          | true     | en-US: | 1        |
+      | image reference | is cover | legend[en-US] | position |
+      | image1          | true     |               | 1        |
     When I add new image "image2" named "logo.jpg" to product "product1"
     Then product "product1" should have following images:
-      | image reference | is cover | legend | position |
-      | image1          | true     | en-US: | 1        |
-      | image2          | false    | en-US: | 2        |
+      | image reference | is cover | legend[en-US] | position |
+      | image1          | true     |               | 1        |
+      | image2          | false    |               | 2        |
     And images "[image1, image2]" should have following types generated:
       | name           | width | height |
       | cart_default   | 125   | 125    |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -13,7 +13,9 @@ Feature: Add basic product from Back Office (BO)
       | is_virtual | false                |
     Then product "product1" should be disabled
     And product "product1" type should be standard
-    And product "product1" localized "name" should be "{en-US:bottle of beer}"
+    And product "product1" localized "name" should be:
+      | locale | value          |
+      | en-US  | bottle of beer |
     And product "product1" should be assigned to default category
 
   Scenario: I add a product with basic information
@@ -22,9 +24,11 @@ Feature: Add basic product from Back Office (BO)
       | is_virtual | true                 |
     Then product "product1" should be disabled
     Then product "product1" should have following options information:
-      | condition        | new            |
+      | condition | new |
     And product "product1" type should be virtual
-    And product "product1" localized "name" should be "{en-US:bottle of beer}"
+    And product "product1" localized "name" should be:
+      | locale | value          |
+      | en-US  | bottle of beer |
     And product "product1" should be assigned to default category
 
   Scenario: I add a product with invalid characters in name
@@ -36,5 +40,7 @@ Feature: Add basic product from Back Office (BO)
   Scenario: I add a product with symbol in its name
     When I add product "product3" with following information:
       | name       | en-US:Shirt - Dom & Jquery |
-      | is_virtual | false             |
-    And product "product3" localized "name" should be "{en-US:Shirt - Dom & Jquery}"
+      | is_virtual | false                      |
+    And product "product3" localized "name" should be:
+      | locale | value                |
+      | en-US  | Shirt - Dom & Jquery |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -9,8 +9,8 @@ Feature: Add basic product from Back Office (BO)
 
   Scenario: I add a product with basic information
     When I add product "product1" with following information:
-      | name       | en-US:bottle of beer |
-      | is_virtual | false                |
+      | name[en-US] | bottle of beer |
+      | is_virtual  | false          |
     Then product "product1" should be disabled
     And product "product1" type should be standard
     And product "product1" localized "name" should be:
@@ -20,8 +20,8 @@ Feature: Add basic product from Back Office (BO)
 
   Scenario: I add a product with basic information
     When I add product "product1" with following information:
-      | name       | en-US:bottle of beer |
-      | is_virtual | true                 |
+      | name[en-US] | bottle of beer |
+      | is_virtual  | true           |
     Then product "product1" should be disabled
     Then product "product1" should have following options information:
       | condition | new |
@@ -33,14 +33,14 @@ Feature: Add basic product from Back Office (BO)
 
   Scenario: I add a product with invalid characters in name
     When I add product "product2" with following information:
-      | name       | en-US: T-shirt #1 |
-      | is_virtual | false             |
+      | name[en-US] | T-shirt #1 |
+      | is_virtual  | false      |
     Then I should get error that product name is invalid
 
   Scenario: I add a product with symbol in its name
     When I add product "product3" with following information:
-      | name       | en-US:Shirt - Dom & Jquery |
-      | is_virtual | false                      |
+      | name[en-US] | Shirt - Dom & Jquery |
+      | is_virtual  | false                |
     And product "product3" localized "name" should be:
       | locale | value                |
       | en-US  | Shirt - Dom & Jquery |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -13,9 +13,18 @@ Feature: Add basic product from Back Office (BO)
       | is_virtual | false                |
     Then product "product1" should be disabled
     And product "product1" type should be standard
-    And product "product1" should have following options information:
+    And product "product1" localized "name" should be "{en-US:bottle of beer}"
+    And product "product1" should be assigned to default category
+
+  Scenario: I add a product with basic information
+    When I add product "product1" with following information:
+      | name       | en-US:bottle of beer |
+      | is_virtual | true                 |
+    Then product "product1" should be disabled
+    Then product "product1" should have following options information:
       | condition        | new            |
-    And product "product1" localized "name" should be "en-US:bottle of beer"
+    And product "product1" type should be virtual
+    And product "product1" localized "name" should be "{en-US:bottle of beer}"
     And product "product1" should be assigned to default category
 
   Scenario: I add a product with invalid characters in name
@@ -28,4 +37,4 @@ Feature: Add basic product from Back Office (BO)
     When I add product "product3" with following information:
       | name       | en-US:Shirt - Dom & Jquery |
       | is_virtual | false             |
-    And product "product3" localized "name" should be "en-US:Shirt - Dom & Jquery"
+    And product "product3" localized "name" should be "{en-US:Shirt - Dom & Jquery}"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/delete_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/delete_product.feature
@@ -8,22 +8,22 @@ Feature: Delete products from Back Office (BO)
 
   Scenario: I delete product
     Given I add product "product1" with following information:
-      | name       | en-US:bottle of ale  |
-      | is_virtual | false                |
+      | name[en-US] | bottle of ale |
+      | is_virtual  | false         |
     And product "product1" type should be standard
     When I delete product product1
     Then product product1 should not exist anymore
 
   Scenario: I bulk delete products
     Given I add product "product1" with following information:
-      | name       | en-US:bottle of wine |
-      | is_virtual | false                |
+      | name[en-US] | bottle of wine |
+      | is_virtual  | false          |
     Given I add product "product2" with following information:
-      | name       | en-US:jar of mead    |
-      | is_virtual | false                |
+      | name[en-US] | jar of mead |
+      | is_virtual  | false       |
     Given I add product "product3" with following information:
-      | name       | en-US:gilded axe     |
-      | is_virtual | false                |
+      | name[en-US] | gilded axe |
+      | is_virtual  | false      |
     And product "product1" type should be standard
     And product "product2" type should be standard
     And product "product3" type should be standard

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -1,7 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-product
 @reset-database-before-feature
 @duplicate-product
-@clear-downloads-after-feature
+@reset-downloads-after-feature
 @clear-cache-after-feature
 Feature: Duplicate product from Back Office (BO).
   As an employee I want to be able to duplicate product
@@ -19,14 +19,18 @@ Feature: Duplicate product from Back Office (BO).
     And carrier carrier1 named "ecoCarrier" exists
     And carrier carrier2 named "Fast carry" exists
     Given I add product "product1" with following information:
-      | name       | en-US:smart sunglasses ;fr-FR:lunettes de soleil |
-      | is_virtual | false                                            |
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | is_virtual  | false              |
     And I add product "product2" with following information:
-      | name       | en-US:Reading glasses ;fr-FR:lunettes |
-      | is_virtual | false                                 |
+      | name[en-US] | Reading glasses |
+      | name[fr-FR] | lunettes        |
+      | is_virtual  | false           |
     And I update product "product1" basic information with following values:
-      | description       | en-US:nice sunglasses ;fr-FR:belles lunettes                    |
-      | description_short | en-US:Simple & nice sunglasses;fr-FR:lunettes simples et belles |
+      | description[en-US]              | nice sunglasses            |
+      | description[fr-FR]              | belles lunettes            |
+      | description_short[en-US] | Simple & nice sunglasses   |
+      | description_short[fr-FR] | lunettes simples et belles |
     And I assign product product1 to following categories:
       | categories       | [home, men, clothes] |
       | default category | clothes              |
@@ -43,7 +47,8 @@ Feature: Duplicate product from Back Office (BO).
       | reference           | ref1              |
       | manufacturer        | studioDesign      |
     And I update product "product1" tags with following values:
-      | tags | en-US:smart,glasses,sunglasses,men ;fr-FR:lunettes,bien,soleil |
+      | tags[en-US] | smart,glasses,sunglasses,men |
+      | tags[fr-FR] | lunettes,bien,soleil         |
     And I update product "product1" prices with following information:
       | price           | 100.00          |
       | ecotax          | 0               |
@@ -53,44 +58,50 @@ Feature: Duplicate product from Back Office (BO).
       | unit_price      | 500             |
       | unity           | bag of ten      |
     And I update product product1 SEO information with following values:
-      | meta_title       | en-US:SUNGLASSES meta title                        |
-      | meta_description | en-US:Its so smart, almost magical ;fr-FR:lel joke |
-      | link_rewrite     | en-US:smart-sunglasses ;fr-FR:lunettes-de-soleil   |
-      | redirect_type    | 301-product                                        |
-      | redirect_target  | product2                                           |
+      | meta_title[en-US]       | SUNGLASSES meta title |
+      | meta_description[en-US] | Its so smart          |
+      | meta_description[fr-FR] | lel joke              |
+      | link_rewrite[en-US]     | smart-sunglasses      |
+      | link_rewrite[fr-FR]     | lunettes-de-soleil    |
+      | redirect_type           | 301-product           |
+      | redirect_target         | product2              |
     And I update product product1 shipping information with following values:
-      | width                            | 10.5                                                  |
-      | height                           | 6                                                     |
-      | depth                            | 7                                                     |
-      | weight                           | 0.5                                                   |
-      | additional_shipping_cost         | 12                                                    |
-      | delivery time notes type         | specific                                              |
-      | delivery time in stock notes     | en-US:product in stock ;fr-FR:en stock                |
-      | delivery time out of stock notes | en-US:product out of stock ;fr-FR:En rupture de stock |
-      | carriers                         | [carrier1,carrier2]                                   |
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time in stock notes[fr-FR]     | en stock             |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
+      | carriers                                | [carrier1,carrier2]  |
     And I add new supplier supplier1 with following properties:
-      | name             | my supplier 1            |
-      | address          | Donelaicio st. 1         |
-      | city             | Kaunas                   |
-      | country          | Lithuania                |
-      | enabled          | true                     |
-      | description      | en-US:just a supplier    |
-      | meta title       | en-US:my supplier nr one |
-      | meta description | en-US:                   |
-      | meta keywords    | en-US:sup,1              |
-      | shops            | [shop1]                  |
+      | name                    | my supplier 1      |
+      | address                 | Donelaicio st. 1   |
+      | city                    | Kaunas             |
+      | country                 | Lithuania          |
+      | enabled                 | true               |
+      | description[en-US]      | just a supplier    |
+      | meta title[en-US]       | my supplier nr one |
+      | meta description[en-US] |                    |
+      | meta keywords[en-US]    | sup,1              |
+      | shops                   | [shop1]            |
     And I set product product1 default supplier to supplier1 and following suppliers:
       | reference         | supplier reference | product supplier reference     | currency | price tax excluded |
       | product1supplier1 | supplier1          | my first supplier for product1 | USD      | 10                 |
     And I set following related products to product product1:
       | product2 |
     And I update product product1 with following customization fields:
-      | reference    | type | name                                                                       | is required |
-      | customField1 | text | en-US:text on top of left lense ;fr-FR:texte en haut de la lentille gauche | true        |
+      | reference    | type | name[en-US]               | name[fr-FR]                         | is required |
+      | customField1 | text | text on top of left lense | texte en haut de la lentille gauche | true        |
     And I add new attachment "att1" with following properties:
-      | description | en-US:puffin photo nr1 ;fr-FR:macareux |
-      | name        | en-US:puffin ;fr-FR:macareux           |
-      | file_name   | app_icon.png                           |
+      | description[en-US] | puffin photo nr1 |
+      | description[fr-FR] | macareux                              |
+      | name[en-US]        | puffin                                |
+      | name[fr-FR]        | macareux                              |
+      | file_name          | app_icon.png                          |
     And I associate attachment "att1" with product product1
     And I enable product "product1"
     When I update product product1 SEO information with following values:
@@ -105,9 +116,18 @@ Feature: Duplicate product from Back Office (BO).
     When I duplicate product product1 to a copy_of_product1
     And product "copy_of_product1" should be disabled
     And product "copy_of_product1" type should be standard
-    And product "copy_of_product1" localized "name" should be "en-US:copy of smart sunglasses; fr-FR:copy of lunettes de soleil"
-    And product "copy_of_product1" localized "description" should be "en-US:nice sunglasses; fr-FR:belles lunettes"
-    And product "copy_of_product1" localized "description_short" should be "en-US:Simple & nice sunglasses; fr-FR:lunettes simples et belles"
+    And product "copy_of_product1" localized "name" should be:
+      | locale | value                      |
+      | en-US  | copy of smart sunglasses   |
+      | fr-FR  | copy of lunettes de soleil |
+    And product "copy_of_product1" localized "description" should be:
+      | locale | value           |
+      | en-US  | nice sunglasses |
+      | fr-FR  | belles lunettes |
+    And product "copy_of_product1" localized "description_short" should be:
+      | locale | value                      |
+      | en-US  | Simple & nice sunglasses   |
+      | fr-FR  | lunettes simples et belles |
     And product copy_of_product1 should be assigned to following categories:
       | categories       | [home, men, clothes] |
       | default category | clothes              |
@@ -123,7 +143,10 @@ Feature: Duplicate product from Back Office (BO).
       | mpn                 | mpn1              |
       | reference           | ref1              |
     And manufacturer "studioDesign" should be assigned to product copy_of_product1
-    And product "copy_of_product1" localized "tags" should be "en-US:smart,glasses,sunglasses,men ;fr-FR:lunettes,bien,soleil"
+    And product "copy_of_product1" localized "tags" should be:
+      | locale | value                        |
+      | en-US  | smart,glasses,sunglasses,men |
+      | fr-FR  | lunettes,bien,soleil         |
     And product copy_of_product1 should have following suppliers:
       | product supplier reference     | currency | price tax excluded |
       | my first supplier for product1 | USD      | 10                 |
@@ -137,25 +160,36 @@ Feature: Duplicate product from Back Office (BO).
       | unit_price       | 500             |
       | unity            | bag of ten      |
       | unit_price_ratio | 0.2             |
-    And product "copy_of_product1" localized "meta_title" should be "en-US:SUNGLASSES meta title"
-    And product "copy_of_product1" localized "meta_description" should be "en-US:Its so smart, almost magical ;fr-FR:lel joke"
-    And product "copy_of_product1" localized "link_rewrite" should be "en-US:smart-sunglasses ;fr-FR:lunettes-de-soleil"
+    And product "copy_of_product1" localized "meta_title" should be:
+      | locale | value                 |
+      | en-US  | SUNGLASSES meta title |
+    And product "copy_of_product1" localized "meta_description" should be:
+      | locale | value                        |
+      | en-US  | Its so smart |
+      | fr-FR  | lel joke                     |
+    And product "copy_of_product1" localized "link_rewrite" should be:
+      | locale | value              |
+      | en-US  | smart-sunglasses   |
+      | fr-FR  | lunettes-de-soleil |
     And product copy_of_product1 should have following seo options:
       | redirect_type   | 301-product |
       | redirect_target | product2    |
     And product "copy_of_product1" should have following shipping information:
-      | width                            | 10.5                                                  |
-      | height                           | 6                                                     |
-      | depth                            | 7                                                     |
-      | weight                           | 0.5                                                   |
-      | additional_shipping_cost         | 12                                                    |
-      | delivery time notes type         | specific                                              |
-      | delivery time in stock notes     | en-US:product in stock ;fr-FR:en stock                |
-      | delivery time out of stock notes | en-US:product out of stock ;fr-FR:En rupture de stock |
-      | carriers                         | [carrier1,carrier2]                                   |
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time in stock notes[fr-FR]     | en stock             |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
+      | carriers                                | [carrier1,carrier2]  |
     And product copy_of_product1 should have following related products:
       | product2 |
     And product copy_of_product1 should have following attachments associated: "[att1]"
     And product copy_of_product1 should have identical customization fields to product1
     And product copy_of_product1 should have 1 customizable text field
     And product copy_of_product1 should have 0 customizable file fields
+#@todo: assert stock info

--- a/tests/Integration/Behaviour/Features/Scenario/Product/specific_price_priorities.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/specific_price_priorities.feature
@@ -6,8 +6,8 @@ Feature: Set Specific Price priorities from Back Office (BO).
 
   Scenario: I set specific price priorities to single product
     Given I add product "product1" with following information:
-      | name       | en-US:pocket watch |
-      | is_virtual | false              |
+      | name[en-US] | pocket watch |
+      | is_virtual  | false        |
     And product "product1" should have following specific price priorities:
       | id_shop | id_currency | id_country | id_group |
     When I set following specific price priorities for product "product1":
@@ -21,11 +21,11 @@ Feature: Set Specific Price priorities from Back Office (BO).
 
   Scenario: I set specific price priorities to all products
     Given I add product "product2" with following information:
-      | name       | en-US:golden wrist watch |
-      | is_virtual | false                    |
+      | name[en-US] | golden wrist watch |
+      | is_virtual  | false              |
     And I add product "product3" with following information:
-      | name       | en-US:silver wrist watch |
-      | is_virtual | false                    |
+      | name[en-US] | silver wrist watch |
+      | is_virtual  | false              |
     And product "product2" should have following specific price priorities:
       | id_shop | id_currency | id_country | id_group |
     And product "product3" should have following specific price priorities:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
@@ -11,30 +11,34 @@ Feature: Update product attachments from Back Office (BO).
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
     When I add product "product1" with following information:
-      | name       | en-US:mug with photo |
-      | is_virtual | false                |
+      | name[en-US] | mug with photo |
+      | is_virtual  | false          |
     Then product "product1" should be disabled
     And product "product1" type should be standard
     Given I add new attachment "att1" with following properties:
-      | description | en-US:puffin photo nr1 |
-      | name        | en-US:puffin           |
-      | file_name   | app_icon.png           |
+      | description[en-US] | puffin photo nr1 |
+      | name[en-US]        | puffin           |
+      | file_name          | app_icon.png     |
     Then attachment "att1" should have following properties:
-      | description | en-US:puffin photo nr1;fr-FR: |
-      | name        | en-US:puffin;fr-FR:puffin     |
-      | file_name   | app_icon.png                  |
-      | mime        | image/png                     |
-      | size        | 19187                         |
+      | description[en-US] | puffin photo nr1 |
+      | description[fr-FR] |                  |
+      | name[en-US]        | puffin           |
+      | name[fr-FR]        | puffin           |
+      | file_name          | app_icon.png     |
+      | mime               | image/png        |
+      | size               | 19187            |
     Given I add new attachment "att2" with following properties:
-      | description | en-US:my shop logo |
-      | name        | en-US:myShop       |
-      | file_name   | logo.jpg           |
+      | name[en-US]        | myShop       |
+      | description[en-US] | my shop logo |
+      | file_name          | logo.jpg     |
     Then attachment "att2" should have following properties:
-      | description | en-US:my shop logo;fr-FR: |
-      | name        | en-US:myShop;fr-FR:myShop |
-      | mime        | image/jpeg                |
-      | file_name   | logo.jpg                  |
-      | size        | 2758                      |
+      | name[en-US]        | myShop       |
+      | name[fr-FR]        | myShop       |
+      | description[en-US] | my shop logo |
+      | description[fr-FR] |              |
+      | mime               | image/jpeg   |
+      | file_name          | logo.jpg     |
+      | size               | 2758         |
     When I associate attachment "att1" with product product1
     Then product product1 should have following attachments associated: "[att1]"
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -7,53 +7,89 @@ Feature: Update product basic information from Back Office (BO)
 
   Scenario: I update product basic information
     Given I add product "product1" with following information:
-      | name       | en-US:funny mug |
-      | is_virtual | false           |
+      | name[en-US] | funny mug |
+      | is_virtual  | false     |
     And product "product1" type should be standard
-    And product "product1" localized "name" should be "en-US:funny mug"
+    And product "product1" localized "name" should be:
+      | locale | value     |
+      | en-US  | funny mug |
     And product product1 should have no manufacturer assigned
     When I update product "product1" basic information with following values:
-      | name              | en-US:photo of funny mug |
-      | is_virtual        | true                     |
-      | description       | en-US:nice mug           |
-      | description_short | en-US:Just a nice mug    |
+      | name[en-US]              | photo of funny mug |
+      | is_virtual               | true               |
+      | description[en-US]       | nice mug           |
+      | description_short[en-US] | Just a nice mug    |
     Then product "product1" type should be virtual
-    And product "product1" localized "name" should be "en-US:photo of funny mug"
-    And product "product1" localized "description" should be "en-US:nice mug"
-    And product "product1" localized "description_short" should be "en-US:Just a nice mug"
+    And product "product1" localized "name" should be:
+      | locale | value              |
+      | en-US  | photo of funny mug |
+    And product "product1" localized "description" should be:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product1" localized "description_short" should be:
+      | locale | value           |
+      | en-US  | Just a nice mug |
 
   Scenario: I update product basic information providing invalid product name
-    Given product "product1" localized "name" is "en-US:photo of funny mug"
+    Given product "product1" localized "name" is:
+      | locale | value              |
+      | en-US  | photo of funny mug |
     When I update product "product1" basic information with following values:
-      | name | en-US:#hashtagmug |
+      | name[en-US] | #hashtagmug |
     Then I should get error that product name is invalid
-    And product "product1" localized "name" should be "en-US:photo of funny mug"
+    And product "product1" localized "name" should be:
+      | locale | value              |
+      | en-US  | photo of funny mug |
 
   Scenario: Partially update product basic information
-    Given product "product1" localized "name" is "en-US:photo of funny mug"
-    And product "product1" localized "description" is "en-US:nice mug"
-    And product "product1" localized "description_short" is "en-US:Just a nice mug"
+    Given product "product1" localized "name" is:
+      | locale | value              |
+      | en-US  | photo of funny mug |
+    And product "product1" localized "description" is:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product1" localized "description_short" is:
+      | locale | value           |
+      | en-US  | Just a nice mug |
     When I update product "product1" basic information with following values:
       | is_virtual | false |
     Then product "product1" type should be standard
-    And product "product1" localized "name" should be "en-US:photo of funny mug"
-    And product "product1" localized "description" should be "en-US:nice mug"
-    And product "product1" localized "description_short" should be "en-US:Just a nice mug"
+    And product "product1" localized "name" should be:
+      | locale | value              |
+      | en-US  | photo of funny mug |
+    And product "product1" localized "description" should be:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product1" localized "description_short" should be:
+      | locale | value           |
+      | en-US  | Just a nice mug |
 
   Scenario: Update product basic information providing invalid characters in description
-    Given product "product1" localized "description" is "en-US:nice mug"
-    And product "product1" localized "description_short" is "en-US:Just a nice mug"
+    Given product "product1" localized "description" is:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product1" localized "description_short" is:
+      | locale | value           |
+      | en-US  | Just a nice mug |
     When I update product "product1" basic information with following values:
-      | description | en-US:<script> |
+      | description[en-US] | <script> |
     Then I should get error that product description is invalid
-    And product "product1" localized "description" should be "en-US:nice mug"
+    And product "product1" localized "description" should be:
+      | locale | value    |
+      | en-US  | nice mug |
     When I update product "product1" basic information with following values:
-      | description_short | en-US:<div onmousedown=hack()> |
+      | description_short[en-US] | <div onmousedown=hack()> |
     Then I should get error that product "description_short" is invalid
-    And product "product1" localized "description_short" should be "en-US:Just a nice mug"
+    And product "product1" localized "description_short" should be:
+      | locale | value           |
+      | en-US  | Just a nice mug |
 
   Scenario: Update product basic information providing allowed symbols in description
-    Given product "product1" localized "description" is "en-US:nice mug"
+    Given product "product1" localized "description" is:
+      | locale | value    |
+      | en-US  | nice mug |
     When I update product "product1" basic information with following values:
-      | description | en-US:it's mug & it's nice |
-    Then product "product1" localized "description" should be "en-US:it's mug & it's nice"
+      | description[en-US] | it's mug & it's nice |
+    Then product "product1" localized "description" should be:
+      | locale | value                |
+      | en-US  | it's mug & it's nice |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
@@ -15,12 +15,12 @@ Feature: Update product categories from Back Office (BO)
 
   Scenario: I assign product to categories
     Given I add product "product1" with following information:
-      | name       | en-US: eastern european tracksuit  |
-      | is_virtual | false                              |
+      | name[en-US] | eastern european tracksuit |
+      | is_virtual  | false                      |
     And product "product1" should be assigned to default category
     Then product product1 should be assigned to following categories:
-      | categories       | [home]               |
-      | default category | home                 |
+      | categories       | [home] |
+      | default category | home   |
     When I assign product product1 to following categories:
       | categories       | [home, men, clothes] |
       | default category | clothes              |
@@ -30,8 +30,8 @@ Feature: Update product categories from Back Office (BO)
 
   Scenario: I assign product to disabled categories
     Given I add product "product2" with following information:
-      | name       | en-US: ring of wealth |
-      | is_virtual | false                 |
+      | name[en-US] | ring of wealth |
+      | is_virtual  | false          |
     And I disable category "women"
     And I disable category "accessories"
     When I assign product product2 to following categories:
@@ -46,25 +46,25 @@ Feature: Update product categories from Back Office (BO)
       | categories       | [home, women, accessories] |
       | default category | women                      |
     When I assign product product2 to following categories:
-      | categories       | [home, women]              |
-      | default category | women                      |
+      | categories       | [home, women] |
+      | default category | women         |
     Then product product2 should be assigned to following categories:
-      | categories       | [home, women]              |
-      | default category | women                      |
+      | categories       | [home, women] |
+      | default category | women         |
 
   Scenario: I assign default category which is not in the list of categories
     Given I add product "product3" with following information:
-      | name       | en-US: golden bracelet       |
-      | is_virtual | false                        |
+      | name[en-US] | golden bracelet |
+      | is_virtual  | false           |
     And product product3 should be assigned to following categories:
-      | categories       | [home]                 |
-      | default category | home                   |
+      | categories       | [home] |
+      | default category | home   |
     When I assign product product3 to following categories:
-      | categories       | [women]                |
-      | default category | accessories            |
+      | categories       | [women]     |
+      | default category | accessories |
     Then product product3 should be assigned to following categories:
-      | categories       | [women, accessories]   |
-      | default category | accessories            |
+      | categories       | [women, accessories] |
+      | default category | accessories          |
 
   Scenario: I assign new categories providing one non-existing category
     Given product product3 should be assigned to following categories:
@@ -83,8 +83,8 @@ Feature: Update product categories from Back Office (BO)
       | categories       | [women, accessories] |
       | default category | accessories          |
     When I assign product product3 to following categories:
-      | categories       | [women]              |
-      | default category | idontexist2          |
+      | categories       | [women]     |
+      | default category | idontexist2 |
     Then I should get error that assigning product to categories failed
     And product product3 should be assigned to following categories:
       | categories       | [women, accessories] |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_customization_fields.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_customization_fields.feature
@@ -12,55 +12,55 @@ Feature: Update product customization fields in Back Office (BO)
 
   Scenario: I add customization fields to product
     When I add product "product1" with following information:
-      | name       | en-US: nice customizable t-shirt  |
-      | is_virtual | false                             |
+      | name[en-US] | nice customizable t-shirt |
+      | is_virtual  | false                     |
     And product "product1" type should be standard
     When I update product product1 with following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField1          | text    | en-US:front-text        | true        |
-      | customField2          | text    | en-US:back-text         | false       |
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | true        |
+      | customField2 | text | back-text   | false       |
     Then product "product1" should require customization
     And product product1 should have 2 customizable text fields
     And product product1 should have 0 customizable file fields
     And product product1 should have following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField1          | text    | en-US:front-text        | true        |
-      | customField2          | text    | en-US:back-text         | false       |
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | true        |
+      | customField2 | text | back-text   | false       |
 
   Scenario: I update some product customization fields and add additional one
     Given product product1 should have following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField1          | text    | en-US:front-text        | true        |
-      | customField2          | text    | en-US:back-text         | false       |
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | true        |
+      | customField2 | text | back-text   | false       |
     When I update product product1 with following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField1          | text    | en-US:front-text        | false       |
-      | customField2          | text    | en-US:bottom-text       | false       |
-      | customField3          | file    | en-US:back image        | false       |
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | bottom-text | false       |
+      | customField3 | file | back image  | false       |
     Then product "product1" should allow customization
     And product product1 should have 2 customizable text fields
     And product product1 should have 1 customizable file field
     And product product1 should have following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField1          | text    | en-US:front-text        | false       |
-      | customField2          | text    | en-US:bottom-text       | false       |
-      | customField3          | file    | en-US:back image        | false       |
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | bottom-text | false       |
+      | customField3 | file | back image  | false       |
 
   Scenario: I delete some product customization fields
     Given product product1 should have following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField1          | text    | en-US:front-text        | false       |
-      | customField2          | text    | en-US:bottom-text       | false       |
-      | customField3          | file    | en-US:back image        | false       |
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | bottom-text | false       |
+      | customField3 | file | back image  | false       |
     When I update product product1 with following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField2          | text    | en-US:bottom-text       | true        |
+      | reference    | type | name[en-US] | is required |
+      | customField2 | text | bottom-text | true        |
     Then product "product1" should require customization
     And product product1 should have 1 customizable text field
     And product product1 should have 0 customizable file fields
     And product product1 should have following customization fields:
-      | reference             | type    | name                    | is required |
-      | customField2          | text    | en-US:bottom-text       | true        |
+      | reference    | type | name[en-US] | is required |
+      | customField2 | text | bottom-text | true        |
 
   Scenario: Update customization field name in different languages
     Given language "french" with locale "fr-FR" exists
@@ -68,38 +68,38 @@ Feature: Update product customization fields in Back Office (BO)
     And product product1 should have 1 customizable text field
     And product product1 should have 0 customizable file fields
     And product product1 should have following customization fields:
-      | reference             | type    | name                                 | is required |
-      | customField2          | text    | en-US:bottom-text;fr-FR:bottom-text  | true        |
+      | reference    | type | name[en-US] | name[fr-FR] | is required |
+      | customField2 | text | bottom-text | bottom-text | true        |
     When I update product product1 with following customization fields:
-      | reference             | type    | name                                 | is required |
-      | customField2          | text    | en-US:bottom-text;fr-FR:texte du bas | true        |
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom-text | texte du bas | true        |
     And product product1 should have following customization fields:
-      | reference             | type    | name                                 | is required |
-      | customField2          | text    | en-US:bottom-text;fr-FR:texte du bas | true        |
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom-text | texte du bas | true        |
     When I update product product1 with following customization fields:
-      | reference             | type    | name                                 | is required |
-      | customField2          | text    | en-US:bottom;fr-FR:texte du bas      | true        |
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
     Then product product1 should have following customization fields:
-      | reference             | type    | name                                 | is required |
-      | customField2          | text    | en-US:bottom;fr-FR:texte du bas      | true        |
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
 
-    Scenario: Update customization field providing invalid name
-      Given product product1 should have following customization fields:
-        | reference             | type    | name                                 | is required |
-        | customField2          | text    | en-US:bottom;fr-FR:texte du bas      | true        |
-      When I update product product1 customization field name with text containing 256 symbols
-      Then I should get error that product customization field name is invalid
-      And product product1 should have following customization fields:
-        | reference             | type    | name                                 | is required |
-        | customField2          | text    | en-US:bottom;fr-FR:texte du bas      | true        |
+  Scenario: Update customization field providing invalid name
+    Given product product1 should have following customization fields:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
+    When I update product product1 customization field name with text containing 256 symbols
+    Then I should get error that product customization field name is invalid
+    And product product1 should have following customization fields:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
 
   Scenario: I delete all customization fields for product
     Given product "product1" should require customization
     And product product1 should have 1 customizable text field
     And product product1 should have 0 customizable file fields
     And product product1 should have following customization fields:
-      | reference             | type    | name                                  | is required |
-      | customField2          | text    | en-US:bottom;fr-FR:texte du bas       | true        |
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
     When I remove all customization fields from product product1
     Then product "product1" should not be customizable
     Then product product1 should have 0 customizable text fields

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
@@ -11,72 +11,74 @@ Feature: Update product options from Back Office (BO)
 
   Scenario: I update product options
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     Then product "product1" should have following options information:
-      | visibility           | both               |
-      | available_for_order  | true               |
-      | online_only          | false              |
-      | show_price           | true               |
-      | condition            | new                |
-      | isbn                 |                    |
-      | upc                  |                    |
-      | ean13                |                    |
-      | mpn                  |                    |
-      | reference            |                    |
-    And product "product1" localized "tags" should be "en-US:"
+      | visibility          | both  |
+      | available_for_order | true  |
+      | online_only         | false |
+      | show_price          | true  |
+      | condition           | new   |
+      | isbn                |       |
+      | upc                 |       |
+      | ean13               |       |
+      | mpn                 |       |
+      | reference           |       |
+    And product "product1" localized "tags" should be:
+      | locale | value |
+      | en-US  |       |
     And product product1 should have no manufacturer assigned
     When I update product "product1" options with following information:
-      | visibility           | catalog            |
-      | available_for_order  | false              |
-      | online_only          | true               |
-      | show_price           | false              |
-      | condition            | used               |
-      | isbn                 | 978-3-16-148410-0  |
-      | upc                  | 72527273070        |
-      | ean13                | 978020137962       |
-      | mpn                  | mpn1               |
-      | reference            | ref1               |
-      | manufacturer         | studioDesign       |
+      | visibility          | catalog           |
+      | available_for_order | false             |
+      | online_only         | true              |
+      | show_price          | false             |
+      | condition           | used              |
+      | isbn                | 978-3-16-148410-0 |
+      | upc                 | 72527273070       |
+      | ean13               | 978020137962      |
+      | mpn                 | mpn1              |
+      | reference           | ref1              |
+      | manufacturer        | studioDesign      |
     Then product "product1" should have following options information:
-      | visibility           | catalog            |
-      | available_for_order  | false              |
-      | online_only          | true               |
-      | show_price           | false              |
-      | condition            | used               |
-      | isbn                 | 978-3-16-148410-0  |
-      | upc                  | 72527273070        |
-      | ean13                | 978020137962       |
-      | mpn                  | mpn1               |
-      | reference            | ref1               |
+      | visibility          | catalog           |
+      | available_for_order | false             |
+      | online_only         | true              |
+      | show_price          | false             |
+      | condition           | used              |
+      | isbn                | 978-3-16-148410-0 |
+      | upc                 | 72527273070       |
+      | ean13               | 978020137962      |
+      | mpn                 | mpn1              |
+      | reference           | ref1              |
     And manufacturer "studioDesign" should be assigned to product product1
 
   Scenario: I only update product availability for order, leaving other properties unchanged
     Given product "product1" should have following options information:
-      | visibility           | catalog            |
-      | available_for_order  | false              |
-      | online_only          | true               |
-      | show_price           | false              |
-      | condition            | used               |
-      | isbn                 | 978-3-16-148410-0  |
-      | upc                  | 72527273070        |
-      | ean13                | 978020137962       |
-      | mpn                  | mpn1               |
-      | reference            | ref1               |
+      | visibility          | catalog           |
+      | available_for_order | false             |
+      | online_only         | true              |
+      | show_price          | false             |
+      | condition           | used              |
+      | isbn                | 978-3-16-148410-0 |
+      | upc                 | 72527273070       |
+      | ean13               | 978020137962      |
+      | mpn                 | mpn1              |
+      | reference           | ref1              |
     And manufacturer "studioDesign" should be assigned to product product1
     When I update product "product1" options with following information:
-      | available_for_order  | true               |
+      | available_for_order | true |
     Then product "product1" should have following options information:
-      | visibility           | catalog            |
-      | available_for_order  | true               |
-      | online_only          | true               |
-      | show_price           | false              |
-      | condition            | used               |
-      | isbn                 | 978-3-16-148410-0  |
-      | upc                  | 72527273070        |
-      | ean13                | 978020137962       |
-      | mpn                  | mpn1               |
-      | reference            | ref1               |
+      | visibility          | catalog           |
+      | available_for_order | true              |
+      | online_only         | true              |
+      | show_price          | false             |
+      | condition           | used              |
+      | isbn                | 978-3-16-148410-0 |
+      | upc                 | 72527273070       |
+      | ean13               | 978020137962      |
+      | mpn                 | mpn1              |
+      | reference           | ref1              |
     And manufacturer "studioDesign" should be assigned to product product1
 
   Scenario: I update manufacturer with invalid values
@@ -94,32 +96,32 @@ Feature: Update product options from Back Office (BO)
       | manufacturer | graphicCorner |
     Then manufacturer "graphicCorner" should be assigned to product product1
     When I update product "product1" options with following information:
-      | manufacturer |               |
+      | manufacturer |  |
     Then product product1 should have no manufacturer assigned
 
   Scenario: I update product options providing invalid values
     Given I add product "product2" with following information:
-      | name       | en-US:'The truth is out there' wallpaper |
-      | is_virtual | true                                     |
+      | name[en-US] | 'The truth is out there' wallpaper |
+      | is_virtual  | true                               |
     When I update product "product2" options with following information:
-      | visibility | show it to me plz  |
+      | visibility | show it to me plz |
     Then I should get error that product visibility is invalid
     When I update product "product2" options with following information:
       | condition | very good condition |
     Then I should get error that product condition is invalid
     When I update product "product2" options with following information:
-      | isbn  | isbn1                   |
+      | isbn | isbn1 |
     Then I should get error that product isbn is invalid
     When I update product "product2" options with following information:
-      | upc   | upc1                    |
+      | upc | upc1 |
     Then I should get error that product upc is invalid
     When I update product "product2" options with following information:
-      | ean13 | ean1                    |
+      | ean13 | ean1 |
     Then I should get error that product ean13 is invalid
     When I update product "product2" options with following information:
-      | mpn   | this is more than forty characters long string |
+      | mpn | this is more than forty characters long string |
     Then I should get error that product mpn is invalid
     When I update product "product2" options with following information:
-      | reference   | invalid chars like ^;{ |
+      | reference | invalid chars like ^;{ |
     Then I should get error that product reference is invalid
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -8,12 +8,12 @@ Feature: Add product to pack from Back Office (BO)
 
   Scenario: I add standard product to a pack
     Given I add product "productPack1" with following information:
-      | name       | en-US: weird sunglasses box |
-      | is_virtual | false                       |
+      | name[en-US] | weird sunglasses box |
+      | is_virtual  | false                |
     And product "productPack1" type should be standard
     And I add product "product2" with following information:
-      | name       | en-US: shady sunglasses |
-      | is_virtual | false                   |
+      | name[en-US] | shady sunglasses |
+      | is_virtual  | false            |
     And product "product2" type should be standard
     When I update pack "productPack1" with following product quantities:
       | product  | quantity |
@@ -25,15 +25,15 @@ Feature: Add product to pack from Back Office (BO)
 
   Scenario: I add virtual products to a pack
     Given I add product "productPack2" with following information:
-      | name       | en-US: street photos |
-      | is_virtual | false                |
+      | name[en-US] | street photos |
+      | is_virtual  | false         |
     And product "productPack2" type should be standard
     And I add product "product3" with following information:
-      | name       | en-US: summerstreet |
-      | is_virtual | true                |
+      | name[en-US] | summerstreet |
+      | is_virtual  | true         |
     And I add product "product4" with following information:
-      | name       | en-US: winterstreet |
-      | is_virtual | true                |
+      | name[en-US] | winterstreet |
+      | is_virtual  | true         |
     And product "product3" type should be virtual
     When I update pack "productPack2" with following product quantities:
       | product  | quantity |
@@ -67,8 +67,8 @@ Feature: Add product to pack from Back Office (BO)
 
   Scenario: I add virtual and standard product to the same pack
     Given I add product productPack4 with following information:
-      | name       | en-US: mixed pack |
-      | is_virtual | false             |
+      | name[en-US] | mixed pack |
+      | is_virtual  | false      |
     Given product "product2" type should be standard
     And product "product3" type should be virtual
     When I update pack productPack4 with following product quantities:
@@ -101,8 +101,8 @@ Feature: Add product to pack from Back Office (BO)
 
   Scenario: Add combination product to a pack
     Given I add product "productSkirt1" with following information:
-      | name       | en-US:regular skirt |
-      | is_virtual | false               |
+      | name[en-US] | regular skirt |
+      | is_virtual  | false         |
     And product "productSkirt1" has following combinations:
       | reference | quantity | attributes         |
       | whiteS    | 15       | Size:S;Color:White |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -6,8 +6,8 @@ Feature: Update product price fields from Back Office (BO).
 
   Background:
     Given I add product "product1" with following information:
-      | name       | en-US:magic staff |
-      | is_virtual | false             |
+      | name[en-US] | magic staff |
+      | is_virtual  | false       |
     And product product1 should have following prices information:
       | price            | 0     |
       | ecotax           | 0     |
@@ -142,26 +142,26 @@ Feature: Update product price fields from Back Office (BO).
 
   Scenario: I update product unit price along with product price
     When I update product "product1" prices with following information:
-      | price            | 20           |
-      | unit_price       | 500          |
+      | price      | 20  |
+      | unit_price | 500 |
     Then product product1 should have following prices information:
-      | price            | 20           |
-      | unit_price       | 500          |
-      | unit_price_ratio | 0.04         |
+      | price            | 20   |
+      | unit_price       | 500  |
+      | unit_price_ratio | 0.04 |
     When I update product "product1" prices with following information:
-      | price            | 0            |
-      | unit_price       | 500          |
+      | price      | 0   |
+      | unit_price | 500 |
     Then product product1 should have following prices information:
-      | price            | 0            |
-      | unit_price       | 0            |
-      | unit_price_ratio | 0            |
+      | price            | 0 |
+      | unit_price       | 0 |
+      | unit_price_ratio | 0 |
 
   Scenario: I update product prices providing non-existing tax rules group
     Given I update product "product1" prices with following information:
       | tax rules group | US-AL Rate (4%) |
     And product product1 should have following prices information:
-      | tax rules group  | US-AL Rate (4%) |
+      | tax rules group | US-AL Rate (4%) |
     When I update product "product1" prices and apply non-existing tax rules group
     Then I should get error that tax rules group does not exist
     And product product1 should have following prices information:
-      | tax rules group  | US-AL Rate (4%) |
+      | tax rules group | US-AL Rate (4%) |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -8,20 +8,20 @@ Feature: Update product related products from Back Office (BO)
 
   Scenario: I set related products
     Given I add product "product1" with following information:
-      | name       | en-US:book of law |
-      | is_virtual | false             |
+      | name[en-US] | book of law |
+      | is_virtual  | false       |
     And I add product "product2" with following information:
-      | name       | en-US:book of love |
-      | is_virtual | false              |
+      | name[en-US] | book of love |
+      | is_virtual  | false        |
     And I add product "product3" with following information:
-      | name       | en-US:lovely books package |
-      | is_virtual | false                      |
+      | name[en-US] | lovely books package |
+      | is_virtual  | false                |
     And I update pack "product3" with following product quantities:
       | product  | quantity |
       | product2 | 5        |
     And I add product "product4" with following information:
-      | name       | en-US:Reading glasses |
-      | is_virtual | false                 |
+      | name[en-US] | Reading glasses |
+      | is_virtual  | false           |
     And product "product4" has following combinations:
       | reference   | quantity | attributes  |
       | whiteFramed | 10       | Color:White |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -12,48 +12,78 @@ Feature: Update product SEO options from Back Office (BO)
     And category "men" in default language named "Men" exists
     And category "clothes" in default language named "Clothes" exists
     Given I add product "product1" with following information:
-      | name       | en-US: just boots;fr-FR: |
-      | is_virtual | false                    |
+      | name[en-US] | just boots |
+      | is_virtual  | false      |
     And product product1 should have following seo options:
       | redirect_type | 404 |
     And product product1 should not have a redirect target
-    And product "product1" localized "meta_title" is "en-US:"
-    And product "product1" localized "meta_description" is "en-US:"
-    And product "product1" localized "link_rewrite" is "en-US:"
+    And product "product1" localized "meta_title" is:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "meta_description" is:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "link_rewrite" is:
+      | locale | value |
+      | en-US  |       |
     And I add product "product2" with following information:
-      | name       | en-US: magical boots;fr-FR: |
-      | is_virtual | true                        |
+      | name[en-US] | magical boots |
+      | is_virtual  | true          |
     And product product2 should have following seo options:
       | redirect_type | 404 |
     And product product2 should not have a redirect target
-    And product "product2" localized "meta_title" is "en-US:"
-    And product "product2" localized "meta_description" is "en-US:"
-    And product "product2" localized "link_rewrite" is "en-US:"
+    And product "product1" localized "meta_title" is:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "meta_description" is:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "link_rewrite" is:
+      | locale | value |
+      | en-US  |       |
 
   Scenario: I update product SEO
     When I update product product2 SEO information with following values:
-      | meta_title       | en-US:product2 meta title       |
-      | meta_description | en-US:product2 meta description |
-      | link_rewrite     | en-US:waterproof-boots          |
-      | redirect_type    | 301-product                     |
-      | redirect_target  | product1                        |
-    Then product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+      | meta_title[en-US]       | product2 meta title       |
+      | meta_description[en-US] | product2 meta description |
+      | link_rewrite[en-US]     | waterproof-boots          |
+      | redirect_type           | 301-product               |
+      | redirect_target         | product1                  |
+    Then product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
     And product product2 should have following seo options:
       | redirect_type   | 301-product |
       | redirect_target | product1    |
 
   Scenario: Update product redirect type without providing redirect target
     Given I update product product2 SEO information with following values:
-      | meta_title       | en-US:product2 meta title       |
-      | meta_description | en-US:product2 meta description |
-      | link_rewrite     | en-US:waterproof-boots          |
-      | redirect_type    | 301-product                     |
-      | redirect_target  | product1                        |
-    And product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+      | meta_title[en-US]       | product2 meta title       |
+      | meta_description[en-US] | product2 meta description |
+      | link_rewrite[en-US]     | waterproof-boots          |
+      | redirect_type           | 301-product               |
+      | redirect_target         | product1                  |
+    Then product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
     And product product2 should have following seo options:
       | redirect_type   | 301-product |
       | redirect_target | product1    |
@@ -82,18 +112,36 @@ Feature: Update product SEO options from Back Office (BO)
     Then product product2 should have following seo options:
       | redirect_type | 404 |
     And product product2 should not have a redirect target
-    And product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+    Then product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
 
   Scenario: I update product seo information providing invalid redirect type
     When I update product product2 SEO information with following values:
-      | meta_title       | en-US:product2 meta title       |
-      | meta_description | en-US:product2 meta description |
-      | link_rewrite     | en-US:waterproof-boots          |
-    And product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+      | meta_title[en-US]       | product2 meta title       |
+      | meta_description[en-US] | product2 meta description |
+      | link_rewrite[en-US]     | waterproof-boots          |
+    Then product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
     When I update product product2 SEO information with following values:
       | redirect_type   | 303-men-category |
       | redirect_target | men              |
@@ -108,18 +156,36 @@ Feature: Update product SEO options from Back Office (BO)
     And product product2 should have following seo options:
       | redirect_type | 404 |
     And product product2 should not have a redirect target
-    And product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+    Then product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
 
   Scenario: I update product seo redirect type providing valid redirect target
     When I update product product2 SEO information with following values:
-      | meta_title       | en-US:product2 meta title       |
-      | meta_description | en-US:product2 meta description |
-      | link_rewrite     | en-US:waterproof-boots          |
-    And product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+      | meta_title[en-US]       | product2 meta title       |
+      | meta_description[en-US] | product2 meta description |
+      | link_rewrite[en-US]     | waterproof-boots          |
+    Then product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
     When I update product product2 SEO information with following values:
       | redirect_type   | 301-product |
       | redirect_target | product1    |
@@ -144,50 +210,104 @@ Feature: Update product SEO options from Back Office (BO)
     And product product2 should have following seo options:
       | redirect_type   | 302-category |
       | redirect_target | clothes      |
-    And product "product2" localized "meta_title" should be "en-US:product2 meta title;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+    And product "product2" localized "meta_title" should be:
+      | locale | value               |
+      | en-US  | product2 meta title |
+      | fr-FR  |                     |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
 
   Scenario: Update product SEO multi-lang fields providing only default language values
-    And product "product2" localized "meta_title" should be "en-US:;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:;fr-FR:"
+    Given product "product2" localized "meta_title" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "product2" localized "meta_description" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
     When I update product product2 SEO information with following values:
-      | meta_title       | en-US:metatitl prod2            |
-      | meta_description | en-US:product2 meta description |
-      | link_rewrite     | en-US:waterproof-boots          |
-    Then product "product2" localized "meta_title" should be "en-US:metatitl prod2;fr-FR:"
-    Then product "product2" localized "meta_description" should be "en-US:product2 meta description;fr-FR:"
-    Then product "product2" localized "link_rewrite" should be "en-US:waterproof-boots;fr-FR:"
+      | meta_title[en-US]       | metatitl prod2            |
+      | meta_description[en-US] | product2 meta description |
+      | link_rewrite[en-US]     | waterproof-boots          |
+    Then product "product2" localized "meta_title" should be:
+      | locale | value          |
+      | en-US  | metatitl prod2 |
+      | fr-FR  |                |
+    And product "product2" localized "meta_description" should be:
+      | locale | value                     |
+      | en-US  | product2 meta description |
+      | fr-FR  |                           |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value            |
+      | en-US  | waterproof-boots |
+      | fr-FR  |                  |
 
   Scenario: Update product SEO multi-lang fields not providing default language values
-    And product "product2" localized "meta_title" should be "en-US:;fr-FR:"
-    And product "product2" localized "meta_description" should be "en-US:;fr-FR:"
-    And product "product2" localized "link_rewrite" should be "en-US:;fr-FR:"
+    Given product "product2" localized "meta_title" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "product2" localized "meta_description" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
     When I update product product2 SEO information with following values:
-      | meta_title       | fr-FR:la meta title1 |
-      | meta_description | fr-FR:la meta desc1  |
-      | link_rewrite     | fr-FR:la-boots       |
-    Then product "product2" localized "meta_title" should be "en-US:;fr-FR:la meta title1"
-    Then product "product2" localized "meta_description" should be "en-US:;fr-FR:la meta desc1"
-    Then product "product2" localized "link_rewrite" should be "en-US:;fr-FR:la-boots"
+      | meta_title[fr-FR]       | la meta title1 |
+      | meta_description[fr-FR] | la meta desc1  |
+      | link_rewrite[fr-FR]     | la-boots       |
+    Then product "product2" localized "meta_title" should be:
+      | locale | value          |
+      | en-US  |                |
+      | fr-FR  | la meta title1 |
+    And product "product2" localized "meta_description" should be:
+      | locale | value         |
+      | en-US  |               |
+      | fr-FR  | la meta desc1 |
+    And product "product2" localized "link_rewrite" should be:
+      | locale | value    |
+      | en-US  |          |
+      | fr-FR  | la-boots |
 
   Scenario: Update product SEO multi-lang fields with invalid values
     Given I update product product1 SEO information with following values:
-      | meta_title       | fr-FR:la meta title1 |
-      | meta_description | fr-FR:la meta desc1  |
-      | link_rewrite     | fr-FR:la-boots       |
-    And product "product1" localized "meta_title" should be "en-US:;fr-FR:la meta title1"
-    And product "product1" localized "meta_description" should be "en-US:;fr-FR:la meta desc1"
-    And product "product1" localized "link_rewrite" should be "en-US:;fr-FR:la-boots"
+      | meta_title[fr-FR]       | la meta title1 |
+      | meta_description[fr-FR] | la meta desc1  |
+      | link_rewrite[fr-FR]     | la-boots       |
+    And product "product1" localized "meta_title" should be:
+      | locale | value          |
+      | en-US  |                |
+      | fr-FR  | la meta title1 |
+    And product "product1" localized "meta_description" should be:
+      | locale | value         |
+      | en-US  |               |
+      | fr-FR  | la meta desc1 |
+    And product "product1" localized "link_rewrite" should be:
+      | locale | value    |
+      | en-US  |          |
+      | fr-FR  | la-boots |
     When I update product product1 SEO information with following values:
-      | meta_title | en-US:#{ |
+      | meta_title[en-US] | #{ |
     Then I should get error that product meta_title is invalid
     When I update product product1 SEO information with following values:
-      | meta_description | en-US:#{ |
+      | meta_description[en-US] | #{ |
     Then I should get error that product meta_description is invalid
     When I update product product1 SEO information with following values:
-      | link_rewrite | en-US:#{&_ |
+      | link_rewrite[en-US] | #{&_ |
     Then I should get error that product link_rewrite is invalid
     When I update product product1 localized SEO field meta_title with a value of 256 symbols length
     Then I should get error that product meta_title is invalid
@@ -195,6 +315,15 @@ Feature: Update product SEO options from Back Office (BO)
     Then I should get error that product meta_description is invalid
     When I update product product1 localized SEO field link_rewrite with a value of 256 symbols length
     Then I should get error that product link_rewrite is invalid
-    And product "product1" localized "meta_title" should be "en-US:;fr-FR:la meta title1"
-    And product "product1" localized "meta_description" should be "en-US:;fr-FR:la meta desc1"
-    And product "product1" localized "link_rewrite" should be "en-US:;fr-FR:la-boots"
+    And product "product1" localized "meta_title" should be:
+      | locale | value          |
+      | en-US  |                |
+      | fr-FR  | la meta title1 |
+    And product "product1" localized "meta_description" should be:
+      | locale | value         |
+      | en-US  |               |
+      | fr-FR  | la meta desc1 |
+    And product "product1" localized "link_rewrite" should be:
+      | locale | value    |
+      | en-US  |          |
+      | fr-FR  | la-boots |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
@@ -7,122 +7,122 @@ Feature: Update product shipping options from Back Office (BO)
 
   Scenario: I update product shipping
     Given I add product "product1" with following information:
-      | name       | en-US:Last samurai dvd |
-      | is_virtual | false                  |
+      | name[en-US] | Last samurai dvd |
+      | is_virtual  | false            |
     And product product1 should have following shipping information:
-      | width                            | 0                 |
-      | height                           | 0                 |
-      | depth                            | 0                 |
-      | weight                           | 0                 |
-      | additional_shipping_cost         | 0                 |
-      | delivery time notes type         | default           |
-      | delivery time in stock notes     | en-US:            |
-      | delivery time out of stock notes | en-US:            |
-      | carriers                         | []                |
+      | width                                   | 0       |
+      | height                                  | 0       |
+      | depth                                   | 0       |
+      | weight                                  | 0       |
+      | additional_shipping_cost                | 0       |
+      | delivery time notes type                | default |
+      | delivery time in stock notes[en-US]     |         |
+      | delivery time out of stock notes[en-US] |         |
+      | carriers                                | []      |
     Given carrier carrier1 named "ecoCarrier" exists
     And carrier carrier2 named "Fast carry" exists
     When I update product product1 shipping information with following values:
-      | width                            | 10.5                       |
-      | height                           | 6                          |
-      | depth                            | 7                          |
-      | weight                           | 0.5                        |
-      | additional_shipping_cost         | 12                         |
-      | delivery time notes type         | specific                   |
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
-      | carriers                         | [carrier1,carrier2]        |
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | carriers                                | [carrier1,carrier2]  |
     Then product product1 should have following shipping information:
-      | width                            | 10.5                       |
-      | height                           | 6                          |
-      | depth                            | 7                          |
-      | weight                           | 0.5                        |
-      | additional_shipping_cost         | 12                         |
-      | delivery time notes type         | specific                   |
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
-      | carriers                         | [carrier1,carrier2]        |
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | carriers                                | [carrier1,carrier2]  |
 
   Scenario: Only update product dimensions without changing other values
     Given product product1 should have following shipping information:
-      | width                            | 10.5                       |
-      | height                           | 6                          |
-      | depth                            | 7                          |
-      | weight                           | 0.5                        |
-      | additional_shipping_cost         | 12                         |
-      | delivery time notes type         | specific                   |
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
-      | carriers                         | [carrier1,carrier2]        |
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | carriers                                | [carrier1,carrier2]  |
     When I update product product1 shipping information with following values:
-      | width                            | 15                         |
-      | height                           | 5                          |
-      | depth                            | 4                          |
-      | weight                           | 2                          |
+      | width  | 15 |
+      | height | 5  |
+      | depth  | 4  |
+      | weight | 2  |
     Then product product1 should have following shipping information:
-      | width                            | 15                         |
-      | height                           | 5                          |
-      | depth                            | 4                          |
-      | weight                           | 2                          |
-      | additional_shipping_cost         | 12                         |
-      | delivery time notes type         | specific                   |
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
-      | carriers                         | [carrier1,carrier2]        |
+      | width                                   | 15                   |
+      | height                                  | 5                    |
+      | depth                                   | 4                    |
+      | weight                                  | 2                    |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | carriers                                | [carrier1,carrier2]  |
 
   Scenario: Provide negative product dimensions
     Given product product1 should have following shipping information:
-      | width                            | 15                         |
-      | height                           | 5                          |
-      | depth                            | 4                          |
-      | weight                           | 2                          |
+      | width  | 15 |
+      | height | 5  |
+      | depth  | 4  |
+      | weight | 2  |
     When I update product product1 shipping information with following values:
-      | width                            | -15                        |
+      | width | -15 |
     Then I should get error that product width is invalid
     When I update product product1 shipping information with following values:
-      | height                            | -5                        |
+      | height | -5 |
     Then I should get error that product height is invalid
     When I update product product1 shipping information with following values:
-      | depth                            | -4                         |
+      | depth | -4 |
     Then I should get error that product depth is invalid
     When I update product product1 shipping information with following values:
-      | weight                            | -2                        |
+      | weight | -2 |
     Then I should get error that product weight is invalid
     And product product1 should have following shipping information:
-      | width                            | 15                         |
-      | height                           | 5                          |
-      | depth                            | 4                          |
-      | weight                           | 2                          |
+      | width  | 15 |
+      | height | 5  |
+      | depth  | 4  |
+      | weight | 2  |
 
   Scenario: Provide negative additional shipping cost
     Given product product1 should have following shipping information:
-      | additional_shipping_cost         | 12                         |
+      | additional_shipping_cost | 12 |
     When I update product product1 shipping information with following values:
-      | additional_shipping_cost         | -12                        |
+      | additional_shipping_cost | -12 |
     Then I should get error that product additional_shipping_cost is invalid
 
   Scenario: Provide invalid delivery notes
     Given product product1 should have following shipping information:
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
     When I update product product1 shipping information with following values:
-      | delivery time in stock notes     | en-US:bla bla <{}            |
+      | delivery time in stock notes[en-US] | bla bla <{} |
     Then I should get error that product delivery_in_stock is invalid
     When I update product product1 shipping information with following values:
-      | delivery time out of stock notes | en-US:ble ble >= |
+      | delivery time out of stock notes[en-US] | ble ble >= |
     Then I should get error that product delivery_out_stock is invalid
     And product product1 should have following shipping information:
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
 
   Scenario: Remove delivery time notes, but still have specific notes type
     Given product product1 should have following shipping information:
-      | delivery time notes type         | specific                   |
-      | delivery time in stock notes     | en-US:product in stock     |
-      | delivery time out of stock notes | en-US:product out of stock |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time out of stock notes[en-US] | product out of stock |
     When I update product product1 shipping information with following values:
-      | delivery time in stock notes     | en-US:                     |
-      | delivery time out of stock notes | en-US:                     |
+      | delivery time in stock notes[en-US]     |  |
+      | delivery time out of stock notes[en-US] |  |
     Given product product1 should have following shipping information:
-      | delivery time notes type         | specific                   |
-      | delivery time in stock notes     | en-US:                     |
-      | delivery time out of stock notes | en-US:                     |
+      | delivery time notes type                | specific |
+      | delivery time in stock notes[en-US]     |          |
+      | delivery time out of stock notes[en-US] |          |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -7,8 +7,8 @@ Feature: Update product status from BO (Back Office)
 
   Scenario: I update standard product status
     Given I add product "product1" with following information:
-      | name       | en-US:Values list poster nr. 1 (paper) |
-      | is_virtual | false                                  |
+      | name[en-US] | Values list poster nr. 1 (paper) |
+      | is_virtual  | false                            |
     And product product1 type should be standard
     And product "product1" should be disabled
     When I enable product "product1"
@@ -18,8 +18,8 @@ Feature: Update product status from BO (Back Office)
 
   Scenario: I update virtual product status
     And I add product "product2" with following information:
-      | name       | en-US:Values list poster nr. 2 (virtual) |
-      | is_virtual | true                                     |
+      | name[en-US] | Values list poster nr. 2 (virtual) |
+      | is_virtual  | true                               |
     And product product2 type should be virtual
     And product "product2" should be disabled
     When I enable product "product2"
@@ -29,8 +29,8 @@ Feature: Update product status from BO (Back Office)
 
   Scenario: I update combination product status
     And I add product "product3" with following information:
-      | name       | en-US:T-Shirt with listed values |
-      | is_virtual | false                            |
+      | name[en-US] | T-Shirt with listed values |
+      | is_virtual  | false                      |
     And product "product3" has following combinations:
       | reference | quantity | attributes         |
       | whiteS    | 100      | Size:S;Color:White |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock_advanced.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock_advanced.feature
@@ -16,8 +16,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I check default stock values
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | use_advanced_stock_management | false      |
       | depends_on_stock              | false      |
@@ -32,8 +32,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I check default stock values for virtual product
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | true                |
+      | name[en-US] | Presta camera |
+      | is_virtual  | true          |
     And product "product1" should have following stock information:
       | use_advanced_stock_management | false      |
       | depends_on_stock              | false      |
@@ -48,55 +48,55 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product stock management
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | use_advanced_stock_management | false       |
+      | use_advanced_stock_management | false |
     When I update product "product1" stock with following information:
-      | use_advanced_stock_management | true        |
+      | use_advanced_stock_management | true |
     Then product "product1" should have following stock information:
-      | use_advanced_stock_management | true        |
+      | use_advanced_stock_management | true |
 
   Scenario: I update product depends on stock (also check automatic update when disabling advanced stock on product)
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | use_advanced_stock_management | false       |
-      | depends_on_stock              | false       |
+      | use_advanced_stock_management | false |
+      | depends_on_stock              | false |
     When I update product "product1" stock with following information:
-      | depends_on_stock | true        |
+      | depends_on_stock | true |
     And I should get error that stock management is disabled on product
     When I update product "product1" stock with following information:
-      | use_advanced_stock_management | false       |
-      | depends_on_stock              | true        |
+      | use_advanced_stock_management | false |
+      | depends_on_stock              | true  |
     And I should get error that stock management is disabled on product
     When I update product "product1" stock with following information:
-      | use_advanced_stock_management | true        |
-      | depends_on_stock              | true        |
+      | use_advanced_stock_management | true |
+      | depends_on_stock              | true |
     Then product "product1" should have following stock information:
-      | use_advanced_stock_management | true        |
-      | depends_on_stock              | true        |
+      | use_advanced_stock_management | true |
+      | depends_on_stock              | true |
     When I update product "product1" stock with following information:
-      | use_advanced_stock_management | false       |
+      | use_advanced_stock_management | false |
     Then product "product1" should have following stock information:
-      | use_advanced_stock_management | false       |
-      | depends_on_stock              | false       |
+      | use_advanced_stock_management | false |
+      | depends_on_stock              | false |
     When I update product "product1" stock with following information:
-      | use_advanced_stock_management | true        |
-      | depends_on_stock              | false       |
+      | use_advanced_stock_management | true  |
+      | depends_on_stock              | false |
     Then product "product1" should have following stock information:
-      | use_advanced_stock_management | true        |
-      | depends_on_stock              | false       |
+      | use_advanced_stock_management | true  |
+      | depends_on_stock              | false |
 
   Scenario: I update pack stock type
     Given I add product "productPack1" with following information:
-      | name       | en-US: weird sunglasses box |
-      | is_virtual | false                       |
+      | name[en-US] | weird sunglasses box |
+      | is_virtual  | false                |
     And product "productPack1" type should be standard
     And I add product "product2" with following information:
-      | name       | en-US: shady sunglasses     |
-      | is_virtual | false                       |
+      | name[en-US] | weird sunglasses box |
+      | is_virtual  | false                |
     And product "product2" type should be standard
     When I update pack "productPack1" with following product quantities:
       | product  | quantity |
@@ -127,16 +127,16 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product pack stock type which depends on stock
     Given I add product "productPack1" with following information:
-      | name       | en-US: weird sunglasses box |
-      | is_virtual | false                       |
+      | name[en-US] | weird sunglasses box |
+      | is_virtual  | false                |
     And product "productPack1" type should be standard
     And I add product "product2" with following information:
-      | name       | en-US: shady sunglasses     |
-      | is_virtual | false                       |
+      | name[en-US] | shady sunglasses |
+      | is_virtual  | false            |
     And product "product2" type should be standard
     And I add product "product3" with following information:
-      | name       | en-US: unicorn boc case     |
-      | is_virtual | false                       |
+      | name[en-US] | unicorn boc case |
+      | is_virtual  | false            |
     And product "product3" type should be standard
     When I update pack "productPack1" with following product quantities:
       | product  | quantity |
@@ -146,63 +146,63 @@ Feature: Update product stock from Back Office (BO)
     # Can not depends on stock since default config depends on product
     Given shop configuration for "PS_PACK_STOCK_TYPE" is set to 1
     When I update product "productPack1" stock with following information:
-      | use_advanced_stock_management | true        |
-      | depends_on_stock              | true        |
+      | use_advanced_stock_management | true |
+      | depends_on_stock              | true |
     And I should get error that pack stock type is incompatible
     # Can not depends on stock since default config depends on both
     Given shop configuration for "PS_PACK_STOCK_TYPE" is set to 2
     When I update product "productPack1" stock with following information:
-      | use_advanced_stock_management | true        |
-      | depends_on_stock              | true        |
+      | use_advanced_stock_management | true |
+      | depends_on_stock              | true |
     And I should get error that pack stock type is incompatible
     # Let's ignore default configuration If it depends on pack stock only it is compatible with depends on stock
     When I update product "productPack1" stock with following information:
-      | use_advanced_stock_management | true                 |
-      | depends_on_stock              | true                 |
+      | use_advanced_stock_management | true      |
+      | depends_on_stock              | true      |
       | pack_stock_type               | pack_only |
     Then product "productPack1" should have following stock information:
-      | use_advanced_stock_management | true                 |
-      | depends_on_stock              | true                 |
+      | use_advanced_stock_management | true      |
+      | depends_on_stock              | true      |
       | pack_stock_type               | pack_only |
     # If pack depends on product or both it is still not possible
     When I update product "productPack1" stock with following information:
-      | pack_stock_type               | products_only |
+      | pack_stock_type | products_only |
     And I should get error that pack stock type is incompatible
     When I update product "productPack1" stock with following information:
-      | pack_stock_type               | both |
+      | pack_stock_type | both |
     And I should get error that pack stock type is incompatible
     # Unless all the pack's products have advanced stock management
     When I update product "product2" stock with following information:
-      | use_advanced_stock_management | true                 |
+      | use_advanced_stock_management | true |
     Then product "product2" should have following stock information:
-      | use_advanced_stock_management | true                 |
+      | use_advanced_stock_management | true |
     When I update product "productPack1" stock with following information:
-      | pack_stock_type               | products_only |
+      | pack_stock_type | products_only |
     And I should get error that pack stock type is incompatible
     # I said ALL of them
     When I update product "product3" stock with following information:
-      | use_advanced_stock_management | true                 |
+      | use_advanced_stock_management | true |
     Then product "product3" should have following stock information:
-      | use_advanced_stock_management | true                 |
+      | use_advanced_stock_management | true |
     When I update product "productPack1" stock with following information:
-      | pack_stock_type               | products_only |
+      | pack_stock_type | products_only |
     Then product "productPack1" should have following stock information:
       | pack_stock_type | products_only |
     # Of course stock type on both works as well
     When I update product "productPack1" stock with following information:
-      | pack_stock_type               | both |
+      | pack_stock_type | both |
     Then product "productPack1" should have following stock information:
       | pack_stock_type | both |
     # We can even switch back to default configuration
     When I update product "productPack1" stock with following information:
-      | pack_stock_type               | default |
+      | pack_stock_type | default |
     Then product "productPack1" should have following stock information:
       | pack_stock_type | default |
 
   Scenario: I update product out of stock
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | out_of_stock_type | default |
     When I update product "product1" stock with following information:
@@ -223,15 +223,15 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: Virtual product is available out of stock by default
     Given I add product "product1" with following information:
-      | name       | en-US:eBook |
-      | is_virtual | true        |
+      | name[en-US] | eBook |
+      | is_virtual  | true  |
     Then product "product1" should have following stock information:
       | out_of_stock_type | available |
 
   Scenario: I update product quantity
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | quantity | 0 |
     When I update product "product1" stock with following information:
@@ -247,10 +247,10 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product quantity specifying if movement must be added or not
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | quantity     | 0 |
+      | quantity | 0 |
     When I update product "product1" stock with following information:
       | quantity     | 51    |
       | add_movement | false |
@@ -265,56 +265,88 @@ Feature: Update product stock from Back Office (BO)
   Scenario: I update product simple stock fields
     Given language "french" with locale "fr-FR" exists
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | minimal_quantity       | 1          |
-      | location               |            |
-      | low_stock_threshold    | 0          |
-      | low_stock_alert        | false      |
-      | available_date         | 0000-00-00 |
-    And product "product1" localized "available_now_labels" should be "en-US:;fr-FR:"
-    And product "product1" localized "available_later_labels" should be "en-US:;fr-FR:"
+      | minimal_quantity    | 1          |
+      | location            |            |
+      | low_stock_threshold | 0          |
+      | low_stock_alert     | false      |
+      | available_date      | 0000-00-00 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
     When I update product "product1" stock with following information:
-      | minimal_quantity       | 12                 |
-      | location               | dtc                |
-      | low_stock_threshold    | 42                 |
-      | low_stock_alert        | true               |
-      | available_now_labels   | en-US:get it now   |
-      | available_later_labels | en-US:too late bro |
-      | available_date         | 1969-07-16         |
+      | minimal_quantity              | 12           |
+      | location                      | dtc          |
+      | low_stock_threshold           | 42           |
+      | low_stock_alert               | true         |
+      | available_now_labels[en-US]   | get it now   |
+      | available_later_labels[en-US] | too late bro |
+      | available_date                | 1969-07-16   |
     And product "product1" should have following stock information:
-      | minimal_quantity       | 12                 |
-      | location               | dtc                |
-      | low_stock_threshold    | 42                 |
-      | low_stock_alert        | true               |
-      | available_date         | 1969-07-16         |
-    And product "product1" localized "available_now_labels" should be "en-US:get it now;fr-FR:"
-    And product "product1" localized "available_later_labels" should be "en-US:too late bro;fr-FR:"
+      | minimal_quantity    | 12         |
+      | location            | dtc        |
+      | low_stock_threshold | 42         |
+      | low_stock_alert     | true       |
+      | available_date      | 1969-07-16 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
     When I update product "product1" stock with following information:
-      | available_now_labels   | en-US:get it now;fr-FR:   |
-      | available_later_labels | en-US:too late bro;fr-FR: |
-    Then product "product1" localized "available_now_labels" should be "en-US:get it now;fr-FR:"
-    And product "product1" localized "available_later_labels" should be "en-US:too late bro;fr-FR:"
+      | available_now_labels[en-US]   | get it now   |
+      | available_now_labels[fr-FR]   |              |
+      | available_later_labels[en-US] | too late bro |
+      | available_later_labels[fr-FR] |              |
+    Then product "product1" localized "available_now_labels" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
     When I update product "product1" stock with following information:
-      | available_now_labels   | en-US:get it now;fr-FR:commande maintenant |
-      | available_later_labels | en-US:too late bro;fr-FR:trop tard mec     |
-    Then product "product1" localized "available_now_labels" should be "en-US:get it now;fr-FR:commande maintenant"
-    And product "product1" localized "available_later_labels" should be "en-US:too late bro;fr-FR:trop tard mec"
+      | available_now_labels[en-US]   | get it now          |
+      | available_now_labels[fr-FR]   | commande maintenant |
+      | available_later_labels[en-US] | too late bro        |
+      | available_later_labels[fr-FR] | trop tard mec       |
+    Then product "product1" localized "available_now_labels" should be:
+      | locale | value               |
+      | en-US  | get it now          |
+      | fr-FR  | commande maintenant |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value         |
+      | en-US  | too late bro  |
+      | fr-FR  | trop tard mec |
 
   Scenario: When I use invalid values update is not authorized
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | quantity                      | 0          |
-      | minimal_quantity              | 1          |
-      | location                      |            |
-      | low_stock_threshold           | 0          |
-      | low_stock_alert               | false      |
-      | available_date                | 0000-00-00 |
-    And product "product1" localized "available_now_labels" should be "en-US:"
-    And product "product1" localized "available_later_labels" should be "en-US:"
+      | quantity            | 0          |
+      | minimal_quantity    | 1          |
+      | location            |            |
+      | low_stock_threshold | 0          |
+      | low_stock_alert     | false      |
+      | available_date      | 0000-00-00 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value |
+      | en-US  |       |
     When I update product "product1" stock with following information:
       | minimal_quantity | -1 |
     Then I should get error that product minimal_quantity is invalid
@@ -322,17 +354,21 @@ Feature: Update product stock from Back Office (BO)
       | location | ssf> |
     Then I should get error that product location is invalid
     When I update product "product1" stock with following information:
-      | available_now_labels | en-US:get it now <3 |
+      | available_now_labels[en-US] | get it now <3 |
     Then I should get error that product available_now_labels is invalid
     When I update product "product1" stock with following information:
-      | available_later_labels | en-US:too late bro<3 |
+      | available_later_labels[en-US] | too late bro<3 |
     Then I should get error that product available_later_labels is invalid
     And product "product1" should have following stock information:
-      | quantity                      | 0          |
-      | minimal_quantity              | 1          |
-      | location                      |            |
-      | low_stock_threshold           | 0          |
-      | low_stock_alert               | false      |
-      | available_date                | 0000-00-00 |
-    And product "product1" localized "available_now_labels" should be "en-US:"
-    And product "product1" localized "available_later_labels" should be "en-US:"
+      | quantity            | 0          |
+      | minimal_quantity    | 1          |
+      | location            |            |
+      | low_stock_threshold | 0          |
+      | low_stock_alert     | false      |
+      | available_date      | 0000-00-00 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value |
+      | en-US  |       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock_classic.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock_classic.feature
@@ -16,8 +16,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I check default stock values
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | use_advanced_stock_management | false      |
       | depends_on_stock              | false      |
@@ -32,8 +32,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I check default stock values for virtual product
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | true                |
+      | name[en-US] | Presta camera |
+      | is_virtual  | true          |
     And product "product1" should have following stock information:
       | use_advanced_stock_management | false      |
       | depends_on_stock              | false      |
@@ -48,8 +48,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product stock management
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | use_advanced_stock_management | false |
     When I update product "product1" stock with following information:
@@ -60,8 +60,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product depends on stock
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | depends_on_stock | false |
     When I update product "product1" stock with following information:
@@ -72,12 +72,12 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product pack stock type
     Given I add product "productPack1" with following information:
-      | name       | en-US: weird sunglasses box |
-      | is_virtual | false                       |
+      | name[en-US] | weird sunglasses box |
+      | is_virtual  | false                |
     And product "productPack1" type should be standard
     And I add product "product2" with following information:
-      | name       | en-US: shady sunglasses     |
-      | is_virtual | false                       |
+      | name[en-US] | shady sunglasses |
+      | is_virtual  | false            |
     And product "product2" type should be standard
     When I update pack "productPack1" with following product quantities:
       | product  | quantity |
@@ -108,8 +108,8 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product out of stock
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | out_of_stock_type | default |
     When I update product "product1" stock with following information:
@@ -130,15 +130,15 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: Virtual product is available out of stock by default
     Given I add product "product1" with following information:
-      | name       | en-US:eBook |
-      | is_virtual | true        |
+      | name[en-US] | eBook |
+      | is_virtual  | true  |
     Then product "product1" should have following stock information:
       | out_of_stock_type | available |
 
   Scenario: I update product quantity
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
       | quantity | 0 |
     When I update product "product1" stock with following information:
@@ -154,10 +154,10 @@ Feature: Update product stock from Back Office (BO)
 
   Scenario: I update product quantity specifying if movement must be added or not
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | quantity     | 0 |
+      | quantity | 0 |
     When I update product "product1" stock with following information:
       | quantity     | 51    |
       | add_movement | false |
@@ -172,56 +172,88 @@ Feature: Update product stock from Back Office (BO)
   Scenario: I update product simple stock fields
     Given language "french" with locale "fr-FR" exists
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | minimal_quantity       | 1          |
-      | location               |            |
-      | low_stock_threshold    | 0          |
-      | low_stock_alert        | false      |
-      | available_date         | 0000-00-00 |
-    And product "product1" localized "available_now_labels" should be "en-US:;fr-FR:"
-    And product "product1" localized "available_later_labels" should be "en-US:;fr-FR:"
+      | minimal_quantity    | 1          |
+      | location            |            |
+      | low_stock_threshold | 0          |
+      | low_stock_alert     | false      |
+      | available_date      | 0000-00-00 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
     When I update product "product1" stock with following information:
-      | minimal_quantity       | 12                 |
-      | location               | dtc                |
-      | low_stock_threshold    | 42                 |
-      | low_stock_alert        | true               |
-      | available_now_labels   | en-US:get it now   |
-      | available_later_labels | en-US:too late bro |
-      | available_date         | 1969-07-16         |
+      | minimal_quantity              | 12           |
+      | location                      | dtc          |
+      | low_stock_threshold           | 42           |
+      | low_stock_alert               | true         |
+      | available_now_labels[en-US]   | get it now   |
+      | available_later_labels[en-US] | too late bro |
+      | available_date                | 1969-07-16   |
     And product "product1" should have following stock information:
-      | minimal_quantity       | 12                 |
-      | location               | dtc                |
-      | low_stock_threshold    | 42                 |
-      | low_stock_alert        | true               |
-      | available_date         | 1969-07-16         |
-    And product "product1" localized "available_now_labels" should be "en-US:get it now;fr-FR:"
-    And product "product1" localized "available_later_labels" should be "en-US:too late bro;fr-FR:"
+      | minimal_quantity    | 12         |
+      | location            | dtc        |
+      | low_stock_threshold | 42         |
+      | low_stock_alert     | true       |
+      | available_date      | 1969-07-16 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
     When I update product "product1" stock with following information:
-      | available_now_labels   | en-US:get it now;fr-FR:   |
-      | available_later_labels | en-US:too late bro;fr-FR: |
-    Then product "product1" localized "available_now_labels" should be "en-US:get it now;fr-FR:"
-    And product "product1" localized "available_later_labels" should be "en-US:too late bro;fr-FR:"
+      | available_now_labels[en-US]   | get it now   |
+      | available_now_labels[fr-FR]   |              |
+      | available_later_labels[en-US] | too late bro |
+      | available_later_labels[fr-FR] |              |
+    Then product "product1" localized "available_now_labels" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
     When I update product "product1" stock with following information:
-      | available_now_labels   | en-US:get it now;fr-FR:commande maintenant |
-      | available_later_labels | en-US:too late bro;fr-FR:trop tard mec     |
-    Then product "product1" localized "available_now_labels" should be "en-US:get it now;fr-FR:commande maintenant"
-    And product "product1" localized "available_later_labels" should be "en-US:too late bro;fr-FR:trop tard mec"
+      | available_now_labels[en-US]   | get it now          |
+      | available_now_labels[fr-FR]   | commande maintenant |
+      | available_later_labels[en-US] | too late bro        |
+      | available_later_labels[fr-FR] | trop tard mec       |
+    Then product "product1" localized "available_now_labels" should be:
+      | locale | value               |
+      | en-US  | get it now          |
+      | fr-FR  | commande maintenant |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value         |
+      | en-US  | too late bro  |
+      | fr-FR  | trop tard mec |
 
   Scenario: When I use invalid values update is not authorized
     Given I add product "product1" with following information:
-      | name       | en-US:Presta camera |
-      | is_virtual | false               |
+      | name[en-US] | Presta camera |
+      | is_virtual  | false         |
     And product "product1" should have following stock information:
-      | quantity                      | 0          |
-      | minimal_quantity              | 1          |
-      | location                      |            |
-      | low_stock_threshold           | 0          |
-      | low_stock_alert               | false      |
-      | available_date                | 0000-00-00 |
-    And product "product1" localized "available_now_labels" should be "en-US:"
-    And product "product1" localized "available_later_labels" should be "en-US:"
+      | quantity            | 0          |
+      | minimal_quantity    | 1          |
+      | location            |            |
+      | low_stock_threshold | 0          |
+      | low_stock_alert     | false      |
+      | available_date      | 0000-00-00 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value |
+      | en-US  |       |
     When I update product "product1" stock with following information:
       | minimal_quantity | -1 |
     Then I should get error that product minimal_quantity is invalid
@@ -229,17 +261,21 @@ Feature: Update product stock from Back Office (BO)
       | location | ssf> |
     Then I should get error that product location is invalid
     When I update product "product1" stock with following information:
-      | available_now_labels | en-US:get it now <3 |
+      | available_now_labels[en-US] | get it now <3 |
     Then I should get error that product available_now_labels is invalid
     When I update product "product1" stock with following information:
-      | available_later_labels | en-US:too late bro<3 |
+      | available_later_labels[en-US] | too late bro<3 |
     Then I should get error that product available_later_labels is invalid
     And product "product1" should have following stock information:
-      | quantity                      | 0          |
-      | minimal_quantity              | 1          |
-      | location                      |            |
-      | low_stock_threshold           | 0          |
-      | low_stock_alert               | false      |
-      | available_date                | 0000-00-00 |
-    And product "product1" localized "available_now_labels" should be "en-US:"
-    And product "product1" localized "available_later_labels" should be "en-US:"
+      | quantity            | 0          |
+      | minimal_quantity    | 1          |
+      | location            |            |
+      | low_stock_threshold | 0          |
+      | low_stock_alert     | false      |
+      | available_date      | 0000-00-00 |
+    And product "product1" localized "available_now_labels" should be:
+      | locale | value |
+      | en-US  |       |
+    And product "product1" localized "available_later_labels" should be:
+      | locale | value |
+      | en-US  |       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -14,48 +14,48 @@ Feature: Update product suppliers from Back Office (BO)
 
   Scenario: Update standard product suppliers
     And I add new supplier supplier1 with following properties:
-      | name                 | my supplier 1                   |
-      | address              | Donelaicio st. 1                |
-      | city                 | Kaunas                          |
-      | country              | Lithuania                       |
-      | enabled              | true                            |
-      | description          | en-US:just a supplier           |
-      | meta title           | en-US:my supplier nr one        |
-      | meta description     | en-US:                          |
-      | meta keywords        | en-US:sup,1                     |
-      | shops                | [shop1]                         |
+      | name                    | my supplier 1      |
+      | address                 | Donelaicio st. 1   |
+      | city                    | Kaunas             |
+      | country                 | Lithuania          |
+      | enabled                 | true               |
+      | description[en-US]      | just a supplier    |
+      | meta title[en-US]       | my supplier nr one |
+      | meta description[en-US] |                    |
+      | meta keywords[en-US]    | sup,1              |
+      | shops                   | [shop1]            |
     And I add new supplier supplier2 with following properties:
-      | name                 | my supplier 2                   |
-      | address              | Donelaicio st. 2                |
-      | city                 | Kaunas                          |
-      | country              | Lithuania                       |
-      | enabled              | true                            |
-      | description          | en-US:just a supplier           |
-      | meta title           | en-US:my supplier nr two        |
-      | meta description     | en-US:                          |
-      | meta keywords        | en-US:sup,2                     |
-      | shops                | [shop1]                         |
+      | name                    | my supplier 2      |
+      | address                 | Donelaicio st. 2   |
+      | city                    | Kaunas             |
+      | country                 | Lithuania          |
+      | enabled                 | true               |
+      | description[en-US]      | just a supplier    |
+      | meta title[en-US]       | my supplier nr two |
+      | meta description[en-US] |                    |
+      | meta keywords[en-US]    | sup,2              |
+      | shops                   | [shop1]            |
     Given I add product "product1" with following information:
-      | name       | en-US:magic staff                         |
-      | is_virtual | false                                     |
+      | name[en-US] | magic staff |
+      | is_virtual  | false       |
     And product product1 type should be standard
     And product product1 should not have any suppliers assigned
     When I set product product1 default supplier to supplier1 and following suppliers:
-      | reference         | supplier reference    | product supplier reference     | currency      | price tax excluded |
-      | product1supplier1 | supplier1             | my first supplier for product1 | USD           | 10                 |
+      | reference         | supplier reference | product supplier reference     | currency | price tax excluded |
+      | product1supplier1 | supplier1          | my first supplier for product1 | USD      | 10                 |
     Then product product1 should have following suppliers:
-      | product supplier reference     | currency      | price tax excluded |
-      | my first supplier for product1 | USD           | 10                 |
+      | product supplier reference     | currency | price tax excluded |
+      | my first supplier for product1 | USD      | 10                 |
     And product product1 should have following supplier values:
-      | default supplier           | supplier1                      |
+      | default supplier | supplier1 |
     When I set product product1 default supplier to supplier2 and following suppliers:
-      | reference         | supplier reference    | product supplier reference      | currency      | price tax excluded |
-      | product1supplier1 | supplier1             | my first supplier for product1  | USD           | 10                 |
-      | product1supplier2 | supplier2             | my second supplier for product1 | EUR           | 11                 |
+      | reference         | supplier reference | product supplier reference      | currency | price tax excluded |
+      | product1supplier1 | supplier1          | my first supplier for product1  | USD      | 10                 |
+      | product1supplier2 | supplier2          | my second supplier for product1 | EUR      | 11                 |
     Then product product1 should have following suppliers:
-      | product supplier reference      | currency      | price tax excluded |
-      | my first supplier for product1  | USD           | 10                 |
-      | my second supplier for product1 | EUR           | 11                 |
+      | product supplier reference      | currency | price tax excluded |
+      | my first supplier for product1  | USD      | 10                 |
+      | my second supplier for product1 | EUR      | 11                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier2                       |
       | default supplier reference | my second supplier for product1 |
@@ -63,9 +63,9 @@ Feature: Update product suppliers from Back Office (BO)
   Scenario: Remove product suppliers
     Given product product1 type should be standard
     And product product1 should have following suppliers:
-      | product supplier reference      | currency      | price tax excluded |
-      | my first supplier for product1  | USD           | 10                 |
-      | my second supplier for product1 | EUR           | 11                 |
+      | product supplier reference      | currency | price tax excluded |
+      | my first supplier for product1  | USD      | 10                 |
+      | my second supplier for product1 | EUR      | 11                 |
     And product product1 should have following supplier values:
       | default supplier           | supplier2                       |
       | default supplier reference | my second supplier for product1 |
@@ -78,8 +78,8 @@ Feature: Update product suppliers from Back Office (BO)
     Given product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
     When I set product product1 default supplier to supplier2 and following suppliers:
-      | reference           | supplier reference    | product supplier reference      | currency      | price tax excluded |
-      | product1supplier1-1 | supplier1             | my first supplier for product1  | USD           | 10                 |
+      | reference           | supplier reference | product supplier reference     | currency | price tax excluded |
+      | product1supplier1-1 | supplier1          | my first supplier for product1 | USD      | 10                 |
     Then I should get error that supplier is not associated with product
     And product product1 should not have any suppliers assigned
     And product product1 should not have a default supplier
@@ -87,8 +87,8 @@ Feature: Update product suppliers from Back Office (BO)
 
   Scenario: Update combination product suppliers
     Given I add product "product2" with following information:
-      | name       | en-US:regular T-shirt        |
-      | is_virtual | false                        |
+      | name[en-US] | regular T-shirt |
+      | is_virtual  | false           |
     And product "product2" has following combinations:
       | reference | quantity | attributes         |
       | whiteM    | 15       | Size:M;Color:White |
@@ -97,11 +97,11 @@ Feature: Update product suppliers from Back Office (BO)
     And product product2 should not have any suppliers assigned
     And product product2 default supplier reference should be empty
     When I set product product2 default supplier to supplier1 and following suppliers:
-      | reference      | supplier reference    | product supplier reference        | currency      | price tax excluded | combination |
-      | product2whiteM | supplier1             | sup white shirt M 1               | USD           | 5                  | whiteM      |
-      | product2whiteL | supplier1             | sup white shirt L 2               | USD           | 3                  | whiteL      |
+      | reference      | supplier reference | product supplier reference | currency | price tax excluded | combination |
+      | product2whiteM | supplier1          | sup white shirt M 1        | USD      | 5                  | whiteM      |
+      | product2whiteL | supplier1          | sup white shirt L 2        | USD      | 3                  | whiteL      |
     Then product product2 should have following suppliers:
-      | product supplier reference        | currency      | price tax excluded | combination |
-      | sup white shirt M 1               | USD           | 5                  | whiteM      |
-      | sup white shirt L 2               | USD           | 3                  | whiteL      |
+      | product supplier reference | currency | price tax excluded | combination |
+      | sup white shirt M 1        | USD      | 5                  | whiteM      |
+      | sup white shirt L 2        | USD      | 3                  | whiteL      |
     Then product product2 default supplier reference should be empty

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -10,28 +10,58 @@ Feature: Update product tags from Back Office (BO)
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
     And I add product "product3" with following information:
-      | name       | en-US:Mechanical watch; fr-FR:montre mécanique |
-      | is_virtual | false                                          |
-    And product "product3" localized "name" should be "en-US:Mechanical watch; fr-FR:montre mécanique"
-    And product "product3" localized "tags" should be "en-US: ;fr-FR:"
+      | name[en-US] | Mechanical watch |
+      | name[fr-FR] | montre mécanique |
+      | is_virtual  | false            |
+    And product "product3" localized "name" should be:
+      | locale | value            |
+      | en-US  | Mechanical watch |
+      | fr-FR  | montre mécanique |
+    And product "product3" localized "tags" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
     When I update product "product3" tags with following values:
-      | tags       | en-US:mechanic,watch; fr-FR:montre,mécanique   |
-    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre,mécanique"
+      | tags[en-US] | mechanic,watch   |
+      | tags[fr-FR] | montre,mécanique |
+    And product "product3" localized "tags" should be:
+      | locale | value            |
+      | en-US  | mechanic,watch   |
+      | fr-FR  | montre,mécanique |
     When I update product "product3" tags with following values:
-      | tags       | en-US:mechanic,watch; fr-FR: |
-    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:"
+      | tags[en-US] | mechanic,watch |
+      | tags[fr-FR] |                |
+    And product "product3" localized "tags" should be:
+      | locale | value          |
+      | en-US  | mechanic,watch |
+      | fr-FR  |                |
     When I update product "product3" tags with following values:
-      | tags       | fr-FR:montre |
-    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
+      | tags[fr-FR] | montre |
+    And product "product3" localized "tags" should be:
+      | locale | value          |
+      | en-US  | mechanic,watch |
+      | fr-FR  | montre         |
 
   Scenario: Update product tags with invalid values
-    Given product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
+    Given product "product3" localized "tags" should be:
+      | locale | value          |
+      | en-US  | mechanic,watch |
+      | fr-FR  | montre         |
     When I update product "product3" tags with following values:
-      | tags       | en-US:#<{ |
+      | tags[en-US] | #<{ |
     Then I should get error that product tag is invalid
-    And product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
+    And product "product3" localized "tags" should be:
+      | locale | value          |
+      | en-US  | mechanic,watch |
+      | fr-FR  | montre         |
 
   Scenario: Remove all product tags
-    Given product "product3" localized "tags" should be "en-US:mechanic,watch; fr-FR:montre"
+    Given product "product3" localized "tags" should be:
+      | locale | value          |
+      | en-US  | mechanic,watch |
+      | fr-FR  | montre         |
     When I remove all product "product3" tags
-    Then product "product3" localized "tags" should be "en-US: ;fr-FR:"
+    And product "product3" localized "tags" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |

--- a/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
@@ -6,29 +6,30 @@ Feature: Supplier management
 
   Background:
     Given shop "shop1" with name "test_shop" exists
-    And language "language1" with locale "en-US" exists
+    And language "language1" with locale "fr-FR" exists
+    And language with iso code "en" is the default one
 
   Scenario: Adding new supplier
     When I add new supplier supplier1 with following properties:
-      | name                 | my supplier 1                   |
-      | address              | Donelaicio st. 1                |
-      | city                 | Kaunas                          |
-      | country              | Lithuania                       |
-      | enabled              | true                            |
-      | description          | en-US:just a supplier           |
-      | meta title           | en-US:my supplier nr one        |
-      | meta description     | en-US:                          |
-      | meta keywords        | en-US:sup,1                     |
-      | shops                | [shop1]                         |
+      | name             | my supplier 1                                        |
+      | address          | Donelaicio st. 1                                     |
+      | city             | Kaunas                                               |
+      | country          | Lithuania                                            |
+      | enabled          | true                                                 |
+      | description      | {"en-US":"just a supplier","fr-FR":"la supplier :D"} |
+      | meta title       | {"en-US":"my supplier nr one"}                       |
+      | meta description | {"en-US":""}                                         |
+      | meta keywords    | {"en-US":"sup,1"}                                    |
+      | shops            | [shop1]                                              |
     Then supplier supplier1 should have following properties:
-      | name                 | my supplier 1                   |
-      | address              | Donelaicio st. 1                |
-      | city                 | Kaunas                          |
-      | country              | Lithuania                       |
-      | enabled              | true                            |
-      | description          | en-US:just a supplier           |
-      | meta title           | en-US:my supplier nr one        |
-      | meta description     | en-US:                          |
-      | meta keywords        | en-US:sup,1                     |
-      | shops                | [shop1]                         |
+      | name             | my supplier 1                                        |
+      | address          | Donelaicio st. 1                                     |
+      | city             | Kaunas                                               |
+      | country          | Lithuania                                            |
+      | enabled          | true                                                 |
+      | description      | {"en-US":"just a supplier","fr-FR":"la supplier :D"} |
+      | meta title       | {"en-US":"my supplier nr one","fr-FR":""}            |
+      | meta description | {"en-US":"","fr-FR":""}                              |
+      | meta keywords    | {"en-US":"sup,1","fr-FR":""}                         |
+      | shops            | [shop1]                                              |
 #@todo: finish up create with optional params too, different cases + update and delete scenarios.

--- a/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
@@ -11,25 +11,30 @@ Feature: Supplier management
 
   Scenario: Adding new supplier
     When I add new supplier supplier1 with following properties:
-      | name             | my supplier 1                                        |
-      | address          | Donelaicio st. 1                                     |
-      | city             | Kaunas                                               |
-      | country          | Lithuania                                            |
-      | enabled          | true                                                 |
-      | description      | {"en-US":"just a supplier","fr-FR":"la supplier :D"} |
-      | meta title       | {"en-US":"my supplier nr one"}                       |
-      | meta description | {"en-US":""}                                         |
-      | meta keywords    | {"en-US":"sup,1"}                                    |
-      | shops            | [shop1]                                              |
+      | name                    | my supplier 1      |
+      | address                 | Donelaicio st. 1   |
+      | city                    | Kaunas             |
+      | country                 | Lithuania          |
+      | enabled                 | true               |
+      | description[en-US]      | just a supplier    |
+      | description[fr-FR]      | la supplier :D     |
+      | meta title[en-US]       | my supplier nr one |
+      | meta description[en-US] |                    |
+      | meta keywords[en-US]    | sup,1              |
+      | shops                   | [shop1]            |
     Then supplier supplier1 should have following properties:
-      | name             | my supplier 1                                        |
-      | address          | Donelaicio st. 1                                     |
-      | city             | Kaunas                                               |
-      | country          | Lithuania                                            |
-      | enabled          | true                                                 |
-      | description      | {"en-US":"just a supplier","fr-FR":"la supplier :D"} |
-      | meta title       | {"en-US":"my supplier nr one","fr-FR":""}            |
-      | meta description | {"en-US":"","fr-FR":""}                              |
-      | meta keywords    | {"en-US":"sup,1","fr-FR":""}                         |
-      | shops            | [shop1]                                              |
+      | name                    | my supplier 1      |
+      | address                 | Donelaicio st. 1   |
+      | city                    | Kaunas             |
+      | country                 | Lithuania          |
+      | enabled                 | true               |
+      | description[en-US]      | just a supplier    |
+      | description[fr-FR]      | la supplier :D     |
+      | meta title[en-US]       | my supplier nr one |
+      | meta title[fr-FR]       |                    |
+      | meta description[en-US] |                    |
+      | meta description[fr-FR] |                    |
+      | meta keywords[en-US]    | sup,1              |
+      | meta keywords[fr-FR]    |                    |
+      | shops                   | [shop1]            |
 #@todo: finish up create with optional params too, different cases + update and delete scenarios.

--- a/tests/Integration/Behaviour/Features/Transform/LocalizedArrayTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/LocalizedArrayTransformContext.php
@@ -64,7 +64,7 @@ class LocalizedArrayTransformContext implements Context
      */
     private function getIdByLocale(string $locale): int
     {
-        $id = Language::getIdByLocale($locale);
+        $id = (int) Language::getIdByLocale($locale, true);
 
         if (!$id) {
             throw new RuntimeException(sprintf('Language by locale "%s" does not exist', $locale));

--- a/tests/Integration/Behaviour/Features/Transform/StringToLocalizedArrayTransformContext.php
+++ b/tests/Integration/Behaviour/Features/Transform/StringToLocalizedArrayTransformContext.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Transform;
+
+use Behat\Behat\Context\Context;
+use Language;
+
+/**
+ * Contains methods to transform string array into localized array
+ */
+class StringToLocalizedArrayTransformContext implements Context
+{
+    /**
+     * @Transform /((\{[a-z]{2})-([A-Z]{2}:.*?\}))/
+     *
+     * @param string $string expected string e.g. {en-US:test;fr-FR:test2}
+     *
+     * @return array<int, string> [langId => value]
+     */
+    public function transformStringToLocalizedArray(string $string): array
+    {
+        $string = str_replace(['{', '}'], '', $string);
+        $arrayValues = array_map('trim', explode(';', $string));
+        $localizedArray = [];
+        foreach ($arrayValues as $arrayValue) {
+            $data = explode(':', $arrayValue);
+            $langKey = $data[0];
+            $langValue = $data[1];
+            if (ctype_digit($langKey)) {
+                $localizedArray[$langKey] = $langValue;
+            } else {
+                $localizedArray[(int) Language::getIdByLocale($langKey, true)] = $langValue;
+            }
+        }
+
+        return $localizedArray;
+    }
+}

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -247,3 +247,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductImageFeatureContext
                 - Tests\Integration\Behaviour\Features\Transform\StringToLocalizedArrayTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -246,5 +246,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
                 - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductImageFeatureContext
-                - Tests\Integration\Behaviour\Features\Transform\StringToLocalizedArrayTransformContext
                 - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -246,3 +246,4 @@ default:
                 - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
                 - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductImageFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToLocalizedArrayTransformContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | read bellow.
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | travis :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21993)
<!-- Reviewable:end -->
**Whats changed**
* New approach of filling localized fields using behat tables:
instead of `en-US:foo;fr-FR:bar` :no_entry_sign: 
```
| name[en-US] | foo |
| name[fr-FR] | bar |
```
:heavy_check_mark: 
It is more friendly because it is standard syntax also it removes some messy parsing of strings in context.
* New approach asserting localized field. Use table instead of same `en-US:foo;fr-FR:bar` :no_entry_sign: 
e.g. 
```
And product "produt1" localized "name" should be:
| locale  | value |
| en-US | foo     |
```
:heavy_check_mark: 
Added LocalizedArrayTransformContext which handles this table convesion to array 

