### PR TITLE
Update logo name without shop name

### DIFF
--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -188,11 +188,8 @@ class LogoUploader
     private function getLogoName($logoPrefix, $fileExtension)
     {
         $shopId = $this->shop->id;
-        $shopName = $this->shop->name;
 
-        $logoName = Tools::link_rewrite($shopName)
-            . '-'
-            . $logoPrefix
+        $logoName = $logoPrefix
             . '-'
             . (int) Configuration::get('PS_IMG_UPDATE_TIME')
             . (int) $shopId . $fileExtension;
@@ -201,9 +198,7 @@ class LogoUploader
             || $shopId == 0
             || Shop::isFeatureActive() == false
         ) {
-            $logoName = Tools::link_rewrite($shopName)
-                . '-'
-                . $logoPrefix . '-' . (int) Configuration::get('PS_IMG_UPDATE_TIME') . $fileExtension;
+            $logoName = $logoPrefix . '-' . (int) Configuration::get('PS_IMG_UPDATE_TIME') . $fileExtension;
         }
 
         return $logoName;


### PR DESCRIPTION
Create logo name without shop name to avoid inconsistence between rel shop name without active multi store mode.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | **https://odysee.com/@mediacom87:4/bug-PrestaShop-1.7-sur-le-nom-de-la-boutique:c?r=AMGFozg92Jni7jGzwR1kcTHKuZhEE7eg**<br>My correction only removes the store name in the logo name to avoid inconsistent information between the actual store name and the logo name but it doesn't correct the inconsistency between the PS_SHOP_NAME variable in the ps_configuration table and the shop name variable in ps_shop.
| Type?         | bug fix
| Category?     | FO
| BC breaks?    |  no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #21917.
| How to test?  | upload a new logo.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21996)
<!-- Reviewable:end -->
