### PR TITLE
Save the newest Guest with updated datas

### DIFF
--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -214,7 +214,7 @@ class GuestCore extends ObjectModel
     {
         // Since the guests are merged, the guest id in the connections table must be changed too
         Db::getInstance()->update('connections', [
-           'id_guest' => (int) $idGuest,
+            'id_guest' => (int) $idGuest,
         ], 'id_guest = ' . (int) $this->id);
 
         // The current guest is removed from the database
@@ -226,6 +226,7 @@ class GuestCore extends ObjectModel
 
         // $this is now the old guest but filled with the most up to date values
         $this->force_id = true;
+
         return $this->add();
     }
 

--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -207,24 +207,26 @@ class GuestCore extends ObjectModel
      *
      * @param int $idGuest Guest ID
      * @param int $idCustomer Customer ID
+     *
+     * @return bool
      */
     public function mergeWithCustomer($idGuest, $idCustomer)
     {
         // Since the guests are merged, the guest id in the connections table must be changed too
-        Db::getInstance()->execute('
-		UPDATE `' . _DB_PREFIX_ . 'connections` c
-		SET c.`id_guest` = ' . (int) ($idGuest) . '
-		WHERE c.`id_guest` = ' . (int) ($this->id));
+        Db::getInstance()->update('connections', array(
+            'id_guest' => (int) $idGuest,
+        ), 'id_guest = ' . (int) $this->id);
 
         // The current guest is removed from the database
         $this->delete();
 
         // $this is still filled with values, so it's id is changed for the old guest
-        $this->id = (int) ($idGuest);
-        $this->id_customer = (int) ($idCustomer);
+        $this->id = (int) $idGuest;
+        $this->id_customer = (int) $idCustomer;
 
         // $this is now the old guest but filled with the most up to date values
-        $this->update();
+        $this->force_id = true;
+        return $this->add();
     }
 
     /**

--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -213,9 +213,9 @@ class GuestCore extends ObjectModel
     public function mergeWithCustomer($idGuest, $idCustomer)
     {
         // Since the guests are merged, the guest id in the connections table must be changed too
-        Db::getInstance()->update('connections', array(
-            'id_guest' => (int) $idGuest,
-        ), 'id_guest = ' . (int) $this->id);
+        Db::getInstance()->update('connections', [
+           'id_guest' => (int) $idGuest,
+        ], 'id_guest = ' . (int) $this->id);
 
         // The current guest is removed from the database
         $this->delete();

--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -217,6 +217,10 @@ class GuestCore extends ObjectModel
             'id_guest' => (int) $idGuest,
         ], 'id_guest = ' . (int) $this->id);
 
+        // The existing guest is removed from the database
+        $existingGuest = new Guest((int) $idGuest);
+        $existingGuest->delete();
+
         // The current guest is removed from the database
         $this->delete();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  |  Right now, with the module statsdata enable, while a guest authenticate, it's call this method. This method will firstly delete the row inside the guest table. After that, it's try to update the same row. Of course, it will never update anything as it's deleted before. The only solution is to add the ObjectModel, with the force_id set to true in order to keep the setted ID.
| Type?         | bug fix 
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Install the statsdata module. Have a guest and authentificate it. See that row inside the guest table is deleted. With this PR, it will be not.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22022)
<!-- Reviewable:end -->
