### PR TITLE
Put invoice customization products on one line

### DIFF
--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -122,10 +122,7 @@
               <table style="width: 100%;">
                 {foreach $customization.datas[Product::CUSTOMIZE_TEXTFIELD] as $customization_infos}
                   <tr>
-                    <td style="width: 30%;">
-                      {$customization_infos.name|string_format:{l s='%s:' d='Shop.Pdf' pdf='true'}}
-                    </td>
-                    <td>{if (int)$customization_infos.id_module}{$customization_infos.value nofilter}{else}{$customization_infos.value}{/if}</td>
+                    <td>{$customization_infos.name|string_format:{l s='%s:' d='Shop.Pdf' pdf='true'}} {if (int)$customization_infos.id_module}{$customization_infos.value nofilter}{else}{$customization_infos.value}{/if}</td>
                   </tr>
                 {/foreach}
               </table>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Customized product in invoice is hard to read
| Type?         | bug fix
| Category?     | IN
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22089.
| How to test?  | Check invoice with customized product with text, text should be on one line (see issue)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22207)
<!-- Reviewable:end -->
