### PR TITLE
[WIP] Display Id product attribute in combinations list

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
@@ -24,6 +24,7 @@
  *#}
 <tr class="combination loaded" id="attribute_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" data-index="{{ form.vars.value.id_product_attribute }}">
   <td width="1%"><input class="js-combination" type="checkbox" data-id="{{ form.vars.value.id_product_attribute }}" data-index="{{ form.vars.value.id_product_attribute }}"></td>
+  <td class="attribute-id">{{ form.vars.value.id_product_attribute }}</td>
   <td class="img"><div class="fake-img"></div></td>
     <td>{{ form.vars.value.name }}</td>
     <td class="attribute-price">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -83,6 +83,7 @@
             <th>
               <input type="checkbox" id="toggle-all-combinations" >
             </th>
+            <th>{{ 'ID'|trans({}, 'Admin.Catalog.Global') }}</th>
             <th></th>
             <th>{{ 'Combinations'|trans({}, 'Admin.Catalog.Feature') }}</th>
             <th>{{ 'Impact on price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
@@ -97,6 +98,9 @@
           {% if has_combinations %}
             <tr class="combination loading timeline-wrapper" id="loading-attribute">
               <td class="timeline-item" width="1%">
+              </td>
+              <td class="attribute-id">
+                <div class="animated-background"></div>
               </td>
               <td class="timeline-item img">
                 <div class="animated-background"></div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Display Id product attribute in combinations list. In some cases it is very useful to have the combinations id..
| Type?         | improvement 
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22150
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/22150
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22151)
<!-- Reviewable:end -->
