### PR TITLE
Fixed unclear error message during api/products/image requests with improper input data

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1221,6 +1221,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     return true;
                 }
             }
+            throw new WebserviceException('Missing tmp_file property. Check supplied input data.', array(67, 400));
         } else {
             throw new WebserviceException('Method ' . $this->wsObject->method . ' is not allowed for an image resource', [77, 405]);
         }

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1220,8 +1220,9 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
                     return true;
                 }
+            } else {
+                throw new WebserviceException('Please set an "image" parameter with image data for value', [76, 400]);
             }
-            throw new WebserviceException('Missing tmp_file property. Check supplied input data.', [67, 400]);
         } else {
             throw new WebserviceException('Method ' . $this->wsObject->method . ' is not allowed for an image resource', [77, 405]);
         }

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -1221,7 +1221,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     return true;
                 }
             }
-            throw new WebserviceException('Missing tmp_file property. Check supplied input data.', array(67, 400));
+            throw new WebserviceException('Missing tmp_file property. Check supplied input data.', [67, 400]);
         } else {
             throw new WebserviceException('Method ' . $this->wsObject->method . ' is not allowed for an image resource', [77, 405]);
         }


### PR DESCRIPTION
Add new throw clause for better debug, when input data are not specified correctly

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Improper input data during api/products/image requests leads to unclear error message. I added a bit more detailed error message.
| Type?         | improvement
| Category         | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22313 .
| How to test?  | Send request with malformed image property - instead of displaying error code 500 / 66: Unable to save this image, response should be 400 / 67: Missing tmp_file property. Check supplied input data.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22309)
<!-- Reviewable:end -->
