### PR TITLE
Be able to don't add anchor in the URL for getProductLink method

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1485,6 +1485,9 @@ class LinkCore
             'alias' => null,
             'ssl' => null,
             'relative_protocol' => true,
+            'with_id_in_anchor' => false,
+            'extra_params' => [],
+            'add_anchor' => true
         ];
         $params = array_merge($default, $params);
 
@@ -1505,7 +1508,10 @@ class LinkCore
                     $params['id_shop'],
                     (isset($params['ipa']) ? (int) $params['ipa'] : 0),
                     false,
-                    $params['relative_protocol']
+                    $params['relative_protocol'],
+                    $params['with_id_in_anchor'],
+                    $params['extra_params'],
+                    $params['add_anchor']
                 );
 
                 break;

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1487,7 +1487,7 @@ class LinkCore
             'relative_protocol' => true,
             'with_id_in_anchor' => false,
             'extra_params' => [],
-            'add_anchor' => true
+            'add_anchor' => true,
         ];
         $params = array_merge($default, $params);
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -152,7 +152,7 @@ class LinkCore
         $relativeProtocol = false,
         $withIdInAnchor = false,
         $extraParams = [],
-        $addAnchor = true
+        bool $addAnchor = true
     ) {
         $dispatcher = Dispatcher::getInstance();
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -132,8 +132,9 @@ class LinkCore
      * @param int|null $idProductAttribute ID product attribute
      * @param bool $force_routes
      * @param bool $relativeProtocol
-     * @param bool $addAnchor
+     * @param bool $withIdInAnchor
      * @param array $extraParams
+     * @param bool $addAnchor
      *
      * @return string
      *
@@ -149,8 +150,9 @@ class LinkCore
         $idProductAttribute = null,
         $force_routes = false,
         $relativeProtocol = false,
-        $addAnchor = false,
-        $extraParams = []
+        $withIdInAnchor = false,
+        $extraParams = [],
+        $addAnchor = true
     ) {
         $dispatcher = Dispatcher::getInstance();
 
@@ -244,7 +246,8 @@ class LinkCore
         if ($idProductAttribute) {
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
-        $anchor = $idProductAttribute ? $product->getAnchor((int) $idProductAttribute, (bool) $addAnchor) : '';
+
+        $anchor = $addAnchor && $idProductAttribute ? $product->getAnchor((int) $idProductAttribute, (bool) $withIdInAnchor) : '';
 
         return $url . $dispatcher->createUrl('product_rule', $idLang, array_merge($params, $extraParams), $force_routes, $anchor, $idShop);
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | We should be able to remove the anchor in the URL.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #11041
| How to test?  | Follow ticket instruction. QA can be done by a dev. `{url id="1" ipa=1 entity="product" add_anchor=true with_id_in_anchor=true}`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22223)
<!-- Reviewable:end -->
