### PR TITLE
Take shop id into account when getting a language list for an order

### DIFF
--- a/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
@@ -57,7 +57,7 @@ final class LanguageByIdChoiceProvider implements ConfigurableFormChoiceProvider
     public function getChoices(array $options = [])
     {
         $choices = [];
-        $shopId = !empty($options['shop_id']) ? $options['shop_id'] : false;
+        $shopId = !empty((int) $options['shop_id']) ? $options['shop_id'] : false;
 
         foreach ($this->languageDataProvider->getLanguages(true, $shopId) as $language) {
             $choices[$language['name']] = $language['id_lang'];

--- a/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
@@ -57,8 +57,7 @@ final class LanguageByIdChoiceProvider implements ConfigurableFormChoiceProvider
     public function getChoices(array $options = [])
     {
         $choices = [];
-        $shopId = !empty((int) $options['shop_id']) ? $options['shop_id'] : false;
-
+        $shopId = isset($options['shop_id']) && (int) $options['shop_id'] > 0 ? $options['shop_id'] : false;
         foreach ($this->languageDataProvider->getLanguages(true, $shopId) as $language) {
             $choices[$language['name']] = $language['id_lang'];
         }

--- a/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
@@ -40,11 +40,20 @@ final class LanguageByIdChoiceProvider implements FormChoiceProviderInterface
     private $languageDataProvider;
 
     /**
-     * @param LanguageDataProvider $languageDataProvider
+     * @var int
      */
-    public function __construct(LanguageDataProvider $languageDataProvider)
+    private $shopId;
+
+    /**
+     * LanguageByIdChoiceProvider constructor.
+     *
+     * @param LanguageDataProvider $languageDataProvider
+     * @param int $shopId
+     */
+    public function __construct(LanguageDataProvider $languageDataProvider, int $shopId)
     {
         $this->languageDataProvider = $languageDataProvider;
+        $this->shopId = $shopId;
     }
 
     /**
@@ -56,7 +65,7 @@ final class LanguageByIdChoiceProvider implements FormChoiceProviderInterface
     {
         $choices = [];
 
-        foreach ($this->languageDataProvider->getLanguages() as $language) {
+        foreach ($this->languageDataProvider->getLanguages(true, $this->shopId) as $language) {
             $choices[$language['name']] = $language['id_lang'];
         }
 

--- a/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
@@ -40,20 +40,13 @@ final class LanguageByIdChoiceProvider implements FormChoiceProviderInterface
     private $languageDataProvider;
 
     /**
-     * @var int
-     */
-    private $shopId;
-
-    /**
      * LanguageByIdChoiceProvider constructor.
      *
      * @param LanguageDataProvider $languageDataProvider
-     * @param int $shopId
      */
-    public function __construct(LanguageDataProvider $languageDataProvider, int $shopId)
+    public function __construct(LanguageDataProvider $languageDataProvider)
     {
         $this->languageDataProvider = $languageDataProvider;
-        $this->shopId = $shopId;
     }
 
     /**
@@ -65,7 +58,7 @@ final class LanguageByIdChoiceProvider implements FormChoiceProviderInterface
     {
         $choices = [];
 
-        foreach ($this->languageDataProvider->getLanguages(true, $this->shopId) as $language) {
+        foreach ($this->languageDataProvider->getLanguages(true) as $language) {
             $choices[$language['name']] = $language['id_lang'];
         }
 

--- a/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/LanguageByIdChoiceProvider.php
@@ -27,12 +27,12 @@
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 
 /**
  * Class LanguageByIdChoiceProvider provides active language choices with ID values.
  */
-final class LanguageByIdChoiceProvider implements FormChoiceProviderInterface
+final class LanguageByIdChoiceProvider implements ConfigurableFormChoiceProviderInterface
 {
     /**
      * @var LanguageDataProvider
@@ -54,11 +54,12 @@ final class LanguageByIdChoiceProvider implements FormChoiceProviderInterface
      *
      * @return array
      */
-    public function getChoices()
+    public function getChoices(array $options = [])
     {
         $choices = [];
+        $shopId = !empty($options['shop_id']) ? $options['shop_id'] : false;
 
-        foreach ($this->languageDataProvider->getLanguages(true) as $language) {
+        foreach ($this->languageDataProvider->getLanguages(true, $shopId) as $language) {
             $choices[$language['name']] = $language['id_lang'];
         }
 

--- a/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/EmailLogsDefinitionFactory.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
 
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
@@ -62,7 +62,7 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
     private $redirectionUrl;
 
     /**
-     * @var FormChoiceProviderInterface
+     * @var ConfigurableFormChoiceProviderInterface
      */
     private $languageChoiceProvider;
 
@@ -70,13 +70,13 @@ final class EmailLogsDefinitionFactory extends AbstractGridDefinitionFactory
      * @param HookDispatcherInterface $hookDispatcher
      * @param string $resetActionUrl
      * @param string $redirectionUrl
-     * @param FormChoiceProviderInterface $languageChoiceProvider
+     * @param ConfigurableFormChoiceProviderInterface $languageChoiceProvider
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
         $resetActionUrl,
         $redirectionUrl,
-        FormChoiceProviderInterface $languageChoiceProvider
+        ConfigurableFormChoiceProviderInterface $languageChoiceProvider
     ) {
         parent::__construct($hookDispatcher);
         $this->resetActionUrl = $resetActionUrl;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -232,7 +232,11 @@ class OrderController extends FrameworkBundleAdminController
         }
 
         $summaryForm = $this->createForm(CartSummaryType::class);
-        $languages = $this->get('prestashop.core.form.choice_provider.language_by_id')->getChoices();
+        $languages = $this->get('prestashop.core.form.choice_provider.language_by_id')->getChoices(
+            [
+                'shop_id' => $shopContextChecker->getContextShopID(),
+            ]
+        );
         $currencies = $this->get('prestashop.core.form.choice_provider.currency_by_id')->getChoices();
 
         $configuration = $this->get('prestashop.adapter.legacy.configuration');

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -6,7 +6,6 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
     arguments:
       - '@prestashop.adapter.data_provider.language'
-      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
 
   prestashop.core.form.choice_provider.all_languages:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -6,6 +6,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageByIdChoiceProvider'
     arguments:
       - '@prestashop.adapter.data_provider.language'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
 
   prestashop.core.form.choice_provider.all_languages:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\LanguageChoiceProvider'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | Current shop was not taken into account when getting the list of available languages
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21817
| How to test?  | See issue #21817 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22020)
<!-- Reviewable:end -->

**BC BREAK:**

`LanguageByIdChoiceProvider` 's interface was changed from `FormChoiceProviderInterface` to `ConfigurableFormChoiceProviderInterface`, as a consequence its `getOptions` method now takes an array of options as a parameter (default: empty array).