### PR TITLE
BO - Logs - Filter in the logs NOK

### DIFF
--- a/src/Core/Grid/Query/LogQueryBuilder.php
+++ b/src/Core/Grid/Query/LogQueryBuilder.php
@@ -81,11 +81,11 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
-        return $this
-            ->getQueryBuilder()
-            ->select('COUNT(*)')
-            ->from($this->dbPrefix . 'log', 'lg')
-        ;
+        $queryBuilder = $this->getQueryBuilder()
+            ->select('COUNT(lg.id_log)')
+            ->from($this->dbPrefix . 'log', 'lg');
+
+        return $this->applyFilters($searchCriteria->getFilters(), $queryBuilder);
     }
 
     private function applyAssociatedQueries(QueryBuilder $queryBuilder): void
@@ -113,7 +113,7 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function appendShopQuery(QueryBuilder $queryBuilder): void
     {
-        $shopQueryBuilder = $this->connection->createQueryBuilder()
+        $shopQueryBuilder = $this->getQueryBuilder()
             ->select('s.name')
             ->from($this->dbPrefix . 'shop', 's')
             ->where('s.id_shop = lg.id_shop')
@@ -129,7 +129,7 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function appendShopGroupQuery(QueryBuilder $queryBuilder): void
     {
-        $shopQueryBuilder = $this->connection->createQueryBuilder()
+        $shopQueryBuilder = $this->getQueryBuilder()
             ->select('sg.name')
             ->from($this->dbPrefix . 'shop_group', 'sg')
             ->where('sg.id_shop_group = lg.id_shop_group')
@@ -145,7 +145,7 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
      */
     private function appendLangQuery(QueryBuilder $queryBuilder): void
     {
-        $shopQueryBuilder = $this->connection->createQueryBuilder()
+        $shopQueryBuilder = $this->getQueryBuilder()
             ->select('lng.name')
             ->from($this->dbPrefix . 'lang', 'lng')
             ->where('lng.id_lang = lg.id_lang')
@@ -172,8 +172,10 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
      *
      * @param array $filters
      * @param QueryBuilder $qb
+     *
+     * @return QueryBuilder
      */
-    private function applyFilters(array $filters, QueryBuilder $qb)
+    private function applyFilters(array $filters, QueryBuilder $qb): QueryBuilder
     {
         $allowedFilters = [
             'id_log',
@@ -217,6 +219,8 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
             $qb->andWhere('`' . $filterName . '` LIKE :' . $filterName);
             $qb->setParameter($filterName, '%' . $filterValue . '%');
         }
+
+        return $qb;
     }
 
     /**

--- a/src/Core/Grid/Query/LogQueryBuilder.php
+++ b/src/Core/Grid/Query/LogQueryBuilder.php
@@ -84,6 +84,7 @@ final class LogQueryBuilder extends AbstractDoctrineQueryBuilder
         $queryBuilder = $this->getQueryBuilder()
             ->select('COUNT(lg.id_log)')
             ->from($this->dbPrefix . 'log', 'lg');
+        $this->applyAssociatedQueries($queryBuilder);
 
         return $this->applyFilters($searchCriteria->getFilters(), $queryBuilder);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | In the BO > Advanced Parameters > Logs page, when we try to filter by any filed, the logs number is incorrect and the pagination is still displayed => NOK.
| Type?         | bug fix 
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22224
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/22224 by @khouloudbelguith 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22229)
<!-- Reviewable:end -->
