### PR TITLE
Simplify product isNew() query

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1563,7 +1563,7 @@ class ProductCore extends ObjectModel
             WHERE p.id_product = ' . (int) $this->id . '
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
 
-        return (bool) Db::getInstance()->getValue($query, true, false);
+        return (bool) Db::getInstance()->getValue($query, false);
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1561,9 +1561,9 @@ class ProductCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
             WHERE p.id_product = ' . (int) $this->id . '
-            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
+            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . (int) $nbDaysNewProduct;
 
-        $result = Db::getInstance()->getValue($query, true, false);
+        return (bool) Db::getInstance()->getValue($query, true, false);
 
         return (bool) $result;
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1556,13 +1556,13 @@ class ProductCore extends ObjectModel
         if (!Validate::isUnsignedInt($nbDaysNewProduct)) {
             $nbDaysNewProduct = 20;
         }
-        
+
         $query = 'SELECT p.id_product
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
             WHERE p.id_product = ' . (int) $this->id . '
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
-        
+
         $result = Db::getInstance()->executeS($query, true, false);
         return count($result) > 0;
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1564,8 +1564,6 @@ class ProductCore extends ObjectModel
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . (int) $nbDaysNewProduct;
 
         return (bool) Db::getInstance()->getValue($query, true, false);
-
-        return (bool) $result;
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1561,7 +1561,7 @@ class ProductCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
             WHERE p.id_product = ' . (int) $this->id . '
-            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . (int) $nbDaysNewProduct;
+            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
 
         return (bool) Db::getInstance()->getValue($query, true, false);
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1564,6 +1564,7 @@ class ProductCore extends ObjectModel
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
 
         $result = Db::getInstance()->executeS($query, true, false);
+
         return count($result) > 0;
     }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1552,18 +1552,17 @@ class ProductCore extends ObjectModel
      */
     public function isNew()
     {
+        $nbDaysNewProduct = Configuration::get('PS_NB_DAYS_NEW_PRODUCT');
+        if (!Validate::isUnsignedInt($nbDaysNewProduct)) {
+            $nbDaysNewProduct = 20;
+        }
+        
         $result = Db::getInstance()->executeS('
             SELECT p.id_product
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
             WHERE p.id_product = ' . (int) $this->id . '
-            AND DATEDIFF(
-                product_shop.`date_add`,
-                DATE_SUB(
-                    "' . date('Y-m-d') . ' 00:00:00",
-                    INTERVAL ' . (Validate::isUnsignedInt(Configuration::get('PS_NB_DAYS_NEW_PRODUCT')) ? Configuration::get('PS_NB_DAYS_NEW_PRODUCT') : 20) . ' DAY
-                )
-            ) > 0
+            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct
         ', true, false);
 
         return count($result) > 0;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1557,15 +1557,15 @@ class ProductCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
 
-        $query = 'SELECT p.id_product
+        $query = 'SELECT COUNT(p.id_product)
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
             WHERE p.id_product = ' . (int) $this->id . '
             AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
 
-        $result = Db::getInstance()->executeS($query, true, false);
+        $result = Db::getInstance()->getValue($query, true, false);
 
-        return count($result) > 0;
+        return (bool) $result;
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1557,14 +1557,13 @@ class ProductCore extends ObjectModel
             $nbDaysNewProduct = 20;
         }
         
-        $result = Db::getInstance()->executeS('
-            SELECT p.id_product
+        $query = 'SELECT p.id_product
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
             WHERE p.id_product = ' . (int) $this->id . '
-            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct
-        ', true, false);
-
+            AND DATEDIFF("' . date('Y-m-d') . ' 00:00:00", product_shop.`date_add`) < ' . $nbDaysNewProduct;
+        
+        $result = Db::getInstance()->executeS($query, true, false);
         return count($result) > 0;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Product->isNew() method have a complex query that can be simplified. It is not necessary to do so many operations with the date.<br><br>Before: `DATEDIFF(p.date_add, DATE_SUB(DATE_SUB(NOW, X DAYS)) > 0`<br>After: `DATEDIFF(NOW, p.date_add) < X`
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | I play with the next query, both columns must have the same values for each product.
```sql
SELECT
    product_shop.`date_add`,
       DATEDIFF('2020-11-30 00:00:00', product_shop.`date_add`) < 20,
       DATEDIFF(
               product_shop.`date_add`,
               DATE_SUB(
                       '2020-11-30 00:00:00',
                       INTERVAL 20 DAY
                   )
           ) > 0
FROM `ps_product` p INNER JOIN ps_product_shop product_shop ON (product_shop.id_product = p.id_product AND product_shop.id_shop = 1)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22290)
<!-- Reviewable:end -->
