### PR TITLE
Set Tab entity default value for 'enabled' field during upgrade process

### DIFF
--- a/install-dev/upgrade/php/ps_1770_preset_tab_enabled.php
+++ b/install-dev/upgrade/php/ps_1770_preset_tab_enabled.php
@@ -25,13 +25,9 @@
  */
 
 /**
- * Preset enabled new column in tabs to true for all (except for disabled modules)
+ * Preset enabled new column in tabs to true for all disabled modules
  */
 function ps_1770_preset_tab_enabled() {
-    //First set all tabs enabled
-    $result = Db::getInstance()->execute(
-        'UPDATE `'._DB_PREFIX_.'tab` SET `enabled` = 1'
-    );
 
     //Then search for inactive modules and disable their tabs
     $inactiveModules = Db::getInstance()->executeS(

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -312,6 +312,7 @@ ALTER TABLE `PREFIX_product_download` CHANGE `display_filename` `display_filenam
 
 /* Doctrine update happens too late to update the new enabled field, so we preset everything here */
 ALTER TABLE `PREFIX_tab` ADD enabled TINYINT(1) NOT NULL;
+UPDATE `PREFIX_tab` SET `enabled` = 1;
 
 /* PHP:ps_1770_preset_tab_enabled(); */;
 /* PHP:ps_1770_update_order_status_colors(); */;

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -90,14 +90,14 @@ class Tab
     /**
      * @var bool
      *
-     * @ORM\Column(name="enabled", type="boolean")
+     * @ORM\Column(name="enabled", type="boolean", options={"default":"1"})
      */
     private $enabled = true;
 
     /**
      * @var bool
      *
-     * @ORM\Column(name="hide_host_mode", type="boolean", options={"default":"1"})
+     * @ORM\Column(name="hide_host_mode", type="boolean")
      */
     private $hideHostMode;
 

--- a/src/PrestaShopBundle/Entity/Tab.php
+++ b/src/PrestaShopBundle/Entity/Tab.php
@@ -97,7 +97,7 @@ class Tab
     /**
      * @var bool
      *
-     * @ORM\Column(name="hide_host_mode", type="boolean")
+     * @ORM\Column(name="hide_host_mode", type="boolean", options={"default":"1"})
      */
     private $hideHostMode;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | After upgrade to 177 the menu is empty, this is linked to the new Tab::enabled field that is used to hide menu links when modules are disabled.
| Type?         | improvement
| Category?     |  CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes part of https://github.com/PrestaShop/PrestaShop/issues/16379 & https://github.com/PrestaShop/PrestaShop/issues/22250 (?)
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/16379


### Run 
Called here : https://github.com/PrestaShop/autoupgrade/blob/master/classes/UpgradeTools/SymfonyAdapter.php#L52
```bash
php bin/console doctrine:schema:update --dump-sql
```

### Before 

```sql
ALTER TABLE PREFIX_tab ADD enabled TINYINT(1) NOT NULL;
```

### After

```sql
ALTER TABLE PREFIX_tab ADD enabled TINYINT(1) DEFAULT '1' NOT NULL;
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22257)
<!-- Reviewable:end -->
