### PR TITLE
Move the default page after the permission profile

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -191,11 +191,6 @@
           </div>
         {% endif %}
 
-        {{ ps.form_group_row(employeeForm.default_page, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}, {
-          'label': 'Default page'|trans,
-          'help': 'This page will be displayed just after login.'|trans({}, 'Admin.Advparameters.Help')
-        }) }}
-
         {{ ps.form_group_row(employeeForm.language, {}, {
           'label': 'Language'|trans({}, 'Admin.Global')
         }) }}
@@ -222,6 +217,11 @@
             }) }}
           {% endif %}
         {% endif %}
+
+        {{ ps.form_group_row(employeeForm.default_page, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}, {
+          'label': 'Default page'|trans,
+          'help': 'This page will be displayed just after login.'|trans({}, 'Admin.Advparameters.Help')
+        }) }}
 
         {% block employee_form_rest %}
           {{ form_rest(employeeForm) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Profiles can access pages that are selected in the ACL.On the employee page, when an employee wants to be created, first profile should be selected, then the default page should be selected according to the profile. In fact, the selection of the default page should be after selecting the profile.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22065
| How to test?  | Create/Edit employee in the admin BO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22034)
<!-- Reviewable:end -->
