### PR TITLE
Fixed Update Quantity in an order in multishop context

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -224,7 +224,7 @@ abstract class ModuleCore implements ModuleInterface
     public static function setContextInstanceForTesting(Context $context)
     {
         /** @var Module $module */
-        foreach (self::$_INSTANCE as $module) {
+        foreach (static::$_INSTANCE as $module) {
             $module->context = $context;
         }
     }
@@ -236,7 +236,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function setBatchMode($value)
     {
-        self::$_batch_mode = (bool) $value;
+        static::$_batch_mode = (bool) $value;
     }
 
     /**
@@ -244,17 +244,17 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getBatchMode()
     {
-        return self::$_batch_mode;
+        return static::$_batch_mode;
     }
 
     public static function processDeferedFuncCall()
     {
-        self::setBatchMode(false);
-        foreach (self::$_defered_func_call as $func_call) {
+        static::setBatchMode(false);
+        foreach (static::$_defered_func_call as $func_call) {
             call_user_func_array($func_call[0], $func_call[1]);
         }
 
-        self::$_defered_func_call = [];
+        static::$_defered_func_call = [];
     }
 
     /**
@@ -262,13 +262,13 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function processDeferedClearCache()
     {
-        self::setBatchMode(false);
+        static::setBatchMode(false);
 
-        foreach (self::$_defered_clearCache as $clearCache_array) {
-            self::_deferedClearCache($clearCache_array[0], $clearCache_array[1], $clearCache_array[2]);
+        foreach (static::$_defered_clearCache as $clearCache_array) {
+            static::_deferedClearCache($clearCache_array[0], $clearCache_array[1], $clearCache_array[2]);
         }
 
-        self::$_defered_clearCache = [];
+        static::$_defered_clearCache = [];
     }
 
     /**
@@ -317,10 +317,10 @@ abstract class ModuleCore implements ModuleInterface
         // If the module has the name we load the corresponding data from the cache
         if ($this->name != null) {
             // If cache is not generated, we generate it
-            if (self::$modules_cache == null && !is_array(self::$modules_cache)) {
+            if (static::$modules_cache == null && !is_array(static::$modules_cache)) {
                 $id_shop = (Validate::isLoadedObject($this->context->shop) ? $this->context->shop->id : Configuration::get('PS_SHOP_DEFAULT'));
 
-                self::$modules_cache = [];
+                static::$modules_cache = [];
                 // Join clause is done to check if the module is activated in current shop context
                 $result = Db::getInstance()->executeS('
                 SELECT m.`id_module`, m.`name`, ms.`id_module`as `mshop`
@@ -329,17 +329,17 @@ abstract class ModuleCore implements ModuleInterface
                 ON m.`id_module` = ms.`id_module`
                 AND ms.`id_shop` = ' . (int) $id_shop);
                 foreach ($result as $row) {
-                    self::$modules_cache[$row['name']] = $row;
-                    self::$modules_cache[$row['name']]['active'] = ($row['mshop'] > 0) ? 1 : 0;
+                    static::$modules_cache[$row['name']] = $row;
+                    static::$modules_cache[$row['name']]['active'] = ($row['mshop'] > 0) ? 1 : 0;
                 }
             }
 
             // We load configuration from the cache
-            if (isset(self::$modules_cache[$this->name])) {
-                if (isset(self::$modules_cache[$this->name]['id_module'])) {
-                    $this->id = self::$modules_cache[$this->name]['id_module'];
+            if (isset(static::$modules_cache[$this->name])) {
+                if (isset(static::$modules_cache[$this->name]['id_module'])) {
+                    $this->id = static::$modules_cache[$this->name]['id_module'];
                 }
-                foreach (self::$modules_cache[$this->name] as $key => $value) {
+                foreach (static::$modules_cache[$this->name] as $key => $value) {
                     if (array_key_exists($key, $this)) {
                         $this->{$key} = $value;
                     }
@@ -347,7 +347,7 @@ abstract class ModuleCore implements ModuleInterface
                 $this->_path = __PS_BASE_URI__ . 'modules/' . $this->name . '/';
             }
             if (!$this->context->controller instanceof Controller) {
-                self::$modules_cache = null;
+                static::$modules_cache = null;
             }
             $this->local_path = _PS_MODULE_DIR_ . $this->name . '/';
         }
@@ -511,7 +511,7 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // Init cache upgrade details
-        self::$modules_cache[$module->name]['upgrade'] = [
+        static::$modules_cache[$module->name]['upgrade'] = [
             'success' => false, // bool to know if upgrade succeed or not
             'available_upgrade' => 0, // Number of available module before any upgrade
             'number_upgraded' => 0, // Number of upgrade done
@@ -535,7 +535,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function runUpgradeModule()
     {
-        $upgrade = &self::$modules_cache[$this->name]['upgrade'];
+        $upgrade = &static::$modules_cache[$this->name]['upgrade'];
         foreach ($upgrade['upgrade_file_left'] as $num => $file_detail) {
             foreach ($file_detail['upgrade_function'] as $item) {
                 if (function_exists($item)) {
@@ -609,7 +609,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function needUpgrade($module)
     {
-        self::$modules_cache[$module->name]['upgrade']['upgraded_from'] = $module->database_version;
+        static::$modules_cache[$module->name]['upgrade']['upgraded_from'] = $module->database_version;
         // Check the version of the module with the registered one and look if any upgrade file exist
         if (Tools::version_compare($module->version, $module->database_version, '>')) {
             $old_version = $module->database_version;
@@ -668,15 +668,15 @@ abstract class ModuleCore implements ModuleInterface
 
         // No files upgrade, then upgrade succeed
         if (count($list) == 0) {
-            self::$modules_cache[$module_name]['upgrade']['success'] = true;
+            static::$modules_cache[$module_name]['upgrade']['success'] = true;
             Module::upgradeModuleVersion($module_name, $module_version);
         }
 
         usort($list, 'ps_module_version_sort');
 
         // Set the list to module cache
-        self::$modules_cache[$module_name]['upgrade']['upgrade_file_left'] = $list;
-        self::$modules_cache[$module_name]['upgrade']['available_upgrade'] = count($list);
+        static::$modules_cache[$module_name]['upgrade']['upgrade_file_left'] = $list;
+        static::$modules_cache[$module_name]['upgrade']['available_upgrade'] = count($list);
 
         return (bool) count($list);
     }
@@ -690,8 +690,8 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getUpgradeStatus($module_name)
     {
-        return isset(self::$modules_cache[$module_name]) &&
-            self::$modules_cache[$module_name]['upgrade']['success'];
+        return isset(static::$modules_cache[$module_name]) &&
+            static::$modules_cache[$module_name]['upgrade']['success'];
     }
 
     /**
@@ -1096,7 +1096,7 @@ abstract class ModuleCore implements ModuleInterface
     {
         // Module can now define AdminTab keeping the module translations method,
         // i.e. in modules/[module name]/[iso_code].php
-        if (!isset(self::$classInModule[$current_class]) && class_exists($current_class)) {
+        if (!isset(static::$classInModule[$current_class]) && class_exists($current_class)) {
             global $_MODULES;
             $_MODULE = [];
             $reflection_class = new ReflectionClass($current_class);
@@ -1105,23 +1105,23 @@ abstract class ModuleCore implements ModuleInterface
             if (substr(realpath($file_path), 0, strlen($realpath_module_dir)) == $realpath_module_dir) {
                 // For controllers in module/controllers path
                 if (basename(dirname(dirname($file_path))) == 'controllers') {
-                    self::$classInModule[$current_class] = basename(dirname(dirname(dirname($file_path))));
+                    static::$classInModule[$current_class] = basename(dirname(dirname(dirname($file_path))));
                 } else {
                     // For old AdminTab controllers
-                    self::$classInModule[$current_class] = substr(dirname($file_path), strlen($realpath_module_dir) + 1);
+                    static::$classInModule[$current_class] = substr(dirname($file_path), strlen($realpath_module_dir) + 1);
                 }
 
-                $file = _PS_MODULE_DIR_ . self::$classInModule[$current_class] . '/' . Context::getContext()->language->iso_code . '.php';
+                $file = _PS_MODULE_DIR_ . static::$classInModule[$current_class] . '/' . Context::getContext()->language->iso_code . '.php';
                 if (Tools::file_exists_cache($file) && include_once($file)) {
                     $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
                 }
             } else {
-                self::$classInModule[$current_class] = false;
+                static::$classInModule[$current_class] = false;
             }
         }
 
         // return name of the module, or false
-        return self::$classInModule[$current_class];
+        return static::$classInModule[$current_class];
     }
 
     /**
@@ -1141,7 +1141,7 @@ abstract class ModuleCore implements ModuleInterface
             return false;
         }
 
-        if (!isset(self::$_INSTANCE[$module_name])) {
+        if (!isset(static::$_INSTANCE[$module_name])) {
             if (!Tools::file_exists_no_cache(_PS_MODULE_DIR_ . $module_name . '/' . $module_name . '.php')) {
                 return false;
             }
@@ -1149,7 +1149,7 @@ abstract class ModuleCore implements ModuleInterface
             return Module::coreLoadModule($module_name);
         }
 
-        return self::$_INSTANCE[$module_name];
+        return static::$_INSTANCE[$module_name];
     }
 
     protected static function coreLoadModule($module_name)
@@ -1162,12 +1162,12 @@ abstract class ModuleCore implements ModuleInterface
             $override = $module_name . 'Override';
 
             if (class_exists($override, false)) {
-                $r = self::$_INSTANCE[$module_name] = ServiceLocator::get($override);
+                $r = static::$_INSTANCE[$module_name] = ServiceLocator::get($override);
             }
         }
 
         if (!$r && class_exists($module_name, false)) {
-            $r = self::$_INSTANCE[$module_name] = ServiceLocator::get($module_name);
+            $r = static::$_INSTANCE[$module_name] = ServiceLocator::get($module_name);
         }
 
         return $r;
@@ -1182,18 +1182,18 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getInstanceById($id_module)
     {
-        if (null === self::$cachedModuleNames) {
-            self::$cachedModuleNames = [];
+        if (null === static::$cachedModuleNames) {
+            static::$cachedModuleNames = [];
             $sql = 'SELECT `id_module`, `name` FROM `' . _DB_PREFIX_ . 'module`';
             if ($results = Db::getInstance()->executeS($sql)) {
                 foreach ($results as $row) {
-                    self::$cachedModuleNames[$row['id_module']] = $row['name'];
+                    static::$cachedModuleNames[$row['id_module']] = $row['name'];
                 }
             }
         }
 
-        if (isset(self::$cachedModuleNames[$id_module])) {
-            return Module::getInstanceByName(self::$cachedModuleNames[$id_module]);
+        if (isset(static::$cachedModuleNames[$id_module])) {
+            return Module::getInstanceByName(static::$cachedModuleNames[$id_module]);
         }
 
         return false;
@@ -1204,7 +1204,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function clearStaticCache()
     {
-        self::$cachedModuleNames = null;
+        static::$cachedModuleNames = null;
     }
 
     public static function configXmlStringFormat($string)
@@ -1446,9 +1446,9 @@ abstract class ModuleCore implements ModuleInterface
                         $module_list[$item->name . '_disk'] = $item;
 
                         if (!$xml_exist || $need_new_config_file) {
-                            self::$_generate_config_xml_mode = true;
+                            static::$_generate_config_xml_mode = true;
                             $tmp_module->_generateConfigXml();
-                            self::$_generate_config_xml_mode = false;
+                            static::$_generate_config_xml_mode = false;
                         }
 
                         unset($tmp_module);
@@ -1482,9 +1482,9 @@ abstract class ModuleCore implements ModuleInterface
 
         // Get Default Country Modules and customer module
         $files_list = [
-            ['type' => 'addonsNative', 'file' => _PS_ROOT_DIR_ . self::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 'loggedOnAddons' => 0],
-            ['type' => 'addonsMustHave', 'file' => _PS_ROOT_DIR_ . self::CACHE_FILE_MUST_HAVE_MODULES_LIST, 'loggedOnAddons' => 0],
-            ['type' => 'addonsBought', 'file' => _PS_ROOT_DIR_ . self::CACHE_FILE_CUSTOMER_MODULES_LIST, 'loggedOnAddons' => 1],
+            ['type' => 'addonsNative', 'file' => _PS_ROOT_DIR_ . static::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 'loggedOnAddons' => 0],
+            ['type' => 'addonsMustHave', 'file' => _PS_ROOT_DIR_ . static::CACHE_FILE_MUST_HAVE_MODULES_LIST, 'loggedOnAddons' => 0],
+            ['type' => 'addonsBought', 'file' => _PS_ROOT_DIR_ . static::CACHE_FILE_CUSTOMER_MODULES_LIST, 'loggedOnAddons' => 1],
         ];
         foreach ($files_list as $f) {
             if (file_exists($f['file']) && ($f['loggedOnAddons'] == 0 || $logged_on_addons)) {
@@ -1582,7 +1582,7 @@ abstract class ModuleCore implements ModuleInterface
             if (!isset($module->tab)) {
                 $module->tab = 'others';
             }
-            if (defined('_PS_HOST_MODE_') && in_array($module->name, self::$hosted_modules_blacklist)) {
+            if (defined('_PS_HOST_MODE_') && in_array($module->name, static::$hosted_modules_blacklist)) {
                 unset($module_list[$key]);
             } elseif (isset($modules_installed[$module->name])) {
                 $module->installed = true;
@@ -1661,7 +1661,7 @@ abstract class ModuleCore implements ModuleInterface
     public static function getNonNativeModuleList()
     {
         $db = Db::getInstance();
-        $module_list_xml = _PS_ROOT_DIR_ . self::CACHE_FILE_MODULES_LIST;
+        $module_list_xml = _PS_ROOT_DIR_ . static::CACHE_FILE_MODULES_LIST;
         $native_modules = @simplexml_load_file($module_list_xml);
         if ($native_modules) {
             $native_modules = $native_modules->modules;
@@ -1688,7 +1688,7 @@ abstract class ModuleCore implements ModuleInterface
 
     public static function getNativeModuleList()
     {
-        $module_list_xml = _PS_ROOT_DIR_ . self::CACHE_FILE_MODULES_LIST;
+        $module_list_xml = _PS_ROOT_DIR_ . static::CACHE_FILE_MODULES_LIST;
         if (!file_exists($module_list_xml)) {
             return false;
         }
@@ -1756,31 +1756,31 @@ abstract class ModuleCore implements ModuleInterface
         // and if the theme hadn't change
         // we use the file, otherwise we regenerate it
         if (!(
-            file_exists(_PS_ROOT_DIR_ . self::CACHE_FILE_TRUSTED_MODULES_LIST)
-            && filesize(_PS_ROOT_DIR_ . self::CACHE_FILE_TRUSTED_MODULES_LIST) > 0
-            && ((time() - filemtime(_PS_ROOT_DIR_ . self::CACHE_FILE_TRUSTED_MODULES_LIST)) < 86400)
+            file_exists(_PS_ROOT_DIR_ . static::CACHE_FILE_TRUSTED_MODULES_LIST)
+            && filesize(_PS_ROOT_DIR_ . static::CACHE_FILE_TRUSTED_MODULES_LIST) > 0
+            && ((time() - filemtime(_PS_ROOT_DIR_ . static::CACHE_FILE_TRUSTED_MODULES_LIST)) < 86400)
             )) {
-            self::generateTrustedXml();
+            static::generateTrustedXml();
         }
 
         if ($trusted_modules_list_content === null) {
-            $trusted_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . self::CACHE_FILE_TRUSTED_MODULES_LIST);
+            $trusted_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . static::CACHE_FILE_TRUSTED_MODULES_LIST);
             if (strpos($trusted_modules_list_content, $context->shop->theme->getName()) === false) {
-                self::generateTrustedXml();
+                static::generateTrustedXml();
             }
         }
 
-        $modulesListCacheFilepath = _PS_ROOT_DIR_ . self::CACHE_FILE_MODULES_LIST;
+        $modulesListCacheFilepath = _PS_ROOT_DIR_ . static::CACHE_FILE_MODULES_LIST;
         if ($modules_list_content === null && is_readable($modulesListCacheFilepath)) {
             $modules_list_content = Tools::file_get_contents($modulesListCacheFilepath);
         }
 
         if ($default_country_modules_list_content === null) {
-            $default_country_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . self::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST);
+            $default_country_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . static::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST);
         }
 
         if ($untrusted_modules_list_content === null) {
-            $untrusted_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . self::CACHE_FILE_UNTRUSTED_MODULES_LIST);
+            $untrusted_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . static::CACHE_FILE_UNTRUSTED_MODULES_LIST);
         }
 
         // If the module is trusted, which includes both partner modules and modules bought on Addons
@@ -1802,7 +1802,7 @@ abstract class ModuleCore implements ModuleInterface
             // If the module isn't in one of the xml files
             // It might have been uploaded recenlty so we check
             // Addons API and clear XML files to be regenerated next time
-            self::deleteTrustedXmlCache();
+            static::deleteTrustedXmlCache();
 
             return (int) Module::checkModuleFromAddonsApi($module_name);
         }
@@ -1813,8 +1813,8 @@ abstract class ModuleCore implements ModuleInterface
      */
     final public static function deleteTrustedXmlCache()
     {
-        Tools::deleteFile(_PS_ROOT_DIR_ . self::CACHE_FILE_TRUSTED_MODULES_LIST);
-        Tools::deleteFile(_PS_ROOT_DIR_ . self::CACHE_FILE_UNTRUSTED_MODULES_LIST);
+        Tools::deleteFile(_PS_ROOT_DIR_ . static::CACHE_FILE_TRUSTED_MODULES_LIST);
+        Tools::deleteFile(_PS_ROOT_DIR_ . static::CACHE_FILE_UNTRUSTED_MODULES_LIST);
     }
 
     /**
@@ -1827,13 +1827,13 @@ abstract class ModuleCore implements ModuleInterface
         $untrusted = [];
 
         $trusted_modules_xml = [
-            _PS_ROOT_DIR_ . self::CACHE_FILE_ALL_COUNTRY_MODULES_LIST,
-            _PS_ROOT_DIR_ . self::CACHE_FILE_MUST_HAVE_MODULES_LIST,
-            _PS_ROOT_DIR_ . self::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST,
+            _PS_ROOT_DIR_ . static::CACHE_FILE_ALL_COUNTRY_MODULES_LIST,
+            _PS_ROOT_DIR_ . static::CACHE_FILE_MUST_HAVE_MODULES_LIST,
+            _PS_ROOT_DIR_ . static::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST,
         ];
 
-        if (file_exists(_PS_ROOT_DIR_ . self::CACHE_FILE_CUSTOMER_MODULES_LIST)) {
-            $trusted_modules_xml[] = _PS_ROOT_DIR_ . self::CACHE_FILE_CUSTOMER_MODULES_LIST;
+        if (file_exists(_PS_ROOT_DIR_ . static::CACHE_FILE_CUSTOMER_MODULES_LIST)) {
+            $trusted_modules_xml[] = _PS_ROOT_DIR_ . static::CACHE_FILE_CUSTOMER_MODULES_LIST;
         }
 
         // Create 2 arrays with trusted and untrusted modules
@@ -1884,7 +1884,7 @@ abstract class ModuleCore implements ModuleInterface
             $module = $modules->addChild('module');
             $module->addAttribute('name', $name);
         }
-        $success = file_put_contents(_PS_ROOT_DIR_ . self::CACHE_FILE_TRUSTED_MODULES_LIST, $trusted_xml->asXML());
+        $success = file_put_contents(_PS_ROOT_DIR_ . static::CACHE_FILE_TRUSTED_MODULES_LIST, $trusted_xml->asXML());
 
         $untrusted_xml = new SimpleXMLElement('<modules_list/>');
         $modules = $untrusted_xml->addChild('modules');
@@ -1893,7 +1893,7 @@ abstract class ModuleCore implements ModuleInterface
             $module = $modules->addChild('module');
             $module->addAttribute('name', $name);
         }
-        $success &= file_put_contents(_PS_ROOT_DIR_ . self::CACHE_FILE_UNTRUSTED_MODULES_LIST, $untrusted_xml->asXML());
+        $success &= file_put_contents(_PS_ROOT_DIR_ . static::CACHE_FILE_UNTRUSTED_MODULES_LIST, $untrusted_xml->asXML());
 
         if ($success) {
             return true;
@@ -1993,7 +1993,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function l($string, $specific = false, $locale = null)
     {
-        if (self::$_generate_config_xml_mode) {
+        if (static::$_generate_config_xml_mode) {
             return $string;
         }
 
@@ -2579,7 +2579,7 @@ abstract class ModuleCore implements ModuleInterface
             $ps_smarty_clear_cache = Configuration::get('PS_SMARTY_CLEAR_CACHE');
         }
 
-        if (self::$_batch_mode) {
+        if (static::$_batch_mode) {
             if ($ps_smarty_clear_cache == 'never') {
                 return 0;
             }
@@ -2589,8 +2589,8 @@ abstract class ModuleCore implements ModuleInterface
             }
 
             $key = $template . '-' . $cache_id . '-' . $compile_id;
-            if (!isset(self::$_defered_clearCache[$key])) {
-                self::$_defered_clearCache[$key] = [$this->getTemplatePath($template), $cache_id, $compile_id];
+            if (!isset(static::$_defered_clearCache[$key])) {
+                static::$_defered_clearCache[$key] = [$this->getTemplatePath($template), $cache_id, $compile_id];
             }
         } else {
             if ($ps_smarty_clear_cache == 'never') {
@@ -2684,11 +2684,11 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getModulesAccessesByIdProfile($idProfile)
     {
-        if (empty(self::$cache_modules_roles)) {
-            self::warmupRolesCache();
+        if (empty(static::$cache_modules_roles)) {
+            static::warmupRolesCache();
         }
 
-        $roles = self::$cache_lgc_access;
+        $roles = static::$cache_lgc_access;
 
         $profileRoles = Db::getInstance()->executeS('
             SELECT `slug`,
@@ -2741,14 +2741,14 @@ abstract class ModuleCore implements ModuleInterface
             $m = Module::getInstanceByName(strtolower($matches['moduleName']));
 
             // the following condition handles invalid modules
-            if ($m && !isset(self::$cache_lgc_access[$matches['moduleName']])) {
-                self::$cache_lgc_access[$matches['moduleName']] = [];
-                self::$cache_lgc_access[$matches['moduleName']]['id_module'] = $m->id;
-                self::$cache_lgc_access[$matches['moduleName']]['name'] = $m->displayName;
-                self::$cache_lgc_access[$matches['moduleName']]['add'] = '0';
-                self::$cache_lgc_access[$matches['moduleName']]['view'] = '0';
-                self::$cache_lgc_access[$matches['moduleName']]['configure'] = '0';
-                self::$cache_lgc_access[$matches['moduleName']]['uninstall'] = '0';
+            if ($m && !isset(static::$cache_lgc_access[$matches['moduleName']])) {
+                static::$cache_lgc_access[$matches['moduleName']] = [];
+                static::$cache_lgc_access[$matches['moduleName']]['id_module'] = $m->id;
+                static::$cache_lgc_access[$matches['moduleName']]['name'] = $m->displayName;
+                static::$cache_lgc_access[$matches['moduleName']]['add'] = '0';
+                static::$cache_lgc_access[$matches['moduleName']]['view'] = '0';
+                static::$cache_lgc_access[$matches['moduleName']]['configure'] = '0';
+                static::$cache_lgc_access[$matches['moduleName']]['uninstall'] = '0';
             }
         }
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1205,7 +1205,6 @@ abstract class ModuleCore implements ModuleInterface
     public static function clearStaticCache()
     {
         self::$cachedModuleNames = null;
-        self::$_INSTANCE = [];
     }
 
     public static function configXmlStringFormat($string)

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -221,6 +221,14 @@ abstract class ModuleCore implements ModuleInterface
 
     public static $hosted_modules_blacklist = ['autoupgrade'];
 
+    public static function setContextInstanceForTesting(Context $context)
+    {
+        /** @var Module $module */
+        foreach (self::$_INSTANCE as $module) {
+            $module->context = $context;
+        }
+    }
+
     /**
      * Set the flag to indicate we are doing an import.
      *
@@ -1197,6 +1205,7 @@ abstract class ModuleCore implements ModuleInterface
     public static function clearStaticCache()
     {
         self::$cachedModuleNames = null;
+        self::$_INSTANCE = [];
     }
 
     public static function configXmlStringFormat($string)

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -203,7 +203,7 @@ abstract class ModuleCore implements ModuleInterface
     private $container;
 
     /** @var array|null used to cache module ids */
-    private static $cachedModuleNames = null;
+    protected static $cachedModuleNames = null;
 
     const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
 

--- a/src/Adapter/Cart/AbstractCartHandler.php
+++ b/src/Adapter/Cart/AbstractCartHandler.php
@@ -77,6 +77,7 @@ abstract class AbstractCartHandler
     protected function setCartContext(ContextStateManager $contextStateManager, Cart $cart): void
     {
         $contextStateManager
+            ->saveCurrentContext()
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
@@ -84,7 +85,6 @@ abstract class AbstractCartHandler
             ->setCountry($this->getCartTaxCountry($cart))
             ->setShop(new Shop($cart->id_shop))
         ;
-        $contextStateManager->saveCurrentContext();
     }
 
     /**

--- a/src/Adapter/Cart/AbstractCartHandler.php
+++ b/src/Adapter/Cart/AbstractCartHandler.php
@@ -26,12 +26,20 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cart;
 
+use Address;
 use Cart;
+use Configuration;
+use Country;
+use Currency;
+use Customer;
+use Language;
+use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Validate;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShopException;
+use Shop;
 
 /**
  * Provides reusable methods for cart handlers
@@ -60,5 +68,39 @@ abstract class AbstractCartHandler
         }
 
         return $cart;
+    }
+
+    /**
+     * @param ContextStateManager $contextStateManager
+     * @param Cart $cart
+     */
+    protected function setCartContext(ContextStateManager $contextStateManager, Cart $cart): void
+    {
+        $contextStateManager
+            ->setCart($cart)
+            ->setCustomer(new Customer($cart->id_customer))
+            ->setCurrency(new Currency($cart->id_currency))
+            ->setLanguage(new Language($cart->id_lang))
+            ->setCountry($this->getCartTaxCountry($cart))
+            ->setShop(new Shop($cart->id_shop))
+        ;
+        $contextStateManager->saveCurrentContext();
+    }
+
+    /**
+     * @param Cart $cart
+     *
+     * @return Country
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    protected function getCartTaxCountry(Cart $cart): Country
+    {
+        $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
+        $taxAddressId = property_exists($cart, $taxAddressType) ? $cart->{$taxAddressType} : $cart->id_address_delivery;
+        $taxAddress = new Address($taxAddressId);
+
+        return new Country($taxAddress->id_country);
     }
 }

--- a/src/Adapter/Cart/AbstractCartHandler.php
+++ b/src/Adapter/Cart/AbstractCartHandler.php
@@ -98,7 +98,7 @@ abstract class AbstractCartHandler
     protected function getCartTaxCountry(Cart $cart): Country
     {
         $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
-        $taxAddressId = property_exists($cart, $taxAddressType) ? $cart->{$taxAddressType} : $cart->id_address_delivery;
+        $taxAddressId = $cart->{$taxAddressType} ?? $cart->id_address_delivery;
         $taxAddress = new Address($taxAddressId);
 
         return new Country($taxAddress->id_country);

--- a/src/Adapter/Cart/AbstractCartHandler.php
+++ b/src/Adapter/Cart/AbstractCartHandler.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Cart;
 use Cart;
 use Currency;
 use Customer;
-use Language;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Validate;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
@@ -78,7 +77,7 @@ abstract class AbstractCartHandler
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCountry($cart->getTaxCountry())
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/AbstractCartHandler.php
+++ b/src/Adapter/Cart/AbstractCartHandler.php
@@ -26,10 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cart;
 
-use Address;
 use Cart;
-use Configuration;
-use Country;
 use Currency;
 use Customer;
 use Language;
@@ -82,25 +79,8 @@ abstract class AbstractCartHandler
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
             ->setLanguage(new Language($cart->id_lang))
-            ->setCountry($this->getCartTaxCountry($cart))
+            ->setCountry($cart->getTaxCountry())
             ->setShop(new Shop($cart->id_shop))
         ;
-    }
-
-    /**
-     * @param Cart $cart
-     *
-     * @return Country
-     *
-     * @throws \PrestaShopDatabaseException
-     * @throws \PrestaShopException
-     */
-    protected function getCartTaxCountry(Cart $cart): Country
-    {
-        $taxAddressType = Configuration::get('PS_TAX_ADDRESS_TYPE');
-        $taxAddressId = $cart->{$taxAddressType} ?? $cart->id_address_delivery;
-        $taxAddress = new Address($taxAddressId);
-
-        return new Country($taxAddress->id_country);
     }
 }

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -27,14 +27,11 @@
 namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
 use Carrier;
-use Currency;
-use Customer;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartCarrierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateCartCarrierHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
-use Shop;
 use Validate;
 
 /**
@@ -63,13 +60,7 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
         $this->assertActiveCarrier($command->getNewCarrierId());
 
         $cart = $this->getCart($command->getCartId());
-        $this->contextStateManager
-            ->setCart($cart)
-            ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage($cart->getAssociatedLanguage())
-            ->setCustomer(new Customer($cart->id_customer))
-            ->setShop(new Shop($cart->id_shop))
-        ;
+        $this->setCartContext($this->contextStateManager, $cart);
 
         try {
             $cart->setDeliveryOption([

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -182,8 +182,8 @@ final class ContextStateManager
      */
     public function restorePreviousContext(): self
     {
-        $currentStashIndex = $this->getCurrentStashIndex();
-        foreach (array_keys($this->contextFieldsStack[$currentStashIndex]) as $fieldName) {
+        $stackFields = array_keys($this->contextFieldsStack[$this->getCurrentStashIndex()]);
+        foreach ($stackFields as $fieldName) {
             $this->restoreContextField($fieldName);
         }
         $this->removeLastSavedContext();

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -57,9 +57,9 @@ final class ContextStateManager
     ];
 
     /**
-     * @var Context
+     * @var LegacyContext
      */
-    private $context;
+    private $legacyContext;
 
     /**
      * @var array|null
@@ -67,11 +67,11 @@ final class ContextStateManager
     private $contextFieldsStack = null;
 
     /**
-     * @param Context $context
+     * @param LegacyContext $legacyContext
      */
-    public function __construct(Context $context)
+    public function __construct(LegacyContext $legacyContext)
     {
-        $this->context = $context;
+        $this->legacyContext = $legacyContext;
     }
 
     /**
@@ -79,7 +79,7 @@ final class ContextStateManager
      */
     public function getContext(): Context
     {
-        return $this->context;
+        return $this->legacyContext->getContext();
     }
 
     /**
@@ -92,7 +92,7 @@ final class ContextStateManager
     public function setCart(?Cart $cart): self
     {
         $this->saveContextField('cart');
-        $this->context->cart = $cart;
+        $this->getContext()->cart = $cart;
 
         return $this;
     }
@@ -107,7 +107,7 @@ final class ContextStateManager
     public function setCountry(?Country $country): self
     {
         $this->saveContextField('country');
-        $this->context->country = $country;
+        $this->getContext()->country = $country;
 
         return $this;
     }
@@ -122,7 +122,7 @@ final class ContextStateManager
     public function setCurrency(?Currency $currency): self
     {
         $this->saveContextField('currency');
-        $this->context->currency = $currency;
+        $this->getContext()->currency = $currency;
 
         return $this;
     }
@@ -137,7 +137,7 @@ final class ContextStateManager
     public function setLanguage(?Language $language): self
     {
         $this->saveContextField('language');
-        $this->context->language = $language;
+        $this->getContext()->language = $language;
 
         return $this;
     }
@@ -152,7 +152,7 @@ final class ContextStateManager
     public function setCustomer(?Customer $customer): self
     {
         $this->saveContextField('customer');
-        $this->context->customer = $customer;
+        $this->getContext()->customer = $customer;
 
         return $this;
     }
@@ -169,7 +169,7 @@ final class ContextStateManager
     public function setShop(Shop $shop): self
     {
         $this->saveContextField('shop');
-        $this->context->shop = $shop;
+        $this->getContext()->shop = $shop;
         Shop::setContext(Shop::CONTEXT_SHOP, $shop->id);
 
         return $this;
@@ -239,10 +239,10 @@ final class ContextStateManager
         // NOTE: array_key_exists important here, isset cannot be used because it would not detect if null is stored
         if (!array_key_exists($fieldName, $this->contextFieldsStack[$currentStashIndex])) {
             if ('shop' === $fieldName) {
-                $this->contextFieldsStack[$currentStashIndex]['shop'] = $this->context->$fieldName;
+                $this->contextFieldsStack[$currentStashIndex]['shop'] = $this->getContext()->$fieldName;
                 $this->contextFieldsStack[$currentStashIndex]['shopContext'] = Shop::getContext();
             } else {
-                $this->contextFieldsStack[$currentStashIndex][$fieldName] = $this->context->$fieldName;
+                $this->contextFieldsStack[$currentStashIndex][$fieldName] = $this->getContext()->$fieldName;
             }
         }
     }
@@ -260,7 +260,7 @@ final class ContextStateManager
             if ('shop' === $fieldName) {
                 $this->restoreShopContext($currentStashIndex);
             }
-            $this->context->$fieldName = $this->contextFieldsStack[$currentStashIndex][$fieldName];
+            $this->getContext()->$fieldName = $this->contextFieldsStack[$currentStashIndex][$fieldName];
             unset($this->contextFieldsStack[$currentStashIndex][$fieldName]);
         }
     }

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -221,6 +221,9 @@ final class ContextStateManager
     }
 
     /**
+     * Return the stack of modified fields
+     * If it's null, no context field has been overridden
+     *
      * @return array|null
      */
     public function getContextFieldsStack(): ?array
@@ -266,6 +269,8 @@ final class ContextStateManager
     }
 
     /**
+     * Returns the index of the current stack
+     *
      * @return int
      */
     private function getCurrentStashIndex(): int

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -78,7 +78,7 @@ class LegacyContext
      */
     public function getContext()
     {
-        if (null === self::$instance) {
+        if (null === static::$instance) {
             $legacyContext = Context::getContext();
 
             if ($legacyContext && !empty($legacyContext->shop) && !isset($legacyContext->controller) && isset($legacyContext->employee)) {
@@ -86,10 +86,10 @@ class LegacyContext
                 $adminController = new AdminController();
                 $adminController->initShopContext();
             }
-            self::$instance = $legacyContext;
+            static::$instance = $legacyContext;
         }
 
-        return self::$instance;
+        return static::$instance;
     }
 
     /**
@@ -352,6 +352,6 @@ class LegacyContext
      */
     public static function setInstanceForTesting(Context $testInstance)
     {
-        self::$instance = $testInstance;
+        static::$instance = $testInstance;
     }
 }

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -44,6 +44,9 @@ use Tab;
  */
 class LegacyContext
 {
+    /** @var Context */
+    protected static $instance = null;
+
     /** @var Currency */
     private $employeeCurrency;
 
@@ -75,9 +78,7 @@ class LegacyContext
      */
     public function getContext()
     {
-        static $legacyContext = null;
-
-        if (null === $legacyContext) {
+        if (null === self::$instance) {
             $legacyContext = Context::getContext();
 
             if ($legacyContext && !empty($legacyContext->shop) && !isset($legacyContext->controller) && isset($legacyContext->employee)) {
@@ -85,9 +86,10 @@ class LegacyContext
                 $adminController = new AdminController();
                 $adminController->initShopContext();
             }
+            self::$instance = $legacyContext;
         }
 
-        return $legacyContext;
+        return self::$instance;
     }
 
     /**
@@ -342,5 +344,14 @@ class LegacyContext
     public function getAvailableLanguages()
     {
         return $this->getLanguages(false);
+    }
+
+    /**
+     * @param Context $testInstance
+     *                              Unit testing purpose only
+     */
+    public static function setInstanceForTesting(Context $testInstance)
+    {
+        self::$instance = $testInstance;
     }
 }

--- a/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
+++ b/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
@@ -185,6 +185,7 @@ abstract class AbstractOrderCommandHandler extends AbstractOrderHandler
     protected function setCartContext(ContextStateManager $contextStateManager, Cart $cart): void
     {
         $contextStateManager
+            ->saveCurrentContext()
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -31,6 +31,8 @@ use BoOrderCore;
 use Cart;
 use Configuration;
 use Context;
+use Currency;
+use Customer;
 use Employee;
 use Exception;
 use Message;
@@ -79,14 +81,6 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
         $this->assertAddressesAreNotDisabled($cart);
 
         //Context country, language and currency is used in PaymentModule::validateOrder (it should rely on cart address country instead)
-        $this->contextStateManager
-            ->setCart($cart)
-            ->setCurrency(new Currency($cart->id_currency))
-            ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage($cart->getAssociatedLanguage())
-            ->setCountry($this->getTaxCountry($cart))
-            ->setShop(new Shop($cart->id_shop))
-        ;
         $this->setCartContext($this->contextStateManager, $cart);
 
         $translator = Context::getContext()->getTranslator();

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -88,7 +88,6 @@ final class AddOrderFromBackOfficeHandler extends AbstractOrderCommandHandler im
             ->setShop(new Shop($cart->id_shop))
         ;
         $this->setCartContext($this->contextStateManager, $cart);
-        $this->contextStateManager->saveCurrentContext();
 
         $translator = Context::getContext()->getTranslator();
         $employee = new Employee($command->getEmployeeId()->getValue());

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -185,8 +185,8 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
         ?Address $address = null
     ): FoundProduct {
         // It's important to use null (not 0) as attribute ID so that Product::priceCalculation can fallback to default combination
-        $priceTaxExcluded = $this->getProductPriceForOrder((int) $product->id, null, false, $computingPrecision, $order);
-        $priceTaxIncluded = $this->getProductPriceForOrder((int) $product->id, null, true, $computingPrecision, $order);
+        $priceTaxExcluded = $this->getProductPriceForOrder((int) $product->id, null, false, $computingPrecision, $order) ?? 0.00;
+        $priceTaxIncluded = $this->getProductPriceForOrder((int) $product->id, null, true, $computingPrecision, $order) ?? 0.00;
         $product->loadStockData();
 
         return new FoundProduct(

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -25,4 +25,4 @@ services:
     prestashop.adapter.context_state_manager:
       class: PrestaShop\PrestaShop\Adapter\ContextStateManager
       arguments:
-        - '@=service("prestashop.adapter.legacy.context").getContext()'
+        - '@prestashop.adapter.legacy.context'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -41,6 +41,7 @@ services:
     arguments:
       - '@prestashop.adapter.order.product_quantity.updater'
       - '@prestashop.adapter.order.order_detail.updater'
+      - '@prestashop.adapter.context_state_manager'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand

--- a/tests-legacy/Unit/ContextMocker.php
+++ b/tests-legacy/Unit/ContextMocker.php
@@ -37,9 +37,11 @@ use Currency;
 use Customer;
 use Language;
 use Link;
+use Module;
 use ObjectModel;
 use Pack;
 use Phake;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use Product;
 use Shop;
@@ -105,6 +107,8 @@ class ContextMocker
         $this->contextBackup = Context::getContext();
         $context             = clone $this->contextBackup;
         Context::setInstanceForTesting($context);
+        LegacyContext::setInstanceForTesting($context);
+        Module::setContextInstanceForTesting($context);
         $context->shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
         Shop::setContext(Shop::CONTEXT_SHOP, (int) Context::getContext()->shop->id);
         $context->customer = Phake::mock('Customer');
@@ -131,5 +135,8 @@ class ContextMocker
     public function resetContext()
     {
         Context::setInstanceForTesting($this->contextBackup);
+        LegacyContext::setInstanceForTesting($this->contextBackup);
+        Shop::setContext(Shop::CONTEXT_SHOP, (int) Context::getContext()->shop->id);
+        Module::setContextInstanceForTesting($this->contextBackup);
     }
 }

--- a/tests-legacy/Unit/ContextMocker.php
+++ b/tests-legacy/Unit/ContextMocker.php
@@ -100,6 +100,8 @@ class ContextMocker
         ObjectModel::resetStaticCache();
         Tools::resetStaticCache();
 
+        Cache::clean('*');
+
         $this->contextBackup = Context::getContext();
         $context             = clone $this->contextBackup;
         Context::setInstanceForTesting($context);
@@ -117,6 +119,7 @@ class ContextMocker
             ? 'https://' : 'http://';
         $context->link     = new Link($protocol_link, $protocol_content);
         $context->currency = new Currency(1, 1, 1);
+        $context->cart     = new Cart();
         $context->smarty   = $smarty;
 
         return $this;

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -310,10 +310,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
             throw new \Exception('Context was not mocked');
         }
         self::$contextMocker->resetContext();
-
-        // If we messed with the context it is safer to reboot the kernel because some services
-        // (like ContextStateManager) may now have invalid references to former context
-        self::rebootKernel();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -203,31 +203,35 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @BeforeScenario @reset-context-after-scenario
+     * @BeforeScenario @mock-context-on-scenario
      */
     public static function mockContextBeforeScenario()
     {
-        /** @var LegacyContext $localeRepository */
-        $legacyContext = self::getContainer()->get('prestashop.adapter.legacy.context');
-        /*
-         * We need to call this before initializing the ContextMocker because this method forcefully init
-         * the shop context thus overriding the expected value
-         */
-        $legacyContext->getContext();
-
-        self::$contextMocker = new ContextMocker();
-        self::$contextMocker->mockContext();
+        self::mockContext();
     }
 
     /**
-     * @AfterScenario @reset-context-after-scenario
+     * @AfterScenario @mock-context-on-scenario
      */
     public static function resetContextAfterScenario()
     {
-        if (empty(self::$contextMocker)) {
-            throw new \Exception('Context was not mocked');
-        }
-        self::$contextMocker->resetContext();
+        self::resetContext();
+    }
+
+    /**
+     * @BeforeFeature @mock-context-on-feature
+     */
+    public static function mockContextBeforeFeature()
+    {
+        self::mockContext();
+    }
+
+    /**
+     * @AfterFeature @mock-context-on-feature
+     */
+    public static function resetContextAfterFeature()
+    {
+        self::resetContext();
     }
 
     /**
@@ -283,6 +287,32 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function rebootKernelOnDemand()
     {
+        self::rebootKernel();
+    }
+
+    private static function mockContext()
+    {
+        /** @var LegacyContext $localeRepository */
+        $legacyContext = self::getContainer()->get('prestashop.adapter.legacy.context');
+        /*
+         * We need to call this before initializing the ContextMocker because this method forcefully init
+         * the shop context thus overriding the expected value
+         */
+        $legacyContext->getContext();
+
+        self::$contextMocker = new ContextMocker();
+        self::$contextMocker->mockContext();
+    }
+
+    private static function resetContext()
+    {
+        if (empty(self::$contextMocker)) {
+            throw new \Exception('Context was not mocked');
+        }
+        self::$contextMocker->resetContext();
+
+        // If we messed with the context it is safer to reboot the kernel because some services
+        // (like ContextStateManager) may now have invalid references to former context
         self::rebootKernel();
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
@@ -54,8 +54,10 @@ class CustomerFeatureContext extends AbstractPrestaShopFeatureContext
         $customer->lastname = 'fake';
         $customer->passwd = 'fakefake';
         $customer->email = $customerEmail;
+        $customer->id_shop = Context::getContext()->shop->id;
         $customer->add();
         $this->customers[$customerName] = $customer;
+        SharedStorage::getStorage()->set($customerName, $customer->id);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -102,7 +102,10 @@ abstract class AbstractDomainFeatureContext implements Context
         return CommonFeatureContext::getContainer();
     }
 
-    protected function assertLastErrorIsNull()
+    /**
+     * @throws RuntimeException
+     */
+    protected function assertLastErrorIsNull(): void
     {
         if (null !== $this->lastException) {
             throw new RuntimeException(sprintf('An unexpected exception was thrown %s: %s', get_class($this->lastException), $this->lastException->getMessage()), 0, $this->lastException);

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -1049,7 +1049,13 @@ class CartFeatureContext extends AbstractDomainFeatureContext
      */
     private function getProductIdByName(string $productName)
     {
-        $products = $this->getQueryBus()->handle(new SearchProducts($productName, 1, Context::getContext()->currency->iso_code));
+        $products = $this->getQueryBus()->handle(
+            new SearchProducts(
+                $productName,
+                1,
+                Context::getContext()->currency->iso_code
+            )
+        );
 
         if (empty($products)) {
             throw new RuntimeException(sprintf('Product with name "%s" was not found', $productName));

--- a/tests/Integration/Behaviour/Features/Context/Domain/CommonDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CommonDomainFeatureContext.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+class CommonDomainFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @Then I should get no error
+     */
+    public function assertLastErrorIsNull(): void
+    {
+        parent::assertLastErrorIsNull();
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -290,12 +290,4 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
     {
         $this->assertLastErrorIs(CurrencyNotFoundException::class);
     }
-
-    /**
-     * @Then I should get no currency error
-     */
-    public function assertNoCurrencyError()
-    {
-        $this->assertLastErrorIsNull();
-    }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1465,9 +1465,11 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
     /**
      * @param string $productName
      *
-     * @return int
+     * @throws RuntimeException
+     *
+     * @return FoundProduct
      */
-    private function getProductByName(string $productName)
+    private function getProductByName(string $productName): FoundProduct
     {
         $products = $this->getQueryBus()->handle(new SearchProducts($productName, 1, Context::getContext()->currency->iso_code));
 

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -31,9 +31,11 @@ use Behat\Gherkin\Node\TableNode;
 use Cart;
 use Combination;
 use Configuration;
+use Context;
 use Customization;
 use CustomizationField;
 use Pack;
+use PrestaShop\PrestaShop\Core\Foundation\IoC\Exception;
 use Product;
 use RuntimeException;
 use SpecificPrice;
@@ -83,13 +85,39 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     /* PRODUCTS */
 
     /**
-     * @param $productName
+     * @param string $productName
      *
      * @return Product
      */
-    public function getProductWithName($productName)
+    public function getProductWithName(string $productName)
     {
-        return $this->products[$productName];
+        $idShop = (int) Context::getContext()->shop->id !== (int) Configuration::get('PS_SHOP_DEFAULT') ?
+            (string) Context::getContext()->shop->id : '';
+
+        return $this->products[$productName . $idShop];
+    }
+
+    /**
+     * @param Product $product
+     */
+    private function addProduct(Product $product): void
+    {
+        $idShop = (int) Context::getContext()->shop->id !== (int) Configuration::get('PS_SHOP_DEFAULT') ?
+            (string) Context::getContext()->shop->id : '';
+        $this->products[$product->name . $idShop] = $product;
+    }
+
+    /**
+     * @param string $productName
+     *
+     * @return bool
+     */
+    private function hasProduct(string $productName): bool
+    {
+        $idShop = (int) Context::getContext()->shop->id !== (int) Configuration::get('PS_SHOP_DEFAULT') ?
+            (string) Context::getContext()->shop->id : '';
+
+        return isset($this->products[$productName . $idShop]);
     }
 
     /**
@@ -117,7 +145,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function iAddProductNamedInMyCartWithQuantity($productQuantity, $productName)
     {
         $this->checkProductWithNameExists($productName);
-        $result = $this->getCurrentCart()->updateQty($productQuantity, $this->products[$productName]->id);
+        $result = $this->getCurrentCart()->updateQty($productQuantity, $this->getProductWithName($productName)->id);
         if (!$result) {
             throw new RuntimeException(sprintf('Expects true, got %s instead', $result));
         }
@@ -130,7 +158,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $expected = $expectedStr == 'OK';
-        $result = $this->getCurrentCart()->updateQty($productQuantity, $this->products[$productName]->id, null, false, $operator);
+        $result = $this->getCurrentCart()->updateQty($productQuantity, $this->getProductWithName($productName)->id, null, false, $operator);
         if ($expected != $result) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $expected, $result));
         }
@@ -142,12 +170,12 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function quantityOfProductNamedInMyCartShouldBe($productQuantity, $productName, $packItemsIncluded = null)
     {
         if ($packItemsIncluded != 'including') {
-            $nbProduct = $this->getCurrentCart()->getProductQuantity($this->products[$productName]->id, null, null);
+            $nbProduct = $this->getCurrentCart()->getProductQuantity($this->getProductWithName($productName)->id, null, null);
             if ($productQuantity != $nbProduct['quantity']) {
                 throw new RuntimeException(sprintf('Expects %s, got %s instead (excluding items in pack)', $productQuantity, $nbProduct['quantity']));
             }
         } else {
-            $nbProduct = $this->getCurrentCart()->getProductQuantity($this->products[$productName]->id, null, null);
+            $nbProduct = $this->getCurrentCart()->getProductQuantity($this->getProductWithName($productName)->id, null, null);
             if ($productQuantity != $nbProduct['deep_quantity']) {
                 throw new RuntimeException(sprintf('Expects %s, got %s instead (including items in pack)', $productQuantity, $nbProduct['deep_quantity']));
             }
@@ -159,9 +187,11 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function remainingQuantityOfProductNamedShouldBe($productName, $productQuantity)
     {
-        $this->checkProductWithNameExists($productName);
+        if (!$this->hasProduct($productName)) {
+            throw new Exception('Product named "' . $productName . '" doesn\'t exist');
+        }
         // Be careful this counts the amount present in the cart as well event if the stock has not been updated yet
-        $nbProduct = Product::getQuantity($this->products[$productName]->id, null, null, $this->getCurrentCart(), null);
+        $nbProduct = Product::getQuantity($this->getProductWithName($productName)->id, null, null, $this->getCurrentCart(), null);
         if ($productQuantity != $nbProduct) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $productQuantity, $nbProduct));
         }
@@ -172,8 +202,10 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function actualQuantityOfProductNamedShouldBe($productName, $productQuantity)
     {
-        $this->checkProductWithNameExists($productName);
-        $nbProduct = StockAvailable::getQuantityAvailableByProduct($this->products[$productName]->id, null);
+        if (!$this->hasProduct($productName)) {
+            throw new Exception('Product named "' . $productName . '" doesn\'t exist');
+        }
+        $nbProduct = StockAvailable::getQuantityAvailableByProduct($this->getProductWithName($productName)->id, null);
         if ($productQuantity != $nbProduct) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $productQuantity, $nbProduct));
         }
@@ -186,7 +218,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCombinationWithNameExists($productName, $combinationName);
-        $nbProduct = StockAvailable::getQuantityAvailableByProduct($this->products[$productName]->id, $this->combinations[$productName][$combinationName]->id);
+        $nbProduct = StockAvailable::getQuantityAvailableByProduct($this->getProductWithName($productName)->id, $this->combinations[$productName][$combinationName]->id);
         if ($combinationQuantity != $nbProduct) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $combinationQuantity, $nbProduct));
         }
@@ -197,7 +229,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function iAmNotAbleToAddProductNamedInMyCartWithQuantity($productQuantity, $productName)
     {
-        $result = $this->getCurrentCart()->updateQty($productQuantity, $this->products[$productName]->id);
+        $result = $this->getCurrentCart()->updateQty($productQuantity, $this->getProductWithName($productName)->id);
         if ($result) {
             throw new RuntimeException(sprintf('Expects false, got %s instead', $result));
         }
@@ -205,7 +237,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
 
     protected function createProduct($productName, $price, $productQuantity)
     {
-        if (isset($this->products[$productName])) {
+        if ($this->hasProduct($productName)) {
             throw new \Exception('Product named "' . $productName . '" was already added in fixtures');
         }
         $product = new Product();
@@ -214,13 +246,14 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         $product->quantity = $productQuantity;
         // Use same default tax rules group as products from fixtures to have the same tax rate
         $product->id_tax_rules_group = TaxRulesGroup::getIdByName('US-FL Rate (6%)');
+        $product->id_shop_default = (int) Context::getContext()->shop->id;
         $productAdded = $product->add();
         if (!$productAdded) {
             throw new RuntimeException('Could not add product in database');
         }
         StockAvailable::setQuantity((int) $product->id, 0, $product->quantity);
 
-        $this->products[$productName] = $product;
+        $this->addProduct($product);
 
         // Fix issue pack cache is set when adding products.
         Pack::resetStaticCache();
@@ -247,11 +280,11 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function productWithNameIsOutOfStock($productName)
     {
         $this->checkProductWithNameExists($productName);
-        $this->products[$productName]->quantity = 0;
-        $this->products[$productName]->out_of_stock = 0;
-        $this->products[$productName]->save();
-        StockAvailable::setQuantity($this->products[$productName]->id, 0, 0);
-        StockAvailable::setProductOutOfStock((int) $this->products[$productName]->id, 0);
+        $this->getProductWithName($productName)->quantity = 0;
+        $this->getProductWithName($productName)->out_of_stock = 0;
+        $this->getProductWithName($productName)->save();
+        StockAvailable::setQuantity($this->getProductWithName($productName)->id, 0, 0);
+        StockAvailable::setProductOutOfStock((int) $this->getProductWithName($productName)->id, 0);
     }
 
     /**
@@ -263,8 +296,8 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function setProductWeight(string $productName, float $weight)
     {
         $this->checkProductWithNameExists($productName);
-        $this->products[$productName]->weight = $weight;
-        $this->products[$productName]->save();
+        $this->getProductWithName($productName)->weight = $weight;
+        $this->getProductWithName($productName)->save();
     }
 
     /**
@@ -293,8 +326,8 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function setProductMinimalQuantity(string $productName, int $minimalQty)
     {
         $this->checkProductWithNameExists($productName);
-        $this->products[$productName]->minimal_quantity = $minimalQty;
-        $this->products[$productName]->save();
+        $this->getProductWithName($productName)->minimal_quantity = $minimalQty;
+        $this->getProductWithName($productName)->save();
     }
 
     /**
@@ -305,7 +338,20 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function productWithNameCanBeOrderedOutOfStock($productName)
     {
         $this->checkProductWithNameExists($productName);
-        StockAvailable::setProductOutOfStock($this->products[$productName]->id, 1);
+        StockAvailable::setProductOutOfStock($this->getProductWithName($productName)->id, 1);
+    }
+
+    /**
+     * @Given /^product "(.+)" cannot be ordered out of stock$/
+     *
+     * @param string $productName
+     */
+    public function productWithNameCannotBeOrderedOutOfStock($productName)
+    {
+        if (!$this->hasProduct($productName)) {
+            throw new Exception('Product named "' . $productName . '" doesn\'t exist');
+        }
+        StockAvailable::setProductOutOfStock($this->getProductWithName($productName)->id, 0);
     }
 
     /**
@@ -327,7 +373,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
             throw new \Exception('Product named "' . $productName . '" has already a specific price named "' . $specificPriceName . '"');
         }
         $specificPrice = new SpecificPrice();
-        $specificPrice->id_product = $this->products[$productName]->id;
+        $specificPrice->id_product = $this->getProductWithName($productName)->id;
         $specificPrice->price = -1;
         $specificPrice->reduction = $specificPriceDiscount;
         $specificPrice->reduction_type = 'amount';
@@ -353,7 +399,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
             throw new \Exception('Product named "' . $productName . '" has already a specific price named "' . $specificPriceName . '"');
         }
         $specificPrice = new SpecificPrice();
-        $specificPrice->id_product = $this->products[$productName]->id;
+        $specificPrice->id_product = $this->getProductWithName($productName)->id;
         $specificPrice->price = -1;
         $specificPrice->reduction = $specificPricePercent / 100;
         $specificPrice->reduction_type = 'percentage';
@@ -430,8 +476,8 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function setProductTaxRuleGroupId($productName, $taxRuleGroupId)
     {
         $this->checkProductWithNameExists($productName);
-        $this->products[$productName]->id_tax_rules_group = $taxRuleGroupId;
-        $this->products[$productName]->save();
+        $this->getProductWithName($productName)->id_tax_rules_group = $taxRuleGroupId;
+        $this->getProductWithName($productName)->save();
     }
 
     /* COMBINATION */
@@ -446,10 +492,10 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         }
         $combination = new Combination();
         $combination->reference = $combinationName;
-        $combination->id_product = $this->products[$productName]->id;
+        $combination->id_product = $this->getProductWithName($productName)->id;
         $combination->quantity = $combinationQuantity;
         $combination->add();
-        StockAvailable::setQuantity((int) $this->products[$productName]->id, $combination->id, $combination->quantity);
+        StockAvailable::setQuantity((int) $this->getProductWithName($productName)->id, $combination->id, $combination->quantity);
         $this->combinations[$productName][$combinationName] = $combination;
     }
 
@@ -475,7 +521,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function productWithNameHasCombinationsWithFollowingDetails($productName, TableNode $table)
     {
         $this->checkProductWithNameExists($productName);
-        $productId = (int) $this->products[$productName]->id;
+        $productId = (int) $this->getProductWithName($productName)->id;
         $combinationsList = $table->getColumnsHash();
         $attributesList = \Attribute::getAttributes((int) Configuration::get('PS_LANG_DEFAULT'));
         foreach ($combinationsList as $combinationDetails) {
@@ -509,7 +555,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCombinationWithNameExists($productName, $combinationName);
-        $nbProduct = Product::getQuantity($this->products[$productName]->id, $this->combinations[$productName][$combinationName]->id, null, $this->getCurrentCart(), null);
+        $nbProduct = Product::getQuantity($this->getProductWithName($productName)->id, $this->combinations[$productName][$combinationName]->id, null, $this->getCurrentCart(), null);
         if ($combinationQuantity != $nbProduct) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $combinationQuantity, $nbProduct));
         }
@@ -522,7 +568,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCombinationWithNameExists($productName, $combinationName);
-        $result = $this->getCurrentCart()->updateQty($combinationQuantity, $this->products[$productName]->id, $this->combinations[$productName][$combinationName]->id);
+        $result = $this->getCurrentCart()->updateQty($combinationQuantity, $this->getProductWithName($productName)->id, $this->combinations[$productName][$combinationName]->id);
         if (!$result) {
             throw new RuntimeException(sprintf('Expects true, got %s instead', $result));
         }
@@ -535,7 +581,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCombinationWithNameExists($productName, $combinationName);
-        $result = $this->getCurrentCart()->updateQty($combinationQuantity, $this->products[$productName]->id, $this->combinations[$productName][$combinationName]->id);
+        $result = $this->getCurrentCart()->updateQty($combinationQuantity, $this->getProductWithName($productName)->id, $this->combinations[$productName][$combinationName]->id);
         if ($result) {
             throw new RuntimeException(sprintf('Expects false, got %s instead', $result));
         }
@@ -548,7 +594,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCombinationWithNameExists($productName, $combinationName);
-        $nbProduct = $this->getCurrentCart()->getProductQuantity($this->products[$productName]->id, $this->combinations[$productName][$combinationName]->id, null);
+        $nbProduct = $this->getCurrentCart()->getProductQuantity($this->getProductWithName($productName)->id, $this->combinations[$productName][$combinationName]->id, null);
         if ($combinationQuantity != $nbProduct['quantity']) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $combinationQuantity, $nbProduct['quantity']));
         }
@@ -586,11 +632,11 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function productWithNameHasACustomizationWithName($productName, $customizationFieldName)
     {
         $this->checkProductWithNameExists($productName);
-        $this->products[$productName]->customizable = 1;
-        $this->products[$productName]->save();
+        $this->getProductWithName($productName)->customizable = 1;
+        $this->getProductWithName($productName)->save();
 
         $customizationField = new CustomizationField();
-        $customizationField->id_product = $this->products[$productName]->id;
+        $customizationField->id_product = $this->getProductWithName($productName)->id;
         $customizationField->type = 1; // text field
         $customizationField->required = 1;
         $customizationField->name = [
@@ -607,7 +653,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCustomizationWithNameExists($productName, $customizationFieldName);
-        $nbProduct = Product::getQuantity($this->products[$productName]->id, null, null, $this->getCurrentCart(), $this->customizationsInCart[$productName]->id);
+        $nbProduct = Product::getQuantity($this->getProductWithName($productName)->id, null, null, $this->getCurrentCart(), $this->customizationsInCart[$productName]->id);
         if ($customizationQuantity != $nbProduct) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $customizationQuantity, $nbProduct));
         }
@@ -620,7 +666,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->addCustomizationInCurrentCartForProductNamedIfNotExist($productName);
-        $result = $this->getCurrentCart()->updateQty($customizationFieldQuantity, $this->products[$productName]->id, null, $this->customizationsInCart[$productName]->id);
+        $result = $this->getCurrentCart()->updateQty($customizationFieldQuantity, $this->getProductWithName($productName)->id, null, $this->customizationsInCart[$productName]->id);
         if (!$result) {
             throw new RuntimeException(sprintf('Expects true, got %s instead', $result));
         }
@@ -634,7 +680,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         $this->checkProductWithNameExists($productName);
         $this->checkCustomizationWithNameExists($productName, $customizationFieldName);
         $this->addCustomizationInCurrentCartForProductNamedIfNotExist($productName);
-        $result = $this->getCurrentCart()->updateQty($customizationFieldQuantity, $this->products[$productName]->id, null, $this->customizationFields[$productName][$customizationFieldName]->id);
+        $result = $this->getCurrentCart()->updateQty($customizationFieldQuantity, $this->getProductWithName($productName)->id, null, $this->customizationFields[$productName][$customizationFieldName]->id);
         if ($result) {
             throw new RuntimeException(sprintf('Expects false, got %s instead', $result));
         }
@@ -647,7 +693,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkProductWithNameExists($productName);
         $this->checkCustomizationWithNameExists($productName, $customizationFieldName);
-        $nbProduct = $this->getCurrentCart()->getProductQuantity($this->products[$productName]->id, null, $this->customizationsInCart[$productName]->id);
+        $nbProduct = $this->getCurrentCart()->getProductQuantity($this->getProductWithName($productName)->id, null, $this->customizationsInCart[$productName]->id);
         if ($customizationFieldQuantity != $nbProduct['quantity']) {
             throw new RuntimeException(sprintf('Expects %s, got %s instead', $customizationFieldQuantity, $nbProduct['quantity']));
         }
@@ -660,7 +706,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         }
 
         $customization = new Customization();
-        $customization->id_product = $this->products[$productName]->id;
+        $customization->id_product = $this->getProductWithName($productName)->id;
         $customization->id_product_attribute = 0;
         $customization->id_address_delivery = 0;
         $customization->quantity = 0;
@@ -756,7 +802,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function productIsConsideredAsAPack($productName)
     {
         $this->checkProductWithNameExists($productName);
-        if (!Pack::isPack($this->products[$productName]->id)) {
+        if (!Pack::isPack($this->getProductWithName($productName)->id)) {
             throw new RuntimeException(sprintf('Expects %s to be considered as a pack, it is not', $productName));
         }
     }
@@ -767,8 +813,8 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     public function productWithNameProductIsVirtual($productName)
     {
         $this->checkProductWithNameExists($productName);
-        $this->products[$productName]->is_virtual = 1;
-        $this->products[$productName]->save();
+        $this->getProductWithName($productName)->is_virtual = 1;
+        $this->getProductWithName($productName)->save();
     }
 
     /**
@@ -781,9 +827,9 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
 
         $category = $this->categoryFeatureContext->getCategoryWithName($categoryName);
 
-        $this->products[$productName]->id_category_default = $category->id_category;
-        $this->products[$productName]->addToCategories([$category->id]);
-        $this->products[$productName]->save();
+        $this->getProductWithName($productName)->id_category_default = $category->id_category;
+        $this->getProductWithName($productName)->addToCategories([$category->id]);
+        $this->getProductWithName($productName)->save();
     }
 
     /**
@@ -795,7 +841,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
         $productPricesList = $this->getCurrentCart()->getProducts(true);
 
         foreach ($productPricesList as $productPrices) {
-            if ($this->products[$productName]->id == $productPrices['id_product'] && $productPrices['price_with_reduction'] != $priceWithReduction) {
+            if ($this->getProductWithName($productName)->id == $productPrices['id_product'] && $productPrices['price_with_reduction'] != $priceWithReduction) {
                 throw new RuntimeException(sprintf('Expects %s, got %s instead', $priceWithReduction, $productPrices['price_with_reduction']));
             }
         }

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -26,9 +26,13 @@
 
 namespace Tests\Integration\Behaviour\Features\Context;
 
+use Cache;
 use Configuration;
+use Context;
+use Db;
 use RuntimeException;
 use Shop;
+use ShopGroup;
 
 class ShopFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -50,11 +54,60 @@ class ShopFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /I add a shop group "(.+)" with name "(.+)"$/
+     *
+     * @param string $reference
+     * @param string $groupName
+     */
+    public function addShopGroup(string $reference, string $groupName): void
+    {
+        $shopGroup = new ShopGroup();
+        $shopGroup->name = $groupName;
+        $shopGroup->active = true;
+        if (!$shopGroup->add()) {
+            throw new RuntimeException(sprintf('Could not create shop group: %s', Db::getInstance()->getMsgError()));
+        }
+
+        SharedStorage::getStorage()->set($reference, $shopGroup);
+    }
+
+    /**
+     * @Given /I add a shop "(.+)" with name "(.+)" for the group "(.+)"$/
+     *
+     * @param string $reference
+     * @param string $shopName
+     * @param string $shopGroupName
+     */
+    public function addShop(string $reference, string $shopName, string $shopGroupName): void
+    {
+        $shop = new Shop();
+        $shop->active = true;
+        $shop->id_shop_group = ShopGroup::getIdByName($shopGroupName);
+        // 2 : ID Category for "Home" in database
+        $shop->id_category = 2;
+        $shop->theme_name = _THEME_NAME_;
+        $shop->name = $shopName;
+        if (!$shop->add()) {
+            throw new RuntimeException(sprintf('Could not create shop: %s', Db::getInstance()->getMsgError()));
+        }
+        $shop->setTheme();
+
+        // Link Country to new Shop
+        Db::getInstance()->execute(
+            'INSERT INTO `' . _DB_PREFIX_ . 'country_shop` (`id_country`, `id_shop`) ' .
+            'SELECT id_country, ' . $shop->id . ' ' .
+            'FROM `' . _DB_PREFIX_ . 'country` '
+        );
+
+        SharedStorage::getStorage()->set($reference, $shop);
+    }
+
+    /**
      * @Given single shop context is loaded
      */
     public function singleShopContextIsLoaded()
     {
-        Shop::setContext(Shop::CONTEXT_SHOP, Configuration::get('PS_SHOP_DEFAULT'));
+        $this->setShopContext(Shop::CONTEXT_SHOP, (int) Configuration::get('PS_SHOP_DEFAULT'));
     }
 
     /**
@@ -62,6 +115,77 @@ class ShopFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function multipleShopContextIsLoaded()
     {
-        Shop::setContext(Shop::CONTEXT_ALL);
+        $this->setShopContext(Shop::CONTEXT_ALL, (int) Configuration::get('PS_SHOP_DEFAULT'));
+    }
+
+    /**
+     * @Given /^shop context "(.+)" is loaded$/
+     *
+     * @param string $shopName
+     */
+    public function specificShopContextIsLoaded(string $shopName): void
+    {
+        $this->setShopContext(Shop::CONTEXT_SHOP, (int) Shop::getIdByName($shopName));
+    }
+
+    /**
+     * @Then /^I should have (\d) shop group(s)$/
+     *
+     * @param int $expectedCount
+     */
+    public function checkShopGroupCount(int $expectedCount)
+    {
+        $countShopGroup = ShopGroup::getTotalShopGroup();
+
+        if ($countShopGroup == $expectedCount) {
+            return;
+        }
+        throw new RuntimeException(
+            sprintf(
+                'Invalid number of shop groups, expected %s but got %s instead',
+                $expectedCount,
+                $countShopGroup
+            )
+        );
+    }
+
+    /**
+     * @Then /^I should have (\d) shop(?:|s) in group "(.+)"$/
+     *
+     * @param int $expectedCount
+     */
+    public function checkShopCount(int $expectedCount, string $shopGroupName)
+    {
+        $shopGroupId = ShopGroup::getIdByName($shopGroupName);
+        if (false === $shopGroupId) {
+            throw new RuntimeException(sprintf('Shop Group with name "%s" does not exist', $shopGroupName));
+        }
+
+        $shops = ShopGroup::getShopsFromGroup($shopGroupId);
+        if (count($shops) == $expectedCount) {
+            return;
+        }
+        throw new RuntimeException(
+            sprintf(
+                'Invalid number of shop groups, expected %s but got %s instead',
+                $expectedCount,
+                count($shops)
+            )
+        );
+    }
+
+    /**
+     * @param int $context
+     * @param int $shopId
+     *
+     * @throws \PrestaShopException
+     */
+    private function setShopContext(int $context, int $shopId): void
+    {
+        Shop::setContext($context, $shopId);
+        Context::getContext()->shop = new Shop($shopId);
+        // Clean cache
+        Cache::clean('Shop::getCompleteListOfShopsID');
+        Cache::clean('StockAvailable::*');
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -13,7 +13,7 @@ Feature: Currency Data
   @currency-data
   Scenario: Get data from an official currency
     When I request reference data for "EUR"
-    Then I should get no currency error
+    Then I should get no error
     And I should get currency data:
       | iso_code         | EUR                   |
       | numeric_iso_code | 978                   |

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -19,7 +19,7 @@ Feature: Currency Management
       | is_enabled       | 1         |
       | is_unofficial    | 0         |
       | shop_association | shop1     |
-    Then I should get no currency error
+    Then I should get no error
     And currency "currency1" should be "EUR"
     And currency "currency1" exchange rate should be 0.88
     And currency "currency1" numeric iso code should be 978
@@ -99,7 +99,7 @@ Feature: Currency Management
       | is_enabled       | 0             |
       | is_unofficial    | 0             |
       | shop_association | shop1         |
-    Then I should get no currency error
+    Then I should get no error
     And database contains 1 rows of currency "GBP"
     And currency with "GBP" is not deleted
     And currency "currency5" should be "GBP"
@@ -134,7 +134,7 @@ Feature: Currency Management
       | is_enabled       | 1                |
       | is_unofficial    | 1                |
       | shop_association | shop1            |
-    Then I should get no currency error
+    Then I should get no error
     And database contains 1 rows of currency "CST"
     And currency "currency7" should be "CST"
     And currency "currency7" exchange rate should be 0.77
@@ -153,7 +153,7 @@ Feature: Currency Management
       | is_enabled       | 0             |
       | is_unofficial    | 1             |
       | shop_association | shop1         |
-    Then I should get no currency error
+    Then I should get no error
     And database contains 0 rows of currency "CST"
     And database contains 1 rows of currency "CUS"
     And currency "currency7" should be "CUS"
@@ -173,7 +173,7 @@ Feature: Currency Management
       | is_enabled       | 1             |
       | is_unofficial    | 1             |
       | shop_association | shop1         |
-    Then I should get no currency error
+    Then I should get no error
     And currency "currency7" should be "CUS"
     And currency "currency7" exchange rate should be 0.88
     And currency "currency7" numeric iso code should be null
@@ -195,7 +195,7 @@ Feature: Currency Management
       | is_enabled       | 1                |
       | is_unofficial    | 1                |
       | shop_association | shop1            |
-    Then I should get no currency error
+    Then I should get no error
     And database contains 1 rows of currency "CST"
     And currency "currency8" should be "CST"
     And currency "currency8" exchange rate should be 0.77
@@ -253,7 +253,7 @@ Feature: Currency Management
       | is_enabled       | 1         |
       | is_unofficial    | 0         |
       | shop_association | shop1     |
-    Then I should get no currency error
+    Then I should get no error
     And currency "currency14" should be "AUD"
     And currency "currency14" exchange rate should be 0.88
     And currency "currency14" numeric iso code should be 036
@@ -272,7 +272,7 @@ Feature: Currency Management
       | is_enabled       | 1         |
       | is_unofficial    | 1         |
       | shop_association | shop1     |
-    Then I should get no currency error
+    Then I should get no error
     And currency "currency15" should be "BTC"
     And currency "currency15" exchange rate should be 0.88
     And currency "currency15" numeric iso code should be null
@@ -292,7 +292,7 @@ Feature: Currency Management
       | is_unofficial    | 0                   |
       | shop_association | shop1               |
       | transformations  | fr-FR:leftWithSpace |
-    Then I should get no currency error
+    Then I should get no error
     And currency "currency16" should be "JPY"
     And currency "currency16" exchange rate should be 0.08
     And currency "currency16" numeric iso code should be 392
@@ -336,7 +336,7 @@ Feature: Currency Management
       | is_unofficial    | 1                      |
       | shop_association | shop1                  |
       | transformations  | fr-FR:leftWithoutSpace |
-    Then I should get no currency error
+    Then I should get no error
     And currency "currency17" should be "JPP"
     And currency "currency17" exchange rate should be 0.8
     And currency "currency17" numeric iso code should be null
@@ -381,7 +381,7 @@ Feature: Currency Management
       | is_enabled       | 0             |
       | is_unofficial    | 1             |
       | shop_association | shop1         |
-    Then I should get no currency error
+    Then I should get no error
     And database contains 1 rows of currency "JPP"
     And currency with "JPP" is not deleted
     And currency "currency18" should be "JPP"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-multi-shop
 @reset-database-before-feature
-@reset-context-after-scenario
+@mock-context-on-scenario
 @clear-cache-before-feature
 @order-multi-shop
 Feature: Order from Back Office (BO)
@@ -296,7 +296,7 @@ Feature: Order from Back Office (BO)
     And I should have 1 shop in group "Default"
     And I should have 1 shop in group "Shop Group 1"
     # Create Products
-    When shop context "Default" is loaded
+    When shop context "test_shop" is loaded
     And there is a product in the catalog named "Product A" with a price of 12.3 and 0 items in stock
     And product "Product A" cannot be ordered out of stock
     Then the available stock for product "Product A" should be 0
@@ -333,7 +333,7 @@ Feature: Order from Back Office (BO)
     # Check Stock
     When shop context "Shop 2" is loaded
     Then the available stock for product "Product B in Shop 2" should be 98
-    When shop context "Default" is loaded
+    When shop context "test_shop" is loaded
     Then the available stock for product "Product A" should be 0
     # Change Context
     When multiple shop context is loaded

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-multi-shop
 @reset-database-before-feature
+@reset-context-after-scenario
 @clear-cache-before-feature
 @order-multi-shop
 Feature: Order from Back Office (BO)
@@ -286,3 +287,57 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 6.00   |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: In All Shop Context, Update product in order
+    # Create Shop Group & Shops
+    When I add a shop group "shopGroup1" with name "Shop Group 1"
+    And I add a shop "shop2" with name "Shop 2" for the group "Shop Group 1"
+    Then I should have 2 shop groups
+    And I should have 1 shop in group "Default"
+    And I should have 1 shop in group "Shop Group 1"
+    # Create Products
+    When shop context "Default" is loaded
+    And there is a product in the catalog named "Product A" with a price of 12.3 and 0 items in stock
+    And product "Product A" cannot be ordered out of stock
+    Then the available stock for product "Product A" should be 0
+    When shop context "Shop 2" is loaded
+    And there is a product in the catalog named "Product B in Shop 2" with a price of 45.6 and 100 items in stock
+    And product "Product B in Shop 2" cannot be ordered out of stock
+    Then the available stock for product "Product B in Shop 2" should be 100
+    # Create Customer
+    # Context : Shop 2
+    When there is a customer named "testCustomerShop2" whose email is "pubshop2@prestashop.com"
+    And I add new address to customer "testCustomerShop2" with following details:
+      | Address alias    | test-customer-address              |
+      | First name       | testFirstName                      |
+      | Last name        | testLastName                       |
+      | Address          | Work address st. 1234567890        |
+      | City             | Birmingham                         |
+      | Country          | United States                      |
+      | State            | Alabama                            |
+      | Postal code      | 12345                              |
+    Then customer "testCustomerShop2" has address in "US" country
+    # Create Order
+    # Context : Shop 2
+    When I create an empty cart "cart_product_B" for customer "testCustomerShop2"
+    And I select "US" address as delivery and invoice address for customer "testCustomerShop2" in cart "cart_product_B"
+    And I add 2 products "Product B in Shop 2" to the cart "cart_product_B"
+    Then the available stock for product "Product B in Shop 2" should be 100
+    When I add order "order_product_B" with the following details:
+      | cart                | cart_product_B             |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    Then the available stock for product "Product B in Shop 2" should be 98
+    And order "order_product_B" should contain 2 products "Product B in Shop 2"
+    # Check Stock
+    When shop context "Shop 2" is loaded
+    Then the available stock for product "Product B in Shop 2" should be 98
+    When shop context "Default" is loaded
+    Then the available stock for product "Product A" should be 0
+    # Change Context
+    When multiple shop context is loaded
+    And I edit product "Product B in Shop 2" to order "order_product_B" with following products details:
+      | amount        | 30                      |
+      | price         | 78.90                   |
+    Then I should get no error

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -428,6 +428,7 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have 1 cart rule
     Then order "bo_order1" should have cart rule "FreeShippingDiscount" with amount "$6.00"
     And order "bo_order1" should have "price_carrier" as a carrier
+    # Shipping cost is 4 (for US zone) + 2 (general fee)
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
@@ -462,6 +463,7 @@ Feature: Order from Back Office (BO)
     And I change order "bo_order1" shipping address to "test-customer-france-address"
     Then order "bo_order1" shipping address should be "test-customer-france-address"
     # Shipping cost changes because we are not in the same zone but the tax is still the one from invoice address
+    # Shipping cost is 3 (for Europe zone) + 2 (general fee)
     Then order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -90,6 +90,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\PriceDisplayMethodConfigurationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
         currency:
             paths:
                 - %paths.base%/Features/Scenario/Currency
@@ -99,6 +100,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
         cldr:
             paths:
                 - %paths.base%/Features/Scenario/CLDR

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -34,10 +34,19 @@ namespace Tests\Unit\Adapter {
     use PHPUnit\Framework\MockObject\MockObject;
     use PHPUnit\Framework\TestCase;
     use PrestaShop\PrestaShop\Adapter\ContextStateManager;
+    use PrestaShop\PrestaShop\Adapter\LegacyContext;
     use Shop;
 
     class ContextStateManagerTest extends TestCase
     {
+        protected $legacyContext;
+
+        protected function setUp()
+        {
+            parent::setUp();
+            $this->legacyContext = new LegacyContext();
+        }
+
         public function testCartState()
         {
             $context = $this->createContextMock([
@@ -45,7 +54,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->cart->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 51));
@@ -68,7 +77,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->country->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 51));
@@ -91,7 +100,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->currency->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 51));
@@ -114,7 +123,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->customer->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 51));
@@ -137,7 +146,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->language->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
@@ -164,7 +173,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
@@ -207,7 +216,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(null, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
@@ -250,7 +259,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
@@ -289,7 +298,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertNull($context->language);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
@@ -319,7 +328,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->customer->id);
             $this->assertEquals(42, $context->language->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager
@@ -354,7 +363,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->language->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
@@ -411,7 +420,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->customer->id);
             $this->assertEquals(42, $context->language->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager
@@ -468,7 +477,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->language->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
@@ -514,7 +523,7 @@ namespace Tests\Unit\Adapter {
             ]);
             $this->assertEquals(42, $context->language->id);
 
-            $contextStateManager = new ContextStateManager($context);
+            $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
 
             // Save point 1
@@ -578,6 +587,7 @@ namespace Tests\Unit\Adapter {
             foreach ($contextFields as $fieldName => $contextValue) {
                 $contextMock->$fieldName = $contextValue;
             }
+            LegacyContext::setInstanceForTesting($contextMock);
 
             return $contextMock;
         }

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -46,14 +46,19 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->cart->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 51));
             $this->assertEquals(51, $context->cart->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCart($this->createContextFieldMock(Cart::class, 69));
             $this->assertEquals(69, $context->cart->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->cart->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testCountryState()
@@ -64,14 +69,19 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->country->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 51));
             $this->assertEquals(51, $context->country->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCountry($this->createContextFieldMock(Country::class, 69));
             $this->assertEquals(69, $context->country->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->country->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testCurrencyState()
@@ -82,14 +92,19 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->currency->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 51));
             $this->assertEquals(51, $context->currency->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCurrency($this->createContextFieldMock(Currency::class, 69));
             $this->assertEquals(69, $context->currency->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->currency->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testCustomerState()
@@ -100,14 +115,19 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->customer->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 51));
             $this->assertEquals(51, $context->customer->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setCustomer($this->createContextFieldMock(Customer::class, 69));
             $this->assertEquals(69, $context->customer->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->customer->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testLanguageState()
@@ -118,14 +138,19 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->language->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
             $this->assertEquals(51, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testShopState()
@@ -140,29 +165,35 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
             $this->assertEquals(51, $context->shop->id);
             $this->assertEquals(51, Shop::getContextShopID());
             $this->assertEquals(51, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 69));
             $this->assertEquals(69, $context->shop->id);
             $this->assertEquals(69, Shop::getContextShopID());
             $this->assertEquals(69, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->shop->id);
             $this->assertEquals(42, Shop::getContextShopID());
             $this->assertEquals(42, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->shop->id);
             $this->assertEquals(42, Shop::getContextShopID());
             $this->assertEquals(42, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testShopStateAll()
@@ -177,29 +208,35 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
             $this->assertEquals(51, $context->shop->id);
             $this->assertEquals(51, Shop::getContextShopID());
             $this->assertEquals(51, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 69));
             $this->assertEquals(69, $context->shop->id);
             $this->assertEquals(69, Shop::getContextShopID());
             $this->assertEquals(69, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->shop->id);
             $this->assertEquals(null, Shop::getContextShopID());
             $this->assertEquals(null, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
+            $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->shop->id);
             $this->assertEquals(null, Shop::getContextShopID());
             $this->assertEquals(null, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_ALL, Shop::getContext());
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testShopStateGroup()
@@ -214,29 +251,35 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 51));
             $this->assertEquals(51, $context->shop->id);
             $this->assertEquals(51, Shop::getContextShopID());
             $this->assertEquals(51, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setShop($this->createContextFieldMock(Shop::class, 69));
             $this->assertEquals(69, $context->shop->id);
             $this->assertEquals(69, Shop::getContextShopID());
             $this->assertEquals(69, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_SHOP, Shop::getContext());
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->shop->id);
             $this->assertEquals(null, Shop::getContextShopID());
             $this->assertEquals(42, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
+            $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->shop->id);
             $this->assertEquals(null, Shop::getContextShopID());
             $this->assertEquals(42, Shop::getContextShopGroupID());
             $this->assertEquals(Shop::CONTEXT_GROUP, Shop::getContext());
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testNullField()
@@ -247,11 +290,15 @@ namespace Tests\Unit\Adapter {
             $this->assertNull($context->language);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
             $this->assertEquals(51, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertNull($context->language);
@@ -273,6 +320,8 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->language->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager
                 ->setCart($this->createContextFieldMock(Cart::class, 51))
                 ->setCountry($this->createContextFieldMock(Country::class, 51))
@@ -280,6 +329,7 @@ namespace Tests\Unit\Adapter {
                 ->setCustomer($this->createContextFieldMock(Customer::class, 51))
                 ->setLanguage($this->createContextFieldMock(Language::class, 51))
             ;
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $this->assertEquals(51, $context->cart->id);
             $this->assertEquals(51, $context->country->id);
@@ -294,6 +344,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->currency->id);
             $this->assertEquals(42, $context->customer->id);
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testSavedContexts()
@@ -304,37 +355,48 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->language->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
             $this->assertEquals(51, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->saveCurrentContext();
+            $this->assertCount(2, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
             $this->assertEquals(93, $context->language->id);
+            $this->assertCount(2, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
 
             // If several sets have been called, the state returns to the value that was saved
             $contextStateManager->saveCurrentContext();
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
             $this->assertEquals(51, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
-        public function testMultipleSavedContextFieds()
+        public function testMultipleSavedContextFields()
         {
             $context = $this->createContextMock([
                 'cart' => $this->createContextFieldMock(Cart::class, 42),
@@ -350,11 +412,14 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->language->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager
                 ->setCart($this->createContextFieldMock(Cart::class, 51))
                 ->setCurrency($this->createContextFieldMock(Currency::class, 51))
                 ->setCustomer($this->createContextFieldMock(Customer::class, 51))
             ;
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $this->assertEquals(51, $context->cart->id);
             $this->assertEquals(42, $context->country->id);
@@ -363,6 +428,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->language->id);
 
             $contextStateManager->saveCurrentContext();
+            $this->assertCount(2, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager
                 ->setCart($this->createContextFieldMock(Cart::class, 69))
@@ -374,6 +440,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(69, $context->currency->id);
             $this->assertEquals(51, $context->customer->id);
             $this->assertEquals(42, $context->language->id);
+            $this->assertCount(2, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
 
@@ -382,6 +449,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(51, $context->currency->id);
             $this->assertEquals(51, $context->customer->id);
             $this->assertEquals(42, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
 
@@ -390,6 +458,7 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->currency->id);
             $this->assertEquals(42, $context->customer->id);
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         public function testTooManyRestore()
@@ -400,32 +469,82 @@ namespace Tests\Unit\Adapter {
             $this->assertEquals(42, $context->language->id);
 
             $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
             $this->assertEquals(51, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->saveCurrentContext();
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
             $this->assertEquals(93, $context->language->id);
+            $this->assertCount(2, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
 
-            // This removes all persisted states, but we always re-init one for future calls
+            // This removes all persisted states, we keep null when nothing is saved
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
             $this->assertEquals(93, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+        }
+
+        public function testSavedContextsFirst()
+        {
+            $context = $this->createContextMock([
+                'language' => $this->createContextFieldMock(Language::class, 42),
+            ]);
+            $this->assertEquals(42, $context->language->id);
+
+            $contextStateManager = new ContextStateManager($context);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
+            // Save point 1
+            $contextStateManager->saveCurrentContext();
+            // Nothing saved yet so no reason to init the stack
+            $this->assertNull($contextStateManager->getContextFieldsStack());
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
+            $this->assertEquals(51, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
+
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
+            $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
+
+            // Save point 2
+            $contextStateManager->saveCurrentContext();
+            $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 93));
+            $this->assertEquals(93, $context->language->id);
+            $this->assertCount(2, $contextStateManager->getContextFieldsStack());
+
+            // Back to save point 2
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(69, $context->language->id);
+            $this->assertCount(1, $contextStateManager->getContextFieldsStack());
+
+            // Back to save point 1
+            $contextStateManager->restorePreviousContext();
+            $this->assertEquals(42, $context->language->id);
+            $this->assertNull($contextStateManager->getContextFieldsStack());
         }
 
         /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fixed UpdateProductInOrder in MultiShop
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #21987
| How to test?  | Cf. #21987

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**:notebook: BC Break** : 
* `classes/module/Module.php` : the static property was in `private` : it's now in `protected`
* `src/Adapter/ContextStateManager.php` : the parameter is not a `Context` but a `PrestaShop\PrestaShop\Adapter\LegacyContext`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22228)
<!-- Reviewable:end -->
