### PR TITLE
Simplified team forms

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -38,6 +38,7 @@ import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field';
 import {EventEmitter} from '@components/event-emitter';
 import Grid from '@components/grid/grid';
+import ChangePasswordControl from '../../components/form/change-password-control';
 import Router from '@components/router';
 import ColorPicker from '@js/app/utils/colorpicker';
 
@@ -140,6 +141,7 @@ const initPrestashopComponents = () => {
     GridExtensions,
     Router,
     ColorPicker,
+    ChangePasswordControl,
     DeltaQuantityInput,
   };
 };

--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -38,7 +38,6 @@ import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field';
 import {EventEmitter} from '@components/event-emitter';
 import Grid from '@components/grid/grid';
-import ChangePasswordControl from '../../components/form/change-password-control';
 import Router from '@components/router';
 import ColorPicker from '@js/app/utils/colorpicker';
 import ChangePasswordControl from '@js/components/form/change-password-control';

--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -41,6 +41,7 @@ import Grid from '@components/grid/grid';
 import ChangePasswordControl from '../../components/form/change-password-control';
 import Router from '@components/router';
 import ColorPicker from '@js/app/utils/colorpicker';
+import ChangePasswordControl from '../../components/form/change-password-control';
 
 // Grid extensions
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';

--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -41,7 +41,7 @@ import Grid from '@components/grid/grid';
 import ChangePasswordControl from '../../components/form/change-password-control';
 import Router from '@components/router';
 import ColorPicker from '@js/app/utils/colorpicker';
-import ChangePasswordControl from '../../components/form/change-password-control';
+import ChangePasswordControl from '@js/components/form/change-password-control';
 
 // Grid extensions
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';

--- a/admin-dev/themes/new-theme/js/components/change-password-handler.ts
+++ b/admin-dev/themes/new-theme/js/components/change-password-handler.ts
@@ -115,7 +115,7 @@ export default class ChangePasswordHandler {
       case $.passy.strength.LOW:
         return {
           message: this.$feedbackContainer.find('.strength-low').text(),
-          elementClass: 'text-danger',
+          elementClass: 'text-warning',
         };
 
       case $.passy.strength.MEDIUM:

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -44,6 +44,7 @@ export default class EmployeeForm {
     this.shopChoiceTreeSelector = employeeFormMap.shopChoiceTree;
     this.shopChoiceTree = new ChoiceTree(this.shopChoiceTreeSelector);
     this.employeeProfileSelector = employeeFormMap.profileSelect;
+    this.multistoreAlert = employeeFormMap.multistoreAlert;
     this.tabsDropdownSelector = employeeFormMap.defaultPageSelect;
 
     this.shopChoiceTree.enableAutoCheckChildren();
@@ -142,12 +143,11 @@ export default class EmployeeForm {
   private toggleShopTree(): void {
     const $employeeProfileDropdown = $(this.employeeProfileSelector);
     const superAdminProfileId = $employeeProfileDropdown.data('admin-profile');
+    const isSuperAdminProfile = parseInt($employeeProfileDropdown.val()) === superAdminProfileId;
     $(this.shopChoiceTreeSelector)
       .closest('.form-group')
-      .toggleClass(
-        'd-none',
-        parseInt($employeeProfileDropdown.val()) === superAdminProfileId,
-      );
+      .toggleClass('d-none', isSuperAdminProfile);
+    $(this.multistoreAlert).toggleClass('d-none', !isSuperAdminProfile);
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -23,9 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+import ChoiceTree from '@components/form/choice-tree';
 import AddonsConnector from '../../components/addons-connector';
 import employeeFormMap from './employee-form-map';
-import ChoiceTree from "@components/form/choice-tree";
 
 /**
  * Class responsible for javascript actions in employee add/edit page.

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -24,7 +24,7 @@
  */
 
 import ChoiceTree from '@components/form/choice-tree';
-import AddonsConnector from '../../components/addons-connector';
+import AddonsConnector from '@components/addons-connector';
 import employeeFormMap from './employee-form-map';
 
 /**

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -25,6 +25,7 @@
 
 import AddonsConnector from '../../components/addons-connector';
 import employeeFormMap from './employee-form-map';
+import ChoiceTree from "@components/form/choice-tree";
 
 /**
  * Class responsible for javascript actions in employee add/edit page.
@@ -37,6 +38,8 @@ export default class EmployeeForm {
   employeeProfileSelector: string;
 
   tabsDropdownSelector: string;
+
+  multistoreAlert: string;
 
   constructor() {
     this.shopChoiceTreeSelector = employeeFormMap.shopChoiceTree;
@@ -141,7 +144,7 @@ export default class EmployeeForm {
   private toggleShopTree(): void {
     const $employeeProfileDropdown = $(this.employeeProfileSelector);
     const superAdminProfileId = $employeeProfileDropdown.data('admin-profile');
-    const isSuperAdminProfile = parseInt($employeeProfileDropdown.val(), 10) === superAdminProfileId;
+    const isSuperAdminProfile = parseInt(<string>$employeeProfileDropdown.val(), 10) === superAdminProfileId;
     $(this.shopChoiceTreeSelector)
       .closest('.form-group')
       .toggleClass('d-none', isSuperAdminProfile);

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -23,9 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import ChoiceTree from '../../components/form/choice-tree';
 import AddonsConnector from '../../components/addons-connector';
-import ChangePasswordControl from '../../components/form/change-password-control';
 import employeeFormMap from './employee-form-map';
 
 /**
@@ -42,7 +40,7 @@ export default class EmployeeForm {
 
   constructor() {
     this.shopChoiceTreeSelector = employeeFormMap.shopChoiceTree;
-    this.shopChoiceTree = new ChoiceTree(this.shopChoiceTreeSelector);
+    this.shopChoiceTree = new window.prestashop.component.ChoiceTree(this.shopChoiceTreeSelector);
     this.employeeProfileSelector = employeeFormMap.profileSelect;
     this.multistoreAlert = employeeFormMap.multistoreAlert;
     this.tabsDropdownSelector = employeeFormMap.defaultPageSelect;
@@ -54,7 +52,7 @@ export default class EmployeeForm {
       employeeFormMap.addonsLoginButton,
     );
 
-    new ChangePasswordControl(
+    new window.prestashop.component.ChangePasswordControl(
       employeeFormMap.changePasswordInputsBlock,
       employeeFormMap.showChangePasswordBlockButton,
       employeeFormMap.hideChangePasswordBlockButton,

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -143,7 +143,7 @@ export default class EmployeeForm {
   private toggleShopTree(): void {
     const $employeeProfileDropdown = $(this.employeeProfileSelector);
     const superAdminProfileId = $employeeProfileDropdown.data('admin-profile');
-    const isSuperAdminProfile = parseInt($employeeProfileDropdown.val()) === superAdminProfileId;
+    const isSuperAdminProfile = parseInt($employeeProfileDropdown.val(), 10) === superAdminProfileId;
     $(this.shopChoiceTreeSelector)
       .closest('.form-group')
       .toggleClass('d-none', isSuperAdminProfile);

--- a/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/EmployeeForm.ts
@@ -146,7 +146,7 @@ export default class EmployeeForm {
       .closest('.form-group')
       .toggleClass(
         'd-none',
-        $employeeProfileDropdown.val() === superAdminProfileId,
+        parseInt($employeeProfileDropdown.val()) === superAdminProfileId,
       );
   }
 

--- a/admin-dev/themes/new-theme/js/pages/employee/employee-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/employee/employee-form-map.ts
@@ -32,6 +32,7 @@ export default {
   defaultPageSelect: '#employee_default_page',
   addonsConnectForm: '#addons-connect-form',
   addonsLoginButton: '#addons_login_btn',
+  multistoreAlert: '#multistore-alert',
 
   // selectors related to "change password" form control
   changePasswordInputsBlock: '.js-change-password-block',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -42,6 +42,7 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidEmployeeIdExcept
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\MissingShopAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
@@ -300,6 +301,7 @@ class EmployeeController extends FrameworkBundleAdminController
         $templateVars = [
             'employeeForm' => $employeeForm->createView(),
             'enableSidebar' => true,
+            'passwordMinLength' => Password::MIN_LENGTH,
         ];
 
         return $this->render(
@@ -383,6 +385,7 @@ class EmployeeController extends FrameworkBundleAdminController
         }
 
         $templateVars = [
+            'passwordMinLength' => Password::MIN_LENGTH,
             'employeeForm' => $employeeForm->createView(),
             'isRestrictedAccess' => $isRestrictedAccess,
             'editableEmployee' => $editableEmployee,

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -50,6 +50,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use PrestaShopBundle\Security\Voter\PageVoter;
@@ -496,8 +497,9 @@ class EmployeeController extends FrameworkBundleAdminController
                     [$iniConfig->getUploadMaxSizeInBytes()]
                 ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
-                    'Image format not recognized, allowed formats are: .gif, .jpg, .png',
-                    'Admin.Notifications.Error'
+                    'Image format not recognized, allowed formats are: %s',
+                    'Admin.Notifications.Error',
+                    [EmployeeType::AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION]
                 ),
             ],
             AdminEmployeeException::class => [

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -499,7 +499,7 @@ class EmployeeController extends FrameworkBundleAdminController
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
                     'Image format not recognized, allowed formats are: %s',
                     'Admin.Notifications.Error',
-                    [EmployeeType::AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION]
+                    [implode(', ', EmployeeType::AVAILABLE_IMAGE_FORMATS)]
                 ),
             ],
             AdminEmployeeException::class => [

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -489,9 +489,9 @@ class EmployeeController extends FrameworkBundleAdminController
             ),
             UploadedImageConstraintException::class => [
                 UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
-                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error', [
-                    $iniConfig->getUploadMaxSizeInBytes(),
-                ]),
+                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error',
+                    [$iniConfig->getUploadMaxSizeInBytes()]
+                ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
                     'Image format not recognized, allowed formats are: .gif, .jpg, .png',
                     'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -475,6 +476,8 @@ class EmployeeController extends FrameworkBundleAdminController
      */
     protected function getErrorMessages(Exception $e)
     {
+        $iniConfig = $this->get('prestashop.core.configuration.ini_configuration');
+
         return [
             InvalidEmployeeIdException::class => $this->trans(
                 'The object cannot be loaded (the identifier is missing or invalid)',
@@ -484,6 +487,16 @@ class EmployeeController extends FrameworkBundleAdminController
                 'The object cannot be loaded (or found)',
                 'Admin.Notifications.Error'
             ),
+            UploadedImageConstraintException::class => [
+                UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
+                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error', [
+                    $iniConfig->getUploadMaxSizeInBytes(),
+                ]),
+                UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
+                    'Image format not recognized, allowed formats are: .gif, .jpg, .png',
+                    'Admin.Notifications.Error'
+                ),
+            ],
             AdminEmployeeException::class => [
                 AdminEmployeeException::CANNOT_CHANGE_LAST_ADMIN => $this->trans(
                     'You cannot disable or delete the administrator account.',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -492,7 +492,7 @@ class EmployeeController extends FrameworkBundleAdminController
             ),
             UploadedImageConstraintException::class => [
                 UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
-                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error',
+                    'Max file size allowed is "%d" bytes.', 'Admin.Notifications.Error',
                     [$iniConfig->getUploadMaxSizeInBytes()]
                 ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileNotFoundException
 use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProfileFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -285,7 +286,19 @@ class ProfileController extends FrameworkBundleAdminController
      */
     protected function getErrorMessages()
     {
+        $iniConfig = $this->get('prestashop.core.configuration.ini_configuration');
+
         return [
+            UploadedImageConstraintException::class => [
+                UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
+                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error', [
+                    $iniConfig->getUploadMaxSizeInBytes(),
+                ]),
+                UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
+                    'Image format not recognized, allowed formats are: .gif, .jpg, .png',
+                    'Admin.Notifications.Error'
+                ),
+            ],
             ProfileConstraintException::class => [
                 ProfileConstraintException::INVALID_NAME => $this->trans(
                     'This field cannot be longer than %limit% characters (incl. HTML tags)',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -291,9 +291,9 @@ class ProfileController extends FrameworkBundleAdminController
         return [
             UploadedImageConstraintException::class => [
                 UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
-                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error', [
-                    $iniConfig->getUploadMaxSizeInBytes(),
-                ]),
+                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error',
+                    [$iniConfig->getUploadMaxSizeInBytes()]
+                ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
                     'Image format not recognized, allowed formats are: .gif, .jpg, .png',
                     'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProfileFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -295,8 +296,9 @@ class ProfileController extends FrameworkBundleAdminController
                     [$iniConfig->getUploadMaxSizeInBytes()]
                 ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
-                    'Image format not recognized, allowed formats are: .gif, .jpg, .png',
-                    'Admin.Notifications.Error'
+                    'Image format not recognized, allowed formats are: %s',
+                    'Admin.Notifications.Error',
+                    [ProfileType::AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION]
                 ),
             ],
             ProfileConstraintException::class => [

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -291,7 +291,7 @@ class ProfileController extends FrameworkBundleAdminController
         return [
             UploadedImageConstraintException::class => [
                 UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
-                    'Max file size allowed is "%s" bytes.', 'Admin.Notifications.Error',
+                    'Max file size allowed is "%d" bytes.', 'Admin.Notifications.Error',
                     [$iniConfig->getUploadMaxSizeInBytes()]
                 ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -64,11 +64,15 @@ class EmployeeOptionsType extends TranslatorAwareType
     {
         $builder
             ->add('password_change_time', TextWithUnitType::class, [
+                'label' => $this->trans('Password regeneration', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('Security: Minimum time to wait between two password changes.', 'Admin.Advparameters.Feature'),
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
                 'disabled' => !$this->canOptionsBeChanged,
             ])
             ->add('allow_employee_specific_language', SwitchType::class, [
+                'label' => $this->trans('Memorize the language used in Admin panel forms', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('Allow employees to select a specific language for the Admin panel form.', 'Admin.Advparameters.Feature'),
                 'required' => false,
                 'disabled' => !$this->canOptionsBeChanged,
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -54,6 +54,16 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 final class EmployeeType extends TranslatorAwareType
 {
+    public const AVAILABLE_IMAGE_FORMATS = [
+        'gif',
+        'jpg',
+        'jpeg',
+        'jpe',
+        'png'
+    ];
+
+    public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png';
+
     /**
      * @var array
      */
@@ -153,7 +163,7 @@ final class EmployeeType extends TranslatorAwareType
                 'label' => $this->trans('Avatar', 'Admin.Global'),
                 'required' => false,
                 'attr' => [
-                    'accept' => 'gif,jpg,jpeg,jpe,png',
+                    'accept' => static::AVAILABLE_IMAGE_FORMATS,
                 ],
             ])
             ->add('has_enabled_gravatar', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -248,15 +248,16 @@ final class EmployeeType extends TranslatorAwareType
                     ]
                 )
             ;
+            if ($this->isMultistoreFeatureActive) {
+                $builder->add('shop_association', ShopChoiceTreeType::class, [
+                    'label' => $this->trans('Shop association', 'Admin.Global'),
+                    'help' => $this->trans('Select the shops the employee is allowed to access.', 'Admin.Advparameters.Help'),
+                    'required' => false,
+                ]);
+            }
+
         }
 
-        if ($this->isMultistoreFeatureActive) {
-            $builder->add('shop_association', ShopChoiceTreeType::class, [
-                'label' => $this->trans('Shop association', 'Admin.Global'),
-                'help' => $this->trans('Select the shops the employee is allowed to access.', 'Admin.Advparameters.Help'),
-                'required' => false,
-            ]);
-        }
 
         $builder
             ->add('default_page', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -54,8 +54,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 final class EmployeeType extends TranslatorAwareType
 {
-    private const PASSWORD_MIN_CHARACTER_AMOUNT = 8;
-
     /**
      * @var array
      */
@@ -211,7 +209,7 @@ final class EmployeeType extends TranslatorAwareType
                 'help' => $this->trans(
                     'Password should be at least %num% characters long.',
                     'Admin.Advparameters.Help',
-                    ['%num%' => self::PASSWORD_MIN_CHARACTER_AMOUNT]
+                    ['%num%' => Password::MIN_LENGTH]
                 ),
                 'constraints' => [
                     $this->getLengthConstraint(Password::MAX_LENGTH, Password::MIN_LENGTH),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -222,15 +222,6 @@ final class EmployeeType extends TranslatorAwareType
                 'label' => $this->trans('Language', 'Admin.Global'),
                 'choices' => $this->languagesChoices,
             ])
-            ->add('default_page', ChoiceType::class, [
-                'choices' => $this->tabChoices,
-                'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
-                'row_attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => '2',
-                ],
-            ])
         ;
 
         if (!$options['is_restricted_access']) {
@@ -257,7 +248,6 @@ final class EmployeeType extends TranslatorAwareType
                     ]
                 )
             ;
-
             if ($this->isMultistoreFeatureActive) {
                 $builder->add('shop_association', ShopChoiceTreeType::class, [
                     'label' => $this->trans('Shop association', 'Admin.Global'),
@@ -267,6 +257,18 @@ final class EmployeeType extends TranslatorAwareType
             }
 
         }
+
+        $builder
+            ->add('default_page', ChoiceType::class, [
+                'choices' => $this->tabChoices,
+                'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
+                'row_attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => '2',
+                ],
+            ])
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -262,7 +262,7 @@ final class EmployeeType extends TranslatorAwareType
                 'choices' => $this->tabChoices,
                 'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
-                'row_attr' => [
+                'attr' => [
                     'data-minimumResultsForSearch' => '7',
                     'data-toggle' => '2',
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -65,8 +65,6 @@ final class EmployeeType extends TranslatorAwareType
         'webp',
     ];
 
-    public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png, webp';
-
     /**
      * @var array
      */

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -264,7 +264,7 @@ final class EmployeeType extends TranslatorAwareType
                 'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
                 'attr' => [
                     'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => '2',
+                    'data-toggle' => 'select2',
                 ],
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -160,7 +160,7 @@ final class EmployeeType extends TranslatorAwareType
             ])
             ->add('has_enabled_gravatar', SwitchType::class, [
                 'required' => false,
-                'label' => $this->trans('Enable gravatar', 'Admin.Global'),
+                'label' => $this->trans('Enable gravatar', 'Admin.Advparameters.Feature'),
             ])
             ->add('email', EmailType::class, [
                 'label' => $this->trans('Email address', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -222,6 +222,15 @@ final class EmployeeType extends TranslatorAwareType
                 'label' => $this->trans('Language', 'Admin.Global'),
                 'choices' => $this->languagesChoices,
             ])
+            ->add('default_page', ChoiceType::class, [
+                'choices' => $this->tabChoices,
+                'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
+                'row_attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => '2',
+                ],
+            ])
         ;
 
         if (!$options['is_restricted_access']) {
@@ -248,6 +257,7 @@ final class EmployeeType extends TranslatorAwareType
                     ]
                 )
             ;
+
             if ($this->isMultistoreFeatureActive) {
                 $builder->add('shop_association', ShopChoiceTreeType::class, [
                     'label' => $this->trans('Shop association', 'Admin.Global'),
@@ -257,19 +267,6 @@ final class EmployeeType extends TranslatorAwareType
             }
 
         }
-
-
-        $builder
-            ->add('default_page', ChoiceType::class, [
-                'choices' => $this->tabChoices,
-                'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
-                'row_attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => '2',
-                ],
-            ])
-        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -168,7 +168,7 @@ final class EmployeeType extends TranslatorAwareType
             ])
             ->add('has_enabled_gravatar', SwitchType::class, [
                 'required' => false,
-                'label' => $this->trans('Enable gravatar', 'Admin.Advparameters.Feature'),
+                'label' => $this->trans('Enable gravatar', 'Admin.Global'),
             ])
             ->add('email', EmailType::class, [
                 'label' => $this->trans('Email address', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -59,7 +59,7 @@ final class EmployeeType extends TranslatorAwareType
         'jpg',
         'jpeg',
         'jpe',
-        'png'
+        'png',
     ];
 
     public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png';

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -106,7 +106,7 @@ final class EmployeeType extends TranslatorAwareType
      * @param string $defaultAvatarUrl
      * @param bool $isAddonsConnected
      * @param int $superAdminProfileId
-     * @param \Symfony\Bundle\FrameworkBundle\Routing\Router $router
+     * @param Router $router
      */
     public function __construct(
         TranslatorInterface $translator,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -176,7 +176,7 @@ final class EmployeeType extends TranslatorAwareType
 
         if ($options['is_restricted_access']) {
             $builder->add('change_password', ChangePasswordType::class, [
-                'label' => $this->trans('Change password...', 'messages'),
+                'label' => $this->trans('Change password...', 'Admin.Actions'),
                 'row_attr' => [
                     'class' => 'btn-outline-secondary js-change-password',
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -168,7 +168,7 @@ final class EmployeeType extends TranslatorAwareType
                     $this->getNotBlankConstraint(),
                     $this->getLengthConstraint(EmployeeEmail::MAX_LENGTH),
                     new Email([
-                        'message' => $this->trans('This field is invalid', 'Admin.Notifications.Error'),
+                        'message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -90,11 +90,6 @@ final class EmployeeType extends TranslatorAwareType
     private $defaultAvatarUrl;
 
     /**
-     * @var bool
-     */
-    private $isAddonsConnected;
-
-    /**
      * @var int
      */
     private $superAdminProfileId;
@@ -112,7 +107,6 @@ final class EmployeeType extends TranslatorAwareType
      * @param array $profilesChoices
      * @param bool $isMultistoreFeatureActive
      * @param string $defaultAvatarUrl
-     * @param bool $isAddonsConnected
      * @param int $superAdminProfileId
      * @param Router $router
      */
@@ -124,7 +118,6 @@ final class EmployeeType extends TranslatorAwareType
         array $profilesChoices,
         bool $isMultistoreFeatureActive,
         string $defaultAvatarUrl,
-        bool $isAddonsConnected,
         int $superAdminProfileId,
         Router $router
     ) {
@@ -134,7 +127,6 @@ final class EmployeeType extends TranslatorAwareType
         $this->profilesChoices = $profilesChoices;
         $this->isMultistoreFeatureActive = $isMultistoreFeatureActive;
         $this->defaultAvatarUrl = $defaultAvatarUrl;
-        $this->isAddonsConnected = $isAddonsConnected;
         $this->superAdminProfileId = $superAdminProfileId;
         $this->router = $router;
     }
@@ -190,27 +182,6 @@ final class EmployeeType extends TranslatorAwareType
                 ],
             ]);
 
-            if ($options['show_addons_connect_button']) {
-                if ($this->isAddonsConnected) {
-                    $label = $this->trans('Sign out from PrestaShop Addons', 'Admin.Advparameters.Feature');
-                    $target = '#module-modal-addons-logout';
-                } else {
-                    $label = $this->trans('Sign in', 'Admin.Advparameters.Feature');
-                    $target = '#module-modal-addons-connect';
-                }
-                $builder->add(
-                    'prestashop_addons',
-                    AddonsConnectType::class,
-                    [
-                        'label' => $label,
-                        'attr' => [
-                            'class' => 'btn-outline-secondary',
-                            'data-toggle' => 'modal',
-                            'data-target' => $target,
-                        ],
-                    ]
-                );
-            }
             $builder->add('change_password', ChangePasswordType::class);
         } else {
             $builder->add('password', PasswordType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -54,15 +54,18 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 final class EmployeeType extends TranslatorAwareType
 {
+    public const MINIMUM_SEARCH_RESULTS = 7;
+
     public const AVAILABLE_IMAGE_FORMATS = [
         'gif',
         'jpg',
         'jpeg',
         'jpe',
         'png',
+        'webp',
     ];
 
-    public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png';
+    public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png, webp';
 
     /**
      * @var array
@@ -244,7 +247,7 @@ final class EmployeeType extends TranslatorAwareType
                 'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
                 'attr' => [
-                    'data-minimumResultsForSearch' => '7',
+                    'data-minimumResultsForSearch' => (string) self::MINIMUM_SEARCH_RESULTS,
                     'data-toggle' => 'select2',
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -241,7 +241,7 @@ final class EmployeeType extends TranslatorAwareType
                     [
                         'choices' => $this->profilesChoices,
                         'label' => $this->trans('Permission profile', 'Admin.Advparameters.Feature'),
-                        'row_attr' => [
+                        'attr' => [
                             'data-admin-profile' => $this->superAdminProfileId,
                             'data-get-tabs-url' => $this->router->generate('admin_employees_get_tabs'),
                         ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -255,7 +255,6 @@ final class EmployeeType extends TranslatorAwareType
                     'required' => false,
                 ]);
             }
-
         }
 
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -220,15 +220,6 @@ final class EmployeeType extends TranslatorAwareType
         }
 
         $builder
-            ->add('default_page', ChoiceType::class, [
-                'choices' => $this->tabChoices,
-                'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
-                'row_attr' => [
-                    'data-minimumResultsForSearch' => '7',
-                    'data-toggle' => '2',
-                ],
-            ])
             ->add('language', ChoiceType::class, [
                 'label' => $this->trans('Language', 'Admin.Global'),
                 'choices' => $this->languagesChoices,
@@ -267,6 +258,18 @@ final class EmployeeType extends TranslatorAwareType
                     'required' => false,
                 ]);
             }
+
+            $builder
+                ->add('default_page', ChoiceType::class, [
+                    'choices' => $this->tabChoices,
+                    'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
+                    'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
+                    'row_attr' => [
+                        'data-minimumResultsForSearch' => '7',
+                        'data-toggle' => '2',
+                    ],
+                ])
+            ;
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -248,27 +248,27 @@ final class EmployeeType extends TranslatorAwareType
                     ]
                 )
             ;
-
-            if ($this->isMultistoreFeatureActive) {
-                $builder->add('shop_association', ShopChoiceTreeType::class, [
-                    'label' => $this->trans('Shop association', 'Admin.Global'),
-                    'help' => $this->trans('Select the shops the employee is allowed to access.', 'Admin.Advparameters.Help'),
-                    'required' => false,
-                ]);
-            }
-
-            $builder
-                ->add('default_page', ChoiceType::class, [
-                    'choices' => $this->tabChoices,
-                    'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
-                    'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
-                    'row_attr' => [
-                        'data-minimumResultsForSearch' => '7',
-                        'data-toggle' => '2',
-                    ],
-                ])
-            ;
         }
+
+        if ($this->isMultistoreFeatureActive) {
+            $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global'),
+                'help' => $this->trans('Select the shops the employee is allowed to access.', 'Admin.Advparameters.Help'),
+                'required' => false,
+            ]);
+        }
+
+        $builder
+            ->add('default_page', ChoiceType::class, [
+                'choices' => $this->tabChoices,
+                'label' => $this->trans('Default page', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('This page will be displayed just after login.', 'Admin.Advparameters.Help'),
+                'row_attr' => [
+                    'data-minimumResultsForSearch' => '7',
+                    'data-toggle' => '2',
+                ],
+            ])
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -35,6 +35,7 @@ use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -43,7 +44,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
@@ -175,6 +175,34 @@ final class EmployeeType extends TranslatorAwareType
         ;
 
         if ($options['is_restricted_access']) {
+            $builder->add('change_password', ChangePasswordType::class, [
+                'label' => $this->trans('Change password...', 'messages'),
+                'row_attr' => [
+                    'class' => 'btn-outline-secondary js-change-password',
+                ],
+            ]);
+
+            if ($options['show_addons_connect_button']) {
+                if ($this->isAddonsConnected) {
+                    $label = $this->trans('Sign out from PrestaShop Addons', 'Admin.Advparameters.Feature');
+                    $target = '#module-modal-addons-logout';
+                } else {
+                    $label = $this->trans('Sign in', 'Admin.Advparameters.Feature');
+                    $target = '#module-modal-addons-connect';
+                }
+                $builder->add(
+                    'prestashop_addons',
+                    AddonsConnectType::class,
+                    [
+                        'label' => $label,
+                        'attr' => [
+                            'class' => 'btn-outline-secondary',
+                            'data-toggle' => 'modal',
+                            'data-target' => $target,
+                        ],
+                    ]
+                );
+            }
             $builder->add('change_password', ChangePasswordType::class);
         } else {
             $builder->add('password', PasswordType::class, [
@@ -182,7 +210,7 @@ final class EmployeeType extends TranslatorAwareType
                 'label' => $this->trans('Password', 'Admin.Global'),
                 'help' => $this->trans(
                     'Password should be at least %num% characters long.',
-                    'Admin.Global',
+                    'Admin.Advparameters.Help',
                     ['%num%' => self::PASSWORD_MIN_CHARACTER_AMOUNT]
                 ),
                 'constraints' => [
@@ -199,7 +227,7 @@ final class EmployeeType extends TranslatorAwareType
                 'row_attr' => [
                     'data-minimumResultsForSearch' => '7',
                     'data-toggle' => '2',
-                ]
+                ],
             ])
             ->add('language', ChoiceType::class, [
                 'label' => $this->trans('Language', 'Admin.Global'),
@@ -226,8 +254,8 @@ final class EmployeeType extends TranslatorAwareType
                         'label' => $this->trans('Permission profile', 'Admin.Advparameters.Feature'),
                         'row_attr' => [
                             'data-admin-profile' => $this->superAdminProfileId,
-                            'data-get-tabs-url' => $this->router->generate('admin_employees_get_tabs')
-                        ]
+                            'data-get-tabs-url' => $this->router->generate('admin_employees_get_tabs'),
+                        ],
                     ]
                 )
             ;

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -31,11 +31,9 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -46,7 +46,7 @@ class ProfileType extends TranslatorAwareType
         'jpg',
         'jpeg',
         'jpe',
-        'png'
+        'png',
     ];
 
     public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png';

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -40,18 +41,8 @@ use Symfony\Component\Validator\Constraints\Length;
 /**
  * Builds form for Profile
  */
-class ProfileType extends AbstractType
+class ProfileType extends TranslatorAwareType
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -60,6 +51,7 @@ class ProfileType extends AbstractType
         $builder
             ->add('name', TranslatableType::class, [
                 'type' => TextType::class,
+                'label' => $this->trans('Name', 'Admin.Global'),
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
@@ -70,16 +62,17 @@ class ProfileType extends AbstractType
                         ]),
                         new Length([
                             'max' => ProfileSettings::NAME_MAX_LENGTH,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => ProfileSettings::NAME_MAX_LENGTH],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => ProfileSettings::NAME_MAX_LENGTH]
                             ),
                         ]),
                     ],
                 ],
             ])
             ->add('avatarUrl', FileType::class, [
+                'label' => $this->trans('Avatar', 'Admin.Global'),
                 'required' => false,
                 'attr' => [
                     'accept' => 'gif,jpg,jpeg,jpe,png',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -41,6 +41,16 @@ use Symfony\Component\Validator\Constraints\Length;
  */
 class ProfileType extends TranslatorAwareType
 {
+    public const AVAILABLE_IMAGE_FORMATS = [
+        'gif',
+        'jpg',
+        'jpeg',
+        'jpe',
+        'png'
+    ];
+
+    public const AVAILABLE_IMAGE_FORMATS_STRING_FOR_TRANSLATION = 'gif, jpg, jpeg, jpe, png';
+
     /**
      * {@inheritdoc}
      */
@@ -73,7 +83,7 @@ class ProfileType extends TranslatorAwareType
                 'label' => $this->trans('Avatar', 'Admin.Global'),
                 'required' => false,
                 'attr' => [
-                    'accept' => 'gif,jpg,jpeg,jpe,png',
+                    'accept' => implode(',', static::AVAILABLE_IMAGE_FORMATS),
                 ],
             ])
         ;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -944,15 +944,15 @@ services:
     public: true
     parent: 'form.type.translatable.aware'
     arguments:
-        - '@=service("prestashop.core.form.choice_provider.all_languages").getChoices()'
-        - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
-        - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
-        - '@=service("prestashop.adapter.multistore_feature").isActive()'
-        - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
-        - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
-        - '@router'
+      - '@=service("prestashop.core.form.choice_provider.all_languages").getChoices()'
+      - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
+      - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
+      - '@=service("prestashop.adapter.multistore_feature").isActive()'
+      - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
+      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - '@router'
     tags:
-        - { name: form.type }
+      - { name: form.type }
 
   form.type.change_password:
     class: 'PrestaShopBundle\Form\Admin\Type\ChangePasswordType'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -939,21 +939,20 @@ services:
     tags:
       - { name: form.type }
 
-    prestashop.bundle.form.admin.configure.advanced_parameters.employee.employee:
-        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeType'
-        public: true
-        parent: 'form.type.translatable.aware'
-        arguments:
-            - '@=service("prestashop.core.form.choice_provider.all_languages").getChoices()'
-            - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
-            - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
-            - '@=service("prestashop.adapter.multistore_feature").isActive()'
-            - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
-            - '@=service("prestashop.adapter.admin.data_provider.addons").isAddonsAuthenticated()'
-            - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
-            - '@router'
-        tags:
-            - { name: form.type }
+  prestashop.bundle.form.admin.configure.advanced_parameters.employee.employee:
+    class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeType'
+    public: true
+    parent: 'form.type.translatable.aware'
+    arguments:
+        - '@=service("prestashop.core.form.choice_provider.all_languages").getChoices()'
+        - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
+        - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
+        - '@=service("prestashop.adapter.multistore_feature").isActive()'
+        - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
+        - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+        - '@router'
+    tags:
+        - { name: form.type }
 
   form.type.change_password:
     class: 'PrestaShopBundle\Form\Admin\Type\ChangePasswordType'
@@ -1268,12 +1267,12 @@ services:
     tags:
       - { name: form.type }
 
-    form.type.configure.advanced_parameters.profile:
-      class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
-      public: true
-      parent: 'form.type.translatable.aware'
-      tags:
-        - { name: form.type }
+  form.type.configure.advanced_parameters.profile:
+    class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
+    public: true
+    parent: 'form.type.translatable.aware'
+    tags:
+      - { name: form.type }
 
   form.type.sell.product.create_product_form_type:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\CreateProductFormType'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -939,18 +939,21 @@ services:
     tags:
       - { name: form.type }
 
-  prestashop.bundle.form.admin.configure.advanced_parameters.employee.employee:
-    class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeType'
-    arguments:
-      - '@=service("prestashop.core.form.choice_provider.all_languages").getChoices()'
-      - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
-      - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
-      - '@=service("prestashop.adapter.multistore_feature").isActive()'
-      - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
-    calls:
-      - { method: setTranslator, arguments: [ '@translator' ] }
-    tags:
-      - { name: form.type }
+    prestashop.bundle.form.admin.configure.advanced_parameters.employee.employee:
+        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeType'
+        public: true
+        parent: 'form.type.translatable.aware'
+        arguments:
+            - '@=service("prestashop.core.form.choice_provider.all_languages").getChoices()'
+            - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
+            - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
+            - '@=service("prestashop.adapter.multistore_feature").isActive()'
+            - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
+            - '@=service("prestashop.adapter.admin.data_provider.addons").isAddonsAuthenticated()'
+            - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+            - '@router'
+        tags:
+            - { name: form.type }
 
   form.type.change_password:
     class: 'PrestaShopBundle\Form\Admin\Type\ChangePasswordType'
@@ -1265,13 +1268,12 @@ services:
     tags:
       - { name: form.type }
 
-  form.type.configure.advanced_parameters.profile:
-    class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
-    public: true
-    arguments:
-      - '@translator'
-    tags:
-      - { name: form.type }
+    form.type.configure.advanced_parameters.profile:
+      class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
+      public: true
+      parent: 'form.type.translatable.aware'
+      tags:
+        - { name: form.type }
 
   form.type.sell.product.create_product_form_type:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\CreateProductFormType'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -49,17 +49,20 @@
 
       {# New password first input #}
       <div class="form-group row">
-        {{ ps.label_with_help('New password'|trans({}, 'Admin.Advparameters.Feature'), passwordHelpMessage, '', change_password.new_password.children.first.vars.id, true) }}
+        {{ ps.label_with_help('New password'|trans({}, 'Admin.Advparameters.Feature'), passwordHelpMessage, 'HII', change_password.new_password.children.first.vars.id, true) }}
         <div class="col-sm">
           {{ ps.form_widget_with_error(change_password.new_password.children.first, change_password.new_password.children.first.vars) }}
+          {# Needed to render the text container for validation feedback messages. #}
+          <small class="form-text text-danger"></small>
         </div>
       </div>
 
       {# New password second input (confirmation) #}
-      {# Empty help text needed to render the text container for validation feedback messages #}
+      {# Help text needed to render the text container for validation feedback messages.
+      Because in help field won't be rendered if empty help here has a single space.  #}
       {{ ps.form_group_row(change_password.new_password.children.second, newPasswordSecondVars, {
         label: 'Confirm password'|trans({}, 'Admin.Advparameters.Feature'),
-        help: '',
+        help: ' ',
         required: true,
       }) }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -23,7 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': 8 }, 'Admin.Advparameters.Help') %}
+{% set passwordMinLength = constant('PrestaShop\\PrestaShop\\Core\\Domain\\Employee\\ValueObject\\Password::MIN_LENGTH') %}
+{% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': passwordMinLength }, 'Admin.Advparameters.Help') %}
 {% set oldPasswordVars = change_password.old_password.vars|merge(old_password|default({})) %}
 {% set newPasswordFirstVars = change_password.new_password.children.first.vars|merge(new_password.first_options|default({})) %}
 {% set newPasswordSecondVars = change_password.new_password.children.second.vars|merge(new_password.second_options|default({})) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -43,7 +43,7 @@
     <div class="card card-body js-change-password-block d-none">
       {# Current password input #}
       {{ ps.form_group_row(change_password.old_password, oldPasswordVars, {
-        label: 'Current password'|trans({}, 'messages'),
+        label: 'Current password'|trans({}, 'Admin.Advparameters.Feature'),
         required: true,
       }) }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -87,7 +87,7 @@
 
       {# Password strength feedback messages - used in JS #}
       <div class="js-password-strength-feedback d-none">
-        <span class="strength-low">{{ 'Invalid'|trans({}, 'messages') }}</span>
+        <span class="strength-low">{{ 'Invalid'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-medium">{{ 'Okay'|trans({}, 'messages') }}</span>
         <span class="strength-high">{{ 'Good'|trans({}, 'messages') }}</span>
         <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'messages') }}</span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set passwordMinLength = constant('PrestaShop\\PrestaShop\\Core\\Domain\\Employee\\ValueObject\\Password::MIN_LENGTH') %}
 {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': passwordMinLength }, 'Admin.Advparameters.Help') %}
 {% set oldPasswordVars = change_password.old_password.vars|merge(old_password|default({})) %}
 {% set newPasswordFirstVars = change_password.new_password.children.first.vars|merge(new_password.first_options|default({})) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -49,7 +49,7 @@
 
       {# New password first input #}
       <div class="form-group row">
-        {{ ps.label_with_help('New password'|trans({}, 'messages'), passwordHelpMessage, '', change_password.new_password.children.first.vars.id, true) }}
+        {{ ps.label_with_help('New password'|trans({}, 'Admin.Advparameters.Feature'), passwordHelpMessage, '', change_password.new_password.children.first.vars.id, true) }}
         <div class="col-sm">
           {{ ps.form_widget_with_error(change_password.new_password.children.first, change_password.new_password.children.first.vars) }}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -90,7 +90,7 @@
 
       {# Password strength feedback messages - used in JS #}
       <div class="js-password-strength-feedback d-none">
-        <span class="strength-low">{{ 'Invalid'|trans({}, 'Admin.Advparameters.Help') }}</span>
+        <span class="strength-low">{{ 'Weak'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-medium">{{ 'Okay'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-high">{{ 'Good'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'Admin.Advparameters.Help') }}</span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -88,7 +88,7 @@
       {# Password strength feedback messages - used in JS #}
       <div class="js-password-strength-feedback d-none">
         <span class="strength-low">{{ 'Invalid'|trans({}, 'Admin.Advparameters.Help') }}</span>
-        <span class="strength-medium">{{ 'Okay'|trans({}, 'messages') }}</span>
+        <span class="strength-medium">{{ 'Okay'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-high">{{ 'Good'|trans({}, 'messages') }}</span>
         <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'messages') }}</span>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -1,0 +1,97 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': 8 }, 'Admin.Advparameters.Help') %}
+{% set oldPasswordVars = change_password.old_password.vars|merge(old_password|default({})) %}
+{% set newPasswordFirstVars = change_password.new_password.children.first.vars|merge(new_password.first_options|default({})) %}
+{% set newPasswordSecondVars = change_password.new_password.children.second.vars|merge(new_password.second_options|default({})) %}
+<div class="form-group row">
+  <label class="form-control-label">
+    {{ 'Password'|trans({}, 'Admin.Global') }}
+  </label>
+  <div class="col-sm">
+    {# "Change password" button #}
+    {{ form_widget(change_password.change_password_button, {
+      label: 'Change password...'|trans({}, 'messages'),
+      attr: {
+        class: 'btn-outline-secondary js-change-password',
+      }
+    }) }}
+
+    <div class="card card-body js-change-password-block d-none">
+      {# Current password input #}
+      {{ ps.form_group_row(change_password.old_password, oldPasswordVars, {
+        label: 'Current password'|trans({}, 'messages'),
+        required: true,
+      }) }}
+
+      {# New password first input #}
+      <div class="form-group row">
+        {{ ps.label_with_help('New password'|trans({}, 'messages'), passwordHelpMessage, '', change_password.new_password.children.first.vars.id, true) }}
+        <div class="col-sm">
+          {{ ps.form_widget_with_error(change_password.new_password.children.first, change_password.new_password.children.first.vars) }}
+        </div>
+      </div>
+
+      {# New password second input (confirmation) #}
+      {# Empty help text needed to render the text container for validation feedback messages #}
+      {{ ps.form_group_row(change_password.new_password.children.second, newPasswordSecondVars, {
+        label: 'Confirm password'|trans({}, 'messages'),
+        help: '',
+        required: true,
+      }) }}
+
+      <div class="form-group row">
+        <label class="form-control-label"></label>
+        <div class="col-sm">
+          {{ form_widget(change_password.generated_password) }}
+        </div>
+        <div class="col-sm">
+          {{ form_widget(change_password.generate_password_button, {
+            label: 'Generate password'|trans({}, 'messages'),
+            attr: {
+              class: 'btn-outline-secondary',
+            }
+          }) }}
+        </div>
+      </div>
+
+      {{ ps.form_group_row(change_password.cancel_button, {
+        label: 'Cancel'|trans({}, 'Admin.Actions'),
+        attr: {
+          class: 'btn-outline-secondary js-change-password-cancel',
+        }
+      }) }}
+
+      {# Password strength feedback messages - used in JS #}
+      <div class="js-password-strength-feedback d-none">
+        <span class="strength-low">{{ 'Invalid'|trans({}, 'messages') }}</span>
+        <span class="strength-medium">{{ 'Okay'|trans({}, 'messages') }}</span>
+        <span class="strength-high">{{ 'Good'|trans({}, 'messages') }}</span>
+        <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'messages') }}</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -89,7 +89,7 @@
       <div class="js-password-strength-feedback d-none">
         <span class="strength-low">{{ 'Invalid'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-medium">{{ 'Okay'|trans({}, 'Admin.Advparameters.Help') }}</span>
-        <span class="strength-high">{{ 'Good'|trans({}, 'messages') }}</span>
+        <span class="strength-high">{{ 'Good'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'messages') }}</span>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -58,7 +58,7 @@
       {# New password second input (confirmation) #}
       {# Empty help text needed to render the text container for validation feedback messages #}
       {{ ps.form_group_row(change_password.new_password.children.second, newPasswordSecondVars, {
-        label: 'Confirm password'|trans({}, 'messages'),
+        label: 'Confirm password'|trans({}, 'Admin.Advparameters.Feature'),
         help: '',
         required: true,
       }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -90,7 +90,7 @@
         <span class="strength-low">{{ 'Invalid'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-medium">{{ 'Okay'|trans({}, 'Admin.Advparameters.Help') }}</span>
         <span class="strength-high">{{ 'Good'|trans({}, 'Admin.Advparameters.Help') }}</span>
-        <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'messages') }}</span>
+        <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'Admin.Advparameters.Help') }}</span>
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -34,7 +34,7 @@
   <div class="col-sm">
     {# "Change password" button #}
     {{ form_widget(change_password.change_password_button, {
-      label: 'Change password...'|trans({}, 'messages'),
+      label: 'Change password...'|trans({}, 'Admin.Actions'),
       attr: {
         class: 'btn-outline-secondary js-change-password',
       }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig
@@ -70,7 +70,7 @@
         </div>
         <div class="col-sm">
           {{ form_widget(change_password.generate_password_button, {
-            label: 'Generate password'|trans({}, 'messages'),
+            label: 'Generate password'|trans({}, 'Admin.Actions'),
             attr: {
               class: 'btn-outline-secondary',
             }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -23,6 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme employeeOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+
 {% block employee_options_form %}
   {{ form_start(employeeOptionsForm, {'action': path('admin_employees_save_options') }) }}
   <div class="card">
@@ -34,16 +36,12 @@
       <div class="card-text">
         <div class="form-group row">
           <label for="{{ employeeOptionsForm.password_change_time.vars.id }}" class="form-control-label">
-            {{ 'Password regeneration'|trans({}, 'Admin.Advparameters.Feature') }}
+            {{ form_label(employeeOptionsForm.password_change_time) }}
           </label>
 
           <div class="col-sm">
             {{ form_errors(employeeOptionsForm.password_change_time) }}
             {{ form_widget(employeeOptionsForm.password_change_time) }}
-            <small class="form-text">
-              {{ 'Security: Minimum time to wait between two password changes.'|trans({}, 'Admin.Advparameters.Feature') }}
-            </small>
-
             {% if not canOptionsBeChanged %}
             <div class="alert alert-warning mt-2 mb-0" role="alert">
               <p class="alert-text">
@@ -56,16 +54,12 @@
 
         <div class="form-group row">
           <label for="{{ employeeOptionsForm.allow_employee_specific_language.vars.id }}" class="form-control-label">
-            {{ 'Memorize the language used in Admin panel forms'|trans({}, 'Admin.Advparameters.Feature') }}
+            {{ form_label(employeeOptionsForm.allow_employee_specific_language) }}
           </label>
 
           <div class="col-sm">
             {{ form_errors(employeeOptionsForm.allow_employee_specific_language) }}
             {{ form_widget(employeeOptionsForm.allow_employee_specific_language) }}
-            <small class="form-text">
-              {{ 'Allow employees to select a specific language for the Admin panel form.'|trans({}, 'Admin.Advparameters.Feature') }}
-            </small>
-
             {% if not canOptionsBeChanged %}
             <div class="alert alert-warning mt-2 mb-0" role="alert">
               <p class="alert-text">
@@ -75,10 +69,7 @@
             {% endif %}
           </div>
         </div>
-
-        {% block employee_options_form_rest %}
-          {{ form_rest(employeeOptionsForm) }}
-        {% endblock %}
+        {{ form_rest(employeeOptionsForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% form_theme employeeOptionsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+{% form_theme employeeOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block employee_options_form %}
   {{ form_start(employeeOptionsForm, {'action': path('admin_employees_save_options') }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -28,11 +28,20 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block employee_form %}
-  <div id="multistore-alert" class="alert alert-info" role="alert">
-    <div class="alert-text">
-      {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.Advparameters.Help') }}<br>
+  {% if isRestrictedAccess %}
+    <div class="alert alert-info" role="alert">
+      <div class="alert-text">
+        {{ 'Note that this profile will be edited for all the stores with which it is associated.'|trans({}, 'Admin.Advparameters.Help') }}<br>
+      </div>
     </div>
-  </div>
+  {% else %}
+    <div id="multistore-alert" class="alert alert-info" role="alert">
+      <div class="alert-text">
+        {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.Advparameters.Help') }}<br>
+      </div>
+    </div>
+  {% endif %}
+
   {{ form_start(employeeForm) }}
   <div class="card">
     <h3 class="card-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -50,7 +50,8 @@
 
         {{ form_row(employeeForm.has_enabled_gravatar) }}
         {{ form_row(employeeForm.email) }}
-        {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': 8 }, 'Admin.Advparameters.Help') %}
+        {% set passwordMinLength = constant('PrestaShop\\PrestaShop\\Core\\Domain\\Employee\\ValueObject\\Password::MIN_LENGTH') %}
+        {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': passwordMinLength }, 'Admin.Advparameters.Help') %}
 
         {% if isRestrictedAccess %}
           {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig' with {'change_password':employeeForm.change_password} %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -28,6 +28,11 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block employee_form %}
+  <div id="multistore-alert" class="alert alert-info" role="alert">
+    <div class="alert-text">
+      {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.International.Help') }}<br>
+    </div>
+  </div>
   {{ form_start(employeeForm) }}
   <div class="card">
     <h3 class="card-header">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -37,7 +37,7 @@
   {% else %}
     <div id="multistore-alert" class="alert alert-info" role="alert">
       <div class="alert-text">
-        {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.Advparameters.Help') }}<br>
+        {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.Notification.Info') }}<br>
       </div>
     </div>
   {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -64,7 +64,6 @@
 
         {{ form_row(employeeForm.has_enabled_gravatar) }}
         {{ form_row(employeeForm.email) }}
-        {% set passwordMinLength = constant('PrestaShop\\PrestaShop\\Core\\Domain\\Employee\\ValueObject\\Password::MIN_LENGTH') %}
         {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': passwordMinLength }, 'Admin.Advparameters.Help') %}
 
         {% if isRestrictedAccess %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -30,7 +30,7 @@
 {% block employee_form %}
   <div id="multistore-alert" class="alert alert-info" role="alert">
     <div class="alert-text">
-      {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.International.Help') }}<br>
+      {{ 'Note that this feature is available in all shops context only. It will be added to all your stores.'|trans({}, 'Admin.Advparameters.Help') }}<br>
     </div>
   </div>
   {{ form_start(employeeForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -64,7 +64,6 @@
 
         {{ form_row(employeeForm.has_enabled_gravatar) }}
         {{ form_row(employeeForm.email) }}
-        {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': passwordMinLength }, 'Admin.Advparameters.Help') %}
 
         {% if isRestrictedAccess %}
           {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig' with {'change_password':employeeForm.change_password} %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme employeeForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
@@ -36,17 +37,9 @@
       <div class="card-text">
         {{ form_errors(employeeForm) }}
 
-        {{ ps.form_group_row(employeeForm.firstname, {}, {
-          'label': 'First name'|trans({}, 'Admin.Global')
-        }) }}
-
-        {{ ps.form_group_row(employeeForm.lastname, {}, {
-          'label': 'Last name'|trans({}, 'Admin.Global')
-        }) }}
-
-        {{ ps.form_group_row(employeeForm.avatarUrl, {}, {
-          'label': 'Avatar'|trans({}, 'Admin.Global')
-        }) }}
+        {{ form_row(employeeForm.firstname) }}
+        {{ form_row(employeeForm.lastname) }}
+        {{ form_row(employeeForm.avatarUrl) }}
 
         <div class="form-group row">
           <label class="form-control-label"></label>
@@ -55,127 +48,15 @@
           </div>
         </div>
 
-        {{ ps.form_group_row(employeeForm.has_enabled_gravatar, {}, {
-          'label': 'Enable gravatar'|trans({}, 'Admin.Global')
-        }) }}
-
-        {{ ps.form_group_row(employeeForm.email, {}, {
-          'label': 'Email address'|trans({}, 'Admin.Global')
-        }) }}
-
+        {{ form_row(employeeForm.has_enabled_gravatar) }}
+        {{ form_row(employeeForm.email) }}
         {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': 8 }, 'Admin.Advparameters.Help') %}
 
         {% if isRestrictedAccess %}
-            {% set oldPasswordVars = employeeForm.change_password.old_password.vars|merge(old_password|default({})) %}
-            {% set newPasswordFirstVars = employeeForm.change_password.new_password.children.first.vars|merge(new_password.first_options|default({})) %}
-            {% set newPasswordSecondVars = employeeForm.change_password.new_password.children.second.vars|merge(new_password.second_options|default({})) %}
-
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Password'|trans({}, 'Admin.Global') }}
-              </label>
-              <div class="col-sm">
-                {# "Change password" button #}
-                {{ form_widget(employeeForm.change_password.change_password_button, {
-                  label: 'Change password...'|trans({}, 'messages'),
-                  attr: {
-                    class: 'btn-outline-secondary js-change-password',
-                  }
-                }) }}
-
-                <div class="card card-body js-change-password-block d-none">
-                  {# Current password input #}
-                  {{ ps.form_group_row(employeeForm.change_password.old_password, oldPasswordVars, {
-                    label: 'Current password'|trans({}, 'messages'),
-                    required: true,
-                  }) }}
-
-                  {# New password first input #}
-                  <div class="form-group row">
-                      {{ ps.label_with_help('New password'|trans({}, 'messages'), passwordHelpMessage, '', employeeForm.change_password.new_password.children.first.vars.id, true) }}
-                    <div class="col-sm">
-                      {{ ps.form_widget_with_error(employeeForm.change_password.new_password.children.first, employeeForm.change_password.new_password.children.first.vars) }}
-                    </div>
-                  </div>
-
-                  {# New password second input (confirmation) #}
-                  {# Empty help text needed to render the text container for validation feedback messages #}
-                  {{ ps.form_group_row(employeeForm.change_password.new_password.children.second, newPasswordSecondVars, {
-                    label: 'Confirm password'|trans({}, 'messages'),
-                    help: '',
-                    required: true,
-                  }) }}
-
-                  <div class="form-group row">
-                    <label class="form-control-label"></label>
-                    <div class="col-sm">
-                      {{ form_widget(employeeForm.change_password.generated_password) }}
-                    </div>
-                    <div class="col-sm">
-                      {{ form_widget(employeeForm.change_password.generate_password_button, {
-                        label: 'Generate password'|trans({}, 'messages'),
-                        attr: {
-                          class: 'btn-outline-secondary',
-                        }
-                      }) }}
-                    </div>
-                  </div>
-
-                  {{ ps.form_group_row(employeeForm.change_password.cancel_button, {
-                    label: 'Cancel'|trans({}, 'Admin.Actions'),
-                    attr: {
-                      class: 'btn-outline-secondary js-change-password-cancel',
-                    }
-                  }) }}
-
-                  {# Password strength feedback messages - used in JS #}
-                  <div class="js-password-strength-feedback d-none">
-                    <span class="strength-low">{{ 'Invalid'|trans({}, 'messages') }}</span>
-                    <span class="strength-medium">{{ 'Okay'|trans({}, 'messages') }}</span>
-                    <span class="strength-high">{{ 'Good'|trans({}, 'messages') }}</span>
-                    <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'messages') }}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+          {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/change_password.html.twig' with {'change_password':employeeForm.change_password} %}
         {% else %}
-          {{ ps.form_group_row(employeeForm.password, {}, {
-            'label': 'Password'|trans({}, 'Admin.Global'),
-            'help': passwordHelpMessage,
-          }) }}
+          {{ form_row(employeeForm.password) }}
         {% endif %}
-
-        {{ ps.form_group_row(employeeForm.language, {}, {
-          'label': 'Language'|trans({}, 'Admin.Global')
-        }) }}
-
-        {% if not isRestrictedAccess %}
-          {{ ps.form_group_row(employeeForm.active, {}, {
-            'label': 'Active'|trans({}, 'Admin.Global'),
-            'help': 'Allow or disallow this employee to log in to the Admin panel.'|trans({}, 'Admin.Advparameters.Help')
-          }) }}
-
-          {{ ps.form_group_row(employeeForm.profile, {
-            'attr': {
-              'data-admin-profile': superAdminProfileId,
-              'data-get-tabs-url': getTabsUrl,
-            }
-          }, {
-            'label': 'Permission profile'|trans({}, 'Admin.Advparameters.Feature')
-          }) }}
-
-          {% if employeeForm.shop_association is defined %}
-            {{ ps.form_group_row(employeeForm.shop_association, {}, {
-              'label': 'Shop association'|trans({}, 'Admin.Global'),
-              'help': 'Select the shops the employee is allowed to access.'|trans({}, 'Admin.Advparameters.Help')
-            }) }}
-          {% endif %}
-        {% endif %}
-
-        {{ ps.form_group_row(employeeForm.default_page, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}, {
-          'label': 'Default page'|trans,
-          'help': 'This page will be displayed just after login.'|trans({}, 'Admin.Advparameters.Help')
-        }) }}
 
         {% block employee_form_rest %}
           {{ form_rest(employeeForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% form_theme employeeForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+{% form_theme employeeForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme profileForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(profileForm) }}
 <div class="card">
@@ -33,16 +33,7 @@
   </h3>
   <div class="card-block row">
     <div class="card-text">
-      {{ form_errors(profileForm) }}
-
-      {{ ps.form_group_row(profileForm.name, {}, {
-        'label': 'Name'|trans({}, 'Admin.Global')
-      }) }}
-
-      {{ ps.form_group_row(profileForm.avatarUrl, {}, {
-        'label': 'Avatar'|trans({}, 'Admin.Global')
-      }) }}
-
+      {{ form_widget(profileForm) }}
       {% if avatarUrl|default('') is not empty %}
       <div class="form-group row">
         <label class="form-control-label"></label>
@@ -51,10 +42,6 @@
         </div>
       </div>
       {% endif %}
-
-      {% block profile_form_rest %}
-        {{ form_rest(profileForm) }}
-      {% endblock %}
     </div>
   </div>
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -79,7 +79,7 @@
       {% set disabledField = true %}
     {% endif %}
 
-    <div {{ block('form_row_attr') }}{% if (attr.visible is defined and not attr.visible) %} style="display: none;"{% endif %}>
+    <div {{ block('form_row_attr') }}>
       {% if attribute(form.parent, multistoreCheckboxName) is defined %}
         {{ form_errors(attribute(form.parent, multistoreCheckboxName)) }}
         {{ form_widget(attribute(form.parent, multistoreCheckboxName)) }}
@@ -114,6 +114,10 @@
   {% set classes = 'form-group row' %}
   {% if (not compound or force_error|default(false)) and not valid %}
     {% set classes = classes ~ ' has-error' %}
+  {% endif %}
+
+  {% if attr.visible is defined and not attr.visible %}
+    {% set classes = classes ~ ' d-none' %}
   {% endif %}
 
   {% if row_attr.class is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -79,7 +79,7 @@
       {% set disabledField = true %}
     {% endif %}
 
-    <div {{ block('form_row_attr') }} {% if (attr.visible is defined and not attr.visible) %} style="display: none;"{% endif %}>
+    <div {{ block('form_row_attr') }}{% if (attr.visible is defined and not attr.visible) %} style="display: none;"{% endif %}>
       {% if attribute(form.parent, multistoreCheckboxName) is defined %}
         {{ form_errors(attribute(form.parent, multistoreCheckboxName)) }}
         {{ form_widget(attribute(form.parent, multistoreCheckboxName)) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -113,7 +113,7 @@
 {% block form_row_attr -%}
   {% set classes = 'form-group row' %}
   {% if (not compound or force_error|default(false)) and not valid %}
-  {% set classes = classes ~ ' has-error' %}
+    {% set classes = classes ~ ' has-error' %}
   {% endif %}
 
   {% if row_attr.class is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -110,9 +110,20 @@
   col-sm input-container
 {%- endblock form_group_class %}
 
-{% block form_row_class -%}
-  form-group row{% if row_attr.class is defined %} {{ row_attr.class }}{% endif %}
-{%- endblock form_row_class %}
+{% block form_row_attr -%}
+  {% set classes = 'form-group row' %}
+  {% if (not compound or force_error|default(false)) and not valid %}
+  {% set classes = classes ~ ' has-error' %}
+  {% endif %}
+
+  {% if row_attr.class is defined %}
+    {% set classes = classes ~ ' ' ~ row_attr.class  %}
+  {% endif %}
+
+  {% set row_attr = row_attr|merge({'class': classes}) %}
+
+  {% for key, rowAttr in row_attr %} {{ key }}="{{ rowAttr }}" {% endfor %}
+{%- endblock form_row_attr %}
 
 {%- block repeated_row -%}
   {{- block('form_rows') -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -113,3 +113,14 @@
 {% block form_row_class -%}
   form-group row{% if row_attr.class is defined %} {{ row_attr.class }}{% endif %}
 {%- endblock form_row_class %}
+
+{%- block repeated_row -%}
+  {{- block('form_rows') -}}
+  {{ block('form_help') }}
+{%- endblock repeated_row -%}
+
+{%- block password_widget -%}
+  {%- set type = type|default('password') -%}
+  {{ block('form_widget_simple') }}
+  {{ block('form_help') }}
+{%- endblock password_widget -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -79,7 +79,7 @@
       {% set disabledField = true %}
     {% endif %}
 
-    <div class="{{ block('form_row_class') }}{{ block('widget_type_class') }}{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}{% if (attr.visible is defined and not attr.visible) %} d-none{% endif %}">
+    <div {{ block('form_row_attr') }} {% if (attr.visible is defined and not attr.visible) %} style="display: none;"{% endif %}>
       {% if attribute(form.parent, multistoreCheckboxName) is defined %}
         {{ form_errors(attribute(form.parent, multistoreCheckboxName)) }}
         {{ form_widget(attribute(form.parent, multistoreCheckboxName)) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies team forms
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Advanced Parameters -> Employee add/edit Employee options and add/edit profile forms. Everything must look the same.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by EmployeeType and ProfileType. This means if any module extends those types they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
