### PR TITLE
Fix customized product being added to cart, instead of standard one

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -220,7 +220,7 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        $('.product-actions input[name=id_customization]').val(0);
+        $(prestashop.selectors.product.input_customization).val(0);
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -220,7 +220,7 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        $(prestashop.selectors.product.input_customization).val(0);
+        $(prestashop.selectors.product.inputCustomization).val(0);
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -220,6 +220,7 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
+        $('.product-actions input[name=id_customization]').val(0);
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -43,7 +43,7 @@ prestashop.selectors = {
       '.quickview .product-add-to-cart, .page-product:not(.modal-open) .row .product-add-to-cart, .page-product:not(.modal-open) .product-container .product-add-to-cart',
     prices:
       '.quickview .product-prices, .page-product:not(.modal-open) .row .product-prices, .page-product:not(.modal-open) .product-container .product-prices',
-    input_customization:
+    inputCustomization:
       '.product-actions input[name="id_customization"]',
     customization:
       '.quickview .product-customization, .page-product:not(.modal-open) .row .product-customization, .page-product:not(.modal-open) .product-container .product-customization',

--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -43,6 +43,8 @@ prestashop.selectors = {
       '.quickview .product-add-to-cart, .page-product:not(.modal-open) .row .product-add-to-cart, .page-product:not(.modal-open) .product-container .product-add-to-cart',
     prices:
       '.quickview .product-prices, .page-product:not(.modal-open) .row .product-prices, .page-product:not(.modal-open) .product-container .product-prices',
+    input_customization:
+      '.product-actions input[name=id_customization]',
     customization:
       '.quickview .product-customization, .page-product:not(.modal-open) .row .product-customization, .page-product:not(.modal-open) .product-container .product-customization',
     variantsUpdate:

--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -44,7 +44,7 @@ prestashop.selectors = {
     prices:
       '.quickview .product-prices, .page-product:not(.modal-open) .row .product-prices, .page-product:not(.modal-open) .product-container .product-prices',
     input_customization:
-      '.product-actions input[name=id_customization]',
+      '.product-actions input[name="id_customization"]',
     customization:
       '.quickview .product-customization, .page-product:not(.modal-open) .row .product-customization, .page-product:not(.modal-open) .product-container .product-customization',
     variantsUpdate:


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | https://github.com/PrestaShop/PrestaShop/issues/16682
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/16682
| How to test?  | Make a product with customization. Customize it. Add it to cart. Customization disappears from product page. Click Add to cart again, you will add second customized piece to cart, instead of normal product. Happens because id_customization is not updated in it's hidden input. My PR fixes this.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22145)
<!-- Reviewable:end -->

ping @kpodemski and @NeOMakinG - Guys, please, edit the selector to your liking. This works, but I am not a JS guy. Thanks! :-)