### PR TITLE
Order zero ratio for order detail tax

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -392,10 +392,6 @@ class OrderDetailCore extends ObjectModel
             return false;
         }
 
-        if ($order->total_products <= 0) {
-            return true;
-        }
-
         $shipping_tax_amount = 0;
 
         foreach ($order->getCartRules() as $cart_rule) {
@@ -406,7 +402,8 @@ class OrderDetailCore extends ObjectModel
             }
         }
 
-        $ratio = $this->unit_price_tax_excl / $order->total_products;
+        $ratio = ($order->total_products > 0) ? ($this->unit_price_tax_excl / $order->total_products) : 1;
+
         $order_reduction_amount = ($order->total_discounts_tax_excl - $shipping_tax_amount) * $ratio;
         $discounted_price_tax_excl = $this->unit_price_tax_excl - $order_reduction_amount;
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -423,7 +423,6 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         }
     }
 
-
     /**
      * @Then order :orderReference should have :expectedCount cart rule(s)
      *


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Handle zero ratio for order detail tax. See details below
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22008
| How to test?  | See ticket

## Details

When an order is empty, property `$order->total_products` is zero.

When adding a product to empty order, we arrive there: https://github.com/PrestaShop/PrestaShop/blob/develop/classes/order/OrderDetail.php#L396
```
        if ($order->total_products <= 0) {
            return true;
        }
        ...

        $ratio = $this->unit_price_tax_excl / $order->total_products;
```

Unfortunately at this moment `order->total_products` is not yet updated so the code exists early, which prevents correct creation of `order_detail_tax`.

After thorough exploration of the logic with @jolelievre we think that this property is only used to compute the ratio below. Since the only usecase where `$order->total_products` is zero is "when we add a product to an empty order", it means the ratio in this case is 1 so in the PR I force the value to 1.

````
$ratio = ($order->total_products > 0) ? ($this->unit_price_tax_excl / $order->total_products) : 1;
```

**I also added a Behat test that, if run on `1.7.7.x` fails so the test validates that the bug is fixed**. QA exploratory tests should complete the validation of this Pull Request.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22018)
<!-- Reviewable:end -->
