### PR TITLE
Display combination image in product pack list

### DIFF
--- a/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -29,11 +29,15 @@
         <div class="thumb-mask">
           <div class="mask">
             <a href="{$product.url}" title="{$product.name}">
-              <img
-                src="{$product.cover.medium.url}"
-                alt="{$product.cover.legend}"
-                data-full-size-image-url="{$product.cover.large.url}"
-              >
+              {if $product.default_image}
+                <img
+                  src="{$product.default_image.medium.url}"
+                  alt="{$product.default_image.legend}"
+                  data-full-size-image-url="{$product.default_image.large.url}"
+                >
+              {else}
+                <img src="{$urls.no_picture_image.bySize.cart_default.url}" />
+              {/if}
             </a>
           </div>
         </div>
@@ -44,12 +48,12 @@
           </a>
         </div>
 
-        {if $showPackProductsPrice} 
+        {if $showPackProductsPrice}
           <div class="pack-product-price">
             <strong>{$product.price}</strong>
           </div>
         {/if}
-        
+
         <div class="pack-product-quantity">
           <span>x {$product.pack_quantity}</span>
         </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>
## DO NOT MERGE UNTIL 1770 RELEASE

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Use default image instead of cover in the pack products list as the default image matches with the combination
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21875
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22103)
<!-- Reviewable:end -->
