### PR TITLE
Allow displaying html in customization summary

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig
@@ -84,7 +84,7 @@
                       {% if customizationField.type == 'customizable_file' %}
                         <img src="{{ customizationField.image }}">
                       {% else %}
-                        {{ customizationField.value }}
+                        {{ customizationField.value | raw }}
                       {% endif %}
                     </div>
                   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -168,7 +168,7 @@
         </div>
       {% endif %}
       {% for customization in product.customizations.textCustomizations %}
-        <p><strong>{{ customization.name }} :</strong> {{ customization.value }}</p>
+        <p><strong>{{ customization.name }} :</strong> {{ customization.value | raw }}</p>
       {% endfor %}
       {% if product.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\Order\\QueryResult\\OrderProductForViewing::TYPE_PACK') %}
         <div class="btn-product-pack-modal mb-3 d-print-none" data-toggle="modal" data-target="#product-pack-modal" data-pack-items="{{ product.packItems|json_encode }}">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow modules to display a html summary of the customization in the admin order/carts page
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22220 
| How to test?  | Repro step described in issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

- Customization are already sanitized when saved by the customer
- Modules using the hook `displayCustomization` may return html so we need to display the customization value as is

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22227)
<!-- Reviewable:end -->
