### PR TITLE
Fix bug on displayed price's calculation in BO order page under specific conditions

### DIFF
--- a/classes/Group.php
+++ b/classes/Group.php
@@ -73,8 +73,8 @@ class GroupCore extends ObjectModel
 
     protected $webserviceParameters = [];
 
-    const PRICE_DISPLAY_METHOD_TAX_INCL = 0;
-    const PRICE_DISPLAY_METHOD_TAX_EXCL = 1;
+    public const PRICE_DISPLAY_METHOD_TAX_INCL = 0;
+    public const PRICE_DISPLAY_METHOD_TAX_EXCL = 1;
 
     public function __construct($id = null, $id_lang = null, $id_shop = null)
     {

--- a/classes/Group.php
+++ b/classes/Group.php
@@ -73,6 +73,9 @@ class GroupCore extends ObjectModel
 
     protected $webserviceParameters = [];
 
+    const PRICE_DISPLAY_METHOD_TAX_INCL = 0;
+    const PRICE_DISPLAY_METHOD_TAX_EXCL = 1;
+
     public function __construct($id = null, $id_lang = null, $id_shop = null)
     {
         parent::__construct($id, $id_lang, $id_shop);

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -94,6 +94,7 @@ use SearchEngine;
 use Shop;
 use ShopGroup;
 use ShopUrl;
+use SpecificPrice;
 use State;
 use Stock;
 use StockAvailable;
@@ -352,5 +353,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
         TaxRule::resetStaticCache();
         TaxRulesGroup::resetStaticCache();
         WebserviceKey::resetStaticCache();
+        SpecificPrice::flushCache();
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Configuration/PriceDisplayMethodConfigurationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Configuration/PriceDisplayMethodConfigurationFeatureContext.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Configuration;
+
+use Customer;
+use Group;
+
+class PriceDisplayMethodConfigurationFeatureContext extends AbstractConfigurationFeatureContext
+{
+    /**
+     * @Given /^price display method for the group of the customer having email "(.+)" is "(tax included|tax excluded)"$/
+     */
+    public function setPriceDisplayMethodForCustomer(string $customerEmail, string $priceDisplayMethod)
+    {
+        $data = Customer::getCustomersByEmail($customerEmail);
+        $customer = new Customer($data[0]['id_customer']);
+
+        $group = new Group($customer->id_default_group);
+        if ($priceDisplayMethod === 'tax included') {
+            $group->price_display_method = Group::PRICE_DISPLAY_METHOD_TAX_INCL;
+        } elseif ($priceDisplayMethod === 'tax excluded') {
+            $group->price_display_method = Group::PRICE_DISPLAY_METHOD_TAX_EXCL;
+        }
+
+        $group->update();
+        Group::clearCachedValues();
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Configuration/PriceDisplayMethodConfigurationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Configuration/PriceDisplayMethodConfigurationFeatureContext.php
@@ -28,6 +28,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Configuration;
 
 use Customer;
 use Group;
+use RuntimeException;
 
 class PriceDisplayMethodConfigurationFeatureContext extends AbstractConfigurationFeatureContext
 {
@@ -37,13 +38,19 @@ class PriceDisplayMethodConfigurationFeatureContext extends AbstractConfiguratio
     public function setPriceDisplayMethodForCustomer(string $customerEmail, string $priceDisplayMethod)
     {
         $data = Customer::getCustomersByEmail($customerEmail);
-        $customer = new Customer($data[0]['id_customer']);
+        $data = reset($data);
+        if (!isset($data['id_customer'])) {
+            throw new RuntimeException(sprintf('Customer with email %s was not found', $customerEmail));
+        }
+        $customer = new Customer($data['id_customer']);
 
         $group = new Group($customer->id_default_group);
         if ($priceDisplayMethod === 'tax included') {
             $group->price_display_method = Group::PRICE_DISPLAY_METHOD_TAX_INCL;
         } elseif ($priceDisplayMethod === 'tax excluded') {
             $group->price_display_method = Group::PRICE_DISPLAY_METHOD_TAX_EXCL;
+        } else {
+            throw new RuntimeException(sprintf('Price display method %s is not known', $priceDisplayMethod));
         }
 
         $group->update();

--- a/tests/Integration/Behaviour/Features/Context/Configuration/PriceDisplayMethodConfigurationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Configuration/PriceDisplayMethodConfigurationFeatureContext.php
@@ -35,7 +35,7 @@ class PriceDisplayMethodConfigurationFeatureContext extends AbstractConfiguratio
     /**
      * @Given /^price display method for the group of the customer having email "(.+)" is "(tax included|tax excluded)"$/
      */
-    public function setPriceDisplayMethodForCustomer(string $customerEmail, string $priceDisplayMethod)
+    public function setPriceDisplayMethodForCustomer(string $customerEmail, string $priceDisplayMethod): void
     {
         $data = Customer::getCustomersByEmail($customerEmail);
         $data = reset($data);

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1726,4 +1726,40 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
 
         return $taxManager->getTaxCalculator();
     }
+
+    /**
+     * @Then the product :productReference in order :orderReference has the following prices for viewing in BO:
+     *
+     * @param string $orderReference
+     * @param TableNode $table
+     */
+    public function checkOrderForViewingWithReference(string $productReference, string $orderReference, TableNode $table)
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $productId = $this->getProductIdByName($productReference);
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing((int) $orderId));
+
+        $productList = $orderForViewing->getProducts()->getProducts();
+        $expectedDetails = $table->getRowsHash();
+        foreach ($productList as $product) {
+            if ($product->getId() == $productId) {
+                Assert::assertEquals(
+                    $expectedDetails['unit_price_tax_excl_raw'],
+                    $product->getUnitPriceTaxExclRaw()
+                );
+                Assert::assertEquals(
+                    $expectedDetails['unit_price_tax_incl_raw'],
+                    $product->getUnitPriceTaxInclRaw()
+                );
+                Assert::assertEquals(
+                    $expectedDetails['unit_price'],
+                    $product->getUnitPrice()
+                );
+                Assert::assertEquals(
+                    $expectedDetails['total_price'],
+                    $product->getTotalPrice()
+                );
+            }
+        }
+    }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1733,11 +1733,11 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
      * @param string $orderReference
      * @param TableNode $table
      */
-    public function checkOrderForViewingWithReference(string $productReference, string $orderReference, TableNode $table)
+    public function checkOrderForViewingWithReference(string $productReference, string $orderReference, TableNode $table): void
     {
         $orderId = SharedStorage::getStorage()->get($orderReference);
         $productId = $this->getProductIdByName($productReference);
-        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing((int) $orderId));
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
 
         $productList = $orderForViewing->getProducts()->getProducts();
         $expectedDetails = $table->getRowsHash();

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1728,7 +1728,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then the product :productReference in order :orderReference has the following prices for viewing in BO:
+     * @Then product :productReference in order :orderReference has following prices for viewing in BO:
      *
      * @param string $orderReference
      * @param TableNode $table

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
@@ -4,7 +4,7 @@
 @order-rounding-type
 
 Feature: In BO, get right display prices for products and totals, depending on the order's rounding type
-  As a BO user, I need to get see the right prices depending on rounding type with odd tax
+  As a BO user, I need to see the right prices depending on rounding type with odd tax
 
   Background:
     Given email sending is disabled

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
@@ -1,0 +1,113 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-rounding-type
+@reset-database-before-feature
+@clear-cache-before-feature
+@order-rounding-type
+
+Feature: In BO, get right display prices for products and totals, depending on the order's rounding type
+  As a BO user, I need to get see the right prices depending on rounding type with odd tax
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "FR" is enabled
+    And I add new tax "odd-tax" with following properties:
+      | name         | Odd Tax (21%) |
+      | rate         | 21            |
+      | is_enabled   | true          |
+    And I add the tax rule group "odd-tax-group" for the tax "odd-tax" with the following conditions:
+      | name         | Odd Tax (21%) |
+      | country      | FR            |
+    And there is a product in the catalog named "Test Product With Odd Tax" with a price of 7.80 and 100 items in stock
+    And I set tax rule group "odd-tax-group" to product "Test Product With Odd Tax"
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And price display method for the group of the customer having email "pub@prestashop.com" is "tax included"
+    And customer "testCustomer" has address in "FR" country
+
+  Scenario: Check prices of an order's product as seen in BO when rounding type is per line
+    Given specific shop configuration for "rounding type" is set to round each line
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "FR" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 80 products "Test Product With Odd Tax" to the cart "dummy_cart"
+    And a carrier "price_carrier" with name "My cheap carrier" exists
+    And I enable carrier "price_carrier"
+    And I associate the tax rule group "odd-tax-group" to carrier "price_carrier"
+    And I select carrier "price_carrier" for cart "dummy_cart"
+    And cart "dummy_cart" should have "price_carrier" as a carrier
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    Then product "Test Product With Odd Tax" in order "bo_order1" has following details:
+      | product_quantity            | 80     |
+      | product_price               | 7.80   |
+      | original_product_price      | 7.80   |
+      | unit_price_tax_incl         | 9.438  |
+      | unit_price_tax_excl         | 7.80   |
+      | total_price_tax_excl        | 624.00 |
+      | total_price_tax_incl        | 755.04 |
+    Then the product "Test Product With Odd Tax" in order "bo_order1" has the following prices for viewing in BO:
+      | unit_price_tax_excl_raw     | 7.8    |
+      | unit_price_tax_incl_raw     | 9.44   |
+      | unit_price                  | $9.44  |
+      | total_price                 | $755.04 |
+
+  Scenario: Check prices of an order's product as seen in BO when rounding type is per item
+    Given specific shop configuration for "rounding type" is set to round each article
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "FR" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 80 products "Test Product With Odd Tax" to the cart "dummy_cart"
+    And a carrier "price_carrier" with name "My cheap carrier" exists
+    And I enable carrier "price_carrier"
+    And I associate the tax rule group "odd-tax-group" to carrier "price_carrier"
+    And I select carrier "price_carrier" for cart "dummy_cart"
+    And cart "dummy_cart" should have "price_carrier" as a carrier
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    Then product "Test Product With Odd Tax" in order "bo_order1" has following details:
+      | product_quantity            | 80     |
+      | product_price               | 7.80   |
+      | original_product_price      | 7.80   |
+      | unit_price_tax_incl         | 9.438  |
+      | unit_price_tax_excl         | 7.80   |
+      | total_price_tax_excl        | 624.00 |
+      | total_price_tax_incl        | 755.20 |
+    Then the product "Test Product With Odd Tax" in order "bo_order1" has the following prices for viewing in BO:
+      | unit_price_tax_excl_raw     | 7.8    |
+      | unit_price_tax_incl_raw     | 9.44   |
+      | unit_price                  | $9.44  |
+      | total_price                 | $755.20|
+
+  Scenario: Check prices of an order's product as seen in BO when rounding type is per cart total
+    Given specific shop configuration for "rounding type" is set to round cart total
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "FR" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 80 products "Test Product With Odd Tax" to the cart "dummy_cart"
+    And a carrier "price_carrier" with name "My cheap carrier" exists
+    And I enable carrier "price_carrier"
+    And I associate the tax rule group "odd-tax-group" to carrier "price_carrier"
+    And I select carrier "price_carrier" for cart "dummy_cart"
+    And cart "dummy_cart" should have "price_carrier" as a carrier
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    Then product "Test Product With Odd Tax" in order "bo_order1" has following details:
+      | product_quantity            | 80     |
+      | product_price               | 7.80   |
+      | original_product_price      | 7.80   |
+      | unit_price_tax_incl         | 9.438  |
+      | unit_price_tax_excl         | 7.80   |
+      | total_price_tax_excl        | 624.00 |
+      | total_price_tax_incl        | 755.04 |
+    Then the product "Test Product With Odd Tax" in order "bo_order1" has the following prices for viewing in BO:
+      | unit_price_tax_excl_raw     | 7.8    |
+      | unit_price_tax_incl_raw     | 9.44   |
+      | unit_price                  | $9.44  |
+      | total_price                 | $755.04 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
@@ -48,7 +48,7 @@ Feature: In BO, get right display prices for products and totals, depending on t
       | unit_price_tax_excl         | 7.80   |
       | total_price_tax_excl        | 624.00 |
       | total_price_tax_incl        | 755.04 |
-    Then the product "Test Product With Odd Tax" in order "bo_order1" has the following prices for viewing in BO:
+    Then product "Test Product With Odd Tax" in order "bo_order1" has following prices for viewing in BO:
       | unit_price_tax_excl_raw     | 7.8    |
       | unit_price_tax_incl_raw     | 9.44   |
       | unit_price                  | $9.44  |
@@ -77,7 +77,7 @@ Feature: In BO, get right display prices for products and totals, depending on t
       | unit_price_tax_excl         | 7.80   |
       | total_price_tax_excl        | 624.00 |
       | total_price_tax_incl        | 755.20 |
-    Then the product "Test Product With Odd Tax" in order "bo_order1" has the following prices for viewing in BO:
+    Then product "Test Product With Odd Tax" in order "bo_order1" has following prices for viewing in BO:
       | unit_price_tax_excl_raw     | 7.8    |
       | unit_price_tax_incl_raw     | 9.44   |
       | unit_price                  | $9.44  |
@@ -106,7 +106,7 @@ Feature: In BO, get right display prices for products and totals, depending on t
       | unit_price_tax_excl         | 7.80   |
       | total_price_tax_excl        | 624.00 |
       | total_price_tax_incl        | 755.04 |
-    Then the product "Test Product With Odd Tax" in order "bo_order1" has the following prices for viewing in BO:
+    Then product "Test Product With Odd Tax" in order "bo_order1" has following prices for viewing in BO:
       | unit_price_tax_excl_raw     | 7.8    |
       | unit_price_tax_incl_raw     | 9.44   |
       | unit_price                  | $9.44  |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -88,6 +88,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Configuration\RoundingTypeConfigurationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Configuration\PriceDisplayMethodConfigurationFeatureContext
         currency:
             paths:
                 - %paths.base%/Features/Scenario/Currency


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | This PR is a bug fix in `OrderForViewing`, when the customer's group price display method is set to "tax inclusive", the shop rounding method is set to "per article", and the tax applied is an odd tax like 21%. Then the total display per order detail is not correct. (only the displayed value for viewing)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21708
| How to test?  | See steps in the issue, it's important to respect all steps, for example you won't reproduce the bug if you don't have an odd tax like 21%.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22126)
<!-- Reviewable:end -->
