### PR TITLE
table import of products of specific prices rates 1.7.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
       env: EXTRA_DEPS=phpHigh  PRESTASHOP_TEST_TYPE=unit
 
 before_install:
+  - composer self-update --1
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_10.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :10 -ac -screen 0 1600x1200x16
   # Avoid Composer authentication issues
   - if [[ "$TRAVIS_REPO_SLUG" = PrestaShop/PrestaShop ]]; then cp travis-scripts/.composer-auth.json ~/.composer/auth.json; fi;

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -31,11 +31,11 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
-    const VERSION = '1.7.6.8';
+    const VERSION = '1.7.6.9';
     const MAJOR_VERSION_STRING = '1.7';
     const MAJOR_VERSION = 17;
     const MINOR_VERSION = 6;
-    const RELEASE_VERSION = 8;
+    const RELEASE_VERSION = 9;
 
     /**
      * @{inheritdoc}

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -58,7 +58,10 @@ class OrderControllerCore extends FrontController
     {
         parent::postProcess();
 
-        if (Tools::isSubmit('submitReorder') && $id_order = (int) Tools::getValue('id_order')) {
+        if (Tools::isSubmit('submitReorder')
+            && $this->context->customer->isLogged()
+            && $id_order = (int) Tools::getValue('id_order')
+        ) {
             $oldCart = new Cart(Order::getCartIdStatic($id_order, $this->context->customer->id));
             $duplication = $oldCart->duplicate();
             if (!$duplication || !Validate::isLoadedObject($duplication['cart'])) {

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -24,6 +24,13 @@ International Registered Trademark & Property of PrestaShop SA
 Release Notes for PrestaShop 1.7
 --------------------------------
 ####################################
+#   v1.7.6.9 - (2020-11-16)
+####################################
+- Core:
+  - Bug fix:
+    - #GHSA-frf2-c9q3-qg9m:  Improper Access Control with submitReorder function (by @PierreRambaud)
+
+####################################
 #   v1.7.6.8 - (2020-09-24)
 ####################################
 - Core:

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-define('_PS_INSTALL_VERSION_', '1.7.6.8');
+define('_PS_INSTALL_VERSION_', '1.7.6.9');
 
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 50600);
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '5.6');

--- a/install-dev/install_version.php
+++ b/install-dev/install_version.php
@@ -24,7 +24,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
-define('_PS_INSTALL_VERSION_', '1.7.6.7');
+define('_PS_INSTALL_VERSION_', '1.7.6.8');
 
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 50600);
 define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '5.6');


### PR DESCRIPTION
Good, you could implement in imports a field that is tax rates in specific prices, in this way you could fix the problem of when a country / state does not have taxes but the prices of the products have a specific price, apply the discount.

I have been looking and I think it is not very complicated, since there is a table of rates in specific prices and it is only in the import to put a field of rates 1 or 0

| Questions    
| Type?          new feature
| Category?       BO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22024)
<!-- Reviewable:end -->
