### PR TITLE
Check if it is same order status when updating

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1698,6 +1698,10 @@ class OrderCore extends ObjectModel
         if (empty($id_order_state) || (int) $id_order_state === (int) $this->current_state) {
             return false;
         }
+        $current_order_state = $this->getCurrentOrderState();
+        if ($current_order_state->id == $id_order_state) {
+            return false;
+        }
         $history = new OrderHistory();
         $history->id_order = (int) $this->id;
         $history->id_employee = (int) $id_employee;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Added check if it is the same order status you are trying to update through Webservice.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22011 
| How to test?  | If you send a request to the order status update web service, it does not now create an OrderHistory instance if it is the same status you want to change to

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22006)
<!-- Reviewable:end -->
