### PR TITLE
Set numeric_iso_code & precision in currency from CLDR when upgrading

### DIFF
--- a/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
@@ -62,7 +62,8 @@ function ps_1760_copy_data_from_currency_to_currency_lang()
 
 function refreshLocalizedCurrencyData(Currency $currency, array $languages, LocaleRepository $localeRepoCLDR)
 {
-    $cldrLocale = $localeRepoCLDR->getLocale(Context::getContext()->language->locale);
+    $language = new Language($languages[0]['id_lang']);
+    $cldrLocale = $localeRepoCLDR->getLocale($language->locale);
     $cldrCurrency = $cldrLocale->getCurrency($currency->iso_code);
 
     if (!empty($cldrCurrency)) {

--- a/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
+++ b/install-dev/upgrade/php/ps_1760_copy_data_from_currency_to_currency_lang.php
@@ -62,6 +62,17 @@ function ps_1760_copy_data_from_currency_to_currency_lang()
 
 function refreshLocalizedCurrencyData(Currency $currency, array $languages, LocaleRepository $localeRepoCLDR)
 {
+    $cldrLocale = $localeRepoCLDR->getLocale(Context::getContext()->language->locale);
+    $cldrCurrency = $cldrLocale->getCurrency($currency->iso_code);
+
+    if (!empty($cldrCurrency)) {
+        $fields = [
+            'numeric_iso_code' => $cldrCurrency->getNumericIsoCode(),
+            'precision' => $cldrCurrency->getDecimalDigits(),
+        ];
+        Db::getInstance()->update('currency', $fields, 'id_currency = ' . (int) $currency->id);
+    }
+
     foreach ($languages as $languageData) {
         $language = new Language($languageData['id_lang']);
         if (empty($language->locale)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | See #22177
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22177
| How to test?  | Upgrade from PS <= 1.7.5 to 1.7.7.0, currencies' precision and numeric_iso_code should be the ones from CLDR

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22178)
<!-- Reviewable:end -->
