### PR TITLE
[WIP] Simplified attachment form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Attachment/AttachmentType.php
@@ -31,8 +31,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\Configuration\AttachmentConstraint;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -41,10 +40,8 @@ use Symfony\Component\Validator\Constraints\Length;
 /**
  * Attachment form type definition
  */
-class AttachmentType extends AbstractType
+class AttachmentType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * {@inheritdoc}
      */
@@ -52,6 +49,7 @@ class AttachmentType extends AbstractType
     {
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->trans('File name', 'Admin.Global'),
                 'type' => TextType::class,
                 'required' => true,
                 'options' => [
@@ -66,8 +64,8 @@ class AttachmentType extends AbstractType
                                 'max' => AttachmentConstraint::MAX_NAME_LENGTH,
                                 'maxMessage' => $this->trans(
                                     'This field cannot be longer than %limit% characters',
-                                    ['%limit%' => AttachmentConstraint::MAX_NAME_LENGTH],
-                                    'Admin.Notifications.Error'
+                                    'Admin.Notifications.Error',
+                                    ['%limit%' => AttachmentConstraint::MAX_NAME_LENGTH]
                                 ),
                             ]
                         ),
@@ -78,6 +76,7 @@ class AttachmentType extends AbstractType
                 ],
             ])
             ->add('file_description', TranslatableType::class, [
+                'label' => $this->trans('Description', 'Admin.Global'),
                 'type' => TextType::class,
                 'required' => false,
                 'options' => [
@@ -87,6 +86,7 @@ class AttachmentType extends AbstractType
                 ],
             ])
             ->add('file', FileType::class, [
+                'label' => $this->trans('File', 'Admin.Global'),
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1171,8 +1171,8 @@ services:
 
     prestashop.bundle.form.admin.sell.attachment.attachment:
         class: 'PrestaShopBundle\Form\Admin\Sell\Attachment\AttachmentType'
-        calls:
-            - { method: setTranslator, arguments: ['@translator'] }
+        public: true
+        parent: form.type.translatable.aware
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme attachmentForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block attachment_form %}
   {{ form_start(attachmentForm) }}
@@ -34,28 +34,7 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          {{ form_errors(attachmentForm) }}
-
-          {{ ps.form_group_row(attachmentForm.name, {}, {
-            'label': 'File name'|trans({}, 'Admin.Global')
-          }) }}
-
-          {{ ps.form_group_row(attachmentForm.file_description, {}, {
-            'label': 'Description'|trans({}, 'Admin.Global')
-          }) }}
-
-          <div class="form-group row">
-            <label class="form-control-label">
-              <span class="text-danger">*</span>
-              {{ 'File'|trans({}, 'Admin.Global') }}
-            </label>
-            <div class="col-sm">
-              {{ form_widget(attachmentForm.file) }}
-              {{ form_errors(attachmentForm.file) }}
-            </div>
-            {% block attachment_download %}{% endblock %}
-          </div>
-
+          {{ form_widget(attachmentForm) }}
           {% if attachmentId is defined %}
             <div class="form-group row">
               <div class="col-sm float-right">
@@ -66,10 +45,6 @@
               </div>
             </div>
           {% endif %}
-
-          {% block attachment_form_rest %}
-            {{ form_rest(attachmentForm) }}
-          {% endblock %}
         </div>
       </div>
       <div class="card-footer">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies files form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Sell -> Catalog -> File form. Everything must and work look the same.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by AttachmentType. This means if any module extends this type they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
