### PR TITLE
Fix duplicated hook data after product page refresh

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -56,5 +56,5 @@
       </ul>
     </div>
   {/block}
-</div>
 {hook h='displayAfterProductThumbs'}
+</div>


### PR DESCRIPTION
Replacement PR, changed the branch.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | https://github.com/PrestaShop/PrestaShop/issues/22113
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22113
| How to test?  | Use module `ps_qualityassurance`<br>Adds  a hook for `displayAfterProductThumbs` : `return 'Display "displayAfterProductThumbs"';`<br>In FrontOffice, follow the scenario<br>**Without the PR:** it's duplicated<br>**With the PR:** it's not duplicated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22114)
<!-- Reviewable:end -->
