### PR TITLE
Add new column template for displayLeft/Right hook

### DIFF
--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock-column.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock-column.tpl
@@ -26,8 +26,7 @@
   {foreach $linkBlocks as $linkBlock}
     <div class="wrapper">
       <p class="h3 hidden-sm-down">{$linkBlock.title}</p>
-      {assign var=_expand_id value=10|mt_rand:100000}
-      <div class="title clearfix hidden-md-up" data-target="#footer_sub_menu_{$_expand_id}" data-toggle="collapse">
+      <div class="title clearfix hidden-md-up" data-target="#footer_sub_menu_{$linkBlock.id}" data-toggle="collapse">
         <span class="h3">{$linkBlock.title}</span>
         <span class="float-xs-right">
           <span class="navbar-toggler collapse-icons">
@@ -36,7 +35,7 @@
           </span>
         </span>
       </div>
-      <ul id="footer_sub_menu_{$_expand_id}" class="collapse">
+      <ul id="footer_sub_menu_{$linkBlock.id}" class="collapse">
         {foreach $linkBlock.links as $link}
           <li>
             <a

--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock-column.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock-column.tpl
@@ -1,0 +1,56 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+<div class="links">
+  {foreach $linkBlocks as $linkBlock}
+    <div class="wrapper">
+      <p class="h3 hidden-sm-down">{$linkBlock.title}</p>
+      {assign var=_expand_id value=10|mt_rand:100000}
+      <div class="title clearfix hidden-md-up" data-target="#footer_sub_menu_{$_expand_id}" data-toggle="collapse">
+        <span class="h3">{$linkBlock.title}</span>
+        <span class="float-xs-right">
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add">&#xE313;</i>
+            <i class="material-icons remove">&#xE316;</i>
+          </span>
+        </span>
+      </div>
+      <ul id="footer_sub_menu_{$_expand_id}" class="collapse">
+        {foreach $linkBlock.links as $link}
+          <li>
+            <a
+                id="{$link.id}-{$linkBlock.id}"
+                class="{$link.class}"
+                href="{$link.url}"
+                title="{$link.description}"
+                {if !empty($link.target)} target="{$link.target}" {/if}
+            >
+              {$link.title}
+            </a>
+          </li>
+        {/foreach}
+      </ul>
+    </div>
+  {/foreach}
+</div>

--- a/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
+++ b/themes/classic/modules/ps_linklist/views/templates/hook/linkblock.tpl
@@ -27,8 +27,7 @@
   {foreach $linkBlocks as $linkBlock}
     <div class="col-md-6 wrapper">
       <p class="h3 hidden-sm-down">{$linkBlock.title}</p>
-      {assign var=_expand_id value=10|mt_rand:100000}
-      <div class="title clearfix hidden-md-up" data-target="#footer_sub_menu_{$_expand_id}" data-toggle="collapse">
+      <div class="title clearfix hidden-md-up" data-target="#footer_sub_menu_{$linkBlock.id}" data-toggle="collapse">
         <span class="h3">{$linkBlock.title}</span>
         <span class="float-xs-right">
           <span class="navbar-toggler collapse-icons">
@@ -37,7 +36,7 @@
           </span>
         </span>
       </div>
-      <ul id="footer_sub_menu_{$_expand_id}" class="collapse">
+      <ul id="footer_sub_menu_{$linkBlock.id}" class="collapse">
         {foreach $linkBlock.links as $link}
           <li>
             <a


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Link list was broken on displayLeftColumn and displayRightColumn hook
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20100.
| How to test?  | See issue (should probably be tested with https://github.com/PrestaShop/ps_linklist/pull/104)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22076)
<!-- Reviewable:end -->
