### PR TITLE
Added error when a customization is not found

### DIFF
--- a/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateProductQuantityI
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
@@ -205,12 +206,15 @@ final class UpdateProductQuantityInCartHandler extends AbstractCartHandler imple
      * @param Product $product
      * @param UpdateProductQuantityInCartCommand $command
      *
-     * @throws ProductException
+     * @throws ProductCustomizationNotFoundException
      */
     private function assertProductCustomization(Product $product, UpdateProductQuantityInCartCommand $command)
     {
         if (null === $command->getCustomizationId() && !$product->hasAllRequiredCustomizableFields()) {
-            throw new ProductException(sprintf('Missing customization for product with id "%s"', $product->id));
+            throw new ProductCustomizationNotFoundException(sprintf(
+                'Missing customization for product with id "%s"',
+                $product->id
+            ));
         }
     }
 

--- a/src/Core/Domain/Product/Exception/ProductCustomizationNotFoundException.php
+++ b/src/Core/Domain/Product/Exception/ProductCustomizationNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Exception;
+
+/**
+ * Is thrown when the customization of a product is not found
+ */
+class ProductCustomizationNotFoundException extends ProductException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -51,6 +51,7 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\FileUploadException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\SpecificPrice\Command\AddSpecificPriceCommand;
 use PrestaShop\PrestaShop\Core\Domain\SpecificPrice\Command\DeleteSpecificPriceByCartProductCommand;
@@ -587,6 +588,10 @@ class CartController extends FrameworkBundleAdminController
                     ['%limit%' => CustomizationSettings::MAX_TEXT_LENGTH]
                 ),
             ],
+            ProductCustomizationNotFoundException::class => $this->trans(
+                'Product customization could not be found. Go to Catalog > Products to customize the product.',
+                'Admin.Catalog.Notification'
+            ),
             ProductOutOfStockException::class => $this->trans(
                 'There are not enough products in stock.',
                 'Admin.Catalog.Notification'

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -19,7 +19,7 @@ Feature: Cancel Order Product from Back Office (BO)
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
     And I add 5 products "Mug The best is yet to come" to the cart "dummy_cart"
     And I add 3 products "Mug Today is a good day" to the cart "dummy_cart"
-    And I add 2 customized products with reference "demo_14" to the cart "dummy_cart"
+    And add 2 customized products with reference "demo_14" with all its customizations to the cart "dummy_cart"
     And I watch the stock of product "Mug The best is yet to come"
     And I watch the stock of product "Mug Today is a good day"
     And I watch the stock of product "Customizable mug"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_to_cart.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_to_cart.feature
@@ -13,7 +13,7 @@ Feature: Check order to cart data copy
     And customer "customer_for_customization" has address in "US" country
     And the module "dummy_payment" is installed
     When I create an empty cart "dummy_custom_cart" for customer "customer_for_customization"
-    And I add 1 customized products with reference "demo_14" to the cart "dummy_custom_cart"
+    And add 1 customized product with reference "demo_14" with all its customizations to the cart "dummy_custom_cart"
     And I select "US" address as delivery and invoice address for customer "customer_for_customization" in cart "dummy_custom_cart"
     And I add order "bo_order_for_customization" from cart "dummy_custom_cart" with "dummy_payment" payment method and "Payment accepted" order status
     Then order "bo_order_for_customization" should have 1 products in total
@@ -21,3 +21,12 @@ Feature: Check order to cart data copy
     Given order "bo_order_for_customization" should have 1 products in total
     When I duplicate "bo_order_for_customization" to create cart "duplicated_bo_order_for_customization"
     # Additional checks should be added to validate the cart is correctly duplicated (even customization address)
+
+  @order-to-cart
+  Scenario: Add a customized product without its customization
+    Given there is customer "customer_for_customization" with email "pub@prestashop.com"
+    And customer "customer_for_customization" has address in "US" country
+    And the module "dummy_payment" is installed
+    When I create an empty cart "dummy_custom_cart" for customer "customer_for_customization"
+    And add 1 customized product with reference "demo_14" without all its customizations to the cart "dummy_custom_cart"
+    Then I should get an error that the product is customizable and the customization is not provided


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | MultiStore - Added error when a customization is not found
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22110
| How to test?  | Cf. #22110

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22175)
<!-- Reviewable:end -->
