### PR TITLE
Fix specific prices redution form

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
@@ -29,11 +29,11 @@
 {% if is_modal == false %}
   {% set column_default_md_3 = 'col-md-3' %}
   {% set column_default_md_2 = 'col-md-2' %}
-  {% set column_default_xl_2 = 'col-xl-2' %}
+  {% set column_default_xl_3 = 'col-xl-3' %}
 {% else %}
   {% set column_default_md_3 = 'col-md-9' %}
   {% set column_default_md_2 = 'col-md-4' %}
-  {% set column_default_xl_2 = 'col-xl-4' %}
+  {% set column_default_xl_3 = 'col-xl-4' %}
 {% endif %}
 
 <div class="card card-block">
@@ -144,21 +144,21 @@
     </div>
   </div>
   <div class="row">
-    <div class="{{ column_default_xl_2 }} col-lg-3">
+    <div class="{{ column_default_xl_3 }} col-lg-3">
       <fieldset class="form-group">
         <label>{{ 'Apply a discount of'|trans({}, 'Admin.Catalog.Feature') }}</label>
         {{ form_errors(form.sp_reduction) }}
         {{ form_widget(form.sp_reduction) }}
       </fieldset>
     </div>
-    <div class="{{ column_default_xl_2 }} col-lg-3">
+    <div class="{{ column_default_xl_3 }} col-lg-3">
       <fieldset class="form-group">
         <label>&nbsp;</label>
         {{ form_errors(form.sp_reduction_type) }}
         {{ form_widget(form.sp_reduction_type) }}
       </fieldset>
     </div>
-    <div class="{{ column_default_xl_2 }} col-lg-3">
+    <div class="{{ column_default_xl_3 }} col-lg-3">
       <fieldset class="form-group">
         <label>&nbsp;</label>
         {{ form_errors(form.sp_reduction_tax) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
@@ -144,7 +144,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="{{ column_default_xl_3 }} col-lg-3">
+    <div class="{{ column_default_xl_3 }} col-lg-4">
       <fieldset class="form-group">
         <label>{{ 'Apply a discount of'|trans({}, 'Admin.Catalog.Feature') }}</label>
         {{ form_errors(form.sp_reduction) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Specific prices redution form not display correctly in screen 1366x768.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A.
| How to test?  | See below.

# Infos

- **Screen** : 1366x768
- **Screen Width**: 1366 pixels
- **Screen Height**: 768 pixels

# Before

![Capture du 2020-11-28 00-59-18](https://user-images.githubusercontent.com/16455155/100489589-4b293c80-3115-11eb-8817-f759b16b72f8.png)

# After

![Capture du 2020-11-28 00-58-36](https://user-images.githubusercontent.com/16455155/100489593-50868700-3115-11eb-92cf-532cc87ec078.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22148)
<!-- Reviewable:end -->
