### PR TITLE
Fix setValue() method of FormField class on checkbox fields

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -191,7 +191,9 @@ abstract class AbstractFormCore implements FormInterface
             } elseif ($field->getType() === 'checkbox') {
                 // checkboxes that are not submitted
                 // are interpreted as booleans switched off
-                $field->setValue(false);
+                if (empty($field->getValue())) {
+                    $field->setValue(false);
+                }
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR fixes an issue that was preventing to use `setValue()` method of `FormField` class (only on checkbox fields).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | -
| Deprecations? | -
| Fixed ticket? | Fixes #9739
| How to test?  | Try to use `setValue(1)` on custom checkbox field to check it (see https://devdocs.prestashop.com/1.7/modules/concepts/forms/)<br><br>We can quickly test this PR with `ps_emailsubscription` module.<br><br>1. Open `modules/ps_emailsubscription/ps_emailsubscription.php`<br>2. Search `->setType('checkbox')` (line 989)<br>3. Add `->setValue(1)` on new line<br>4. Check on registration page that newsletter checkbox is checked by default
| Sponsor company | @Creabilis

All credits to @tfayolle for this correction. Thanks to him.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22285)
<!-- Reviewable:end -->
