### PR TITLE
Hide product quantity in Order view page when stock management is disabled

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -52,7 +52,7 @@ class FrameworkBundleAdminController extends Controller
     const PRESTASHOP_CORE_CONTROLLERS_TAG = 'prestashop.core.controllers';
 
     /**
-     * @var ConfigurationInterface
+     * @var ConfigurationInterface|Configuration
      */
     protected $configuration;
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -528,6 +528,7 @@ class OrderController extends FrameworkBundleAdminController
             'nextOrderId' => $orderSiblingProvider->getNextOrderId($orderId),
             'paginationNum' => $paginationNum,
             'paginationNumOptions' => $paginationNumOptions,
+            'isAvailableQuantityDisplayed' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT'),
         ]);
     }
 
@@ -727,6 +728,7 @@ class OrderController extends FrameworkBundleAdminController
                 'product' => $newProduct,
                 'isColumnLocationDisplayed' => $newProduct->getLocation() !== '',
                 'isColumnRefundedDisplayed' => $newProduct->getQuantityRefunded() > 0,
+                'isAvailableQuantityDisplayed' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT'),
                 'cancelProductForm' => $cancelProductForm->createView(),
                 'orderCurrency' => $orderCurrency,
             ]);
@@ -967,6 +969,7 @@ class OrderController extends FrameworkBundleAdminController
             'cancelProductForm' => $cancelProductForm->createView(),
             'isColumnLocationDisplayed' => $product->getLocation() !== '',
             'isColumnRefundedDisplayed' => $product->getQuantityRefunded() > 0,
+            'isAvailableQuantityDisplayed' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT'),
             'orderCurrency' => $orderCurrency,
             'orderForViewing' => $orderForViewing,
             'product' => $product,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -528,7 +528,7 @@ class OrderController extends FrameworkBundleAdminController
             'nextOrderId' => $orderSiblingProvider->getNextOrderId($orderId),
             'paginationNum' => $paginationNum,
             'paginationNumOptions' => $paginationNumOptions,
-            'isAvailableQuantityDisplayed' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT'),
+            'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
         ]);
     }
 
@@ -641,7 +641,7 @@ class OrderController extends FrameworkBundleAdminController
      */
     private function handleOutOfStockProduct(OrderForViewing $orderForViewing)
     {
-        $isStockManagementEnabled = $this->configuration->get('PS_STOCK_MANAGEMENT');
+        $isStockManagementEnabled = $this->configuration->getBoolean('PS_STOCK_MANAGEMENT');
         if (!$isStockManagementEnabled || $orderForViewing->isDelivered() || $orderForViewing->isShipped()) {
             return;
         }
@@ -728,7 +728,7 @@ class OrderController extends FrameworkBundleAdminController
                 'product' => $newProduct,
                 'isColumnLocationDisplayed' => $newProduct->getLocation() !== '',
                 'isColumnRefundedDisplayed' => $newProduct->getQuantityRefunded() > 0,
-                'isAvailableQuantityDisplayed' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT'),
+                'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
                 'cancelProductForm' => $cancelProductForm->createView(),
                 'orderCurrency' => $orderCurrency,
             ]);
@@ -969,7 +969,7 @@ class OrderController extends FrameworkBundleAdminController
             'cancelProductForm' => $cancelProductForm->createView(),
             'isColumnLocationDisplayed' => $product->getLocation() !== '',
             'isColumnRefundedDisplayed' => $product->getQuantityRefunded() > 0,
-            'isAvailableQuantityDisplayed' => (bool) $this->configuration->get('PS_STOCK_MANAGEMENT'),
+            'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
             'orderCurrency' => $orderCurrency,
             'orderForViewing' => $orderForViewing,
             'product' => $product,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig
@@ -55,7 +55,7 @@
   </td>
   <td id="addProductLocation" class="cellProductLocation"></td>
   <td id="addProductRefunded" class="cellProductRefunded"></td>
-  <td id="addProductAvailable"></td>
+  <td id="addProductAvailable"{% if not isAvailableQuantityDisplayed %} class="d-none"{% endif %}></td>
   <td id="addProductTotalPrice"></td>
   {% if orderForViewing.hasInvoice() %}
     <td class="addProductInvoice pr-2">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig
@@ -35,7 +35,7 @@
   </td>
   <td class="editProductLocation cellProductLocation"></td>
   <td class="editProductRefunded cellProductRefunded"></td>
-  <td class="editProductAvailable"></td>
+  <td class="editProductAvailable{% if not isAvailableQuantityDisplayed %} d-none{% endif %}"></td>
   <td class="editProductTotalPrice"></td>
   {% if orderForViewing.hasInvoice() %}
     <td class="cellProductInvoice">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -22,6 +22,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
+
+{% set isAvailableQuantityDisplayed = isAvailableQuantityDisplayed|default(true) %}
 {% set rowIsDisplayed =  (productIndex is defined and paginationNum is defined and productIndex > paginationNum) %}
 <tr id="orderProduct_{{ product.orderDetailId }}" class="cellProduct{% if rowIsDisplayed %} d-none d-print-table-row{% endif %}">
   <td class="cellProductImg">
@@ -69,7 +71,7 @@
       {{ product.quantityRefunded }} ({{ product.amountRefunded }} {{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }})
     {% endif %}
   </td>
-  <td class="cellProductAvailableQuantity text-center">{{ product.availableQuantity }}</td>
+  <td class="cellProductAvailableQuantity text-center{% if not isAvailableQuantityDisplayed %} d-none{% endif %}">{{ product.availableQuantity }}</td>
   <td class="cellProductTotalPrice">{{ product.totalPrice }}</td>
   {% if orderForViewing.hasInvoice() %}
     <td>{{ product.orderInvoiceNumber }}</td>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set isAvailableQuantityDisplayed = isAvailableQuantityDisplayed|default(true) %}
 {% set rowIsDisplayed =  (productIndex is defined and paginationNum is defined and productIndex > paginationNum) %}
 <tr id="orderProduct_{{ product.orderDetailId }}" class="cellProduct{% if rowIsDisplayed %} d-none d-print-table-row{% endif %}">
   <td class="cellProductImg">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% set isAvailableQuantityDisplayed = isAvailableQuantityDisplayed|default(true) %}
 {% set isColumnLocationDisplayed = false %}
 {% set isColumnRefundedDisplayed = false %}
 {% for product in orderForViewing.products.products|slice(0, paginationNum) %}
@@ -71,7 +72,7 @@
         <th class="cellProductRefunded{% if not isColumnRefundedDisplayed %} d-none{% endif %}">
           <p>{{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
         </th>
-        <th>
+        <th {% if not isAvailableQuantityDisplayed %}class="d-none"{% endif %}>
           <p>{{ 'Available'|trans({}, 'Admin.Global') }}</p>
         </th>
         <th>
@@ -100,7 +101,8 @@
           'productIndex': loop.index,
           'paginationNum': paginationNum,
           'isColumnLocationDisplayed': isColumnLocationDisplayed,
-          'isColumnRefundedDisplayed': isColumnRefundedDisplayed
+          'isColumnRefundedDisplayed': isColumnRefundedDisplayed,
+          'isAvailableQuantityDisplayed': isAvailableQuantityDisplayed
         } %}
       {% endfor %}
       {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set isAvailableQuantityDisplayed = isAvailableQuantityDisplayed|default(true) %}
 {% set isColumnLocationDisplayed = false %}
 {% set isColumnRefundedDisplayed = false %}
 {% for product in orderForViewing.products.products|slice(0, paginationNum) %}
@@ -101,8 +100,7 @@
           'productIndex': loop.index,
           'paginationNum': paginationNum,
           'isColumnLocationDisplayed': isColumnLocationDisplayed,
-          'isColumnRefundedDisplayed': isColumnRefundedDisplayed,
-          'isAvailableQuantityDisplayed': isAvailableQuantityDisplayed
+          'isColumnRefundedDisplayed': isColumnRefundedDisplayed
         } %}
       {% endfor %}
       {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig' %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Hide product quantity in Order view page when PS_STOCK_MANAGEMENT is disabled
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21767
| How to test?  | In Shop Parameters > product settings disable `Enable stock management` option The order view page shouldn't display product stock available quantities any more

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22082)
<!-- Reviewable:end -->
