### PR TITLE
Attrs for combination are incorrectly selected

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2633,7 +2633,7 @@ class ProductCore extends ObjectModel
                 GROUP BY pac.id_product_attribute');
 
         foreach ($lang as $k => $row) {
-            $key = array_search((int)$row['id_product_attribute'], $product_attributes);
+            $key = array_search((int) $row['id_product_attribute'], $product_attributes);
             if ($key !== false) {
                 $combinations[$k]['attribute_designation'] = $row['attribute_designation'];
             }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2633,7 +2633,10 @@ class ProductCore extends ObjectModel
                 GROUP BY pac.id_product_attribute');
 
         foreach ($lang as $k => $row) {
-            $combinations[$k]['attribute_designation'] = $row['attribute_designation'];
+            $key = array_search((int)$row['id_product_attribute'], $product_attributes);
+            if ($key !== false) {
+                $combinations[$k]['attribute_designation'] = $row['attribute_designation'];
+            }
         }
 
         //Get quantity of each variations


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | It turned out that the attributes for the combinations were not loaded correctly, i chose one and in fact the system said that I chose another
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/22052
| How to test?  | Here description: https://github.com/PrestaShop/PrestaShop/issues/22052

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22053)
<!-- Reviewable:end -->
