### PR TITLE
Use PS cache config as driver.cache

### DIFF
--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -55,7 +55,29 @@ if ($container instanceof \Symfony\Component\DependencyInjection\Container) {
         $container->setParameter($key, $value);
     }
 
-    $container->setParameter('cache.driver', extension_loaded('apc') ? 'apc': 'array');
+    $driver = 'array';
+    $cacheType = [
+        'CacheMemcache' => ['memcache'],
+        'CacheMemcached' => ['memcached'],
+        'CacheApc' => ['apcu', 'apc'],
+        'CacheXcache' => ['xcache'],
+    ];
+
+    if (isset(
+            $parameters['parameters']['ps_cache_enable'],
+            $parameters['parameters']['ps_caching'],
+            $cacheType[$parameters['parameters']['ps_caching']]
+        )
+        && true === $parameters['parameters']['ps_cache_enable']
+    ) {
+        foreach ($cacheType[$parameters['parameters']['ps_caching']] as $type) {
+            if (extension_loaded($type)) {
+                $driver = $type;
+                break;
+            }
+        }
+    }
+    $container->setParameter('cache.driver', $driver);
 
     // Parameter used only in dev and test env
     $envParameter = getenv('DISABLE_DEBUG_TOOLBAR');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Because APC was used as cache.driver (when available) for doctrine even when the cache setting of PrestaShop was disabled, that led to a cache not being cleared while upgrading and the schema upgrade was then using old Entities.
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22250
| How to test?  | With apcu **& [apcu_bc](https://pecl.php.net/package/apcu_bc)**, try to upgrade from 1.7.6.9 to 1.7.7.0. Everything should works and you should still have the left menu in the BO.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22293)
<!-- Reviewable:end -->
