### PR TITLE
Improve grid definition action column extendability

### DIFF
--- a/src/Core/Grid/Column/AbstractColumn.php
+++ b/src/Core/Grid/Column/AbstractColumn.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Column;
 
+use Symfony\Component\OptionsResolver\Exception\NoSuchOptionException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -102,6 +103,18 @@ abstract class AbstractColumn implements ColumnInterface
         }
 
         return $this->options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOption(string $name)
+    {
+        if (array_key_exists($name, $this->options)) {
+            return $this->options[$name];
+        }
+
+        throw new NoSuchOptionException(sprintf('Option "%s" does not exist in "%s"', $name, get_class($this)));
     }
 
     /**

--- a/src/Core/Grid/Column/ColumnInterface.php
+++ b/src/Core/Grid/Column/ColumnInterface.php
@@ -69,6 +69,13 @@ interface ColumnInterface
     public function getOptions();
 
     /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getOption(string $name);
+
+    /**
      * Set column options.
      *
      * @param array $options

--- a/src/Core/Grid/Definition/GridDefinition.php
+++ b/src/Core/Grid/Definition/GridDefinition.php
@@ -30,6 +30,8 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
+use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
 use PrestaShop\PrestaShop\Core\Grid\Exception\InvalidDataException;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
 
@@ -122,6 +124,21 @@ final class GridDefinition implements GridDefinitionInterface
     public function getColumns()
     {
         return $this->columns;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumn(string $id): ColumnInterface
+    {
+        /** @var ColumnInterface $column */
+        foreach ($this->columns as $column) {
+            if ($id === $column->getId()) {
+                return $column;
+            }
+        }
+
+        throw new ColumnNotFoundException('Column with id "%s" not found');
     }
 
     /**

--- a/src/Core/Grid/Definition/GridDefinition.php
+++ b/src/Core/Grid/Definition/GridDefinition.php
@@ -138,7 +138,7 @@ final class GridDefinition implements GridDefinitionInterface
             }
         }
 
-        throw new ColumnNotFoundException('Column with id "%s" not found');
+        throw new ColumnNotFoundException(sprintf('Column with id "%s" not found', $id));
     }
 
     /**

--- a/src/Core/Grid/Definition/GridDefinition.php
+++ b/src/Core/Grid/Definition/GridDefinition.php
@@ -129,7 +129,7 @@ final class GridDefinition implements GridDefinitionInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumn(string $id): ColumnInterface
+    public function getColumnById(string $id): ColumnInterface
     {
         /** @var ColumnInterface $column */
         foreach ($this->columns as $column) {

--- a/src/Core/Grid/Definition/GridDefinitionInterface.php
+++ b/src/Core/Grid/Definition/GridDefinitionInterface.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnInterface;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
 
 /**
@@ -57,6 +58,13 @@ interface GridDefinitionInterface
      * @return ColumnCollectionInterface
      */
     public function getColumns();
+
+    /**
+     * @param string $id
+     *
+     * @return ColumnInterface
+     */
+    public function getColumn(string $id): ColumnInterface;
 
     /**
      * @return BulkActionCollectionInterface

--- a/src/Core/Grid/Definition/GridDefinitionInterface.php
+++ b/src/Core/Grid/Definition/GridDefinitionInterface.php
@@ -64,7 +64,7 @@ interface GridDefinitionInterface
      *
      * @return ColumnInterface
      */
-    public function getColumn(string $id): ColumnInterface;
+    public function getColumnById(string $id): ColumnInterface;
 
     /**
      * @return BulkActionCollectionInterface


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | related to https://github.com/PrestaShop/docs/issues/823 the problem is clearly defined. So this would enable to extend actions easier (see bellow table)
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | related to https://github.com/PrestaShop/docs/issues/823
| How to test?  | Added example module Pr using this functionality https://github.com/PrestaShop/example-modules/pull/30. It can be used to check if this works. Read more in module

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
**BC BREAKS** :warning: 
* added getColumnById and getOption methods respectively to GridDefinitionInterface and ColumnInterface

**How to use**
 now extending column actions should look like this;
```
$gridDefinition->getColumnById('action')
    ->getOption('actions')
    ->add(new SubitRowAction())
;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22284)
<!-- Reviewable:end -->
