### PR TITLE
Remove or cancel all products

### DIFF
--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -426,9 +426,6 @@ class OrderAmountUpdater
                 $invoiceProducts[$orderProduct['id_order_invoice']][] = $orderProduct;
             }
         }
-        if (empty($invoiceProducts)) {
-            return;
-        }
 
         $invoiceCollection = $order->getInvoicesCollection();
         $firstInvoice = $invoiceCollection->getFirst();

--- a/src/Adapter/Order/Refund/OrderProductRemover.php
+++ b/src/Adapter/Order/Refund/OrderProductRemover.php
@@ -28,12 +28,10 @@ namespace PrestaShop\PrestaShop\Adapter\Order\Refund;
 
 use Cart;
 use CartRule;
-use Configuration;
 use Db;
 use Order;
 use OrderCartRule;
 use OrderDetail;
-use OrderHistory;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DeleteCustomizedProductFromOrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\DeleteProductFromOrderException;
 use Psr\Log\LoggerInterface;
@@ -182,21 +180,6 @@ class OrderProductRemover
     ) {
         if (!$orderDetail->delete()) {
             throw new DeleteProductFromOrderException('Could not delete order detail');
-        }
-        if (count($order->getProductsDetail()) == 0) {
-            $history = new OrderHistory();
-            $history->id_order = (int) $order->id;
-            $history->changeIdOrderState(Configuration::get('PS_OS_CANCELED'), $order);
-            if (!$history->addWithemail()) {
-                // email failure must not block order update process
-                $this->logger->warning(
-                    $this->translator->trans(
-                        'Order history email could not be sent, test your email configuration in the Advanced Parameters > E-mail section of your back office.',
-                        [],
-                        'Admin.Orderscustomers.Notification'
-                    )
-                );
-            }
         }
 
         $order->update();

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -723,6 +723,26 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then order :orderReference has :statusNb status(es) in history
+     *
+     * @param string $orderReference
+     * @param int $statusNb
+     *
+     * @throws RuntimeException
+     */
+    public function countOrderStatus(string $orderReference, int $statusNb)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        $actualStatusNb = count($orderForViewing->getHistory()->getStatuses());
+        if ($statusNb !== $actualStatusNb) {
+            throw new RuntimeException(sprintf('Incorrect number of statuses in history expected %d but got %d instead', $statusNb, $actualStatusNb));
+        }
+    }
+
+    /**
      * @When I update order :orderReference status to :status
      *
      * @param string $orderReference

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -99,6 +99,30 @@ Feature: Cancel Order Product from Back Office (BO)
     And order "bo_order_cancel_product" should contain 5 products "Mug The best is yet to come"
     And order "bo_order_cancel_product" should contain 3 products "Mug Today is a good day"
     And order "bo_order_cancel_product" should contain 2 products "Customizable mug"
+    When I generate invoice for "bo_order_cancel_product" order
+    Then order "bo_order_cancel_product" should have 1 invoices
+    And order "bo_order_cancel_product" should have following details:
+      | total_products           | 123.00 |
+      | total_products_wt        | 130.38 |
+      | total_discounts_tax_excl | 0.000  |
+      | total_discounts_tax_incl | 0.000  |
+      | total_paid_tax_excl      | 130.00 |
+      | total_paid_tax_incl      | 137.80 |
+      | total_paid               | 137.80 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    And the first invoice from order "bo_order_cancel_product" should have following details:
+      | total_products          | 123.00 |
+      | total_products_wt       | 130.38 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 130.00 |
+      | total_paid_tax_incl     | 137.80 |
+      | total_shipping_tax_excl | 7.0    |
+      | total_shipping_tax_incl | 7.42   |
+    Then order "bo_order_cancel_product" has status "Awaiting check payment"
+    And order "bo_order_cancel_product" has 1 status in history
     When I cancel the following products from order "bo_order_cancel_product":
       | product_name                | quantity |
       | Mug The best is yet to come | 5        |
@@ -109,6 +133,7 @@ Feature: Cancel Order Product from Back Office (BO)
     And order "bo_order_cancel_product" should contain 0 products "Mug Today is a good day"
     And order "bo_order_cancel_product" should contain 0 products "Customizable mug"
     And order "bo_order_cancel_product" has status "Canceled"
+    And order "bo_order_cancel_product" has 2 statuses in history
     And order "bo_order_cancel_product" should have following details:
       | total_products           | 0.0000 |
       | total_products_wt        | 0.0000 |
@@ -120,6 +145,15 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_paid_tax_incl      | 0.0000 |
       | total_paid               | 0.0000 |
       | total_paid_real          | 0.0    |
+    And the first invoice from order "bo_order_cancel_product" should have following details:
+      | total_products          | 0.000 |
+      | total_products_wt       | 0.000 |
+      | total_discount_tax_excl | 0.0   |
+      | total_discount_tax_incl | 0.0   |
+      | total_paid_tax_excl     | 0.000 |
+      | total_paid_tax_incl     | 0.000 |
+      | total_shipping_tax_excl | 0.000 |
+      | total_shipping_tax_incl | 0.000 |
 
   Scenario: Quantity is required
     Given I add order "bo_order_cancel_product" with the following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -546,3 +546,99 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: Delete all products from order
+    Given there is a product in the catalog named "Test Added Product" with a price of 15.0 and 100 items in stock
+    And order with reference "bo_order1" does not contain product "Test Added Product"
+    And the available stock for product "Test Added Product" should be 100
+    When I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Added Product |
+      | amount        | 2                  |
+      | price         | 15                 |
+    And I generate invoice for "bo_order1" order
+    Then order "bo_order1" should contain 2 products "Test Added Product"
+    And product "Test Added Product" in order "bo_order1" should have no specific price
+    And the available stock for product "Test Added Product" should be 98
+    And order "bo_order1" should have 4 products in total
+    And order "bo_order1" should have 1 invoice
+    And product "Test Added Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
+      | unit_price_tax_excl         | 15.00 |
+      | unit_price_tax_incl         | 15.90 |
+      | total_price_tax_excl        | 30.00 |
+      | total_price_tax_incl        | 31.80 |
+    And order "bo_order1" should have following details:
+      | total_products           | 53.80 |
+      | total_products_wt        | 57.03 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 60.80 |
+      | total_paid_tax_incl      | 64.45 |
+      | total_paid               | 64.45 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 53.80 |
+      | total_products_wt       | 57.03 |
+      | total_discount_tax_excl | 0.0   |
+      | total_discount_tax_incl | 0.0   |
+      | total_paid_tax_excl     | 60.80 |
+      | total_paid_tax_incl     | 64.45 |
+      | total_shipping_tax_excl | 7.0   |
+      | total_shipping_tax_incl | 7.42  |
+    Then order "bo_order1" has status "Awaiting bank wire payment"
+    And order "bo_order1" has 1 status in history
+    When I remove product "Test Added Product" from order "bo_order1"
+    And order "bo_order1" should contain 0 product "Test Added Product"
+    And cart of order "bo_order1" should contain 0 product "Test Added Product"
+    And order "bo_order1" should have following details:
+      | total_products           | 23.80 |
+      | total_products_wt        | 25.23 |
+      | total_discounts_tax_excl | 0.000 |
+      | total_discounts_tax_incl | 0.000 |
+      | total_paid_tax_excl      | 30.80 |
+      | total_paid_tax_incl      | 32.65 |
+      | total_paid               | 32.65 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 7.0   |
+      | total_shipping_tax_incl  | 7.42  |
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 23.80 |
+      | total_products_wt       | 25.23 |
+      | total_discount_tax_excl | 0.0   |
+      | total_discount_tax_incl | 0.0   |
+      | total_paid_tax_excl     | 30.80 |
+      | total_paid_tax_incl     | 32.65 |
+      | total_shipping_tax_excl | 7.0   |
+      | total_shipping_tax_incl | 7.42  |
+    When I remove product "Mug The best is yet to come" from order "bo_order1"
+    Then product "Test Added Product" in order "bo_order1" should have no specific price
+    And order "bo_order1" should have 0 products in total
+    And order "bo_order1" should contain 0 product "Mug The best is yet to come"
+    And cart of order "bo_order1" should contain 0 product "Mug The best is yet to come"
+    And the available stock for product "Test Added Product" should be 100
+    And order "bo_order1" should have following details:
+      | total_products           | 0.000 |
+      | total_products_wt        | 0.000 |
+      | total_discounts_tax_excl | 0.0   |
+      | total_discounts_tax_incl | 0.0   |
+      | total_paid_tax_excl      | 0.000 |
+      | total_paid_tax_incl      | 0.000 |
+      | total_paid               | 0.000 |
+      | total_paid_real          | 0.0   |
+      | total_shipping_tax_excl  | 0.000 |
+      | total_shipping_tax_incl  | 0.000 |
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 0.000 |
+      | total_products_wt       | 0.000 |
+      | total_discount_tax_excl | 0.0   |
+      | total_discount_tax_incl | 0.0   |
+      | total_paid_tax_excl     | 0.000 |
+      | total_paid_tax_incl     | 0.000 |
+      | total_shipping_tax_excl | 0.000 |
+      | total_shipping_tax_incl | 0.000 |
+    Then order "bo_order1" has status "Awaiting bank wire payment"
+    And order "bo_order1" has 1 status in history


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | In OrderAmountUpdater we need to update invoices even when they have no more products in order to reset their total to zero And in Cancel handler no need to update the order status to Canceled because it is already handled by OrderProductRemover
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21903 and Fixes #21991 and Fixes #22010 and Fixes #21902
| How to test?  | See issue details

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21994)
<!-- Reviewable:end -->
