### PR TITLE
Fix upgrade script from < 1.7.6.0 to 1.7.7.0

### DIFF
--- a/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
@@ -54,9 +54,39 @@ function ps_1760_copy_data_from_currency_to_currency_lang()
     /** @var LocaleRepository $localeRepoCLDR */
     $localeRepoCLDR = $container->get('prestashop.core.localization.cldr.locale_repository');
     foreach ($currencies as $currency) {
-        $currency->refreshLocalizedCurrencyData($languages, $localeRepoCLDR);
-        $currency->save();
+        refreshLocalizedCurrencyData($currency, $languages, $localeRepoCLDR);
     }
 
     ObjectModel::enableCache();
+}
+
+function refreshLocalizedCurrencyData($currency, $languages, $localeRepoCLDR)
+{
+    foreach ($languages as $languageData) {
+        $language = new Language($languageData['id_lang']);
+        if (empty($language->locale)) {
+            // Language doesn't have locale we can't install this language
+            continue;
+        }
+
+        // CLDR locale give us the CLDR reference specification
+        $cldrLocale = $localeRepoCLDR->getLocale($language->locale);
+        // CLDR currency gives data from CLDR reference, for the given language
+        $cldrCurrency = $cldrLocale->getCurrency($currency->iso_code);
+
+        if (empty($cldrCurrency)) {
+            continue;
+        }
+
+        $symbol = (string) $cldrCurrency->getSymbol() ?: $currency->iso_code;
+        $name = $cldrCurrency->getDisplayName();
+        $fields = [
+            'name' => $name,
+            'symbol' => $symbol
+        ];
+
+        $where = 'id_currency = ' . (int) $currency->id
+            . ' AND id_lang = ' . (int) $language->id;
+        Db::getInstance()->update( 'currency_lang', $fields, $where);
+    }
 }

--- a/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
@@ -78,15 +78,13 @@ function refreshLocalizedCurrencyData($currency, $languages, $localeRepoCLDR)
             continue;
         }
 
-        $symbol = (string) $cldrCurrency->getSymbol() ?: $currency->iso_code;
-        $name = $cldrCurrency->getDisplayName();
         $fields = [
-            'name' => $name,
-            'symbol' => $symbol
+            'name' => $cldrCurrency->getDisplayName(),
+            'symbol' => (string) $cldrCurrency->getSymbol() ?: $currency->iso_code
         ];
 
         $where = 'id_currency = ' . (int) $currency->id
             . ' AND id_lang = ' . (int) $language->id;
-        Db::getInstance()->update( 'currency_lang', $fields, $where);
+        Db::getInstance()->update('currency_lang', $fields, $where);
     }
 }

--- a/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
@@ -60,7 +60,7 @@ function ps_1760_copy_data_from_currency_to_currency_lang()
     ObjectModel::enableCache();
 }
 
-function refreshLocalizedCurrencyData($currency, $languages, $localeRepoCLDR)
+function refreshLocalizedCurrencyData(Currency $currency, array $languages, LocaleRepository $localeRepoCLDR)
 {
     foreach ($languages as $languageData) {
         $language = new Language($languageData['id_lang']);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because the table `ps_currency` has been changed on 1.7.7.x, when executing the 1.7.6.0 upgrade script, currencies weren't properly updated. This PR fixes it.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Try to upgrade a shop from PrestaShop < 1.7.6.0 to 1.7.7.0, the currency symbol should still be present on the FO and the BO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22164)
<!-- Reviewable:end -->
