### PR TITLE
Email alert productoutofstock should be sent only for this shop employees in case of multi-store

### DIFF
--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -311,6 +311,9 @@ class StockManager
         // send email to every employee who have permission for this
         foreach (Employee::getEmployees() as $employeeData) {
             $employee = new Employee($employeeData['id_employee']);
+            if (!in_array($idShop, $employee->getAssociatedShops())) {
+                continue;
+            }
 
             if (Access::isGranted('ROLE_MOD_TAB_ADMINSTOCKMANAGEMENT_READ', $employee->id_profile)) {
                 $templateVars['{firstname}'] = $employee->firstname;


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes bug #22142 email alert productoutofstock should be sent only for this shop employees in case of multi-store
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | 
| Deprecations? | 
| Fixed ticket? | Fixes #22142
| How to test?  | Set multi-store<br>Set employees for every store<br>Set a stock alert below the current stock on the product page in the admin<br>Order the product<br>Check sent mails log\inbox of employees

**Additional information**
PrestaShop version: 1.7.6.8
PHP version: 7.1

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22166)
<!-- Reviewable:end -->
