### PR TITLE
Remove duplicate id on product-list-bottom

### DIFF
--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -58,7 +58,7 @@
           {/block}
         </div>
 
-        <div id="js-product-list-bottom">
+        <div>
           {block name='product_list_bottom'}
             {include file='catalog/_partials/products-bottom.tpl' listing=$listing}
           {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Having 2 same ids on the same page is invalid
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20093.
| How to test?  | Go on category page, inspect code and search for js-product-list-bottom, it should have only one in the page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22027)
<!-- Reviewable:end -->
