### PR TITLE
The LIMIT 1 has no aim, retrieve all connected guest instead

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -67,7 +67,6 @@ class AdminCartsControllerCore extends AdminController
             FROM `' . _DB_PREFIX_ . 'connections`
             WHERE
                 TIME_TO_SEC(TIMEDIFF(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', `date_add`)) < 1800
-            LIMIT 1
        ) AS co ON co.`id_guest` = a.`id_guest`';
 
         if (Tools::getValue('action') && Tools::getValue('action') == 'filterOnlyAbandonedCarts') {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | I really don't remember why I added the LIMIT 1 in the past, but there is no reason and it produces a bug.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15267.
| How to test?  | Create a cart with a guest, then open a new window in incognito mode and create one more cart. Reach the Shopping Cart in the BO, you should see ![image](https://user-images.githubusercontent.com/1462701/100248697-14e49500-2f3c-11eb-9821-9e5b8cd92416.png) instead of ![image](https://user-images.githubusercontent.com/1462701/100248728-1f9f2a00-2f3c-11eb-818b-0e9712398216.png)

.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22107)
<!-- Reviewable:end -->
