### PR TITLE
Use the same condition as it is in ShopUrlType

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -97,6 +97,8 @@ class MetaController extends FrameworkBundleAdminController
             new GetShowcaseCardIsClosed((int) $this->getContext()->employee->id, ShowcaseCard::SEO_URLS_CARD)
         );
 
+        $doesMainShopUrlExist = $this->get('prestashop.adapter.shop.shop_url')->doesMainShopUrlExist();
+
         return $this->render(
             '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/index.html.twig',
             [
@@ -121,6 +123,7 @@ class MetaController extends FrameworkBundleAdminController
                 'isRobotsTextFileValid' => $urlFileChecker->isRobotsFileWritable(),
                 'isShopFeatureActive' => $isShopFeatureActive,
                 'isHostMode' => $hostingInformation->isHostMode(),
+                'doesMainShopUrlExist' => $doesMainShopUrlExist,
                 'enableSidebar' => true,
                 'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
                 'helperDocLink' => $helperBlockLinkProvider->getLink('meta'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -49,7 +49,7 @@
     </div>
   {% endif %}
 
-  {% if shopUrlsForm.children is not empty %}
+  {% if not isShopFeatureActive and not isHostMode and doesMainShopUrlExist %}
     <div class="card">
       <h3 class="card-header">
         <i class="material-icons">settings</i> {{ cardHeaderLabel }}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The condition in the template is not the same as it is in ShopUrlType. The problem is, the form has always at least one element (_token), and that doesn't mean all elements are in the form.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20863
| How to test?  | In the Multishop context, go into: http://ps-develop.localhost/admin-dev/index.php/configure/shop/seo-urls/.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22079)
<!-- Reviewable:end -->
