### PR TITLE
Mark URLFragmentSerializer as deprecated

### DIFF
--- a/src/Core/Product/Search/URLFragmentSerializer.php
+++ b/src/Core/Product/Search/URLFragmentSerializer.php
@@ -26,6 +26,14 @@
 
 namespace PrestaShop\PrestaShop\Core\Product\Search;
 
+@trigger_error(
+    sprintf(
+        '%s is deprecated since version 1.7.8.0 and will be removed in the next major version.',
+        URLFragmentSerializer::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
  * This class is a serializer for URL fragments.
  *

--- a/src/Core/Product/Search/URLFragmentSerializer.php
+++ b/src/Core/Product/Search/URLFragmentSerializer.php
@@ -28,6 +28,8 @@ namespace PrestaShop\PrestaShop\Core\Product\Search;
 
 /**
  * This class is a serializer for URL fragments.
+ *
+ * @deprecated since version 1.7.8 and will be removed in the next major version.
  */
 class URLFragmentSerializer
 {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This class is not used in the Core, currently only in old versions of facetedsearch module, but this class is broken and tests are useless.
| Type?         | refacto
| Category?     | CO
| BC breaks?    | no
| Deprecations? | yes
| How to test?  | No need QA, no need Issue.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22308)
<!-- Reviewable:end -->
