### PR TITLE
Move hook `actionOrderStatusPostUpdate` after stock sync

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -417,9 +417,6 @@ class OrderHistoryCore extends ObjectModel
             $order->setDelivery();
         }
 
-        // executes hook
-        Hook::exec('actionOrderStatusPostUpdate', ['newOrderStatus' => $new_os, 'id_order' => (int) $order->id], null, false, true, false, $order->id_shop);
-
         // sync all stock
         (new StockManagerAdapter())->updatePhysicalProductQuantity(
             (int) $order->id_shop,
@@ -428,6 +425,9 @@ class OrderHistoryCore extends ObjectModel
             null,
             (int) $order->id
         );
+        
+        // executes hook
+        Hook::exec('actionOrderStatusPostUpdate', ['newOrderStatus' => $new_os, 'id_order' => (int) $order->id], null, false, true, false, $order->id_shop);
 
         ShopUrl::resetMainDomainCache();
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch       | develop
| Description  | Physical & Reserved quantity actualized before call the hook actionOrderStatusPostUpdate<br>We develop a module for a client and i wish to have physical quantity value actualized after hook Strange to have the hook call actionOrderStatusPostUpdate before the process has completed.<br><br>Move this hook after the quantity has updated.<br>Permit to have the quantity reserved, available, physiq  actualized<br>We develop a module for a client and i wish to have physical quantity value actualized after hook Strange to have the hook call actionOrderStatusPostUpdate before the process has completed.
| Type         | improvement
| Category     | CO
| BC breaks    | no
| Deprecations | no
| Fixed ticket | Fixes #22218
| How to test  | ## Requirement<br>- Have a module registered to the hook actionOrderStatusPostUpdate who log physical quantity<br>- A product "test" with quantity equal to 1<br><br>## Make a order<br>- Add the product "test" and buy it<br>## Change the  status of order<br>- Change status to shipped<br>## Test ok<br>In module log the physical quantity is equal to 0``


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22219)
<!-- Reviewable:end -->
