### PR TITLE
When refreshing an order, display shipping price if needed

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/order/OrderViewPageMap.js
@@ -150,6 +150,7 @@ export default {
   orderDiscountsTotalContainer: '#order-discounts-total-container',
   orderDiscountsTotal: '#orderDiscountsTotal',
   orderWrappingTotal: '#orderWrappingTotal',
+  orderShippingTotalContainer: '#order-shipping-total-container',
   orderShippingTotal: '#orderShippingTotal',
   orderTaxesTotal: '#orderTaxesTotal',
   orderTotal: '#orderTotal',

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-prices-refresher.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-prices-refresher.js
@@ -40,6 +40,7 @@ export default class OrderPricesRefresher {
       $(OrderViewPageMap.orderDiscountsTotalContainer).toggleClass('d-none', !response.discountsAmountDisplayed);
       $(OrderViewPageMap.orderProductsTotal).text(response.productsTotalFormatted);
       $(OrderViewPageMap.orderShippingTotal).text(response.shippingTotalFormatted);
+      $(OrderViewPageMap.orderShippingTotalContainer).toggleClass('d-none', !response.shippingTotalDisplayed);
       $(OrderViewPageMap.orderTaxesTotal).text(response.taxesTotalFormatted);
     });
   }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1449,6 +1449,7 @@ class OrderController extends FrameworkBundleAdminController
             'discountsAmountDisplayed' => $orderForViewingPrices->getDiscountsAmountRaw()->isGreaterThanZero(),
             'productsTotalFormatted' => $orderForViewingPrices->getProductsPriceFormatted(),
             'shippingTotalFormatted' => $orderForViewingPrices->getShippingPriceFormatted(),
+            'shippingTotalDisplayed' => $orderForViewingPrices->getShippingPriceRaw()->isGreaterThanZero(),
             'taxesTotalFormatted' => $orderForViewingPrices->getTaxesAmountFormatted(),
         ]);
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -182,28 +182,21 @@
               </div>
             {% endif %}
 
-            {% if orderForViewing.prices.shippingPriceRaw.greaterThan(number(0)) %}
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
-                <div class="shipping-price">
-                  <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
-                  <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-                    <div class="input-group">
-                      {{ form_widget(cancelProductForm.shipping_amount) }}
-                      <div class="input-group-append">
-                        <div class="input-group-text">{{ orderCurrency.symbol }}</div>
-                      </div>
+            <div id="order-shipping-total-container" class="col-sm text-center{% if not orderForViewing.prices.shippingPriceRaw.greaterThan((number(0))) %} d-none{% endif %}">
+              <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
+              <div class="shipping-price">
+                <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
+                <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+                  <div class="input-group">
+                    {{ form_widget(cancelProductForm.shipping_amount) }}
+                    <div class="input-group-append">
+                      <div class="input-group-text">{{ orderCurrency.symbol }}</div>
                     </div>
-                    <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
                   </div>
+                  <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
                 </div>
               </div>
-            {% else %}
-              {# No shippping, the form field is hidden in this div to avoid it being displayed through automatic form_rest #}
-              <div class="d-none">
-                {{ form_widget(cancelProductForm.shipping_amount) }}
-              </div>
-            {% endif %}
+            </div>
 
             {% if not orderForViewing.taxIncluded %}
               <div class="col-sm text-center">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | When refreshing an order, display shipping price if needed
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22071
| How to test?  | Build assets & Cf. #22071

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22171)
<!-- Reviewable:end -->
