### PR TITLE
Rename UpdateCombinationOptionsCommand to *Details* and add $weight handling

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateCombinationDetailsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateCombinationDetailsHandler.php
@@ -30,14 +30,14 @@ namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
 use Combination;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\CombinationRepository;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationOptionsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateCombinationOptionsHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationDetailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateCombinationDetailsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CannotUpdateCombinationException;
 
 /**
- * Handles @see UpdateCombinationOptionsCommand using legacy object model
+ * Handles @see UpdateCombinationDetailsCommand using legacy object model
  */
-final class UpdateCombinationOptionsHandler implements UpdateCombinationOptionsHandlerInterface
+final class UpdateCombinationDetailsHandler implements UpdateCombinationDetailsHandlerInterface
 {
     /**
      * @var CombinationRepository
@@ -56,7 +56,7 @@ final class UpdateCombinationOptionsHandler implements UpdateCombinationOptionsH
     /**
      * {@inheritdoc}
      */
-    public function handle(UpdateCombinationOptionsCommand $command): void
+    public function handle(UpdateCombinationDetailsCommand $command): void
     {
         $combination = $this->combinationRepository->get($command->getCombinationId());
         $updatableProperties = $this->fillUpdatableProperties($combination, $command);
@@ -70,11 +70,11 @@ final class UpdateCombinationOptionsHandler implements UpdateCombinationOptionsH
 
     /**
      * @param Combination $combination
-     * @param UpdateCombinationOptionsCommand $command
+     * @param UpdateCombinationDetailsCommand $command
      *
      * @return string[]|array<string, int[]>
      */
-    private function fillUpdatableProperties(Combination $combination, UpdateCombinationOptionsCommand $command): array
+    private function fillUpdatableProperties(Combination $combination, UpdateCombinationDetailsCommand $command): array
     {
         //@todo: ps_stock table contains properties(reference, ean13 etc.) that should be updated too depending if we still support ADVANCED_STOCK_MANAGEMENT
         //  check Product::updateAttribute L 2165

--- a/src/Adapter/Product/CommandHandler/UpdateCombinationDetailsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateCombinationDetailsHandler.php
@@ -105,6 +105,10 @@ final class UpdateCombinationDetailsHandler implements UpdateCombinationDetailsH
             $updatableProperties[] = 'upc';
         }
 
+        if (null !== $command->getWeight()) {
+            $combination->weight = (float) (string) $command->getWeight();
+        }
+
         return $updatableProperties;
     }
 }

--- a/src/Adapter/Product/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetCombinationForEditingHandler.php
@@ -33,8 +33,8 @@ use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\CombinationRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetCombinationForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryHandler\GetCombinationForEditingHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForEditing;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationOptions;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationPrices;
 
 /**
@@ -64,7 +64,7 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
         $combination = $this->combinationRepository->get($query->getCombinationId());
 
         return new CombinationForEditing(
-            $this->getOptions($combination),
+            $this->getDetails($combination),
             $this->getPrices($combination)
         );
     }
@@ -72,11 +72,11 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
     /**
      * @param Combination $combination
      *
-     * @return CombinationOptions
+     * @return CombinationDetails
      */
-    private function getOptions(Combination $combination): CombinationOptions
+    private function getDetails(Combination $combination): CombinationDetails
     {
-        return new CombinationOptions(
+        return new CombinationDetails(
             $combination->ean13,
             $combination->isbn,
             $combination->mpn,

--- a/src/Adapter/Product/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetCombinationForEditingHandler.php
@@ -81,7 +81,8 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
             $combination->isbn,
             $combination->mpn,
             $combination->reference,
-            $combination->upc
+            $combination->upc,
+            new DecimalNumber($combination->weight)
         );
     }
 

--- a/src/Adapter/Product/Validate/CombinationValidator.php
+++ b/src/Adapter/Product/Validate/CombinationValidator.php
@@ -43,7 +43,7 @@ class CombinationValidator extends AbstractObjectModelValidator
      */
     public function validate(Combination $combination): void
     {
-        $this->validateOptions($combination);
+        $this->validateDetails($combination);
         $this->validatePrices($combination);
     }
 
@@ -53,13 +53,14 @@ class CombinationValidator extends AbstractObjectModelValidator
      * @throws CoreException
      * @throws ProductConstraintException
      */
-    private function validateOptions(Combination $combination): void
+    private function validateDetails(Combination $combination): void
     {
         $this->validateCombinationProperty($combination, 'ean13', ProductConstraintException::INVALID_EAN_13);
         $this->validateCombinationProperty($combination, 'isbn', ProductConstraintException::INVALID_ISBN);
         $this->validateCombinationProperty($combination, 'mpn', ProductConstraintException::INVALID_MPN);
         $this->validateCombinationProperty($combination, 'reference', ProductConstraintException::INVALID_REFERENCE);
         $this->validateCombinationProperty($combination, 'upc', ProductConstraintException::INVALID_UPC);
+        $this->validateCombinationProperty($combination, 'weight', ProductConstraintException::INVALID_WEIGHT);
     }
 
     /**

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationDetailsCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationDetailsCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
@@ -69,6 +70,11 @@ class UpdateCombinationDetailsCommand
      * @var Upc|null
      */
     private $upc;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $weight;
 
     /**
      * @param int $combinationId
@@ -185,6 +191,26 @@ class UpdateCombinationDetailsCommand
     public function setUpc(string $upc): UpdateCombinationDetailsCommand
     {
         $this->upc = new Upc($upc);
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getWeight(): ?DecimalNumber
+    {
+        return $this->weight;
+    }
+
+    /**
+     * @param string $weight
+     *
+     * @return UpdateCombinationDetailsCommand
+     */
+    public function setWeight(string $weight): UpdateCombinationDetailsCommand
+    {
+        $this->weight = new DecimalNumber($weight);
 
         return $this;
     }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationDetailsCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationDetailsCommand.php
@@ -36,9 +36,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
 
 /**
- * Updates combination options
+ * Updates combination details
  */
-class UpdateCombinationOptionsCommand
+class UpdateCombinationDetailsCommand
 {
     /**
      * @var CombinationId
@@ -100,9 +100,9 @@ class UpdateCombinationOptionsCommand
     /**
      * @param string $ean13
      *
-     * @return UpdateCombinationOptionsCommand
+     * @return UpdateCombinationDetailsCommand
      */
-    public function setEan13(string $ean13): UpdateCombinationOptionsCommand
+    public function setEan13(string $ean13): UpdateCombinationDetailsCommand
     {
         $this->ean13 = new Ean13($ean13);
 
@@ -120,9 +120,9 @@ class UpdateCombinationOptionsCommand
     /**
      * @param string $isbn
      *
-     * @return UpdateCombinationOptionsCommand
+     * @return UpdateCombinationDetailsCommand
      */
-    public function setIsbn(string $isbn): UpdateCombinationOptionsCommand
+    public function setIsbn(string $isbn): UpdateCombinationDetailsCommand
     {
         $this->isbn = new Isbn($isbn);
 
@@ -140,9 +140,9 @@ class UpdateCombinationOptionsCommand
     /**
      * @param string $mpn
      *
-     * @return UpdateCombinationOptionsCommand
+     * @return UpdateCombinationDetailsCommand
      */
-    public function setMpn(string $mpn): UpdateCombinationOptionsCommand
+    public function setMpn(string $mpn): UpdateCombinationDetailsCommand
     {
         $this->mpn = $mpn;
 
@@ -160,9 +160,9 @@ class UpdateCombinationOptionsCommand
     /**
      * @param string $reference
      *
-     * @return UpdateCombinationOptionsCommand
+     * @return UpdateCombinationDetailsCommand
      */
-    public function setReference(string $reference): UpdateCombinationOptionsCommand
+    public function setReference(string $reference): UpdateCombinationDetailsCommand
     {
         $this->reference = new Reference($reference);
 
@@ -180,9 +180,9 @@ class UpdateCombinationOptionsCommand
     /**
      * @param string $upc
      *
-     * @return UpdateCombinationOptionsCommand
+     * @return UpdateCombinationDetailsCommand
      */
-    public function setUpc(string $upc): UpdateCombinationOptionsCommand
+    public function setUpc(string $upc): UpdateCombinationDetailsCommand
     {
         $this->upc = new Upc($upc);
 

--- a/src/Core/Domain/Product/Combination/CommandHandler/UpdateCombinationDetailsHandlerInterface.php
+++ b/src/Core/Domain/Product/Combination/CommandHandler/UpdateCombinationDetailsHandlerInterface.php
@@ -26,15 +26,15 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationOptionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationDetailsCommand;
 
 /**
- * Defines contract to handle @see UpdateCombinationOptionsCommand
+ * Defines contract to handle @see UpdateCombinationDetailsCommand
  */
-interface UpdateCombinationOptionsHandlerInterface
+interface UpdateCombinationDetailsHandlerInterface
 {
     /**
-     * @param UpdateCombinationOptionsCommand $command
+     * @param UpdateCombinationDetailsCommand $command
      */
-    public function handle(UpdateCombinationOptionsCommand $command): void;
+    public function handle(UpdateCombinationDetailsCommand $command): void;
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationDetails.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationDetails.php
@@ -28,6 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult;
 
+use PrestaShop\Decimal\DecimalNumber;
+
 /**
  * Transfers combination details
  */
@@ -59,24 +61,32 @@ class CombinationDetails
     private $upc;
 
     /**
+     * @var DecimalNumber
+     */
+    private $weight;
+
+    /**
      * @param string $ean13
      * @param string $isbn
      * @param string $mpn
      * @param string $reference
      * @param string $upc
+     * @param DecimalNumber $weight
      */
     public function __construct(
         string $ean13,
         string $isbn,
         string $mpn,
         string $reference,
-        string $upc
+        string $upc,
+        DecimalNumber $weight
     ) {
         $this->ean13 = $ean13;
         $this->isbn = $isbn;
         $this->mpn = $mpn;
         $this->reference = $reference;
         $this->upc = $upc;
+        $this->weight = $weight;
     }
 
     /**
@@ -117,5 +127,13 @@ class CombinationDetails
     public function getUpc(): string
     {
         return $this->upc;
+    }
+
+    /**
+     * @return DecimalNumber
+     */
+    public function getWeight(): DecimalNumber
+    {
+        return $this->weight;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationDetails.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationDetails.php
@@ -29,9 +29,9 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult;
 
 /**
- * Transfers combination options information
+ * Transfers combination details
  */
-class CombinationOptions
+class CombinationDetails
 {
     /**
      * @var string

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationForEditing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationForEditing.php
@@ -36,7 +36,7 @@ class CombinationForEditing
     /**
      * @var CombinationDetails
      */
-    private $options;
+    private $details;
 
     /**
      * @var CombinationPrices
@@ -44,14 +44,14 @@ class CombinationForEditing
     private $prices;
 
     /**
-     * @param CombinationDetails $options
+     * @param CombinationDetails $details
      * @param CombinationPrices $prices
      */
     public function __construct(
-        CombinationDetails $options,
+        CombinationDetails $details,
         CombinationPrices $prices
     ) {
-        $this->options = $options;
+        $this->details = $details;
         $this->prices = $prices;
     }
 
@@ -60,7 +60,7 @@ class CombinationForEditing
      */
     public function getDetails(): CombinationDetails
     {
-        return $this->options;
+        return $this->details;
     }
 
     /**

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationForEditing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationForEditing.php
@@ -34,7 +34,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult;
 class CombinationForEditing
 {
     /**
-     * @var CombinationOptions
+     * @var CombinationDetails
      */
     private $options;
 
@@ -44,11 +44,11 @@ class CombinationForEditing
     private $prices;
 
     /**
-     * @param CombinationOptions $options
+     * @param CombinationDetails $options
      * @param CombinationPrices $prices
      */
     public function __construct(
-        CombinationOptions $options,
+        CombinationDetails $options,
         CombinationPrices $prices
     ) {
         $this->options = $options;
@@ -56,9 +56,9 @@ class CombinationForEditing
     }
 
     /**
-     * @return CombinationOptions
+     * @return CombinationDetails
      */
-    public function getOptions(): CombinationOptions
+    public function getDetails(): CombinationDetails
     {
         return $this->options;
     }

--- a/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
@@ -276,7 +276,7 @@ class UpdateProductShippingCommand
      *
      * @return UpdateProductShippingCommand
      */
-    public function setLocalizedDeliveryTimeOutOfStockNotes(array $localizedDeliveryTimeOutOfStockNotes)
+    public function setLocalizedDeliveryTimeOutOfStockNotes(array $localizedDeliveryTimeOutOfStockNotes): UpdateProductShippingCommand
     {
         $this->localizedDeliveryTimeOutOfStockNotes = $localizedDeliveryTimeOutOfStockNotes;
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -524,13 +524,13 @@ services:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetCombinationForEditing
 
-    prestashop.adapter.product.command.update_combination_options_handler:
-        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateCombinationOptionsHandler
+    prestashop.adapter.product.command.update_combination_details_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateCombinationDetailsHandler
         arguments:
             - '@prestashop.adapter.product.repository.combination_repository'
         tags:
             - name: tactician.handler
-              command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationOptionsCommand
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationDetailsCommand
 
     prestashop.adapter.product.validate.combination_validator:
         class: PrestaShop\PrestaShop\Adapter\Product\Validate\CombinationValidator

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationDetailsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationDetailsFeatureContext.php
@@ -30,36 +30,36 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combinatio
 
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationOptionsCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationDetailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-class UpdateCombinationOptionsFeatureContext extends AbstractCombinationFeatureContext
+class UpdateCombinationDetailsFeatureContext extends AbstractCombinationFeatureContext
 {
     /**
-     * @When I update combination :combinationReference options with following details:
+     * @When I update combination :combinationReference details with following values:
      *
      * @param string $combinationReference
      * @param TableNode $tableNode
      */
-    public function updateOptions(string $combinationReference, TableNode $tableNode): void
+    public function updateDetails(string $combinationReference, TableNode $tableNode): void
     {
-        $command = new UpdateCombinationOptionsCommand($this->getSharedStorage()->get($combinationReference));
+        $command = new UpdateCombinationDetailsCommand($this->getSharedStorage()->get($combinationReference));
 
         $this->fillCommand($command, $tableNode->getRowsHash());
         $this->getCommandBus()->handle($command);
     }
 
     /**
-     * @Then combination :combinationReference should have following options:
+     * @Then combination :combinationReference should have following details:
      *
      * @param string $combinationReference
-     * @param CombinationOptions $expectedOptions
+     * @param CombinationDetails $expectedOptions
      */
-    public function assertOptions(string $combinationReference, CombinationOptions $expectedOptions): void
+    public function assertOptions(string $combinationReference, CombinationDetails $expectedOptions): void
     {
         $optionPropertyNames = ['ean13', 'isbn', 'mpn', 'reference', 'upc'];
-        $actualOptions = $this->getCombinationForEditing($combinationReference)->getOptions();
+        $actualOptions = $this->getCombinationForEditing($combinationReference)->getDetails();
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($optionPropertyNames as $propertyName) {
@@ -72,17 +72,17 @@ class UpdateCombinationOptionsFeatureContext extends AbstractCombinationFeatureC
     }
 
     /**
-     * @Transform table:combination option,value
+     * @Transform table:combination detail,value
      *
      * @param TableNode $tableNode
      *
-     * @return CombinationOptions
+     * @return CombinationDetails
      */
-    public function transformOptions(TableNode $tableNode): CombinationOptions
+    public function transformOptions(TableNode $tableNode): CombinationDetails
     {
         $options = $tableNode->getRowsHash();
 
-        return new CombinationOptions(
+        return new CombinationDetails(
             $options['ean13'],
             $options['isbn'],
             $options['mpn'],
@@ -92,10 +92,10 @@ class UpdateCombinationOptionsFeatureContext extends AbstractCombinationFeatureC
     }
 
     /**
-     * @param UpdateCombinationOptionsCommand $command
+     * @param UpdateCombinationDetailsCommand $command
      * @param array $dataRows
      */
-    private function fillCommand(UpdateCombinationOptionsCommand $command, array $dataRows): void
+    private function fillCommand(UpdateCombinationDetailsCommand $command, array $dataRows): void
     {
         if (isset($dataRows['ean13'])) {
             $command->setEan13($dataRows['ean13']);

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
@@ -1,11 +1,11 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-options
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-details
 @reset-database-before-feature
 @clear-cache-before-feature
 @update-combination
-@update-combination-options
-Feature: Update product combination options in Back Office (BO)
+@update-combination-details
+Feature: Update product combination details in Back Office (BO)
   As an employee
-  I need to be able to update product combination options from BO
+  I need to be able to update product combination details from BO
 
   Background:
     Given language with iso code "en" is the default one
@@ -19,7 +19,7 @@ Feature: Update product combination options in Back Office (BO)
     And attribute "Blue" named "Blue" in en language exists
     And attribute "Red" named "Red" in en language exists
 
-  Scenario: I update combination options:
+  Scenario: I update combination details:
     Given I add product "product1" with following information:
       | name[en-US] | universal T-shirt |
       | is_virtual  | false             |
@@ -35,47 +35,47 @@ Feature: Update product combination options in Back Office (BO)
       | product1MWhite | Size - M, Color - White | [Size:M,Color:White] | 0               | 0           | 0        | false      |
       | product1MBlack | Size - M, Color - Black | [Size:M,Color:Black] | 0               | 0           | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  | [Size:M,Color:Blue]  | 0               | 0           | 0        | false      |
-    And combination "product1SWhite" should have following options:
-      | combination option | value |
+    And combination "product1SWhite" should have following details:
+      | combination detail | value |
       | ean13              |       |
       | isbn               |       |
       | mpn                |       |
       | reference          |       |
       | upc                |       |
-    When I update combination "product1SWhite" options with following details:
+    When I update combination "product1SWhite" details with following values:
       | ean13     | 978020137962      |
       | isbn      | 978-3-16-148410-0 |
       | mpn       | mpn1              |
       | reference | ref1              |
       | upc       | 72527273070       |
-    Then combination "product1SWhite" should have following options:
-      | combination option | value             |
+    Then combination "product1SWhite" should have following details:
+      | combination detail | value             |
       | ean13              | 978020137962      |
       | isbn               | 978-3-16-148410-0 |
       | mpn                | mpn1              |
       | reference          | ref1              |
       | upc                | 72527273070       |
-    When I update combination "product1SWhite" options with following details:
+    When I update combination "product1SWhite" details with following values:
       | ean13     | 978020137962      |
       | isbn      | 978-3-16-148410-0 |
       | mpn       |                   |
       | reference | ref1              |
       | upc       |                   |
-    Then combination "product1SWhite" should have following options:
-      | combination option | value             |
+    Then combination "product1SWhite" should have following details:
+      | combination detail | value             |
       | ean13              | 978020137962      |
       | isbn               | 978-3-16-148410-0 |
       | mpn                |                   |
       | reference          | ref1              |
       | upc                |                   |
-    When I update combination "product1SWhite" options with following details:
+    When I update combination "product1SWhite" details with following values:
       | ean13     |  |
       | isbn      |  |
       | mpn       |  |
       | reference |  |
       | upc       |  |
-    Then combination "product1SWhite" should have following options:
-      | combination option | value |
+    Then combination "product1SWhite" should have following details:
+      | combination detail | value |
       | ean13              |       |
       | isbn               |       |
       | mpn                |       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
@@ -42,12 +42,14 @@ Feature: Update product combination details in Back Office (BO)
       | mpn                |       |
       | reference          |       |
       | upc                |       |
+      | weight             | 0     |
     When I update combination "product1SWhite" details with following values:
       | ean13     | 978020137962      |
       | isbn      | 978-3-16-148410-0 |
       | mpn       | mpn1              |
       | reference | ref1              |
       | upc       | 72527273070       |
+      | weight    | 17.25             |
     Then combination "product1SWhite" should have following details:
       | combination detail | value             |
       | ean13              | 978020137962      |
@@ -55,6 +57,7 @@ Feature: Update product combination details in Back Office (BO)
       | mpn                | mpn1              |
       | reference          | ref1              |
       | upc                | 72527273070       |
+      | weight             | 17.25             |
     When I update combination "product1SWhite" details with following values:
       | ean13     | 978020137962      |
       | isbn      | 978-3-16-148410-0 |
@@ -68,12 +71,14 @@ Feature: Update product combination details in Back Office (BO)
       | mpn                |                   |
       | reference          | ref1              |
       | upc                |                   |
+      | weight             | 17.25             |
     When I update combination "product1SWhite" details with following values:
-      | ean13     |  |
-      | isbn      |  |
-      | mpn       |  |
-      | reference |  |
-      | upc       |  |
+      | ean13     |   |
+      | isbn      |   |
+      | mpn       |   |
+      | reference |   |
+      | upc       |   |
+      | weight    | 0 |
     Then combination "product1SWhite" should have following details:
       | combination detail | value |
       | ean13              |       |
@@ -81,3 +86,4 @@ Feature: Update product combination details in Back Office (BO)
       | mpn                |       |
       | reference          |       |
       | upc                |       |
+      | weight             | 0     |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -252,5 +252,5 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttributeFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationOptionsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationDetailsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationPricesFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Rename UpdateCombinationOptions to UpdateCombinationDetails and add $weight property handling handling
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | part of #14773
| How to test?  | Travis :heavy_check_mark: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22238)
<!-- Reviewable:end -->
