### PR TITLE
Fix numeric_iso_code in the upgrade to 1.7.7.1

### DIFF
--- a/install-dev/upgrade/sql/1.7.7.1.sql
+++ b/install-dev/upgrade/sql/1.7.7.1.sql
@@ -1,3 +1,3 @@
 /* PHP:ps_1771_update_customer_note(); */;
 
-UPDATE `PREFIX_currency` SET numeric_iso_code = CONCAT('0', numeric_iso_code) WHERE LENGTH(numeric_iso_code) = 2;
+UPDATE `PREFIX_currency` SET numeric_iso_code = LPAD(numeric_iso_code, 3, '0') WHERE LENGTH(numeric_iso_code) != 3;

--- a/install-dev/upgrade/sql/1.7.7.1.sql
+++ b/install-dev/upgrade/sql/1.7.7.1.sql
@@ -1,1 +1,3 @@
 /* PHP:ps_1771_update_customer_note(); */;
+
+UPDATE `PREFIX_currency` SET numeric_iso_code = CONCAT('0', numeric_iso_code) WHERE LENGTH(numeric_iso_code) = 2;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Since 1.7.7.0, currency's `numeric_iso_code` should be 3 characters long. This PR aims to update older `numeric_iso_code` that were 2 characters long by prepending them with a '0' during the upgrade process.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22208
| How to test?  | 1. Install a 1.7.6 shop<br>2. Add the DZD currency<br>3. Either make a 1.7.7.1 build with this PR and upgrade to it or Checkout the 1.7.7.x branch with this PR, update `_PS_INSTALL_VERSION_` in `install-dev/install_version` to `1.7.7.1` and run `php install-dev/upgrade/upgrade.php`<br>4. You should be able to edit/delete the DZD currency without any error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22214)
<!-- Reviewable:end -->
