### PR TITLE
Bug fix with check usedKeys

### DIFF
--- a/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
+++ b/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
@@ -68,7 +68,7 @@ final class CategoryMenuThumbnailUploader implements ImageUploaderInterface
         foreach ($files as $file) {
             $matches = [];
 
-            if (preg_match('/^' . $categoryId . '-([0-9])?_thumb.jpg$/i', $file, $matches) === 1) {
+            if (preg_match('/^' . $categoryId . '-(\d)?_thumb.jpg$/i', $file, $matches) === 1) {
                 $usedKeys[] = (int) $matches[1];
             }
         }

--- a/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
+++ b/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
@@ -68,7 +68,7 @@ final class CategoryMenuThumbnailUploader implements ImageUploaderInterface
         foreach ($files as $file) {
             $matches = [];
 
-            if (preg_match('/^' . $categoryId . '-([0-9])?_thumb.jpg/i', $file, $matches) === 1) {
+            if (preg_match('/^' . $categoryId . '-([0-9])?_thumb.jpg$/i', $file, $matches) === 1) {
                 $usedKeys[] = (int) $matches[1];
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I use webp photo generation and stack next to jpeg file. That is, I always have two files on the server. xxxx.jpg and xxxx.jpg.webp. The second time I added the menu thumbnail to the category, I ran into such a problem that it started creating a file with index 1, although it should have created a file with index 0
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21999.
| How to test?  | Here https://github.com/PrestaShop/PrestaShop/issues/21999

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22000)
<!-- Reviewable:end -->
