### PR TITLE
Add accordion to contact information in footer on classic theme

### DIFF
--- a/themes/classic/_dev/css/components/footer.scss
+++ b/themes/classic/_dev/css/components/footer.scss
@@ -5,6 +5,10 @@
     color: $gray-darker;
   }
 
+  .navbar-toggler .material-icons {
+    color: $gray-darker;
+  }
+
   @include media-breakpoint-down(sm) {
     #contact-infos {
       padding: 0.625rem;

--- a/themes/classic/_dev/css/components/footer.scss
+++ b/themes/classic/_dev/css/components/footer.scss
@@ -4,6 +4,13 @@
   .block-contact-title {
     color: $gray-darker;
   }
+
+  @include media-breakpoint-down(sm) {
+    #contact-infos {
+      padding: 0.625rem;
+      padding-top: 0;
+    }
+  }
 }
 
 .linklist {

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -24,44 +24,48 @@
  *}
 
 <div class="block-contact col-md-3 links wrapper">
-  <div class="hidden-sm-down">
-    <p class="h4 text-uppercase block-contact-title">{l s='Store information' d='Shop.Theme.Global'}</p>
-      {$contact_infos.address.formatted nofilter}
-      {if $contact_infos.phone}
-        <br>
-        {* [1][/1] is for a HTML tag. *}
-        {l s='Call us: [1]%phone%[/1]'
-          sprintf=[
+  <div class="title clearfix hidden-md-up" data-target="#contact-infos" data-toggle="collapse">
+    <span class="h3">{l s='Store information' d='Shop.Theme.Global'}</span>
+    <span class="float-xs-right">
+      <span class="navbar-toggler collapse-icons">
+        <i class="material-icons add"></i>
+        <i class="material-icons remove"></i>
+      </span>
+    </span>
+  </div>
+
+  <p class="h4 text-uppercase block-contact-title hidden-sm-down">{l s='Store information' d='Shop.Theme.Global'}</p>
+  <div id="contact-infos" class="collapse">
+    {$contact_infos.address.formatted nofilter}
+    {if $contact_infos.phone}
+      <br>
+      {* [1][/1] is for a HTML tag. *}
+      {l s='Call us: [1]%phone%[/1]'
+        sprintf=[
+        '[1]' => '<span>',
+        '[/1]' => '</span>',
+        '%phone%' => $contact_infos.phone
+        ]
+        d='Shop.Theme.Global'
+      }
+    {/if}
+    {if $contact_infos.fax}
+      <br>
+      {* [1][/1] is for a HTML tag. *}
+      {l
+        s='Fax: [1]%fax%[/1]'
+        sprintf=[
           '[1]' => '<span>',
           '[/1]' => '</span>',
-          '%phone%' => $contact_infos.phone
-          ]
-          d='Shop.Theme.Global'
-        }
-      {/if}
-      {if $contact_infos.fax}
-        <br>
-        {* [1][/1] is for a HTML tag. *}
-        {l
-          s='Fax: [1]%fax%[/1]'
-          sprintf=[
-            '[1]' => '<span>',
-            '[/1]' => '</span>',
-            '%fax%' => $contact_infos.fax
-          ]
-          d='Shop.Theme.Global'
-        }
-      {/if}
-      {if $contact_infos.email && $display_email}
-        <br>
-          {l s='Email us:' d='Shop.Theme.Global'}
-          {mailto address=$contact_infos.email encode="javascript"}
-      {/if}
-  </div>
-  <div class="hidden-md-up">
-    <div class="title">
-      <a class="h3" href="{$urls.pages.stores}">{l s='Store information' d='Shop.Theme.Global'}</a>
-
-    </div>
+          '%fax%' => $contact_infos.fax
+        ]
+        d='Shop.Theme.Global'
+      }
+    {/if}
+    {if $contact_infos.email && $display_email}
+      <br>
+        {l s='Email us:' d='Shop.Theme.Global'}
+        {mailto address=$contact_infos.email encode="javascript"}
+    {/if}
   </div>
 </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl
@@ -28,8 +28,8 @@
     <span class="h3">{l s='Store information' d='Shop.Theme.Global'}</span>
     <span class="float-xs-right">
       <span class="navbar-toggler collapse-icons">
-        <i class="material-icons add"></i>
-        <i class="material-icons remove"></i>
+        <i class="material-icons add">keyboard_arrow_down</i>
+        <i class="material-icons remove">keyboard_arrow_up</i>
       </span>
     </span>
   </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Every footer columns got an accordion on mobile, but not the contact information one
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9946.
| How to test?  | Check contact information column in the classic theme footer on desktop and mobile, on mobile it should be an accordion

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22074)
<!-- Reviewable:end -->
