### PR TITLE
Fix BO - Can't create category on product page

### DIFF
--- a/src/Core/Domain/Product/Command/AssignProductToCategoryCommand.php
+++ b/src/Core/Domain/Product/Command/AssignProductToCategoryCommand.php
@@ -54,7 +54,7 @@ class AssignProductToCategoryCommand
      *
      * @throws CategoryConstraintException
      * @throws ProductConstraintException */
-    public function __construct($categoryId, $productId)
+    public function __construct(int $categoryId, int $productId)
     {
         $this->setCategoryId($categoryId);
         $this->setProductId($productId);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In the BO > Catalog > Products page > Create a new Product, when we try to create a new category, we have an exception in the console. See screen here https://github.com/PrestaShop/PrestaShop/issues/22144 by @khouloudbelguith 
| Type?         | bug fix 
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22144.
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/22144 by @khouloudbelguith 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22149)
<!-- Reviewable:end -->
