### PR TITLE
Fix dependency which is targeting the v1.3.0 instead of the 1.3 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "require": {
         "php": ">=7.1.3",
         "ext-curl": "*",
-        "ext-fileinfo": "*",
-        "ext-intl": "*",
-        "ext-zip": "*",
-        "ext-iconv": "*",
-        "ext-json": "*",
-        "ext-gd": "*",
         "ext-dom": "*",
+        "ext-fileinfo": "*",
+        "ext-gd": "*",
+        "ext-iconv": "*",
+        "ext-intl": "*",
+        "ext-json": "*",
+        "ext-zip": "*",
         "beberlei/doctrineextensions": "^1.0",
         "composer/ca-bundle": "^1.0",
         "composer/installers": "^1.0.21",
-        "csa/guzzle-bundle": "1.3",
+        "csa/guzzle-bundle": "dev-compat-php",
         "cssjanus/cssjanus": "dev-patch-1",
         "curl/curl": "^1.2.1",
         "defuse/php-encryption": "~2.0.1",
@@ -124,11 +124,13 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/prestashop/php-cssjanus"
+            "url": "https://github.com/PrestaShop/php-cssjanus",
+            "canonical": false
         },
         {
             "type": "vcs",
-            "url": "https://github.com/prestashop/CsaGuzzleBundle"
+            "url": "https://github.com/PrestaShop/CsaGuzzleBundle",
+            "canonical": false
         }
     ],
     "require-dev": {
@@ -154,7 +156,10 @@
             "PrestaShop\\PrestaShop\\": "src/",
             "PrestaShopBundle\\": "src/PrestaShopBundle/"
         },
-        "classmap": ["app/AppKernel.php", "app/AppCache.php"]
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppCache.php"
+        ]
     },
     "scripts": {
         "post-install-cmd": [
@@ -231,7 +236,7 @@
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
-          "file": "app/config/parameters.yml"
+            "file": "app/config/parameters.yml"
         },
         "symfony": {
             "require": "~3.4"
@@ -247,5 +252,6 @@
             "homepage": "http://contributors.prestashop.com/"
         }
     ],
-    "license": "OSL-3.0"
+    "license": "OSL-3.0",
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -253,5 +253,6 @@
         }
     ],
     "license": "OSL-3.0",
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e21eec7cf712a2fb9ec36e2881bfdf71",
+    "content-hash": "679c3d819efab16eb4f351db268c1a31",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -259,32 +259,34 @@
         },
         {
             "name": "csa/guzzle-bundle",
-            "version": "v1.3.0",
+            "version": "dev-compat-php",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/CsaGuzzleBundle.git",
-                "reference": "079fc43d6ce7fb738d5dd742a21220da3f9b632b"
+                "reference": "59385d8d6cbcd697c9487ea747a147979ab535df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/CsaGuzzleBundle/zipball/079fc43d6ce7fb738d5dd742a21220da3f9b632b",
-                "reference": "079fc43d6ce7fb738d5dd742a21220da3f9b632b",
+                "url": "https://api.github.com/repos/PrestaShop/CsaGuzzleBundle/zipball/59385d8d6cbcd697c9487ea747a147979ab535df",
+                "reference": "59385d8d6cbcd697c9487ea747a147979ab535df",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "~4.0|~5.0",
-                "guzzlehttp/log-subscriber": "~1.0",
-                "php": ">=5.4.0",
-                "symfony/expression-language": "~2.4|~3.0",
-                "symfony/framework-bundle": "~2.3|~3.0",
-                "twig/twig": "~1.12"
+                "guzzlehttp/guzzle": "^5.3",
+                "guzzlehttp/log-subscriber": "^1.0",
+                "php": "^7.1",
+                "symfony/dependency-injection": "^3.4",
+                "symfony/expression-language": "^3.4",
+                "symfony/framework-bundle": "^3.4",
+                "symfony/http-kernel": "^3.4",
+                "twig/twig": "^1.34|^2.4"
             },
             "require-dev": {
-                "doctrine/cache": "~1.1",
-                "guzzlehttp/guzzle-services": "~0.3",
-                "phpunit/phpunit": "~4.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0",
-                "symfony/web-profiler-bundle": "~2.3"
+                "doctrine/cache": "^1.1",
+                "guzzlehttp/guzzle-services": "^0.6",
+                "phpunit/phpunit": "^7",
+                "symfony/web-profiler-bundle": "^3.4",
+                "symfony/yaml": "^3.4"
             },
             "suggest": {
                 "doctrine/cache": "Allows caching of responses",
@@ -312,9 +314,9 @@
             ],
             "description": "A bundle integrating GuzzleHttp >= 4.0",
             "support": {
-                "source": "https://github.com/PrestaShop/CsaGuzzleBundle/tree/v1.3.0"
+                "source": "https://github.com/PrestaShop/CsaGuzzleBundle/tree/1.3"
             },
-            "time": "2015-06-12T13:09:26+00:00"
+            "time": "2019-09-30T13:13:08+00:00"
         },
         {
             "name": "cssjanus/cssjanus",
@@ -1544,6 +1546,7 @@
                 "reflection",
                 "static"
             ],
+            "abandoned": "roave/better-reflection",
             "time": "2020-01-08T19:53:19+00:00"
         },
         {
@@ -1985,7 +1988,7 @@
         },
         {
             "name": "guzzlehttp/log-subscriber",
-            "version": "1.0.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/log-subscriber.git",
@@ -2034,6 +2037,10 @@
                 "log",
                 "plugin"
             ],
+            "support": {
+                "issues": "https://github.com/guzzle/log-subscriber/issues",
+                "source": "https://github.com/guzzle/log-subscriber/tree/1.0.1"
+            },
             "abandoned": true,
             "time": "2014-10-13T03:31:43+00:00"
         },
@@ -3772,9 +3779,6 @@
             ],
             "description": "PrestaShop module blockreassurance",
             "homepage": "https://github.com/PrestaShop/blockreassurance",
-            "support": {
-                "source": "https://github.com/PrestaShop/blockreassurance/tree/v5.0.0"
-            },
             "time": "2020-07-17T14:12:46+00:00"
         },
         {
@@ -3864,9 +3868,6 @@
             ],
             "description": "PrestaShop module contactform",
             "homepage": "https://github.com/PrestaShop/contactform",
-            "support": {
-                "source": "https://github.com/PrestaShop/contactform/tree/v4.3.0"
-            },
             "time": "2020-09-15T09:37:15+00:00"
         },
         {
@@ -3899,9 +3900,6 @@
             ],
             "description": "PrestaShop module dashactivity",
             "homepage": "https://github.com/PrestaShop/dashactivity",
-            "support": {
-                "source": "https://github.com/PrestaShop/dashactivity/tree/master"
-            },
             "time": "2017-12-08T11:06:01+00:00"
         },
         {
@@ -3934,9 +3932,6 @@
             ],
             "description": "PrestaShop module dashgoals",
             "homepage": "https://github.com/PrestaShop/dashgoals",
-            "support": {
-                "source": "https://github.com/PrestaShop/dashgoals/tree/v2.0.2"
-            },
             "time": "2018-01-29T17:51:57+00:00"
         },
         {
@@ -3969,9 +3964,6 @@
             ],
             "description": "PrestaShop module dashproducts",
             "homepage": "https://github.com/PrestaShop/dashproducts",
-            "support": {
-                "source": "https://github.com/PrestaShop/dashproducts/tree/v2.1.1"
-            },
             "time": "2020-09-28T11:23:29+00:00"
         },
         {
@@ -4012,9 +4004,6 @@
             ],
             "description": "PrestaShop module dashtrends",
             "homepage": "https://github.com/PrestaShop/dashtrends",
-            "support": {
-                "source": "https://github.com/PrestaShop/dashtrends/tree/v2.0.3"
-            },
             "time": "2020-10-14T13:35:03+00:00"
         },
         {
@@ -4099,9 +4088,6 @@
             ],
             "description": "PrestaShop module graphnvd3",
             "homepage": "https://github.com/PrestaShop/graphnvd3",
-            "support": {
-                "source": "https://github.com/PrestaShop/graphnvd3/tree/v2.0.1"
-            },
             "time": "2019-04-03T08:19:54+00:00"
         },
         {
@@ -4134,9 +4120,6 @@
             ],
             "description": "PrestaShop module gridhtml",
             "homepage": "https://github.com/PrestaShop/gridhtml",
-            "support": {
-                "source": "https://github.com/PrestaShop/gridhtml/tree/dev"
-            },
             "time": "2017-02-22T11:03:13+00:00"
         },
         {
@@ -4169,9 +4152,6 @@
             ],
             "description": "PrestaShop module gsitemap",
             "homepage": "https://github.com/PrestaShop/gsitemap",
-            "support": {
-                "source": "https://github.com/PrestaShop/gsitemap/tree/v4.2.0"
-            },
             "time": "2020-06-23T05:58:30+00:00"
         },
         {
@@ -4204,9 +4184,6 @@
             ],
             "description": "PrestaShop module pagesnotfound",
             "homepage": "https://github.com/PrestaShop/pagesnotfound",
-            "support": {
-                "source": "https://github.com/PrestaShop/pagesnotfound/tree/dev"
-            },
             "time": "2017-02-20T11:14:52+00:00"
         },
         {
@@ -4287,9 +4264,6 @@
             ],
             "description": "PrestaShop module ps_banner",
             "homepage": "https://github.com/PrestaShop/ps_banner",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_banner/tree/dev"
-            },
             "time": "2018-02-05T21:44:48+00:00"
         },
         {
@@ -4322,10 +4296,6 @@
             ],
             "description": "PrestaShop category tree links",
             "homepage": "https://github.com/PrestaShop/ps_categorytree",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_categorytree/issues",
-                "source": "https://github.com/PrestaShop/ps_categorytree/tree/dev"
-            },
             "time": "2017-02-01T09:28:43+00:00"
         },
         {
@@ -4367,9 +4337,6 @@
             ],
             "description": "PrestaShop module ps_checkpayment",
             "homepage": "https://github.com/PrestaShop/ps_checkpayment",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_checkpayment/tree/v2.0.5"
-            },
             "time": "2020-10-16T07:20:00+00:00"
         },
         {
@@ -4402,9 +4369,6 @@
             ],
             "description": "PrestaShop module ps_contactinfo",
             "homepage": "https://github.com/PrestaShop/ps_contactinfo",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_contactinfo/tree/master"
-            },
             "time": "2020-05-28T12:57:52+00:00"
         },
         {
@@ -4437,10 +4401,6 @@
             ],
             "description": "PrestaShop - Cross selling",
             "homepage": "https://github.com/PrestaShop/ps_crossselling",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_crossselling/issues",
-                "source": "https://github.com/PrestaShop/ps_crossselling/tree/v2.0.0"
-            },
             "time": "2017-06-23T09:47:31+00:00"
         },
         {
@@ -4477,9 +4437,6 @@
             ],
             "description": "PrestaShop module ps_currencyselector",
             "homepage": "https://github.com/PrestaShop/ps_currencyselector",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_currencyselector/tree/master"
-            },
             "time": "2019-12-31T16:04:31+00:00"
         },
         {
@@ -4512,9 +4469,6 @@
             ],
             "description": "PrestaShop module ps_customeraccountlinks",
             "homepage": "https://github.com/PrestaShop/ps_customeraccountlinks",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_customeraccountlinks/tree/master"
-            },
             "time": "2017-12-08T10:53:29+00:00"
         },
         {
@@ -4555,9 +4509,6 @@
             ],
             "description": "PrestaShop - Customer 'Sign in' link",
             "homepage": "https://github.com/PrestaShop/ps_customersignin",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_customersignin/tree/v2.0.3"
-            },
             "time": "2020-09-18T07:24:23+00:00"
         },
         {
@@ -4599,9 +4550,6 @@
             ],
             "description": "PrestaShop module ps_customtext",
             "homepage": "https://github.com/PrestaShop/ps_customtext",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_customtext/tree/v4.1.1"
-            },
             "time": "2020-09-17T10:27:07+00:00"
         },
         {
@@ -4634,10 +4582,6 @@
             ],
             "description": "PrestaShop - Data privacy",
             "homepage": "https://github.com/PrestaShop/ps_dataprivacy",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_dataprivacy/issues",
-                "source": "https://github.com/PrestaShop/ps_dataprivacy/tree/v2.0.0"
-            },
             "time": "2017-06-23T09:45:26+00:00"
         },
         {
@@ -4670,9 +4614,6 @@
             ],
             "description": "PrestaShop module ps_emailsubscription",
             "homepage": "https://github.com/PrestaShop/ps_emailsubscription",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_emailsubscription/tree/v2.6.0"
-            },
             "time": "2020-06-18T06:13:36+00:00"
         },
         {
@@ -4722,9 +4663,6 @@
             ],
             "description": "PrestaShop module ps_facetedsearch",
             "homepage": "https://github.com/PrestaShop/ps_facetedsearch",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_facetedsearch/tree/v3.6.0"
-            },
             "time": "2020-09-08T07:05:01+00:00"
         },
         {
@@ -4766,9 +4704,6 @@
             ],
             "description": "PrestaShop - Favicon notification BO",
             "homepage": "https://github.com/PrestaShop/ps_faviconnotificationbo",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_faviconnotificationbo/tree/v2.1.0"
-            },
             "time": "2020-06-09T08:08:54+00:00"
         },
         {
@@ -4801,9 +4736,6 @@
             ],
             "description": "PrestaShop - Featured products",
             "homepage": "https://github.com/PrestaShop/ps_featuredproducts",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.0"
-            },
             "time": "2020-07-22T16:21:40+00:00"
         },
         {
@@ -4836,9 +4768,6 @@
             ],
             "description": "PrestaShop - Image slider",
             "homepage": "https://github.com/PrestaShop/ps_imageslider",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_imageslider/tree/master"
-            },
             "time": "2020-06-01T13:57:45+00:00"
         },
         {
@@ -4871,9 +4800,6 @@
             ],
             "description": "PrestaShop module ps_languageselector",
             "homepage": "https://github.com/PrestaShop/ps_languageselector",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_languageselector/tree/v2.1.0"
-            },
             "time": "2020-06-26T07:00:29+00:00"
         },
         {
@@ -4918,10 +4844,6 @@
             ],
             "description": "PrestaShop - Link list",
             "homepage": "https://github.com/PrestaShop/ps_linklist",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_linklist/issues",
-                "source": "https://github.com/PrestaShop/ps_linklist/tree/master"
-            },
             "time": "2020-07-10T07:10:55+00:00"
         },
         {
@@ -4954,9 +4876,6 @@
             ],
             "description": "PrestaShop - Main menu",
             "homepage": "https://github.com/PrestaShop/ps_mainmenu",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_mainmenu/tree/v2.2.0"
-            },
             "time": "2020-07-10T14:25:07+00:00"
         },
         {
@@ -4989,10 +4908,6 @@
             ],
             "description": "PrestaShop module ps_searchbar",
             "homepage": "https://github.com/PrestaShop/ps_searchbar",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_searchbar/issues",
-                "source": "https://github.com/PrestaShop/ps_searchbar/tree/dev"
-            },
             "time": "2017-03-23T10:36:40+00:00"
         },
         {
@@ -5025,9 +4940,6 @@
             ],
             "description": "PrestaShop module ps_sharebuttons",
             "homepage": "https://github.com/PrestaShop/ps_sharebuttons",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_sharebuttons/tree/master"
-            },
             "time": "2020-05-20T12:16:49+00:00"
         },
         {
@@ -5064,10 +4976,6 @@
             ],
             "description": "PrestaShop module ps_shoppingcart",
             "homepage": "https://github.com/PrestaShop/ps_shoppingcart",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_shoppingcart/issues",
-                "source": "https://github.com/PrestaShop/ps_shoppingcart/tree/master"
-            },
             "time": "2019-10-30T14:07:17+00:00"
         },
         {
@@ -5100,10 +5008,6 @@
             ],
             "description": "PrestaShop module ps_socialfollow",
             "homepage": "https://github.com/PrestaShop/ps_socialfollow",
-            "support": {
-                "issues": "https://github.com/PrestaShop/ps_socialfollow/issues",
-                "source": "https://github.com/PrestaShop/ps_socialfollow/tree/v2.1.0"
-            },
             "time": "2020-04-15T15:03:48+00:00"
         },
         {
@@ -5146,9 +5050,6 @@
             ],
             "description": "PrestaShop module ps_themecusto",
             "homepage": "https://github.com/PrestaShop/ps_themecusto",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_themecusto/tree/v1.2.0"
-            },
             "time": "2020-04-29T06:18:04+00:00"
         },
         {
@@ -5184,9 +5085,6 @@
             ],
             "description": "PrestaShop module ps_wirepayment",
             "homepage": "https://github.com/PrestaShop/ps_wirepayment",
-            "support": {
-                "source": "https://github.com/PrestaShop/ps_wirepayment/tree/master"
-            },
             "time": "2020-06-24T19:32:51+00:00"
         },
         {
@@ -5219,9 +5117,6 @@
             ],
             "description": "PrestaShop module sekeywords",
             "homepage": "https://github.com/PrestaShop/sekeywords",
-            "support": {
-                "source": "https://github.com/PrestaShop/sekeywords/tree/dev"
-            },
             "time": "2017-01-30T15:46:25+00:00"
         },
         {
@@ -5254,9 +5149,6 @@
             ],
             "description": "PrestaShop module statsbestcategories",
             "homepage": "https://github.com/PrestaShop/statsbestcategories",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsbestcategories/tree/master"
-            },
             "time": "2017-12-08T14:47:07+00:00"
         },
         {
@@ -5289,9 +5181,6 @@
             ],
             "description": "PrestaShop module statsbestcustomers",
             "homepage": "https://github.com/PrestaShop/statsbestcustomers",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsbestcustomers/tree/v2.0.2"
-            },
             "time": "2018-01-29T17:21:50+00:00"
         },
         {
@@ -5324,9 +5213,6 @@
             ],
             "description": "PrestaShop module statsbestmanufacturers",
             "homepage": "https://github.com/PrestaShop/statsbestmanufacturers",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsbestmanufacturers/tree/dev"
-            },
             "time": "2017-01-31T17:03:07+00:00"
         },
         {
@@ -5359,9 +5245,6 @@
             ],
             "description": "PrestaShop module statsbestproducts",
             "homepage": "https://github.com/PrestaShop/statsbestproducts",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsbestproducts/tree/dev"
-            },
             "time": "2017-01-30T16:33:56+00:00"
         },
         {
@@ -5394,9 +5277,6 @@
             ],
             "description": "PrestaShop module statsbestsuppliers",
             "homepage": "https://github.com/PrestaShop/statsbestsuppliers",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsbestsuppliers/tree/dev"
-            },
             "time": "2017-01-30T16:34:19+00:00"
         },
         {
@@ -5429,9 +5309,6 @@
             ],
             "description": "PrestaShop module statsbestvouchers",
             "homepage": "https://github.com/PrestaShop/statsbestvouchers",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsbestvouchers/tree/dev"
-            },
             "time": "2017-01-30T16:34:41+00:00"
         },
         {
@@ -5464,9 +5341,6 @@
             ],
             "description": "PrestaShop module statscarrier",
             "homepage": "https://github.com/PrestaShop/statscarrier",
-            "support": {
-                "source": "https://github.com/PrestaShop/statscarrier/tree/dev"
-            },
             "time": "2017-01-30T17:03:51+00:00"
         },
         {
@@ -5499,9 +5373,6 @@
             ],
             "description": "PrestaShop module statscatalog",
             "homepage": "https://github.com/PrestaShop/statscatalog",
-            "support": {
-                "source": "https://github.com/PrestaShop/statscatalog/tree/dev"
-            },
             "time": "2017-02-02T08:39:32+00:00"
         },
         {
@@ -5534,9 +5405,6 @@
             ],
             "description": "PrestaShop module statscheckup",
             "homepage": "https://github.com/PrestaShop/statscheckup",
-            "support": {
-                "source": "https://github.com/PrestaShop/statscheckup/tree/master"
-            },
             "time": "2018-12-17T09:59:57+00:00"
         },
         {
@@ -5569,9 +5437,6 @@
             ],
             "description": "PrestaShop module statsdata",
             "homepage": "https://github.com/PrestaShop/statsdata",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsdata/tree/master"
-            },
             "time": "2020-07-15T13:10:39+00:00"
         },
         {
@@ -5604,9 +5469,6 @@
             ],
             "description": "PrestaShop module statsequipment",
             "homepage": "https://github.com/PrestaShop/statsequipment",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsequipment/tree/dev"
-            },
             "time": "2017-01-31T17:01:36+00:00"
         },
         {
@@ -5639,9 +5501,6 @@
             ],
             "description": "PrestaShop module statsforecast",
             "homepage": "https://github.com/PrestaShop/statsforecast",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsforecast/tree/dev"
-            },
             "time": "2018-01-29T18:37:54+00:00"
         },
         {
@@ -5674,9 +5533,6 @@
             ],
             "description": "PrestaShop module statslive",
             "homepage": "https://github.com/PrestaShop/statslive",
-            "support": {
-                "source": "https://github.com/PrestaShop/statslive/tree/master"
-            },
             "time": "2020-03-24T08:54:00+00:00"
         },
         {
@@ -5709,9 +5565,6 @@
             ],
             "description": "PrestaShop module statsnewsletter",
             "homepage": "https://github.com/PrestaShop/statsnewsletter",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsnewsletter/tree/v2.0.2"
-            },
             "time": "2018-01-29T18:39:03+00:00"
         },
         {
@@ -5744,9 +5597,6 @@
             ],
             "description": "PrestaShop module statsorigin",
             "homepage": "https://github.com/PrestaShop/statsorigin",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsorigin/tree/v2.0.2"
-            },
             "time": "2018-01-29T19:17:31+00:00"
         },
         {
@@ -5779,9 +5629,6 @@
             ],
             "description": "PrestaShop module statspersonalinfos",
             "homepage": "https://github.com/PrestaShop/statspersonalinfos",
-            "support": {
-                "source": "https://github.com/PrestaShop/statspersonalinfos/tree/master"
-            },
             "time": "2020-06-01T12:28:27+00:00"
         },
         {
@@ -5814,9 +5661,6 @@
             ],
             "description": "PrestaShop module statsproduct",
             "homepage": "https://github.com/PrestaShop/statsproduct",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsproduct/tree/master"
-            },
             "time": "2018-01-29T18:57:47+00:00"
         },
         {
@@ -5849,9 +5693,6 @@
             ],
             "description": "PrestaShop module statsregistrations",
             "homepage": "https://github.com/PrestaShop/statsregistrations",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsregistrations/tree/master"
-            },
             "time": "2017-01-31T17:22:19+00:00"
         },
         {
@@ -5884,9 +5725,6 @@
             ],
             "description": "PrestaShop module statssales",
             "homepage": "https://github.com/PrestaShop/statssales",
-            "support": {
-                "source": "https://github.com/PrestaShop/statssales/tree/dev"
-            },
             "time": "2017-01-31T17:23:19+00:00"
         },
         {
@@ -5919,9 +5757,6 @@
             ],
             "description": "PrestaShop module statssearch",
             "homepage": "https://github.com/PrestaShop/statssearch",
-            "support": {
-                "source": "https://github.com/PrestaShop/statssearch/tree/master"
-            },
             "time": "2017-12-08T12:37:58+00:00"
         },
         {
@@ -5954,9 +5789,6 @@
             ],
             "description": "PrestaShop module statsstock",
             "homepage": "https://github.com/PrestaShop/statsstock",
-            "support": {
-                "source": "https://github.com/PrestaShop/statsstock/tree/dev"
-            },
             "time": "2017-01-31T17:24:06+00:00"
         },
         {
@@ -6092,9 +5924,6 @@
             ],
             "description": "Welcome module for PrestaShop helping the users to create products.",
             "homepage": "https://github.com/PrestaShop/welcome",
-            "support": {
-                "source": "https://github.com/PrestaShop/welcome/tree/v6.0.3"
-            },
             "time": "2020-10-19T13:11:06+00:00"
         },
         {
@@ -10156,8 +9985,9 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
+        "csa/guzzle-bundle": 20,
         "cssjanus/cssjanus": 20,
         "phake/phake": 0
     },
@@ -10166,13 +9996,13 @@
     "platform": {
         "php": ">=7.1.3",
         "ext-curl": "*",
+        "ext-dom": "*",
         "ext-fileinfo": "*",
-        "ext-intl": "*",
-        "ext-zip": "*",
-        "ext-iconv": "*",
-        "ext-json": "*",
         "ext-gd": "*",
-        "ext-dom": "*"
+        "ext-iconv": "*",
+        "ext-intl": "*",
+        "ext-json": "*",
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "679c3d819efab16eb4f351db268c1a31",
+    "content-hash": "843f2cf784d32077051a7cb0c5aae2cb",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -9991,7 +9991,7 @@
         "cssjanus/cssjanus": 20,
         "phake/phake": 0
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -1988,7 +1988,7 @@
         },
         {
             "name": "guzzlehttp/log-subscriber",
-            "version": "dev-master",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/log-subscriber.git",
@@ -2039,7 +2039,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/log-subscriber/issues",
-                "source": "https://github.com/guzzle/log-subscriber/tree/1.0.1"
+                "source": "https://github.com/guzzle/log-subscriber/tree/master"
             },
             "abandoned": true,
             "time": "2014-10-13T03:31:43+00:00"

--- a/composer.lock
+++ b/composer.lock
@@ -263,12 +263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/CsaGuzzleBundle.git",
-                "reference": "59385d8d6cbcd697c9487ea747a147979ab535df"
+                "reference": "7282d89834960347c830efd43dcd788f09a9959a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/CsaGuzzleBundle/zipball/59385d8d6cbcd697c9487ea747a147979ab535df",
-                "reference": "59385d8d6cbcd697c9487ea747a147979ab535df",
+                "url": "https://api.github.com/repos/PrestaShop/CsaGuzzleBundle/zipball/7282d89834960347c830efd43dcd788f09a9959a",
+                "reference": "7282d89834960347c830efd43dcd788f09a9959a",
                 "shasum": ""
             },
             "require": {
@@ -314,9 +314,9 @@
             ],
             "description": "A bundle integrating GuzzleHttp >= 4.0",
             "support": {
-                "source": "https://github.com/PrestaShop/CsaGuzzleBundle/tree/1.3"
+                "source": "https://github.com/PrestaShop/CsaGuzzleBundle/tree/compat-php"
             },
-            "time": "2019-09-30T13:13:08+00:00"
+            "time": "2020-11-26T16:15:58+00:00"
         },
         {
             "name": "cssjanus/cssjanus",


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | It was targeting the wrong version. We need a branch, not the tag. And it was also targeting a very old commit.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixed #22125.
| How to test?  | See ticket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22130)
<!-- Reviewable:end -->
