### PR TITLE
Fix upgrade from ps < 1.7.0.0

### DIFF
--- a/install-dev/upgrade/php/add_new_status_stock.php
+++ b/install-dev/upgrade/php/add_new_status_stock.php
@@ -26,6 +26,7 @@
 
 function add_new_status_stock()
 {
+    Language::resetCache();
     $translator = Context::getContext()->getTranslator();
     $languages  = Language::getLanguages();
 

--- a/install-dev/upgrade/php/migrate_tabs_17.php
+++ b/install-dev/upgrade/php/migrate_tabs_17.php
@@ -24,8 +24,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-use PrestaShopBundle\Install\Install;
+use PrestaShop\PrestaShop\Adapter\Entity\Language;
 use PrestaShopBundle\Install\LanguageList;
+use PrestaShopBundle\Install\XmlLoader;
 
 /**
  * Migrate BO tabs for 1.7 (new reorganization of BO)
@@ -59,12 +60,46 @@ function migrate_tabs_17()
     /* insert the new structure */
     ProfileCore::resetCacheAccesses();
     LanguageCore::resetCache();
-    $install = new Install();
-    $install->populateDatabase('tab');
+    if (!populateTab()) {
+        return false;
+    }
 
     /* update remaining idParent */
     foreach($moduleParents as $idParent => $className) {
         $idTab = Db::getInstance()->getValue('SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name='.pSQL($className));
         Db::getInstance()->execute('UPDATE '._DB_PREFIX_.'tab SET id_parent='.(int)$idTab.' WHERE id_parent='.(int)$idParent);
+    }
+
+    return true;
+}
+
+function populateTab()
+{
+    $languages = [];
+    foreach (Language::getLanguages() as $lang) {
+        $languages[$lang['id_lang']] = $lang['iso_code'];
+    }
+
+    $xml_loader = new \XmlLoader1700();
+    $xml_loader->setTranslator(Context::getContext()->getTranslator());
+    $xml_loader->setLanguages($languages);
+
+    try {
+        $xml_loader->populateEntity('tab');
+    } catch (PrestashopInstallerException $e) {
+        return false;
+    }
+
+    return true;
+}
+
+class XmlLoader1700 extends XmlLoader
+{
+    public function createEntityTab($identifier, array $data, array $data_lang): void
+    {
+        if (isset($data['enabled'])) {
+            unset($data['enabled']);
+        }
+        parent::createEntityTab($identifier, $data, $data_lang);
     }
 }

--- a/install-dev/upgrade/php/migrate_tabs_17.php
+++ b/install-dev/upgrade/php/migrate_tabs_17.php
@@ -80,6 +80,8 @@ function populateTab()
         $languages[$lang['id_lang']] = $lang['iso_code'];
     }
 
+    // Because we use 1.7.7+ files but with a not-yet migrated Tab entity, we need to use
+    // a custom XmlLoader to remove the `enabled` key before inserting to the DB
     $xml_loader = new \XmlLoader1700();
     $xml_loader->setTranslator(Context::getContext()->getTranslator());
     $xml_loader->setLanguages($languages);

--- a/install-dev/upgrade/php/ps_1770_update_charset.php
+++ b/install-dev/upgrade/php/ps_1770_update_charset.php
@@ -26,24 +26,21 @@
 
 function ps_1770_update_charset()
 {
-    $adminFilterTableExists = false;
-    $adminFilterFilterIdExists = false;
-    $moduleHistoryTableExists = false;
-    $translationTableExists = false;
+    $adminFilterTableExists = $adminFilterFilterIdExists = $moduleHistoryTableExists = $translationTableExists = false;
 
     try {
-        $adminFilterTableExists = Db::getInstance()->executeS(
+        $adminFilterTableExists = (bool) Db::getInstance()->executeS(
             'SELECT count(*) FROM ' . _DB_PREFIX_ . 'admin_filter'
         );
         if ($adminFilterTableExists) {
-            $adminFilterFilterIdExists = Db::getInstance()->executeS(
+            $adminFilterFilterIdExists = (bool) Db::getInstance()->executeS(
                 'SELECT count(filter_id) FROM ' . _DB_PREFIX_ . 'admin_filter'
             );
         }
-        $moduleHistoryTableExists = Db::getInstance()->executeS(
+        $moduleHistoryTableExists = (bool) Db::getInstance()->executeS(
             'SELECT count(*) FROM ' . _DB_PREFIX_ . 'module_history'
         );
-        $translationTableExists = Db::getInstance()->executeS(
+        $translationTableExists = (bool) Db::getInstance()->executeS(
             'SELECT count(*) FROM ' . _DB_PREFIX_ . 'translation'
         );
 
@@ -80,5 +77,5 @@ function ps_1770_update_charset()
         );
     }
 
-    return $result;
+    return (bool) $result;
 }

--- a/install-dev/upgrade/php/ps_1770_update_charset.php
+++ b/install-dev/upgrade/php/ps_1770_update_charset.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+function ps_1770_update_charset()
+{
+    $adminFilterTableExists = false;
+    $adminFilterFilterIdExists = false;
+    $moduleHistoryTableExists = false;
+    $translationTableExists = false;
+
+    try {
+        $adminFilterTableExists = Db::getInstance()->executeS(
+            'SELECT count(*) FROM ' . _DB_PREFIX_ . 'admin_filter'
+        );
+        if ($adminFilterTableExists) {
+            $adminFilterFilterIdExists = Db::getInstance()->executeS(
+                'SELECT count(filter_id) FROM ' . _DB_PREFIX_ . 'admin_filter'
+            );
+        }
+        $moduleHistoryTableExists = Db::getInstance()->executeS(
+            'SELECT count(*) FROM ' . _DB_PREFIX_ . 'module_history'
+        );
+        $translationTableExists = Db::getInstance()->executeS(
+            'SELECT count(*) FROM ' . _DB_PREFIX_ . 'translation'
+        );
+
+    } catch (Exception $e) {
+
+    }
+
+    $result = true;
+
+    if ($adminFilterTableExists) {
+        if ($adminFilterFilterIdExists) {
+            $result &= Db::getInstance()->execute(
+                'UPDATE ' . _DB_PREFIX_ . '`admin_filter` SET `filter_id` = SUBSTRING(`filter_id`, 1, 191)'
+            );
+            $result &= Db::getInstance()->execute(
+                'ALTER TABLE ' . _DB_PREFIX_ . '`admin_filter` CHANGE `filter_id` `filter_id` VARCHAR(191) NOT NULL'
+            );
+        }
+        $result &= Db::getInstance()->execute(
+            'ALTER TABLE `PREFIX_admin_filter` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci'
+        );
+    }
+
+    if ($moduleHistoryTableExists) {
+        $result &= Db::getInstance()->execute(
+            'ALTER TABLE `PREFIX_module_history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci'
+        );
+    }
+
+
+    if ($translationTableExists) {
+        $result &= Db::getInstance()->execute(
+            'ALTER TABLE `PREFIX_translation` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci'
+        );
+    }
+
+    return $result;
+}

--- a/install-dev/upgrade/php/ps_1770_update_charset.php
+++ b/install-dev/upgrade/php/ps_1770_update_charset.php
@@ -37,9 +37,19 @@ function ps_1770_update_charset()
                 'SELECT count(filter_id) FROM ' . _DB_PREFIX_ . 'admin_filter'
             );
         }
+    } catch (Exception $e) {
+
+    }
+
+    try {
         $moduleHistoryTableExists = (bool) Db::getInstance()->executeS(
             'SELECT count(*) FROM ' . _DB_PREFIX_ . 'module_history'
         );
+    } catch (Exception $e) {
+
+    }
+
+    try {
         $translationTableExists = (bool) Db::getInstance()->executeS(
             'SELECT count(*) FROM ' . _DB_PREFIX_ . 'translation'
         );

--- a/install-dev/upgrade/sql/1.7.7.0.sql
+++ b/install-dev/upgrade/sql/1.7.7.0.sql
@@ -30,8 +30,7 @@ UPDATE `PREFIX_hook_alias` SET `name` = SUBSTRING(`name`, 1, 191), `alias` = SUB
 ALTER TABLE `PREFIX_hook_alias` CHANGE `name` `name` VARCHAR(191) NOT NULL;
 ALTER TABLE `PREFIX_hook_alias` CHANGE `alias` `alias` VARCHAR(191) NOT NULL;
 
-UPDATE `PREFIX_admin_filter` SET `filter_id` = SUBSTRING(`filter_id`, 1, 191);
-ALTER TABLE `PREFIX_admin_filter` CHANGE `filter_id` `filter_id` VARCHAR(191) NOT NULL;
+/* php:ps_1770_update_charset */
 
 UPDATE `PREFIX_alias` SET `alias` = SUBSTRING(`alias`, 1, 191);
 ALTER TABLE `PREFIX_alias` CHANGE `alias` `alias` VARCHAR(191) NOT NULL;
@@ -63,7 +62,6 @@ ALTER TABLE `PREFIX_access` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_gen
 ALTER TABLE `PREFIX_accessory` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_address` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_address_format` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-ALTER TABLE `PREFIX_admin_filter` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_alias` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_attachment` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_attachment_lang` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
@@ -162,9 +160,6 @@ ALTER TABLE `PREFIX_image_type` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4
 ALTER TABLE `PREFIX_import_match` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_lang` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_lang_shop` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-ALTER TABLE `PREFIX_link_block` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-ALTER TABLE `PREFIX_link_block_lang` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-ALTER TABLE `PREFIX_link_block_shop` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_mail` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_manufacturer` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
@@ -181,7 +176,6 @@ ALTER TABLE `PREFIX_module_carrier` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf
 ALTER TABLE `PREFIX_module_country` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_module_currency` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_module_group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-ALTER TABLE `PREFIX_module_history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_module_preference` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_module_shop` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_operating_system` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
@@ -283,7 +277,6 @@ ALTER TABLE `PREFIX_tax_rule` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_g
 ALTER TABLE `PREFIX_tax_rules_group` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_tax_rules_group_shop` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_timezone` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-ALTER TABLE `PREFIX_translation` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_warehouse` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_warehouse_carrier` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE `PREFIX_warehouse_product_location` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;

--- a/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
@@ -78,7 +78,7 @@ class SqlTranslationLoader implements LoaderInterface
             SELECT `key`, `translation`, `domain`
             FROM `' . _DB_PREFIX_ . 'translation`
             WHERE `id_lang` = ' . $localeResults[$locale]['id_lang'];
-        $translations = Db::getInstance()->executeS($selectTranslationsQuery);
+        $translations = Db::getInstance()->executeS($selectTranslationsQuery) ?: [];
 
         $catalogue = new MessageCatalogue($locale);
         $this->addTranslationsToCatalogue($translations, $catalogue);
@@ -87,7 +87,7 @@ class SqlTranslationLoader implements LoaderInterface
             $selectThemeTranslationsQuery =
                 $selectTranslationsQuery . "\n" .
                 "AND theme = '" . $this->theme->getName() . "'";
-            $themeTranslations = Db::getInstance()->executeS($selectThemeTranslationsQuery);
+            $themeTranslations = Db::getInstance()->executeS($selectThemeTranslationsQuery) ?: [];
             $this->addTranslationsToCatalogue($themeTranslations, $catalogue);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because the table `ps_tab` has been changed on 1.7.7.x, when executing the 1.7.0.0 upgrade script, tabs weren't properly updated. The other issue was that because of a previous upgrade script, the `Language` class had cache that wasn't up-to-date with the new database structure leading to an SQL update error. This PR fixes both bugs.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22237 #22294
| How to test?  | Try to upgrade a shop from PrestaShop < 1.7.0.0 (1.6.1.24) to 1.7.7.0, the upgrade process should finish without any error.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22274)
<!-- Reviewable:end -->
