### PR TITLE
WIP: Introduce form type DecimalNumberType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Type/DecimalNumberType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DecimalNumberType.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Type;
+
+use Currency;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Currency\CurrencyDataProviderInterface;
+use PrestaShopBundle\Form\DataTransformer\DecimalNumberToLocalizedStringTransformer;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DecimalNumberType extends NumberType
+{
+    /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
+     * @var CurrencyDataProviderInterface
+     */
+    private $currencyDataProvider;
+
+    public function __construct(
+        LegacyContext $legacyContext,
+        CurrencyDataProviderInterface $currencyDataProvider
+    ) {
+        $this->legacyContext = $legacyContext;
+        $this->currencyDataProvider = $currencyDataProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addViewTransformer(new DecimalNumberToLocalizedStringTransformer(
+            $options['scale'],
+            $options['grouping'],
+            $options['rounding_mode'],
+            $options['empty_data']
+        ), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $scale = !empty($options['scale']) ? $options['scale'] : $this->getCurrencyPrecision();
+        $resolver->setDefaults([
+            'empty_data' => '0.0',
+            'scale' => $scale,
+        ]);
+
+        $resolver->setAllowedTypes('empty_data', ['null', 'string']);
+    }
+
+    /**
+     * Get precision from context or default currency
+     *
+     * @return int
+     */
+    private function getCurrencyPrecision(): int
+    {
+        if ($this->legacyContext->getContext()->currency instanceof Currency) {
+            $currency = $this->legacyContext->getContext()->currency;
+        } else {
+            $defaultIso = $this->currencyDataProvider->getDefaultCurrencyIsoCode();
+            $currency = $this->currencyDataProvider->getCurrencyByIsoCode($defaultIso);
+        }
+
+        return (int) $currency->precision;
+    }
+}

--- a/src/PrestaShopBundle/Form/DataTransformer/DecimalNumberToLocalizedStringTransformer.php
+++ b/src/PrestaShopBundle/Form/DataTransformer/DecimalNumberToLocalizedStringTransformer.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\DataTransformer;
+
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\Decimal\Operation\Rounding;
+use PrestaShopBundle\Form\Admin\Type\DecimalNumberType;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
+
+/**
+ * This transformer allows to use DecimalNumber as input in a form straight away @see DecimalNumberType
+ */
+class DecimalNumberToLocalizedStringTransformer extends NumberToLocalizedStringTransformer
+{
+    private const ROUNDING_MAP = [
+        self::ROUND_HALF_UP => Rounding::ROUND_HALF_UP,
+        self::ROUND_HALF_EVEN => Rounding::ROUND_HALF_EVEN,
+        self::ROUND_HALF_DOWN => Rounding::ROUND_HALF_DOWN,
+        self::ROUND_FLOOR => Rounding::ROUND_FLOOR,
+        self::ROUND_CEILING => Rounding::ROUND_CEIL,
+        self::ROUND_DOWN => Rounding::ROUND_HALF_DOWN,
+        self::ROUND_UP => Rounding::ROUND_HALF_UP,
+    ];
+
+    /**
+     * @var int|null
+     */
+    private $scale;
+
+    /**
+     * @var string
+     */
+    private $emptyData;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($scale = null, $grouping = false, $roundingMode = self::ROUND_HALF_UP, $emptyData = '')
+    {
+        $this->scale = $scale;
+        $this->emptyData = $emptyData ?: '0.0';
+        parent::__construct($scale, $grouping, $roundingMode);
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     *
+     * @param DecimalNumber $value The value in the original representation
+     *
+     * @return string The value in the transformed representation
+     */
+    public function transform($value)
+    {
+        if (null === $value) {
+            $value = new DecimalNumber($this->emptyData);
+        }
+
+        if (!($value instanceof DecimalNumber)) {
+            throw new TransformationFailedException(sprintf('Expected a %s.', DecimalNumber::class));
+        }
+
+        return parent::transform($value->toPrecision($this->scale, $this->getRounding($this->roundingMode)));
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     *
+     * @param string $value The value in the transformed representation
+     *
+     * @return DecimalNumber The value in the original representation
+     */
+    public function reverseTransform($value)
+    {
+        $value = $value ?: $this->emptyData;
+        // We use parent method to apply rounding
+        $transformedValue = parent::reverseTransform($value);
+
+        return new DecimalNumber((string) $transformedValue);
+    }
+
+    /**
+     * @param int $roundingMode
+     *
+     * @return string
+     */
+    private function getRounding(int $roundingMode): string
+    {
+        if (!isset(self::ROUNDING_MAP[$roundingMode])) {
+            return Rounding::ROUND_TRUNCATE;
+        }
+
+        return self::ROUNDING_MAP[$roundingMode];
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1226,3 +1226,11 @@ services:
       public: true
       tags:
         - { name: form.type }
+
+    form.type.decimal_number:
+        class: PrestaShopBundle\Form\Admin\Type\DecimalNumberType
+        arguments:
+            - '@prestashop.adapter.legacy.context'
+            - '@prestashop.adapter.data_provider.currency'
+        tags:
+            - { name: form.type }

--- a/tests/Unit/PrestaShopBundle/Form/DataTransformer/DecimalNumberToLocalizedStringTransformerTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/DataTransformer/DecimalNumberToLocalizedStringTransformerTest.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShopBundle\Form\DataTransformer\DecimalNumberToLocalizedStringTransformer;
+
+class DecimalNumberToLocalizedStringTransformerTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private static $defaultLocale;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        static::$defaultLocale = \Locale::getDefault();
+        \Locale::setDefault('en');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        \Locale::setDefault(static::$defaultLocale);
+    }
+
+    /**
+     * @dataProvider getTransformations
+     *
+     * @param int|null $scale
+     * @param string $emptyData
+     * @param int $roundingMode
+     * @param DecimalNumber|null $number
+     * @param string $expectedOutput
+     */
+    public function testTransform(?int $scale, string $emptyData, int $roundingMode, ?DecimalNumber $number, string $expectedOutput)
+    {
+        $transformer = new DecimalNumberToLocalizedStringTransformer($scale, false, $roundingMode, $emptyData);
+        $transformedOutput = $transformer->transform($number);
+        $this->assertSame($expectedOutput, $transformedOutput);
+    }
+
+    public function getTransformations()
+    {
+        yield [
+            2,
+            '',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            new DecimalNumber('0.0'),
+            '0,00',
+        ];
+
+        yield [
+            3,
+            '1',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            new DecimalNumber('0.0'),
+            '0,000',
+        ];
+
+        yield [
+            3,
+            '1',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            null,
+            '1,000',
+        ];
+
+        yield [
+            3,
+            '1.12369',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            null,
+            '1,124',
+        ];
+
+        yield [
+            3,
+            '1.12357',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            null,
+            '1,124',
+        ];
+
+        yield [
+            3,
+            '1.12357',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_DOWN,
+            null,
+            '1,123',
+        ];
+
+        yield [
+            3,
+            '1.12357',
+            DecimalNumberToLocalizedStringTransformer::ROUND_UP,
+            null,
+            '1,124',
+        ];
+
+        yield [
+            3,
+            '1.12357',
+            DecimalNumberToLocalizedStringTransformer::ROUND_DOWN,
+            null,
+            '1,123',
+        ];
+
+        yield [
+            3,
+            '42.89',
+            DecimalNumberToLocalizedStringTransformer::ROUND_FLOOR,
+            new DecimalNumber('1.12365'),
+            '1,123',
+        ];
+
+        yield [
+            3,
+            '2.0',
+            DecimalNumberToLocalizedStringTransformer::ROUND_CEILING,
+            new DecimalNumber('1.12332'),
+            '1,124',
+        ];
+    }
+
+    /**
+     * @dataProvider getReverseTransformations
+     *
+     * @param int|null $scale
+     * @param string $emptyData
+     * @param int $roundingMode
+     * @param string|float|int $input
+     * @param DecimalNumber|null $expectedNumber
+     */
+    public function testReverseTransform(?int $scale, string $emptyData, int $roundingMode, $input, ?DecimalNumber $expectedNumber)
+    {
+        $transformer = new DecimalNumberToLocalizedStringTransformer($scale, false, $roundingMode, $emptyData);
+        $reversedNumber = $transformer->reverseTransform($input);
+        $this->assertInstanceOf(DecimalNumber::class, $reversedNumber);
+        $this->assertTrue(
+            $expectedNumber->equals($reversedNumber),
+            sprintf(
+                'Invalid value expected %s but actually got %s',
+                (string) $expectedNumber,
+                (string) $reversedNumber
+            )
+        );
+    }
+
+    public function getReverseTransformations()
+    {
+        yield [
+            3,
+            '',
+            DecimalNumberToLocalizedStringTransformer::ROUND_UP,
+            null,
+            new DecimalNumber('0'),
+        ];
+
+        yield [
+            3,
+            '1.2',
+            DecimalNumberToLocalizedStringTransformer::ROUND_UP,
+            null,
+            new DecimalNumber('1.20'),
+        ];
+
+        yield [
+            3,
+            '1.2',
+            DecimalNumberToLocalizedStringTransformer::ROUND_UP,
+            '',
+            new DecimalNumber('1.20'),
+        ];
+
+        yield [
+            3,
+            '1.2356',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_UP,
+            '',
+            new DecimalNumber('1.236'),
+        ];
+
+        yield [
+            3,
+            '0.0',
+            DecimalNumberToLocalizedStringTransformer::ROUND_HALF_DOWN,
+            '1.2354',
+            new DecimalNumber('1.235'),
+        ];
+
+        yield [
+            3,
+            '0.0',
+            DecimalNumberToLocalizedStringTransformer::ROUND_CEILING,
+            '1.2354',
+            new DecimalNumber('1.236'),
+        ];
+
+        yield [
+            3,
+            '0.0',
+            DecimalNumberToLocalizedStringTransformer::ROUND_FLOOR,
+            '1.2358',
+            new DecimalNumber('1.235'),
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add form type to handle DecimalNumber input type in forms This is only the beginning some features that need to be searched:<br>- `MoneyDecimalType` which displays the currency (like MoneyType)<br>- should `MoneyDecimalType` be based on CLDR display<br>- should `DecimalNumberType` be based on CLDR number display<br>- should we use our implementation of `NumberFormatter`
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22162)
<!-- Reviewable:end -->
