### PR TITLE
Integrate ContextStateManager into refund handlers

### DIFF
--- a/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
@@ -31,6 +31,7 @@ use Hook;
 use Order;
 use OrderCarrier;
 use PrestaShop\Decimal\Number;
+use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Order\Refund\OrderRefundCalculator;
 use PrestaShop\PrestaShop\Adapter\Order\Refund\OrderRefundSummary;
 use PrestaShop\PrestaShop\Adapter\Order\Refund\OrderRefundUpdater;
@@ -75,24 +76,32 @@ class IssueReturnProductHandler extends AbstractOrderCommandHandler implements I
     private $refundUpdater;
 
     /**
+     * @var ContextStateManager
+     */
+    private $contextStateManager;
+
+    /**
      * @param ConfigurationInterface $configuration
      * @param OrderRefundCalculator $orderRefundCalculator
      * @param OrderSlipCreator $orderSlipCreator
      * @param VoucherGenerator $voucherGenerator
      * @param OrderRefundUpdater $refundUpdater
+     * @param ContextStateManager $contextStateManager
      */
     public function __construct(
         ConfigurationInterface $configuration,
         OrderRefundCalculator $orderRefundCalculator,
         OrderSlipCreator $orderSlipCreator,
         VoucherGenerator $voucherGenerator,
-        OrderRefundUpdater $refundUpdater
+        OrderRefundUpdater $refundUpdater,
+        ContextStateManager $contextStateManager
     ) {
         $this->configuration = $configuration;
         $this->orderRefundCalculator = $orderRefundCalculator;
         $this->orderSlipCreator = $orderSlipCreator;
         $this->voucherGenerator = $voucherGenerator;
         $this->refundUpdater = $refundUpdater;
+        $this->contextStateManager = $contextStateManager;
     }
 
     /**
@@ -104,7 +113,6 @@ class IssueReturnProductHandler extends AbstractOrderCommandHandler implements I
             throw new ReturnProductDisabledException();
         }
 
-        /** @var Order $order */
         $order = $this->getOrder($command->getOrderId());
         if (!$order->hasBeenDelivered()) {
             throw new InvalidOrderStateException(
@@ -112,7 +120,17 @@ class IssueReturnProductHandler extends AbstractOrderCommandHandler implements I
                 'Can not perform return product on order with not delivered yet'
             );
         }
+        $this->setOrderContext($this->contextStateManager, $order);
 
+        try {
+            $this->issueReturn($command, $order);
+        } finally {
+            $this->contextStateManager->restorePreviousContext();
+        }
+    }
+
+    private function issueReturn(IssueReturnProductCommand $command, Order $order): void
+    {
         $shippingRefundAmount = new Number((string) ($command->refundShippingCost() ? $order->total_shipping_tax_incl : 0));
         /** @var OrderRefundSummary $orderRefundSummary */
         $orderRefundSummary = $this->orderRefundCalculator->computeOrderRefund(

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -131,6 +131,7 @@ services:
       - '@prestashop.adapter.order.refund.order_slip_creator'
       - '@prestashop.adapter.order.refund.voucher_generator'
       - '@prestashop.adapter.order.refund.updater'
+      - '@prestashop.adapter.context_state_manager'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\IssueStandardRefundCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -118,6 +118,7 @@ services:
       - '@prestashop.adapter.order.refund.order_slip_creator'
       - '@prestashop.adapter.order.refund.voucher_generator'
       - '@prestashop.adapter.order.refund.updater'
+      - '@prestashop.adapter.context_state_manager'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\IssuePartialRefundCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -142,6 +142,7 @@ services:
       - '@prestashop.adapter.order.refund.order_slip_creator'
       - '@prestashop.adapter.order.refund.voucher_generator'
       - '@prestashop.adapter.order.refund.updater'
+      - '@prestashop.adapter.context_state_manager'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\IssueReturnProductCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1133,6 +1133,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @Then /^there are ([\-\d]+) (less|more) "(.+)" in stock$/
+     * @Then /^there is ([\-\d]+) (less|more) "(.+)" in stock$/
      *
      * @param int $productDifference
      * @param string $factor

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -75,8 +75,8 @@ Feature: Cancel Order Product from Back Office (BO)
       | total_refunded_tax_excl     | 0.000000    |
       | total_refunded_tax_incl     | 0.000000    |
     And there are 2 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
-    And there are 1 more "Customizable mug" in stock
+    And there is 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Customizable mug" in stock
     And order "bo_order_cancel_product" should have following details:
       | total_products           | 73.40  |
       | total_products_wt        | 77.80  |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -138,3 +138,51 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: Return product from order
+    When I update order "bo_order1" status to "Processing in progress"
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 32.650 |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2 |
+    And I watch the stock of product "Mug The best is yet to come"
+    And return product is enabled
+    When I issue a return product on "bo_order1" with restock with credit slip without voucher on following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 1        |
+    Then "bo_order1" has 1 credit slips
+    Then "bo_order1" last credit slip is:
+      | amount                  | 11.9   |
+      | shipping_cost_amount    | 0.0    |
+      | total_shipping_tax_incl | 0.0    |
+      | total_shipping_tax_excl | 0.0    |
+      | total_products_tax_excl | 11.9   |
+      | total_products_tax_incl | 12.610 |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_quantity_refunded   | 0     |
+      | product_quantity_return     | 1     |
+      | product_quantity_reinjected | 1     |
+      | total_refunded_tax_excl     | 11.90 |
+      | total_refunded_tax_incl     | 12.61 |
+    And there is 1 more "Mug The best is yet to come" in stock
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 32.650 |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -139,6 +139,52 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
 
+  Scenario: Partial refund product from order
+    When I update order "bo_order1" status to "Processing in progress"
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 32.650 |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2 |
+    And I watch the stock of product "Mug The best is yet to come"
+    When I issue a partial refund on "bo_order1" with restock with credit slip without voucher on following products:
+      | product_name                | quantity                 | amount |
+      | Mug The best is yet to come | 2                        | 7.5    |
+    Then "bo_order1" has 1 credit slips
+    Then "bo_order1" last credit slip is:
+      | amount                  | 7.5  |
+      | total_products_tax_excl | 7.5  |
+      | total_products_tax_incl | 7.95 |
+      | shipping_cost_amount    | 0.0  |
+      | total_shipping_tax_incl | 0.0  |
+      | total_shipping_tax_excl | 0.0  |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2    |
+      | product_quantity_refunded   | 2    |
+      | product_quantity_reinjected | 2    |
+      | total_refunded_tax_excl     | 7.5  |
+      | total_refunded_tax_incl     | 7.95 |
+    And there are 2 more "Mug The best is yet to come" in stock
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 32.650 |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+
   Scenario: Return product from order
     When I update order "bo_order1" status to "Processing in progress"
     Then order "bo_order1" should have following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -232,3 +232,59 @@ Feature: Order from Back Office (BO)
       | total_paid_real          | 32.650 |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+
+  Scenario: Standard refund product from order
+    Then order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 00.000 |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2 |
+    And I watch the stock of product "Mug The best is yet to come"
+    # We add a payment to allow the standard refund, instead of changing its status to Payment accepted Because then it
+    # would create an invoice which would update the shop context, and it wouldn't validate the bug we want to prevent
+    And I pay order "bo_order1" with the following details:
+      | date           | 2019-11-26 13:56:23 |
+      | payment_method | Payments by check   |
+      | transaction_id | test123             |
+      | currency       | USD                 |
+      | amount         | 6.00                |
+    And "bo_order1" has 0 credit slips
+    And order "bo_order1" has status "Awaiting bank wire payment"
+    And return product is enabled
+    When I issue a standard refund on "bo_order1" with credit slip without voucher on following products:
+      | product_name                | quantity |
+      | Mug The best is yet to come | 1        |
+    Then "bo_order1" has 1 credit slips
+    Then "bo_order1" last credit slip is:
+      | amount                  | 11.90 |
+      | shipping_cost_amount    | 0.0   |
+      | total_shipping_tax_excl | 0.0   |
+      | total_shipping_tax_incl | 0.0   |
+      | total_products_tax_excl | 11.90 |
+      | total_products_tax_incl | 12.61 |
+    And product "Mug The best is yet to come" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | product_quantity_refunded   | 1     |
+      | product_quantity_reinjected | 1     |
+      | total_refunded_tax_excl     | 11.90 |
+      | total_refunded_tax_incl     | 12.61 |
+    And there is 1 more "Mug The best is yet to come" in stock
+    And order "bo_order1" should have following details:
+      | total_products           | 23.800 |
+      | total_products_wt        | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 30.800 |
+      | total_paid_tax_incl      | 32.650 |
+      | total_paid               | 32.650 |
+      | total_paid_real          | 6.00   |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -45,7 +45,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 10.5   |
@@ -96,7 +96,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 2                        | 7.5    |
@@ -134,7 +134,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 2                        | 7.5    |
@@ -184,7 +184,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 8      |
@@ -210,7 +210,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 8.0  |
       | total_refunded_tax_incl     | 8.48 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7   |
       | total_products_wt        | 37.840000 |
@@ -250,7 +250,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 8      |
@@ -316,7 +316,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip with voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 8      |
@@ -370,7 +370,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 1024   |
@@ -412,7 +412,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock without credit slip with voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 10.5   |
@@ -430,8 +430,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1    |
       | total_refunded_tax_excl     | 3.5  |
       | total_refunded_tax_incl     | 3.71 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 14.0
 
   @order-refund
@@ -447,7 +447,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount              |
       | Mug The best is yet to come | 1                        | 10.5456889623154870 |
@@ -488,7 +488,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 0                        | 8      |
@@ -508,7 +508,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
     Then I should get error that no refunds is invalid
@@ -527,7 +527,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name    | quantity | amount |
       | shipping_refund |          | 3.5    |
@@ -567,7 +567,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 3                        | 8      |
@@ -587,7 +587,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 0      |
@@ -607,7 +607,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | -2.5   |
@@ -628,7 +628,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 8      |
@@ -649,7 +649,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock without credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug Today is a good day     | 1                        | 8      |
@@ -670,7 +670,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
       | Mug The best is yet to come | 1                        | 10.5   |
@@ -691,7 +691,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And I pay order "bo_order_refund" with the following details:
       | date           | 2019-11-26 13:56:23 |
       | payment_method | Payments by check   |
@@ -725,8 +725,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1    |
       | total_refunded_tax_excl     | 3.5  |
       | total_refunded_tax_incl     | 3.71 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-partial-refund
@@ -741,7 +741,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
@@ -785,7 +785,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a partial refund on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity                 | amount |
@@ -813,8 +813,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1    |
       | total_refunded_tax_excl     | 3.5  |
       | total_refunded_tax_incl     | 3.71 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-partial-refund
@@ -829,7 +829,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And I add new tax "state-tax" with following properties:
       | name         | State tax |
       | rate         | 10        |
@@ -857,4 +857,4 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug The best is yet to come" in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
@@ -33,7 +33,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
       | Mug The best is yet to come | 1        |
@@ -54,7 +54,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -76,7 +76,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -110,7 +110,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -138,8 +138,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7  |
       | total_products_wt        | 37.84 |
@@ -166,7 +166,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" without restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -210,7 +210,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -239,7 +239,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-return-product
@@ -267,7 +267,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -299,7 +299,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7  |
       | total_products_wt        | 37.84 |
@@ -326,7 +326,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip with voucher on following products:
       | product_name                | quantity |
@@ -355,7 +355,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 18.9
 
   @order-refund
@@ -371,7 +371,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock without credit slip with voucher on following products:
       | product_name                | quantity |
@@ -392,8 +392,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 23.8
 
   @order-refund
@@ -409,7 +409,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -430,7 +430,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -450,7 +450,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name    | quantity |
@@ -493,7 +493,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -514,7 +514,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -536,7 +536,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -558,7 +558,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock without credit slip without voucher on following products:
       | product_name                | quantity |
@@ -580,7 +580,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -607,7 +607,7 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 0 |
       | total_refunded_tax_excl     | 0 |
       | total_refunded_tax_incl     | 0 |
-    And there are 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
     And there are 0 more "Mug Today is a good day" in stock
     When I issue a return product on "bo_order_refund" with restock with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -635,5 +635,5 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -33,7 +33,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
       | Mug The best is yet to come | 1        |
@@ -54,7 +54,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -76,7 +76,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And I pay order "bo_order_refund" with the following details:
       | date           | 2019-11-26 13:56:23 |
       | payment_method | Payments by check   |
@@ -110,8 +110,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-standard-refund
@@ -126,7 +126,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -160,7 +160,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -186,8 +186,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7  |
       | total_products_wt        | 37.84 |
@@ -214,7 +214,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -241,7 +241,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
 
   @order-refund
   @order-standard-refund
@@ -269,7 +269,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -299,7 +299,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And order "bo_order_refund" should have following details:
       | total_products           | 35.7  |
       | total_products_wt        | 37.84 |
@@ -326,7 +326,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip with voucher on following products:
       | product_name                | quantity |
@@ -353,7 +353,7 @@ Feature: Refund Order from Back Office (BO)
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
     And there are 0 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 18.9
 
   @order-refund
@@ -369,7 +369,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" without credit slip with voucher on following products:
       | product_name                | quantity |
@@ -388,8 +388,8 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock
     And customer "testCustomer" last voucher is 23.8
 
   @order-refund
@@ -405,7 +405,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -426,7 +426,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -446,7 +446,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name    | quantity |
@@ -487,7 +487,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -508,7 +508,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -530,7 +530,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -552,7 +552,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" without credit slip without voucher on following products:
       | product_name                | quantity |
@@ -574,7 +574,7 @@ Feature: Refund Order from Back Office (BO)
     And product "Mug Today is a good day" in order "bo_order_refund" has following details:
       | product_quantity            | 1 |
     And there are 2 less "Mug The best is yet to come" in stock
-    And there are 1 less "Mug Today is a good day" in stock
+    And there is 1 less "Mug Today is a good day" in stock
     And return product is enabled
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -599,7 +599,7 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 0 |
       | total_refunded_tax_excl     | 0 |
       | total_refunded_tax_incl     | 0 |
-    And there are 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
     And there are 0 more "Mug Today is a good day" in stock
     When I issue a standard refund on "bo_order_refund" with credit slip without voucher on following products:
       | product_name                | quantity |
@@ -625,5 +625,5 @@ Feature: Refund Order from Back Office (BO)
       | product_quantity_reinjected | 1      |
       | total_refunded_tax_excl     | 11.9   |
       | total_refunded_tax_incl     | 12.610000 |
-    And there are 1 more "Mug The best is yet to come" in stock
-    And there are 1 more "Mug Today is a good day" in stock
+    And there is 1 more "Mug The best is yet to come" in stock
+    And there is 1 more "Mug Today is a good day" in stock


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | The ContextStateManager was not used in all handlers related to refund, it's now added which prevents this action from bugging when the BO is in All shops mode
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #21990
| How to test?  | See the issue, it only mentions return product, but partial and standard products were also buggy

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22246)
<!-- Reviewable:end -->
