### PR TITLE
Fix group reduction when specific price is set

### DIFF
--- a/classes/GroupReduction.php
+++ b/classes/GroupReduction.php
@@ -291,6 +291,6 @@ class GroupReductionCore extends ObjectModel
      */
     public static function resetStaticCache()
     {
-        GroupReduction::$reduction_cache = [];
+        static::$reduction_cache = [];
     }
 }

--- a/classes/GroupReduction.php
+++ b/classes/GroupReduction.php
@@ -285,4 +285,12 @@ class GroupReductionCore extends ObjectModel
 
         return true;
     }
+
+    /**
+     * Reset static cache (mainly for test environment)
+     */
+    public static function resetStaticCache()
+    {
+        GroupReduction::$reduction_cache = [];
+    }
 }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3527,7 +3527,11 @@ class ProductCore extends ObjectModel
         }
 
         // Group reduction
-        if (!$specific_price && $use_group_reduction) {
+        // if there is no specificPrice or specificPrice exists but not applied to a customer or cart, then apply group reduction
+        if (
+            (!$specific_price || (empty($specific_price['id_cart']) && empty($specific_price['id_customer'])))
+            && $use_group_reduction
+        ) {
             $reduction_from_category = GroupReduction::getValueForProduct($id_product, $id_group);
             if ($reduction_from_category !== false) {
                 $group_reduction = $price * (float) $reduction_from_category;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3527,11 +3527,7 @@ class ProductCore extends ObjectModel
         }
 
         // Group reduction
-        // if there is no specificPrice or specificPrice exists but not applied to a customer or cart, then apply group reduction
-        if (
-            (!$specific_price || (empty($specific_price['id_cart']) && empty($specific_price['id_customer'])))
-            && $use_group_reduction
-        ) {
+        if ($use_group_reduction) {
             $reduction_from_category = GroupReduction::getValueForProduct($id_product, $id_group);
             if ($reduction_from_category !== false) {
                 $group_reduction = $price * (float) $reduction_from_category;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3527,7 +3527,7 @@ class ProductCore extends ObjectModel
         }
 
         // Group reduction
-        if ($use_group_reduction) {
+        if (!$specific_price && $use_group_reduction) {
             $reduction_from_category = GroupReduction::getValueForProduct($id_product, $id_group);
             if ($reduction_from_category !== false) {
                 $group_reduction = $price * (float) $reduction_from_category;

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -66,19 +66,19 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
         $productId = $this->getProductIdByName($productName);
 
         $product = new Product($productId);
-        $category = new Category($product->id_category_default);
-        if (!$category) {
+        if (!Category::categoryExists($product->id_category_default)) {
             throw new RuntimeException('The product doesn\'t have default category');
         }
 
         $customerId = SharedStorage::getStorage()->get($customerReference);
-        $customer = new Customer((int) $customerId);
-        if (!$customer) {
+        if (!Customer::customerIdExistsStatic($customerId)) {
             throw new RuntimeException('The customer doesn\'t exist');
         }
 
+        $customer = new Customer((int) $customerId);
+
         $groupReduction = new GroupReduction();
-        $groupReduction->id_category = $category->id;
+        $groupReduction->id_category = $product->id_category_default;
         $groupReduction->id_group = $customer->id_default_group;
         $groupReduction->reduction = $reductionPercent / 100;
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -90,6 +90,22 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then The category of product :productName has no reduction
+     */
+    public function theCategoryOfProductHasNoReductionForCustomer(string $productName)
+    {
+        $productId = $this->getProductIdByName($productName);
+
+        GroupReduction::deleteProductReduction($productId);
+
+        $product = new Product($productId);
+
+        GroupReduction::deleteCategory($product->id_category_default);
+
+        GroupReduction::resetStaticCache();
+    }
+
+    /**
      * @param string $productName
      *
      * @return int

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -59,7 +59,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then The category of product :productName has reduction of :reductionPercent% for the customer :customerReference
+     * @Given The category of product :productName has reduction of :reductionPercent% for the customer :customerReference
      */
     public function addReductionOnProductCategoryForCustomerGroup(string $productName, float $reductionPercent, string $customerReference)
     {
@@ -90,7 +90,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then The category of product :productName has no reduction
+     * @Given The category of product :productName has no reduction
      */
     public function deleteReductionOnProductCategory(string $productName)
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -61,7 +61,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then The category of product :productName has reduction of :reductionPercent% for the customer :customerReference
      */
-    public function theCategoryOfProductHasReductionOfForCustomer(string $productName, float $reductionPercent, string $customerReference)
+    public function addReductionOnProductCategoryForCustomerGroup(string $productName, float $reductionPercent, string $customerReference)
     {
         $productId = $this->getProductIdByName($productName);
 
@@ -92,7 +92,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then The category of product :productName has no reduction
      */
-    public function theCategoryOfProductHasNoReductionForCustomer(string $productName)
+    public function deleteReductionOnProductCategory(string $productName)
     {
         $productId = $this->getProductIdByName($productName);
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -59,9 +59,9 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Given The category of product :productName has reduction of :reductionPercent% for the customer :customerReference
+     * @Given The default category of product :productName has a group reduction of :reductionPercent% for the customer :customerReference
      */
-    public function addReductionOnProductCategoryForCustomerGroup(string $productName, float $reductionPercent, string $customerReference)
+    public function addGroupReductionOnProductDefaultCategoryForCustomerGroup(string $productName, float $reductionPercent, string $customerReference)
     {
         $productId = $this->getProductIdByName($productName);
 
@@ -90,9 +90,9 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Given The category of product :productName has no reduction
+     * @Given The default category of product :productName has no group reduction
      */
-    public function deleteReductionOnProductCategory(string $productName)
+    public function deleteGroupReductionOnProductDefaultCategory(string $productName)
     {
         $productId = $this->getProductIdByName($productName);
 

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -31,7 +31,7 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And I create an empty cart "dummy_cart" for customer "testCustomer"
     And I update the cart "dummy_cart" currency to "currency2"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
-    And the category of product "Mug The best is yet to come" has no reduction
+    And the default category of product "Mug The best is yet to come" has no group reduction
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
     And I add order "bo_order1" with the following details:
       | cart                | dummy_cart                 |
@@ -220,7 +220,7 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_incl  | 74.20  |
 
   Scenario: Update product quantity in order with secondary currency when its category has discount
-    Given the category of product "Mug The best is yet to come" has reduction of 50.00% for the customer "testCustomer"
+    Given the default category of product "Mug The best is yet to come" has a group reduction of 50.00% for the customer "testCustomer"
     When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
       | amount        | 3                       |
       | price         | 11.90                   |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -227,19 +227,19 @@ Feature: Multiple currencies for Order in Back Office (BO)
     Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 3     |
-      | product_price               | 59.50 |
-      | unit_price_tax_incl         | 63.07 |
-      | unit_price_tax_excl         | 59.50 |
-      | total_price_tax_incl        | 189.21 |
-      | total_price_tax_excl        | 178.50 |
+      | product_price               | 11.90 |
+      | unit_price_tax_incl         | 12.614 |
+      | unit_price_tax_excl         | 11.90 |
+      | total_price_tax_incl        | 37.84 |
+      | total_price_tax_excl        | 35.70 |
     And order "bo_order1" should have following details:
-      | total_products           | 178.50 |
-      | total_products_wt        | 189.21 |
+      | total_products           | 35.70 |
+      | total_products_wt        | 37.84 |
       | total_discounts_tax_excl | 0.00   |
       | total_discounts_tax_incl | 0.00   |
-      | total_paid_tax_excl      | 248.50 |
-      | total_paid_tax_incl      | 263.41 |
-      | total_paid               | 263.41 |
+      | total_paid_tax_excl      | 105.70 |
+      | total_paid_tax_incl      | 112.04 |
+      | total_paid               | 112.04 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -218,6 +218,53 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
 
+  Scenario: Update product quantity in order with secondary currency when its category has discount
+    Given the category of product "Mug The best is yet to come" has reduction of 50.00% for the customer "testCustomer"
+    When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
+      | amount        | 3                       |
+      | price         | 11.90                   |
+    Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 3     |
+      | product_price               | 59.50 |
+      | unit_price_tax_incl         | 63.07 |
+      | unit_price_tax_excl         | 59.50 |
+      | total_price_tax_incl        | 189.21 |
+      | total_price_tax_excl        | 178.50 |
+    And order "bo_order1" should have following details:
+      | total_products           | 178.50 |
+      | total_products_wt        | 189.21 |
+      | total_discounts_tax_excl | 0.00   |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 248.50 |
+      | total_paid_tax_incl      | 263.41 |
+      | total_paid               | 263.41 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
+    When I edit product "Mug The best is yet to come" to order "bo_order1" with following products details:
+      | amount        | 3                       |
+      | price         | 20.00                   |
+    Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 3     |
+      | product_price               | 20.00 |
+      | unit_price_tax_incl         | 21.20 |
+      | unit_price_tax_excl         | 20.00 |
+      | total_price_tax_incl        | 63.60 |
+      | total_price_tax_excl        | 60.00 |
+    And order "bo_order1" should have following details:
+      | total_products           | 60.00 |
+      | total_products_wt        | 63.60 |
+      | total_discounts_tax_excl | 0.00   |
+      | total_discounts_tax_incl | 0.00   |
+      | total_paid_tax_excl      | 130.00 |
+      | total_paid_tax_incl      | 137.80 |
+      | total_paid               | 137.80 |
+      | total_paid_real          | 0.0    |
+      | total_shipping_tax_excl  | 70.00  |
+      | total_shipping_tax_incl  | 74.20  |
+
   Scenario: Check invoice for an order with secondary currency and discount
     Given I add discount to order "bo_order1" with following details:
       | name      | discount ten-euros    |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -264,6 +264,7 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
+    And the category of product "Mug The best is yet to come" has no reduction
 
   Scenario: Check invoice for an order with secondary currency and discount
     Given I add discount to order "bo_order1" with following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -31,6 +31,7 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And I create an empty cart "dummy_cart" for customer "testCustomer"
     And I update the cart "dummy_cart" currency to "currency2"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And the category of product "Mug The best is yet to come" has no reduction
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
     And I add order "bo_order1" with the following details:
       | cart                | dummy_cart                 |
@@ -264,7 +265,6 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 70.00  |
       | total_shipping_tax_incl  | 74.20  |
-    And the category of product "Mug The best is yet to come" has no reduction
 
   Scenario: Check invoice for an order with secondary currency and discount
     Given I add discount to order "bo_order1" with following details:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Group reduction was applied twice when quantity of a product in an order is updated. To fix it we don't apply category discount if specific price is defined
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22096
| How to test?  | See issue https://github.com/PrestaShop/PrestaShop/issues/22096

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22161)
<!-- Reviewable:end -->
