### PR TITLE
Adjust container of positions page and alert size

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_improve.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_improve.scss
@@ -1,0 +1,5 @@
+.alert {
+  &-can-move {
+    width: 100%;
+  }
+}

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -69,6 +69,7 @@
 @import "pages/customer_thread";
 @import "pages/customer";
 @import "pages/compromised";
+@import "pages/improve";
 
 // Main Layout
 @import "pages/modules";

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
@@ -26,9 +26,9 @@
 {% trans_default_domain "Admin.Design.Feature" %}
 
 {% block content %}
-  <div class="row">
+  <div class="row m-0">
     {% if not canMove %}
-      <p class="alert alert-warning">
+      <p class="alert alert-warning alert-can-move">
         {{ 'If you want to order/move the following data, please select a shop from the shop list.' | trans({}, 'Admin.Design.Notification') }}
       </p>
     {% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Positions page container was not right centered and alert was not full size
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21742.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22073)
<!-- Reviewable:end -->
