### PR TITLE
Add confirm modal on module update

### DIFF
--- a/admin-dev/themes/new-theme/js/components/modal.js
+++ b/admin-dev/themes/new-theme/js/components/modal.js
@@ -34,6 +34,7 @@ const {$} = window;
  * @param {String} closeButtonLabel
  * @param {String} confirmButtonLabel
  * @param {String} confirmButtonClass
+ * @param {Array} customButtons
  * @param {Boolean} closable
  * @param {Function} confirmCallback
  *
@@ -53,7 +54,7 @@ export default function ConfirmModal(params, confirmCallback) {
   this.modal.confirmButton.addEventListener('click', confirmCallback);
 
   this.$modal.modal({
-    backdrop: (closable ? true : 'static'),
+    backdrop: closable ? true : 'static',
     keyboard: closable !== undefined ? closable : true,
     closable: closable !== undefined ? closable : true,
     show: false,
@@ -79,6 +80,7 @@ function Modal({
   closeButtonLabel = 'Close',
   confirmButtonLabel = 'Accept',
   confirmButtonClass = 'btn-primary',
+  customButtons = [],
 }) {
   const modal = {};
 
@@ -133,7 +135,7 @@ function Modal({
   modal.closeButton.dataset.dismiss = 'modal';
   modal.closeButton.innerHTML = closeButtonLabel;
 
-  // Modal close button element
+  // Modal confirm button element
   modal.confirmButton = document.createElement('button');
   modal.confirmButton.setAttribute('type', 'button');
   modal.confirmButton.classList.add('btn', confirmButtonClass, 'btn-lg', 'btn-confirm-submit');
@@ -148,7 +150,7 @@ function Modal({
   }
 
   modal.body.appendChild(modal.message);
-  modal.footer.append(modal.closeButton, modal.confirmButton);
+  modal.footer.append(modal.closeButton, ...customButtons, modal.confirmButton);
   modal.content.append(modal.header, modal.body, modal.footer);
   modal.dialog.appendChild(modal.content);
   modal.container.appendChild(modal.dialog);

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -28,7 +28,7 @@ const {$} = window;
 
 const BOEvent = {
   on(eventName, callback, context) {
-    document.addEventListener(eventName, event => {
+    document.addEventListener(eventName, (event) => {
       if (typeof context !== 'undefined') {
         callback.call(context, event);
       } else {
@@ -42,7 +42,7 @@ const BOEvent = {
     // true values stand for: can bubble, and is cancellable
     event.initEvent(eventName, true, true);
     document.dispatchEvent(event);
-  }
+  },
 };
 
 /**
@@ -78,10 +78,10 @@ export default class ModuleCard {
   initActionButtons() {
     const self = this;
 
-    $(document).on('click', this.forceDeletionOption, function() {
+    $(document).on('click', this.forceDeletionOption, function () {
       const btn = $(
         self.moduleActionModalUninstallLinkSelector,
-        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
+        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
       );
 
       if ($(this).prop('checked') === true) {
@@ -91,128 +91,139 @@ export default class ModuleCard {
       }
     });
 
-    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function () {
       if ($('#modal-prestatrust').length) {
         $('#modal-prestatrust').modal('hide');
       }
 
       return (
-        self.dispatchPreEvent('install', this) &&
-        self.confirmAction('install', this) &&
-        self.requestToController('install', $(this))
+        self.dispatchPreEvent('install', this)
+        && self.confirmAction('install', this)
+        && self.requestToController('install', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function () {
       return (
-        self.dispatchPreEvent('enable', this) &&
-        self.confirmAction('enable', this) &&
-        self.requestToController('enable', $(this))
+        self.dispatchPreEvent('enable', this)
+        && self.confirmAction('enable', this)
+        && self.requestToController('enable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function () {
       return (
-        self.dispatchPreEvent('uninstall', this) &&
-        self.confirmAction('uninstall', this) &&
-        self.requestToController('uninstall', $(this))
+        self.dispatchPreEvent('uninstall', this)
+        && self.confirmAction('uninstall', this)
+        && self.requestToController('uninstall', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function () {
       return (
-        self.dispatchPreEvent('disable', this) &&
-        self.confirmAction('disable', this) &&
-        self.requestToController('disable', $(this))
+        self.dispatchPreEvent('disable', this)
+        && self.confirmAction('disable', this)
+        && self.requestToController('disable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function () {
       return (
-        self.dispatchPreEvent('enable_mobile', this) &&
-        self.confirmAction('enable_mobile', this) &&
-        self.requestToController('enable_mobile', $(this))
+        self.dispatchPreEvent('enable_mobile', this)
+        && self.confirmAction('enable_mobile', this)
+        && self.requestToController('enable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function () {
       return (
-        self.dispatchPreEvent('disable_mobile', this) &&
-        self.confirmAction('disable_mobile', this) &&
-        self.requestToController('disable_mobile', $(this))
+        self.dispatchPreEvent('disable_mobile', this)
+        && self.confirmAction('disable_mobile', this)
+        && self.requestToController('disable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuResetLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuResetLinkSelector, function () {
       return (
-        self.dispatchPreEvent('reset', this) &&
-        self.confirmAction('reset', this) &&
-        self.requestToController('reset', $(this))
+        self.dispatchPreEvent('reset', this)
+        && self.confirmAction('reset', this)
+        && self.requestToController('reset', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function(event) {
+    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function (event) {
       event.preventDefault();
       const modal = $(`#${$(this).data('confirm_modal')}`);
+      const isMaintenanceMode = true;
 
       if (modal.length !== 1) {
+        // Modal body element
+        const maintenanceLink = document.createElement('a');
+        maintenanceLink.classList.add('btn', 'btn-primary', 'btn-lg');
+        maintenanceLink.setAttribute('href', '#');
+        maintenanceLink.innerHTML = 'Go to maintenance page';
+
         const updateConfirmModal = new ConfirmModal(
           {
             id: 'confirm-modal',
             confirmTitle: 'Are you sure you want to upgrade this module?',
             closeButtonLabel: 'Cancel',
-            confirmButtonLabel: 'Upgrade',
-            confirmButtonClass: 'btn-primary',
-            closable: true
+            confirmButtonLabel: isMaintenanceMode ? 'Upgrade' : 'Upgrade anyway',
+            confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
+            confirmMessage: isMaintenanceMode
+              ? ''
+              : 'We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues.',
+            closable: true,
+            customButtons: isMaintenanceMode ? [] : [maintenanceLink],
           },
-          () =>
-            self.dispatchPreEvent('update', this) &&
-            self.confirmAction('update', this) &&
-            self.requestToController('update', $(this))
+          () => self.dispatchPreEvent('update', this)
+            && self.confirmAction('update', this)
+            && self.requestToController('update', $(this)),
         );
 
         updateConfirmModal.show();
       } else {
         return (
-          self.dispatchPreEvent('update', this) &&
-          self.confirmAction('update', this) &&
-          self.requestToController('update', $(this))
+          self.dispatchPreEvent('update', this)
+          && self.confirmAction('update', this)
+          && self.requestToController('update', $(this))
         );
       }
+
+      return false;
     });
 
-    $(document).on('click', this.moduleActionModalDisableLinkSelector, function() {
+    $(document).on('click', this.moduleActionModalDisableLinkSelector, function () {
       return self.requestToController(
         'disable',
         $(
           self.moduleActionMenuDisableLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
-        )
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
+        ),
       );
     });
 
-    $(document).on('click', this.moduleActionModalResetLinkSelector, function() {
+    $(document).on('click', this.moduleActionModalResetLinkSelector, function () {
       return self.requestToController(
         'reset',
         $(
           self.moduleActionMenuResetLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
-        )
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
+        ),
       );
     });
 
-    $(document).on('click', this.moduleActionModalUninstallLinkSelector, e => {
+    $(document).on('click', this.moduleActionModalUninstallLinkSelector, (e) => {
       $(e.target)
         .parents('.modal')
-        .on('hidden.bs.modal', () =>
-          self.requestToController(
-            'uninstall',
-            $(
-              self.moduleActionMenuUninstallLinkSelector,
-              $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`)
-            ),
-            $(e.target).attr('data-deletion')
-          )
+        .on('hidden.bs.modal', () => self.requestToController(
+          'uninstall',
+          $(
+            self.moduleActionMenuUninstallLinkSelector,
+            $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`),
+          ),
+          $(e.target).attr('data-deletion'),
+        ),
         );
     });
   }
@@ -253,7 +264,7 @@ export default class ModuleCard {
         // Find related form, update it and submit it
         const installButton = $(
           that.moduleActionMenuInstallLinkSelector,
-          `.module-item[data-tech-name="${result.module.attributes.name}"]`
+          `.module-item[data-tech-name="${result.module.attributes.name}"]`,
         );
 
         const form = installButton.parent('form');
@@ -261,7 +272,7 @@ export default class ModuleCard {
           .attr({
             type: 'hidden',
             value: '1',
-            name: 'actionParams[confirmPrestaTrust]'
+            name: 'actionParams[confirmPrestaTrust]',
           })
           .appendTo(form);
 
@@ -341,13 +352,13 @@ export default class ModuleCard {
       beforeSend() {
         jqElementObj.hide();
         jqElementObj.after(spinnerObj);
-      }
+      },
     })
-      .done(result => {
+      .done((result) => {
         if (result === undefined) {
           $.growl.error({
             message: 'No answer received from server',
-            fixed: true
+            fixed: true,
           });
           return;
         }
@@ -370,7 +381,7 @@ export default class ModuleCard {
 
         $.growl({
           message: result[moduleTechName].msg,
-          duration: 6000
+          duration: 6000,
         });
 
         const alteredSelector = self.getModuleItemSelector().replace('.', '');
@@ -402,7 +413,7 @@ export default class ModuleCard {
         const techName = moduleItem.data('techName');
         $.growl.error({
           message: `Could not perform action ${action} for module ${techName}`,
-          fixed: true
+          fixed: true,
         });
       })
       .always(() => {

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -28,7 +28,7 @@ const {$} = window;
 
 const BOEvent = {
   on(eventName, callback, context) {
-    document.addEventListener(eventName, event => {
+    document.addEventListener(eventName, (event) => {
       if (typeof context !== 'undefined') {
         callback.call(context, event);
       } else {
@@ -42,7 +42,7 @@ const BOEvent = {
     // true values stand for: can bubble, and is cancellable
     event.initEvent(eventName, true, true);
     document.dispatchEvent(event);
-  }
+  },
 };
 
 /**
@@ -78,10 +78,10 @@ export default class ModuleCard {
   initActionButtons() {
     const self = this;
 
-    $(document).on('click', this.forceDeletionOption, function() {
+    $(document).on('click', this.forceDeletionOption, function () {
       const btn = $(
         self.moduleActionModalUninstallLinkSelector,
-        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
+        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
       );
 
       if ($(this).prop('checked') === true) {
@@ -91,67 +91,67 @@ export default class ModuleCard {
       }
     });
 
-    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function () {
       if ($('#modal-prestatrust').length) {
         $('#modal-prestatrust').modal('hide');
       }
 
       return (
-        self.dispatchPreEvent('install', this) &&
-        self.confirmAction('install', this) &&
-        self.requestToController('install', $(this))
+        self.dispatchPreEvent('install', this)
+        && self.confirmAction('install', this)
+        && self.requestToController('install', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function () {
       return (
-        self.dispatchPreEvent('enable', this) &&
-        self.confirmAction('enable', this) &&
-        self.requestToController('enable', $(this))
+        self.dispatchPreEvent('enable', this)
+        && self.confirmAction('enable', this)
+        && self.requestToController('enable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function () {
       return (
-        self.dispatchPreEvent('uninstall', this) &&
-        self.confirmAction('uninstall', this) &&
-        self.requestToController('uninstall', $(this))
+        self.dispatchPreEvent('uninstall', this)
+        && self.confirmAction('uninstall', this)
+        && self.requestToController('uninstall', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function () {
       return (
-        self.dispatchPreEvent('disable', this) &&
-        self.confirmAction('disable', this) &&
-        self.requestToController('disable', $(this))
+        self.dispatchPreEvent('disable', this)
+        && self.confirmAction('disable', this)
+        && self.requestToController('disable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function () {
       return (
-        self.dispatchPreEvent('enable_mobile', this) &&
-        self.confirmAction('enable_mobile', this) &&
-        self.requestToController('enable_mobile', $(this))
+        self.dispatchPreEvent('enable_mobile', this)
+        && self.confirmAction('enable_mobile', this)
+        && self.requestToController('enable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function () {
       return (
-        self.dispatchPreEvent('disable_mobile', this) &&
-        self.confirmAction('disable_mobile', this) &&
-        self.requestToController('disable_mobile', $(this))
+        self.dispatchPreEvent('disable_mobile', this)
+        && self.confirmAction('disable_mobile', this)
+        && self.requestToController('disable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuResetLinkSelector, function() {
+    $(document).on('click', this.moduleActionMenuResetLinkSelector, function () {
       return (
-        self.dispatchPreEvent('reset', this) &&
-        self.confirmAction('reset', this) &&
-        self.requestToController('reset', $(this))
+        self.dispatchPreEvent('reset', this)
+        && self.confirmAction('reset', this)
+        && self.requestToController('reset', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function(event) {
+    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function (event) {
       event.preventDefault();
       const modal = $(`#${$(this).data('confirm_modal')}`);
       const isMaintenanceMode = window.isShopMaintenance;
@@ -174,59 +174,57 @@ export default class ModuleCard {
             confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
             confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
             closable: true,
-            customButtons: isMaintenanceMode ? [] : [maintenanceLink]
+            customButtons: isMaintenanceMode ? [] : [maintenanceLink],
           },
 
-          () =>
-            self.dispatchPreEvent('update', this) &&
-            self.confirmAction('update', this) &&
-            self.requestToController('update', $(this))
+          () => self.dispatchPreEvent('update', this)
+            && self.confirmAction('update', this)
+            && self.requestToController('update', $(this)),
         );
 
         updateConfirmModal.show();
       } else {
         return (
-          self.dispatchPreEvent('update', this) &&
-          self.confirmAction('update', this) &&
-          self.requestToController('update', $(this))
+          self.dispatchPreEvent('update', this)
+          && self.confirmAction('update', this)
+          && self.requestToController('update', $(this))
         );
       }
 
       return false;
     });
 
-    $(document).on('click', this.moduleActionModalDisableLinkSelector, function() {
+    $(document).on('click', this.moduleActionModalDisableLinkSelector, function () {
       return self.requestToController(
         'disable',
         $(
           self.moduleActionMenuDisableLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
-        )
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
+        ),
       );
     });
 
-    $(document).on('click', this.moduleActionModalResetLinkSelector, function() {
+    $(document).on('click', this.moduleActionModalResetLinkSelector, function () {
       return self.requestToController(
         'reset',
         $(
           self.moduleActionMenuResetLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
-        )
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
+        ),
       );
     });
 
-    $(document).on('click', this.moduleActionModalUninstallLinkSelector, e => {
+    $(document).on('click', this.moduleActionModalUninstallLinkSelector, (e) => {
       $(e.target)
         .parents('.modal')
-        .on('hidden.bs.modal', () =>
-          self.requestToController(
-            'uninstall',
-            $(
-              self.moduleActionMenuUninstallLinkSelector,
-              $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`)
-            ),
-            $(e.target).attr('data-deletion')
-          )
+        .on('hidden.bs.modal', () => self.requestToController(
+          'uninstall',
+          $(
+            self.moduleActionMenuUninstallLinkSelector,
+            $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`),
+          ),
+          $(e.target).attr('data-deletion'),
+        ),
         );
     });
   }
@@ -267,7 +265,7 @@ export default class ModuleCard {
         // Find related form, update it and submit it
         const installButton = $(
           that.moduleActionMenuInstallLinkSelector,
-          `.module-item[data-tech-name="${result.module.attributes.name}"]`
+          `.module-item[data-tech-name="${result.module.attributes.name}"]`,
         );
 
         const form = installButton.parent('form');
@@ -275,7 +273,7 @@ export default class ModuleCard {
           .attr({
             type: 'hidden',
             value: '1',
-            name: 'actionParams[confirmPrestaTrust]'
+            name: 'actionParams[confirmPrestaTrust]',
           })
           .appendTo(form);
 
@@ -355,13 +353,13 @@ export default class ModuleCard {
       beforeSend() {
         jqElementObj.hide();
         jqElementObj.after(spinnerObj);
-      }
+      },
     })
-      .done(result => {
+      .done((result) => {
         if (result === undefined) {
           $.growl.error({
             message: 'No answer received from server',
-            fixed: true
+            fixed: true,
           });
           return;
         }
@@ -384,7 +382,7 @@ export default class ModuleCard {
 
         $.growl({
           message: result[moduleTechName].msg,
-          duration: 6000
+          duration: 6000,
         });
 
         const alteredSelector = self.getModuleItemSelector().replace('.', '');
@@ -416,7 +414,7 @@ export default class ModuleCard {
         const techName = moduleItem.data('techName');
         $.growl.error({
           message: `Could not perform action ${action} for module ${techName}`,
-          fixed: true
+          fixed: true,
         });
       })
       .always(() => {

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -28,7 +28,7 @@ const {$} = window;
 
 const BOEvent = {
   on(eventName, callback, context) {
-    document.addEventListener(eventName, (event) => {
+    document.addEventListener(eventName, event => {
       if (typeof context !== 'undefined') {
         callback.call(context, event);
       } else {
@@ -42,7 +42,7 @@ const BOEvent = {
     // true values stand for: can bubble, and is cancellable
     event.initEvent(eventName, true, true);
     document.dispatchEvent(event);
-  },
+  }
 };
 
 /**
@@ -78,10 +78,10 @@ export default class ModuleCard {
   initActionButtons() {
     const self = this;
 
-    $(document).on('click', this.forceDeletionOption, function () {
+    $(document).on('click', this.forceDeletionOption, function() {
       const btn = $(
         self.moduleActionModalUninstallLinkSelector,
-        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
+        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
       );
 
       if ($(this).prop('checked') === true) {
@@ -91,139 +91,142 @@ export default class ModuleCard {
       }
     });
 
-    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function() {
       if ($('#modal-prestatrust').length) {
         $('#modal-prestatrust').modal('hide');
       }
 
       return (
-        self.dispatchPreEvent('install', this)
-        && self.confirmAction('install', this)
-        && self.requestToController('install', $(this))
+        self.dispatchPreEvent('install', this) &&
+        self.confirmAction('install', this) &&
+        self.requestToController('install', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function() {
       return (
-        self.dispatchPreEvent('enable', this)
-        && self.confirmAction('enable', this)
-        && self.requestToController('enable', $(this))
+        self.dispatchPreEvent('enable', this) &&
+        self.confirmAction('enable', this) &&
+        self.requestToController('enable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function() {
       return (
-        self.dispatchPreEvent('uninstall', this)
-        && self.confirmAction('uninstall', this)
-        && self.requestToController('uninstall', $(this))
+        self.dispatchPreEvent('uninstall', this) &&
+        self.confirmAction('uninstall', this) &&
+        self.requestToController('uninstall', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function() {
       return (
-        self.dispatchPreEvent('disable', this)
-        && self.confirmAction('disable', this)
-        && self.requestToController('disable', $(this))
+        self.dispatchPreEvent('disable', this) &&
+        self.confirmAction('disable', this) &&
+        self.requestToController('disable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function() {
       return (
-        self.dispatchPreEvent('enable_mobile', this)
-        && self.confirmAction('enable_mobile', this)
-        && self.requestToController('enable_mobile', $(this))
+        self.dispatchPreEvent('enable_mobile', this) &&
+        self.confirmAction('enable_mobile', this) &&
+        self.requestToController('enable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function() {
       return (
-        self.dispatchPreEvent('disable_mobile', this)
-        && self.confirmAction('disable_mobile', this)
-        && self.requestToController('disable_mobile', $(this))
+        self.dispatchPreEvent('disable_mobile', this) &&
+        self.confirmAction('disable_mobile', this) &&
+        self.requestToController('disable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuResetLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuResetLinkSelector, function() {
       return (
-        self.dispatchPreEvent('reset', this)
-        && self.confirmAction('reset', this)
-        && self.requestToController('reset', $(this))
+        self.dispatchPreEvent('reset', this) &&
+        self.confirmAction('reset', this) &&
+        self.requestToController('reset', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function (event) {
+    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function(event) {
       event.preventDefault();
       const modal = $(`#${$(this).data('confirm_modal')}`);
-      const isMaintenanceMode = true;
+      const isMaintenanceMode = window.isShopMaintenance;
 
       if (modal.length !== 1) {
         // Modal body element
         const maintenanceLink = document.createElement('a');
         maintenanceLink.classList.add('btn', 'btn-primary', 'btn-lg');
-        maintenanceLink.setAttribute('href', '#');
-        maintenanceLink.innerHTML = 'Go to maintenance page';
+        maintenanceLink.setAttribute('href', window.moduleURLs.maintenancePage);
+        maintenanceLink.innerHTML = window.moduleTranslations.moduleModalUpdateMaintenance;
 
         const updateConfirmModal = new ConfirmModal(
           {
             id: 'confirm-module-update-modal',
-            confirmTitle: 'Are you sure you want to upgrade this module?',
-            closeButtonLabel: 'Cancel',
-            confirmButtonLabel: isMaintenanceMode ? 'Upgrade' : 'Upgrade anyway',
+            confirmTitle: window.moduleTranslations.singleModuleModalUpdateTitle,
+            closeButtonLabel: window.moduleTranslations.moduleModalUpdateCancel,
+            confirmButtonLabel: isMaintenanceMode
+              ? window.moduleTranslations.moduleModalUpdateUpgrade
+              : window.moduleTranslations.multipleModuleModalUpdateUpgrade,
             confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
-            confirmMessage: isMaintenanceMode
-              ? ''
-              : 'We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues.',
+            confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
             closable: true,
-            customButtons: isMaintenanceMode ? [] : [maintenanceLink],
+            customButtons: isMaintenanceMode ? [] : [maintenanceLink]
           },
-          () => self.dispatchPreEvent('update', this)
-            && self.confirmAction('update', this)
-            && self.requestToController('update', $(this)),
+
+          () =>
+            self.dispatchPreEvent('update', this) &&
+            self.confirmAction('update', this) &&
+            self.requestToController('update', $(this))
         );
 
         updateConfirmModal.show();
       } else {
         return (
-          self.dispatchPreEvent('update', this)
-          && self.confirmAction('update', this)
-          && self.requestToController('update', $(this))
+          self.dispatchPreEvent('update', this) &&
+          self.confirmAction('update', this) &&
+          self.requestToController('update', $(this))
         );
       }
 
       return false;
     });
 
-    $(document).on('click', this.moduleActionModalDisableLinkSelector, function () {
+    $(document).on('click', this.moduleActionModalDisableLinkSelector, function() {
       return self.requestToController(
         'disable',
         $(
           self.moduleActionMenuDisableLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
-        ),
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
+        )
       );
     });
 
-    $(document).on('click', this.moduleActionModalResetLinkSelector, function () {
+    $(document).on('click', this.moduleActionModalResetLinkSelector, function() {
       return self.requestToController(
         'reset',
         $(
           self.moduleActionMenuResetLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
-        ),
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
+        )
       );
     });
 
-    $(document).on('click', this.moduleActionModalUninstallLinkSelector, (e) => {
+    $(document).on('click', this.moduleActionModalUninstallLinkSelector, e => {
       $(e.target)
         .parents('.modal')
-        .on('hidden.bs.modal', () => self.requestToController(
-          'uninstall',
-          $(
-            self.moduleActionMenuUninstallLinkSelector,
-            $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`),
-          ),
-          $(e.target).attr('data-deletion'),
-        ),
+        .on('hidden.bs.modal', () =>
+          self.requestToController(
+            'uninstall',
+            $(
+              self.moduleActionMenuUninstallLinkSelector,
+              $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`)
+            ),
+            $(e.target).attr('data-deletion')
+          )
         );
     });
   }
@@ -264,7 +267,7 @@ export default class ModuleCard {
         // Find related form, update it and submit it
         const installButton = $(
           that.moduleActionMenuInstallLinkSelector,
-          `.module-item[data-tech-name="${result.module.attributes.name}"]`,
+          `.module-item[data-tech-name="${result.module.attributes.name}"]`
         );
 
         const form = installButton.parent('form');
@@ -272,7 +275,7 @@ export default class ModuleCard {
           .attr({
             type: 'hidden',
             value: '1',
-            name: 'actionParams[confirmPrestaTrust]',
+            name: 'actionParams[confirmPrestaTrust]'
           })
           .appendTo(form);
 
@@ -352,13 +355,13 @@ export default class ModuleCard {
       beforeSend() {
         jqElementObj.hide();
         jqElementObj.after(spinnerObj);
-      },
+      }
     })
-      .done((result) => {
+      .done(result => {
         if (result === undefined) {
           $.growl.error({
             message: 'No answer received from server',
-            fixed: true,
+            fixed: true
           });
           return;
         }
@@ -381,7 +384,7 @@ export default class ModuleCard {
 
         $.growl({
           message: result[moduleTechName].msg,
-          duration: 6000,
+          duration: 6000
         });
 
         const alteredSelector = self.getModuleItemSelector().replace('.', '');
@@ -413,7 +416,7 @@ export default class ModuleCard {
         const techName = moduleItem.data('techName');
         $.growl.error({
           message: `Could not perform action ${action} for module ${techName}`,
-          fixed: true,
+          fixed: true
         });
       })
       .always(() => {

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -22,12 +22,13 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+import ConfirmModal from '@components/modal';
 
 const {$} = window;
 
 const BOEvent = {
   on(eventName, callback, context) {
-    document.addEventListener(eventName, (event) => {
+    document.addEventListener(eventName, event => {
       if (typeof context !== 'undefined') {
         callback.call(context, event);
       } else {
@@ -41,7 +42,7 @@ const BOEvent = {
     // true values stand for: can bubble, and is cancellable
     event.initEvent(eventName, true, true);
     document.dispatchEvent(event);
-  },
+  }
 };
 
 /**
@@ -77,10 +78,10 @@ export default class ModuleCard {
   initActionButtons() {
     const self = this;
 
-    $(document).on('click', this.forceDeletionOption, function () {
+    $(document).on('click', this.forceDeletionOption, function() {
       const btn = $(
         self.moduleActionModalUninstallLinkSelector,
-        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
+        $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
       );
 
       if ($(this).prop('checked') === true) {
@@ -90,105 +91,128 @@ export default class ModuleCard {
       }
     });
 
-    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuInstallLinkSelector, function() {
       if ($('#modal-prestatrust').length) {
         $('#modal-prestatrust').modal('hide');
       }
 
       return (
-        self.dispatchPreEvent('install', this)
-        && self.confirmAction('install', this)
-        && self.requestToController('install', $(this))
+        self.dispatchPreEvent('install', this) &&
+        self.confirmAction('install', this) &&
+        self.requestToController('install', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuEnableLinkSelector, function() {
       return (
-        self.dispatchPreEvent('enable', this)
-        && self.confirmAction('enable', this)
-        && self.requestToController('enable', $(this))
+        self.dispatchPreEvent('enable', this) &&
+        self.confirmAction('enable', this) &&
+        self.requestToController('enable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuUninstallLinkSelector, function() {
       return (
-        self.dispatchPreEvent('uninstall', this)
-        && self.confirmAction('uninstall', this)
-        && self.requestToController('uninstall', $(this))
+        self.dispatchPreEvent('uninstall', this) &&
+        self.confirmAction('uninstall', this) &&
+        self.requestToController('uninstall', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuDisableLinkSelector, function() {
       return (
-        self.dispatchPreEvent('disable', this)
-        && self.confirmAction('disable', this)
-        && self.requestToController('disable', $(this))
+        self.dispatchPreEvent('disable', this) &&
+        self.confirmAction('disable', this) &&
+        self.requestToController('disable', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuEnableMobileLinkSelector, function() {
       return (
-        self.dispatchPreEvent('enable_mobile', this)
-        && self.confirmAction('enable_mobile', this)
-        && self.requestToController('enable_mobile', $(this))
+        self.dispatchPreEvent('enable_mobile', this) &&
+        self.confirmAction('enable_mobile', this) &&
+        self.requestToController('enable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuDisableMobileLinkSelector, function() {
       return (
-        self.dispatchPreEvent('disable_mobile', this)
-        && self.confirmAction('disable_mobile', this)
-        && self.requestToController('disable_mobile', $(this))
+        self.dispatchPreEvent('disable_mobile', this) &&
+        self.confirmAction('disable_mobile', this) &&
+        self.requestToController('disable_mobile', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuResetLinkSelector, function () {
+    $(document).on('click', this.moduleActionMenuResetLinkSelector, function() {
       return (
-        self.dispatchPreEvent('reset', this)
-        && self.confirmAction('reset', this)
-        && self.requestToController('reset', $(this))
+        self.dispatchPreEvent('reset', this) &&
+        self.confirmAction('reset', this) &&
+        self.requestToController('reset', $(this))
       );
     });
 
-    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function () {
-      return (
-        self.dispatchPreEvent('update', this)
-        && self.confirmAction('update', this)
-        && self.requestToController('update', $(this))
-      );
+    $(document).on('click', this.moduleActionMenuUpdateLinkSelector, function(event) {
+      event.preventDefault();
+      const modal = $(`#${$(this).data('confirm_modal')}`);
+
+      if (modal.length !== 1) {
+        const updateConfirmModal = new ConfirmModal(
+          {
+            id: 'confirm-modal',
+            confirmTitle: 'Are you sure you want to upgrade this module?',
+            closeButtonLabel: 'Cancel',
+            confirmButtonLabel: 'Upgrade',
+            confirmButtonClass: 'btn-primary',
+            closable: true
+          },
+          () =>
+            self.dispatchPreEvent('update', this) &&
+            self.confirmAction('update', this) &&
+            self.requestToController('update', $(this))
+        );
+
+        updateConfirmModal.show();
+      } else {
+        return (
+          self.dispatchPreEvent('update', this) &&
+          self.confirmAction('update', this) &&
+          self.requestToController('update', $(this))
+        );
+      }
     });
 
-    $(document).on('click', this.moduleActionModalDisableLinkSelector, function () {
+    $(document).on('click', this.moduleActionModalDisableLinkSelector, function() {
       return self.requestToController(
         'disable',
         $(
           self.moduleActionMenuDisableLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
-        ),
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
+        )
       );
     });
 
-    $(document).on('click', this.moduleActionModalResetLinkSelector, function () {
+    $(document).on('click', this.moduleActionModalResetLinkSelector, function() {
       return self.requestToController(
         'reset',
         $(
           self.moduleActionMenuResetLinkSelector,
-          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`),
-        ),
+          $(`div.module-item-list[data-tech-name='${$(this).attr('data-tech-name')}']`)
+        )
       );
     });
 
-    $(document).on('click', this.moduleActionModalUninstallLinkSelector, (e) => {
+    $(document).on('click', this.moduleActionModalUninstallLinkSelector, e => {
       $(e.target)
         .parents('.modal')
-        .on('hidden.bs.modal', () => self.requestToController(
-          'uninstall',
-          $(
-            self.moduleActionMenuUninstallLinkSelector,
-            $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`),
-          ),
-          $(e.target).attr('data-deletion'),
-        ),
+        .on('hidden.bs.modal', () =>
+          self.requestToController(
+            'uninstall',
+            $(
+              self.moduleActionMenuUninstallLinkSelector,
+              $(`div.module-item-list[data-tech-name='${$(e.target).attr('data-tech-name')}']`)
+            ),
+            $(e.target).attr('data-deletion')
+          )
         );
     });
   }
@@ -229,7 +253,7 @@ export default class ModuleCard {
         // Find related form, update it and submit it
         const installButton = $(
           that.moduleActionMenuInstallLinkSelector,
-          `.module-item[data-tech-name="${result.module.attributes.name}"]`,
+          `.module-item[data-tech-name="${result.module.attributes.name}"]`
         );
 
         const form = installButton.parent('form');
@@ -237,7 +261,7 @@ export default class ModuleCard {
           .attr({
             type: 'hidden',
             value: '1',
-            name: 'actionParams[confirmPrestaTrust]',
+            name: 'actionParams[confirmPrestaTrust]'
           })
           .appendTo(form);
 
@@ -317,13 +341,13 @@ export default class ModuleCard {
       beforeSend() {
         jqElementObj.hide();
         jqElementObj.after(spinnerObj);
-      },
+      }
     })
-      .done((result) => {
+      .done(result => {
         if (result === undefined) {
           $.growl.error({
             message: 'No answer received from server',
-            fixed: true,
+            fixed: true
           });
           return;
         }
@@ -346,7 +370,7 @@ export default class ModuleCard {
 
         $.growl({
           message: result[moduleTechName].msg,
-          duration: 6000,
+          duration: 6000
         });
 
         const alteredSelector = self.getModuleItemSelector().replace('.', '');
@@ -378,7 +402,7 @@ export default class ModuleCard {
         const techName = moduleItem.data('techName');
         $.growl.error({
           message: `Could not perform action ${action} for module ${techName}`,
-          fixed: true,
+          fixed: true
         });
       })
       .always(() => {

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -170,7 +170,7 @@ export default class ModuleCard {
             closeButtonLabel: window.moduleTranslations.moduleModalUpdateCancel,
             confirmButtonLabel: isMaintenanceMode
               ? window.moduleTranslations.moduleModalUpdateUpgrade
-              : window.moduleTranslations.multipleModuleModalUpdateUpgrade,
+              : window.moduleTranslations.upgradeAnywayButtonText,
             confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
             confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
             closable: true,

--- a/admin-dev/themes/new-theme/js/components/module-card.js
+++ b/admin-dev/themes/new-theme/js/components/module-card.js
@@ -165,7 +165,7 @@ export default class ModuleCard {
 
         const updateConfirmModal = new ConfirmModal(
           {
-            id: 'confirm-modal',
+            id: 'confirm-module-update-modal',
             confirmTitle: 'Are you sure you want to upgrade this module?',
             closeButtonLabel: 'Cancel',
             confirmButtonLabel: isMaintenanceMode ? 'Upgrade' : 'Upgrade anyway',

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -1098,7 +1098,7 @@ class AdminModuleController {
 
       const updateAllConfirmModal = new ConfirmModal(
         {
-          id: 'confirm-modal',
+          id: 'confirm-module-update-modal',
           confirmTitle: 'Are you sure you want to upgrade this module?',
           closeButtonLabel: 'Cancel',
           confirmButtonLabel: isMaintenanceMode ? 'Upgrade' : 'Upgrade anyway',

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -23,6 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+import ConfirmModal from '@components/modal';
+
 const {$} = window;
 
 /**
@@ -90,7 +92,7 @@ class AdminModuleController {
     // Upgrade All selectors
     this.upgradeAllSource = '.module_action_menu_upgrade_all';
     this.upgradeContainer = '#modules-list-container-update';
-    this.upgradeAllTargets = `${this.upgradeContainer}' .module_action_menu_upgrade:visible`;
+    this.upgradeAllTargets = `${this.upgradeContainer} .module_action_menu_upgrade:visible`;
 
     // Notification selectors
     this.notificationContainer = '#modules-list-container-notification';
@@ -165,7 +167,7 @@ class AdminModuleController {
   initFilterStatusDropdown() {
     const self = this;
     const body = $('body');
-    body.on('click', self.statusItemSelector, function () {
+    body.on('click', self.statusItemSelector, function() {
       // Get data from li DOM input
       self.currentRefStatus = parseInt($(this).data('status-ref'), 10);
       // Change dropdown label to set it to the current status' displayname
@@ -174,7 +176,7 @@ class AdminModuleController {
       self.updateModuleVisibility();
     });
 
-    body.on('click', self.statusResetBtnSelector, function () {
+    body.on('click', self.statusResetBtnSelector, function() {
       $(self.statusSelectorLabelSelector).text($(this).text());
       $(this).hide();
       self.currentRefStatus = null;
@@ -198,7 +200,7 @@ class AdminModuleController {
     body.on('click', self.bulkItemSelector, function initializeBodyChange() {
       if ($(self.getBulkCheckboxesCheckedSelector()).length === 0) {
         $.growl.warning({
-          message: window.translate_javascripts['Bulk Action - One module minimum'],
+          message: window.translate_javascripts['Bulk Action - One module minimum']
         });
         return;
       }
@@ -221,7 +223,7 @@ class AdminModuleController {
       $(self.bulkConfirmModalSelector).modal('show');
     });
 
-    body.on('click', this.bulkConfirmModalAckBtnSelector, (event) => {
+    body.on('click', this.bulkConfirmModalAckBtnSelector, event => {
       event.preventDefault();
       event.stopPropagation();
       $(self.bulkConfirmModalSelector).modal('hide');
@@ -262,9 +264,9 @@ class AdminModuleController {
 
     $.ajax({
       method: 'GET',
-      url: window.moduleURLs.catalogRefresh,
+      url: window.moduleURLs.catalogRefresh
     })
-      .done((response) => {
+      .done(response => {
         if (response.status === true) {
           if (typeof response.domElements === 'undefined') response.domElements = null;
           if (typeof response.msg === 'undefined') response.msg = null;
@@ -300,7 +302,7 @@ class AdminModuleController {
           });
         }
       })
-      .fail((response) => {
+      .fail(response => {
         $(self.placeholderGlobalSelector).fadeOut(800, () => {
           $(self.placeholderFailureMsgSelector).text(response.statusText);
           $(self.placeholderFailureGlobalSelector).fadeIn(800);
@@ -335,7 +337,7 @@ class AdminModuleController {
           active: parseInt($this.data('active'), 10),
           access: $this.data('last-access'),
           display: $this.hasClass('module-item-list') ? self.DISPLAY_LIST : self.DISPLAY_GRID,
-          container,
+          container
         });
 
         if (self.isModulesPage()) {
@@ -404,11 +406,11 @@ class AdminModuleController {
       const container = $(this);
       const nbModulesInContainer = container.find('.module-item').length;
       if (
-        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name')))
-        || (self.currentRefStatus !== null && nbModulesInContainer === 0)
-        || (nbModulesInContainer === 0
-          && String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED)
-        || (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
+        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name'))) ||
+        (self.currentRefStatus !== null && nbModulesInContainer === 0) ||
+        (nbModulesInContainer === 0 &&
+          String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED) ||
+        (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
       ) {
         container.hide();
         return;
@@ -447,11 +449,11 @@ class AdminModuleController {
     const counter = {};
     const checkTag = (index, value) => {
       newValue = value.toLowerCase();
-      tagExists
-        |= currentModule.name.indexOf(newValue) !== -1
-        || currentModule.description.indexOf(newValue) !== -1
-        || currentModule.author.indexOf(newValue) !== -1
-        || currentModule.techName.indexOf(newValue) !== -1;
+      tagExists |=
+        currentModule.name.indexOf(newValue) !== -1 ||
+        currentModule.description.indexOf(newValue) !== -1 ||
+        currentModule.author.indexOf(newValue) !== -1 ||
+        currentModule.techName.indexOf(newValue) !== -1;
     };
 
     for (let i = 0; i < modulesListLength; i += 1) {
@@ -459,9 +461,10 @@ class AdminModuleController {
       if (currentModule.display === self.currentDisplay) {
         isVisible = true;
 
-        moduleCategory = self.currentRefCategory === self.CATEGORY_RECENTLY_USED
-          ? self.CATEGORY_RECENTLY_USED
-          : currentModule.categories;
+        moduleCategory =
+          self.currentRefCategory === self.CATEGORY_RECENTLY_USED
+            ? self.CATEGORY_RECENTLY_USED
+            : currentModule.categories;
 
         // Check for same category
         if (self.currentRefCategory !== null) {
@@ -492,9 +495,10 @@ class AdminModuleController {
             counter[moduleCategory] = 0;
           }
 
-          defaultMax = moduleCategory === self.CATEGORY_RECENTLY_USED
-            ? self.DEFAULT_MAX_RECENTLY_USED
-            : self.DEFAULT_MAX_PER_CATEGORIES;
+          defaultMax =
+            moduleCategory === self.CATEGORY_RECENTLY_USED
+              ? self.DEFAULT_MAX_RECENTLY_USED
+              : self.DEFAULT_MAX_PER_CATEGORIES;
           if (counter[moduleCategory] >= defaultMax) {
             isVisible &= self.currentCategoryDisplay[moduleCategory];
           }
@@ -528,8 +532,8 @@ class AdminModuleController {
     $(window).on('beforeunload', () => {
       if (self.isUploadStarted === true) {
         return (
-          'It seems some critical operation are running, are you sure you want to change page? '
-          + 'It might cause some unexepcted behaviors.'
+          'It seems some critical operation are running, are you sure you want to change page? ' +
+          'It might cause some unexepcted behaviors.'
         );
       }
 
@@ -587,8 +591,8 @@ class AdminModuleController {
         beforeSend: () => {
           $(self.addonsLoginButtonSelector).show();
           $('button.btn[type="submit"]', self.addonsConnectForm).hide();
-        },
-      }).done((response) => {
+        }
+      }).done(response => {
         if (response.success === 1) {
           window.location.reload();
         } else {
@@ -616,7 +620,7 @@ class AdminModuleController {
     body.on('click', this.moduleImportFailureRetrySelector, () => {
       /* eslint-disable max-len */
       $(
-        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`,
+        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`
       ).fadeOut(() => {
         /**
          * Added timeout for a better render of animation
@@ -655,10 +659,10 @@ class AdminModuleController {
           event.stopPropagation();
           event.preventDefault();
         }
-      },
+      }
     );
 
-    body.on('click', this.moduleImportSelectFileManualSelector, (event) => {
+    body.on('click', this.moduleImportSelectFileManualSelector, event => {
       event.stopPropagation();
       event.preventDefault();
       /**
@@ -712,7 +716,7 @@ class AdminModuleController {
       error: (file, message) => {
         self.displayOnUploadError(message);
       },
-      complete: (file) => {
+      complete: file => {
         if (file.status !== 'error') {
           const responseObject = $.parseJSON(file.xhr.response);
           if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
@@ -722,7 +726,7 @@ class AdminModuleController {
         }
         // State that we have finish the process to unlock some actions
         self.isUploadStarted = false;
-      },
+      }
     };
 
     dropzone.dropzone($.extend(dropzoneOptions));
@@ -813,12 +817,12 @@ class AdminModuleController {
 
         // Install ajax call
         $.post(result.module.attributes.urls.install, {
-          'actionParams[confirmPrestaTrust]': '1',
+          'actionParams[confirmPrestaTrust]': '1'
         })
-          .done((data) => {
+          .done(data => {
             self.displayOnUploadDone(data[moduleName]);
           })
-          .fail((data) => {
+          .fail(data => {
             self.displayOnUploadError(data[moduleName]);
           })
           .always(() => {
@@ -857,10 +861,10 @@ class AdminModuleController {
   updateNotificationsCount(badge) {
     const destinationTabs = {
       to_configure: $('#subtab-AdminModulesNotifications'),
-      to_update: $('#subtab-AdminModulesUpdates'),
+      to_update: $('#subtab-AdminModulesUpdates')
     };
 
-    Object.keys(destinationTabs).forEach((destinationKey) => {
+    Object.keys(destinationTabs).forEach(destinationKey => {
       if (destinationTabs[destinationKey].length !== 0) {
         destinationTabs[destinationKey].find('.notification-counter').text(badge[destinationKey]);
       }
@@ -944,7 +948,7 @@ class AdminModuleController {
       'bulk-enable': 'enable',
       'bulk-disable-mobile': 'disable_mobile',
       'bulk-enable-mobile': 'enable_mobile',
-      'bulk-reset': 'reset',
+      'bulk-reset': 'reset'
     };
 
     // Note no grid selector used yet since we do not needed it at dev time
@@ -952,7 +956,7 @@ class AdminModuleController {
     // use this functionality elsewhere but "manage my module" section
     if (typeof bulkActionToUrl[requestedBulkAction] === 'undefined') {
       $.growl.error({
-        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction),
+        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction)
       });
       return false;
     }
@@ -974,7 +978,7 @@ class AdminModuleController {
         techName: moduleTechName,
         actionMenuObj: $(this)
           .closest('.module-checkbox-bulk-list')
-          .next(),
+          .next()
       });
     });
 
@@ -1021,7 +1025,7 @@ class AdminModuleController {
         actionMenuLink,
         forceDeletion,
         disableCacheClear,
-        requestEndCallback,
+        requestEndCallback
       );
     }
 
@@ -1048,7 +1052,7 @@ class AdminModuleController {
       $.each(actions, (index, moduleData) => {
         actionMenuLink = $(
           self.moduleCardController.moduleActionMenuLinkSelector + bulkModuleAction,
-          moduleData.actionMenuObj,
+          moduleData.actionMenuObj
         );
         if (actionMenuLink.length > 0) {
           menuLinks.push(actionMenuLink);
@@ -1056,7 +1060,7 @@ class AdminModuleController {
           $.growl.error({
             message: window.translate_javascripts['Bulk Action - Request not available for module']
               .replace('[1]', bulkModuleAction)
-              .replace('[2]', moduleData.techName),
+              .replace('[2]', moduleData.techName)
           });
         }
       });
@@ -1077,33 +1081,49 @@ class AdminModuleController {
 
       $.ajax({
         url: $this.data('url'),
-        dataType: 'json',
+        dataType: 'json'
       }).done(() => {
         $next.fadeOut();
       });
     });
 
     // "Upgrade All" button handler
-    $('body').on('click', self.upgradeAllSource, (event) => {
+    $('body').on('click', self.upgradeAllSource, event => {
       event.preventDefault();
 
-      if ($(self.upgradeAllTargets).length <= 0) {
-        console.warn(window.translate_javascripts['Upgrade All Action - One module minimum']);
-        return false;
-      }
+      const updateAllConfirmModal = new ConfirmModal(
+        {
+          id: 'confirm-modal',
+          confirmTitle: 'Are you sure you want to upgrade these modules?',
+          closeButtonLabel: 'Cancel',
+          confirmButtonLabel: 'Upgrade',
+          confirmButtonClass: 'btn-primary',
+          closable: true
+        },
+        () => {
+          if ($(self.upgradeAllTargets).length <= 0) {
+            console.warn(window.translate_javascripts['Upgrade All Action - One module minimum']);
+            return false;
+          }
 
-      const modulesActions = [];
-      let moduleTechName;
-      $(self.upgradeAllTargets).each(function bulkActionSelector() {
-        const moduleItemList = $(this).closest('.module-item-list');
-        moduleTechName = moduleItemList.data('tech-name');
-        modulesActions.push({
-          techName: moduleTechName,
-          actionMenuObj: $('.module-actions', moduleItemList),
-        });
-      });
+          const modulesActions = [];
+          let moduleTechName;
+          $(self.upgradeAllTargets).each(function bulkActionSelector() {
+            const moduleItemList = $(this).closest('.module-item-list');
+            moduleTechName = moduleItemList.data('tech-name');
+            modulesActions.push({
+              techName: moduleTechName,
+              actionMenuObj: $('.module-actions', moduleItemList)
+            });
+          });
 
-      this.performModulesAction(modulesActions, 'upgrade');
+          this.performModulesAction(modulesActions, 'upgrade');
+
+          return true;
+        }
+      );
+
+      updateAllConfirmModal.show();
 
       return true;
     });
@@ -1138,7 +1158,7 @@ class AdminModuleController {
   initSearchBlock() {
     const self = this;
     self.pstaggerInput = $('#module-search-bar').pstagger({
-      onTagsChanged: (tagList) => {
+      onTagsChanged: tagList => {
         self.currentTagsList = tagList;
         self.updateModuleVisibility();
       },
@@ -1148,10 +1168,10 @@ class AdminModuleController {
       },
       inputPlaceholder: window.translate_javascripts['Search - placeholder'],
       closingCross: true,
-      context: self,
+      context: self
     });
 
-    $('body').on('click', '.module-addons-search-link', (event) => {
+    $('body').on('click', '.module-addons-search-link', event => {
       event.preventDefault();
       event.stopPropagation();
       window.open($(this).attr('href'), '_blank');
@@ -1192,14 +1212,20 @@ class AdminModuleController {
     $(`${self.moduleShortList} ${self.seeMoreSelector}`).on('click', function seeMore() {
       self.currentCategoryDisplay[$(this).data('category')] = true;
       $(this).addClass('d-none');
-      $(this).closest(self.moduleShortList).find(self.seeLessSelector).removeClass('d-none');
+      $(this)
+        .closest(self.moduleShortList)
+        .find(self.seeLessSelector)
+        .removeClass('d-none');
       self.updateModuleVisibility();
     });
 
     $(`${self.moduleShortList} ${self.seeLessSelector}`).on('click', function seeMore() {
       self.currentCategoryDisplay[$(this).data('category')] = false;
       $(this).addClass('d-none');
-      $(this).closest(self.moduleShortList).find(self.seeMoreSelector).removeClass('d-none');
+      $(this)
+        .closest(self.moduleShortList)
+        .find(self.seeMoreSelector)
+        .removeClass('d-none');
       self.updateModuleVisibility();
     });
   }
@@ -1219,7 +1245,7 @@ class AdminModuleController {
         const $this = $(this);
         replaceFirstWordBy(
           $this.find('.module-search-result-wording'),
-          $this.next('.modules-list').find('.module-item').length,
+          $this.next('.modules-list').find('.module-item').length
         );
       });
 
@@ -1228,23 +1254,21 @@ class AdminModuleController {
       const modulesCount = $('.modules-list').find('.module-item').length;
       replaceFirstWordBy($('.module-search-result-wording'), modulesCount);
 
-      const selectorToToggle = (self.currentDisplay === self.DISPLAY_LIST)
-        ? this.addonItemListSelector
-        : this.addonItemGridSelector;
-      $(selectorToToggle).toggle(modulesCount !== (this.modulesList.length / 2));
+      const selectorToToggle =
+        self.currentDisplay === self.DISPLAY_LIST ? this.addonItemListSelector : this.addonItemGridSelector;
+      $(selectorToToggle).toggle(modulesCount !== this.modulesList.length / 2);
 
       if (modulesCount === 0) {
         $('.module-addons-search-link').attr(
           'href',
-          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`,
+          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`
         );
       }
     }
   }
 
   isModulesPage() {
-    return $(this.upgradeContainer).length === 0
-      && $(this.notificationContainer).length === 0;
+    return $(this.upgradeContainer).length === 0 && $(this.notificationContainer).length === 0;
   }
 }
 

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -167,7 +167,7 @@ class AdminModuleController {
   initFilterStatusDropdown() {
     const self = this;
     const body = $('body');
-    body.on('click', self.statusItemSelector, function () {
+    body.on('click', self.statusItemSelector, function() {
       // Get data from li DOM input
       self.currentRefStatus = parseInt($(this).data('status-ref'), 10);
       // Change dropdown label to set it to the current status' displayname
@@ -176,7 +176,7 @@ class AdminModuleController {
       self.updateModuleVisibility();
     });
 
-    body.on('click', self.statusResetBtnSelector, function () {
+    body.on('click', self.statusResetBtnSelector, function() {
       $(self.statusSelectorLabelSelector).text($(this).text());
       $(this).hide();
       self.currentRefStatus = null;
@@ -200,7 +200,7 @@ class AdminModuleController {
     body.on('click', self.bulkItemSelector, function initializeBodyChange() {
       if ($(self.getBulkCheckboxesCheckedSelector()).length === 0) {
         $.growl.warning({
-          message: window.translate_javascripts['Bulk Action - One module minimum'],
+          message: window.translate_javascripts['Bulk Action - One module minimum']
         });
         return;
       }
@@ -223,7 +223,7 @@ class AdminModuleController {
       $(self.bulkConfirmModalSelector).modal('show');
     });
 
-    body.on('click', this.bulkConfirmModalAckBtnSelector, (event) => {
+    body.on('click', this.bulkConfirmModalAckBtnSelector, event => {
       event.preventDefault();
       event.stopPropagation();
       $(self.bulkConfirmModalSelector).modal('hide');
@@ -264,9 +264,9 @@ class AdminModuleController {
 
     $.ajax({
       method: 'GET',
-      url: window.moduleURLs.catalogRefresh,
+      url: window.moduleURLs.catalogRefresh
     })
-      .done((response) => {
+      .done(response => {
         if (response.status === true) {
           if (typeof response.domElements === 'undefined') response.domElements = null;
           if (typeof response.msg === 'undefined') response.msg = null;
@@ -302,7 +302,7 @@ class AdminModuleController {
           });
         }
       })
-      .fail((response) => {
+      .fail(response => {
         $(self.placeholderGlobalSelector).fadeOut(800, () => {
           $(self.placeholderFailureMsgSelector).text(response.statusText);
           $(self.placeholderFailureGlobalSelector).fadeIn(800);
@@ -337,7 +337,7 @@ class AdminModuleController {
           active: parseInt($this.data('active'), 10),
           access: $this.data('last-access'),
           display: $this.hasClass('module-item-list') ? self.DISPLAY_LIST : self.DISPLAY_GRID,
-          container,
+          container
         });
 
         if (self.isModulesPage()) {
@@ -406,11 +406,11 @@ class AdminModuleController {
       const container = $(this);
       const nbModulesInContainer = container.find('.module-item').length;
       if (
-        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name')))
-        || (self.currentRefStatus !== null && nbModulesInContainer === 0)
-        || (nbModulesInContainer === 0
-          && String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED)
-        || (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
+        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name'))) ||
+        (self.currentRefStatus !== null && nbModulesInContainer === 0) ||
+        (nbModulesInContainer === 0 &&
+          String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED) ||
+        (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
       ) {
         container.hide();
         return;
@@ -449,11 +449,11 @@ class AdminModuleController {
     const counter = {};
     const checkTag = (index, value) => {
       newValue = value.toLowerCase();
-      tagExists
-        |= currentModule.name.indexOf(newValue) !== -1
-        || currentModule.description.indexOf(newValue) !== -1
-        || currentModule.author.indexOf(newValue) !== -1
-        || currentModule.techName.indexOf(newValue) !== -1;
+      tagExists |=
+        currentModule.name.indexOf(newValue) !== -1 ||
+        currentModule.description.indexOf(newValue) !== -1 ||
+        currentModule.author.indexOf(newValue) !== -1 ||
+        currentModule.techName.indexOf(newValue) !== -1;
     };
 
     for (let i = 0; i < modulesListLength; i += 1) {
@@ -461,9 +461,10 @@ class AdminModuleController {
       if (currentModule.display === self.currentDisplay) {
         isVisible = true;
 
-        moduleCategory = self.currentRefCategory === self.CATEGORY_RECENTLY_USED
-          ? self.CATEGORY_RECENTLY_USED
-          : currentModule.categories;
+        moduleCategory =
+          self.currentRefCategory === self.CATEGORY_RECENTLY_USED
+            ? self.CATEGORY_RECENTLY_USED
+            : currentModule.categories;
 
         // Check for same category
         if (self.currentRefCategory !== null) {
@@ -494,9 +495,10 @@ class AdminModuleController {
             counter[moduleCategory] = 0;
           }
 
-          defaultMax = moduleCategory === self.CATEGORY_RECENTLY_USED
-            ? self.DEFAULT_MAX_RECENTLY_USED
-            : self.DEFAULT_MAX_PER_CATEGORIES;
+          defaultMax =
+            moduleCategory === self.CATEGORY_RECENTLY_USED
+              ? self.DEFAULT_MAX_RECENTLY_USED
+              : self.DEFAULT_MAX_PER_CATEGORIES;
           if (counter[moduleCategory] >= defaultMax) {
             isVisible &= self.currentCategoryDisplay[moduleCategory];
           }
@@ -530,8 +532,8 @@ class AdminModuleController {
     $(window).on('beforeunload', () => {
       if (self.isUploadStarted === true) {
         return (
-          'It seems some critical operation are running, are you sure you want to change page? '
-          + 'It might cause some unexepcted behaviors.'
+          'It seems some critical operation are running, are you sure you want to change page? ' +
+          'It might cause some unexepcted behaviors.'
         );
       }
 
@@ -589,8 +591,8 @@ class AdminModuleController {
         beforeSend: () => {
           $(self.addonsLoginButtonSelector).show();
           $('button.btn[type="submit"]', self.addonsConnectForm).hide();
-        },
-      }).done((response) => {
+        }
+      }).done(response => {
         if (response.success === 1) {
           window.location.reload();
         } else {
@@ -618,7 +620,7 @@ class AdminModuleController {
     body.on('click', this.moduleImportFailureRetrySelector, () => {
       /* eslint-disable max-len */
       $(
-        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`,
+        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`
       ).fadeOut(() => {
         /**
          * Added timeout for a better render of animation
@@ -657,10 +659,10 @@ class AdminModuleController {
           event.stopPropagation();
           event.preventDefault();
         }
-      },
+      }
     );
 
-    body.on('click', this.moduleImportSelectFileManualSelector, (event) => {
+    body.on('click', this.moduleImportSelectFileManualSelector, event => {
       event.stopPropagation();
       event.preventDefault();
       /**
@@ -714,7 +716,7 @@ class AdminModuleController {
       error: (file, message) => {
         self.displayOnUploadError(message);
       },
-      complete: (file) => {
+      complete: file => {
         if (file.status !== 'error') {
           const responseObject = $.parseJSON(file.xhr.response);
           if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
@@ -724,7 +726,7 @@ class AdminModuleController {
         }
         // State that we have finish the process to unlock some actions
         self.isUploadStarted = false;
-      },
+      }
     };
 
     dropzone.dropzone($.extend(dropzoneOptions));
@@ -815,12 +817,12 @@ class AdminModuleController {
 
         // Install ajax call
         $.post(result.module.attributes.urls.install, {
-          'actionParams[confirmPrestaTrust]': '1',
+          'actionParams[confirmPrestaTrust]': '1'
         })
-          .done((data) => {
+          .done(data => {
             self.displayOnUploadDone(data[moduleName]);
           })
-          .fail((data) => {
+          .fail(data => {
             self.displayOnUploadError(data[moduleName]);
           })
           .always(() => {
@@ -859,10 +861,10 @@ class AdminModuleController {
   updateNotificationsCount(badge) {
     const destinationTabs = {
       to_configure: $('#subtab-AdminModulesNotifications'),
-      to_update: $('#subtab-AdminModulesUpdates'),
+      to_update: $('#subtab-AdminModulesUpdates')
     };
 
-    Object.keys(destinationTabs).forEach((destinationKey) => {
+    Object.keys(destinationTabs).forEach(destinationKey => {
       if (destinationTabs[destinationKey].length !== 0) {
         destinationTabs[destinationKey].find('.notification-counter').text(badge[destinationKey]);
       }
@@ -946,7 +948,7 @@ class AdminModuleController {
       'bulk-enable': 'enable',
       'bulk-disable-mobile': 'disable_mobile',
       'bulk-enable-mobile': 'enable_mobile',
-      'bulk-reset': 'reset',
+      'bulk-reset': 'reset'
     };
 
     // Note no grid selector used yet since we do not needed it at dev time
@@ -954,7 +956,7 @@ class AdminModuleController {
     // use this functionality elsewhere but "manage my module" section
     if (typeof bulkActionToUrl[requestedBulkAction] === 'undefined') {
       $.growl.error({
-        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction),
+        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction)
       });
       return false;
     }
@@ -976,7 +978,7 @@ class AdminModuleController {
         techName: moduleTechName,
         actionMenuObj: $(this)
           .closest('.module-checkbox-bulk-list')
-          .next(),
+          .next()
       });
     });
 
@@ -1023,7 +1025,7 @@ class AdminModuleController {
         actionMenuLink,
         forceDeletion,
         disableCacheClear,
-        requestEndCallback,
+        requestEndCallback
       );
     }
 
@@ -1050,7 +1052,7 @@ class AdminModuleController {
       $.each(actions, (index, moduleData) => {
         actionMenuLink = $(
           self.moduleCardController.moduleActionMenuLinkSelector + bulkModuleAction,
-          moduleData.actionMenuObj,
+          moduleData.actionMenuObj
         );
         if (actionMenuLink.length > 0) {
           menuLinks.push(actionMenuLink);
@@ -1058,7 +1060,7 @@ class AdminModuleController {
           $.growl.error({
             message: window.translate_javascripts['Bulk Action - Request not available for module']
               .replace('[1]', bulkModuleAction)
-              .replace('[2]', moduleData.techName),
+              .replace('[2]', moduleData.techName)
           });
         }
       });
@@ -1079,35 +1081,35 @@ class AdminModuleController {
 
       $.ajax({
         url: $this.data('url'),
-        dataType: 'json',
+        dataType: 'json'
       }).done(() => {
         $next.fadeOut();
       });
     });
 
     // "Upgrade All" button handler
-    $('body').on('click', self.upgradeAllSource, (event) => {
+    $('body').on('click', self.upgradeAllSource, event => {
       event.preventDefault();
-      const isMaintenanceMode = true;
+      const isMaintenanceMode = window.isShopMaintenance;
 
       // Modal body element
       const maintenanceLink = document.createElement('a');
       maintenanceLink.classList.add('btn', 'btn-primary', 'btn-lg');
-      maintenanceLink.setAttribute('href', '#');
-      maintenanceLink.innerHTML = 'Go to maintenance page';
+      maintenanceLink.setAttribute('href', window.moduleURLs.maintenancePage);
+      maintenanceLink.innerHTML = window.moduleTranslations.moduleModalUpdateMaintenance;
 
       const updateAllConfirmModal = new ConfirmModal(
         {
           id: 'confirm-module-update-modal',
-          confirmTitle: 'Are you sure you want to upgrade this module?',
-          closeButtonLabel: 'Cancel',
-          confirmButtonLabel: isMaintenanceMode ? 'Upgrade' : 'Upgrade anyway',
+          confirmTitle: window.moduleTranslations.singleModuleModalUpdateTitle,
+          closeButtonLabel: window.moduleTranslations.moduleModalUpdateCancel,
+          confirmButtonLabel: isMaintenanceMode
+            ? window.moduleTranslations.moduleModalUpdateUpgrade
+            : window.moduleTranslations.multipleModuleModalUpdateUpgrade,
           confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
-          confirmMessage: isMaintenanceMode
-            ? ''
-            : 'We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues.',
+          confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
           closable: true,
-          customButtons: isMaintenanceMode ? [] : [maintenanceLink],
+          customButtons: isMaintenanceMode ? [] : [maintenanceLink]
         },
         () => {
           if ($(self.upgradeAllTargets).length <= 0) {
@@ -1122,14 +1124,14 @@ class AdminModuleController {
             moduleTechName = moduleItemList.data('tech-name');
             modulesActions.push({
               techName: moduleTechName,
-              actionMenuObj: $('.module-actions', moduleItemList),
+              actionMenuObj: $('.module-actions', moduleItemList)
             });
           });
 
           this.performModulesAction(modulesActions, 'upgrade');
 
           return true;
-        },
+        }
       );
 
       updateAllConfirmModal.show();
@@ -1167,7 +1169,7 @@ class AdminModuleController {
   initSearchBlock() {
     const self = this;
     self.pstaggerInput = $('#module-search-bar').pstagger({
-      onTagsChanged: (tagList) => {
+      onTagsChanged: tagList => {
         self.currentTagsList = tagList;
         self.updateModuleVisibility();
       },
@@ -1177,10 +1179,10 @@ class AdminModuleController {
       },
       inputPlaceholder: window.translate_javascripts['Search - placeholder'],
       closingCross: true,
-      context: self,
+      context: self
     });
 
-    $('body').on('click', '.module-addons-search-link', (event) => {
+    $('body').on('click', '.module-addons-search-link', event => {
       event.preventDefault();
       event.stopPropagation();
       window.open($(this).attr('href'), '_blank');
@@ -1254,7 +1256,7 @@ class AdminModuleController {
         const $this = $(this);
         replaceFirstWordBy(
           $this.find('.module-search-result-wording'),
-          $this.next('.modules-list').find('.module-item').length,
+          $this.next('.modules-list').find('.module-item').length
         );
       });
 
@@ -1271,7 +1273,7 @@ class AdminModuleController {
       if (modulesCount === 0) {
         $('.module-addons-search-link').attr(
           'href',
-          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`,
+          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`
         );
       }
     }

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -167,7 +167,7 @@ class AdminModuleController {
   initFilterStatusDropdown() {
     const self = this;
     const body = $('body');
-    body.on('click', self.statusItemSelector, function() {
+    body.on('click', self.statusItemSelector, function () {
       // Get data from li DOM input
       self.currentRefStatus = parseInt($(this).data('status-ref'), 10);
       // Change dropdown label to set it to the current status' displayname
@@ -176,7 +176,7 @@ class AdminModuleController {
       self.updateModuleVisibility();
     });
 
-    body.on('click', self.statusResetBtnSelector, function() {
+    body.on('click', self.statusResetBtnSelector, function () {
       $(self.statusSelectorLabelSelector).text($(this).text());
       $(this).hide();
       self.currentRefStatus = null;
@@ -200,7 +200,7 @@ class AdminModuleController {
     body.on('click', self.bulkItemSelector, function initializeBodyChange() {
       if ($(self.getBulkCheckboxesCheckedSelector()).length === 0) {
         $.growl.warning({
-          message: window.translate_javascripts['Bulk Action - One module minimum']
+          message: window.translate_javascripts['Bulk Action - One module minimum'],
         });
         return;
       }
@@ -223,7 +223,7 @@ class AdminModuleController {
       $(self.bulkConfirmModalSelector).modal('show');
     });
 
-    body.on('click', this.bulkConfirmModalAckBtnSelector, event => {
+    body.on('click', this.bulkConfirmModalAckBtnSelector, (event) => {
       event.preventDefault();
       event.stopPropagation();
       $(self.bulkConfirmModalSelector).modal('hide');
@@ -264,9 +264,9 @@ class AdminModuleController {
 
     $.ajax({
       method: 'GET',
-      url: window.moduleURLs.catalogRefresh
+      url: window.moduleURLs.catalogRefresh,
     })
-      .done(response => {
+      .done((response) => {
         if (response.status === true) {
           if (typeof response.domElements === 'undefined') response.domElements = null;
           if (typeof response.msg === 'undefined') response.msg = null;
@@ -302,7 +302,7 @@ class AdminModuleController {
           });
         }
       })
-      .fail(response => {
+      .fail((response) => {
         $(self.placeholderGlobalSelector).fadeOut(800, () => {
           $(self.placeholderFailureMsgSelector).text(response.statusText);
           $(self.placeholderFailureGlobalSelector).fadeIn(800);
@@ -337,7 +337,7 @@ class AdminModuleController {
           active: parseInt($this.data('active'), 10),
           access: $this.data('last-access'),
           display: $this.hasClass('module-item-list') ? self.DISPLAY_LIST : self.DISPLAY_GRID,
-          container
+          container,
         });
 
         if (self.isModulesPage()) {
@@ -406,11 +406,11 @@ class AdminModuleController {
       const container = $(this);
       const nbModulesInContainer = container.find('.module-item').length;
       if (
-        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name'))) ||
-        (self.currentRefStatus !== null && nbModulesInContainer === 0) ||
-        (nbModulesInContainer === 0 &&
-          String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED) ||
-        (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
+        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name')))
+        || (self.currentRefStatus !== null && nbModulesInContainer === 0)
+        || (nbModulesInContainer === 0
+          && String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED)
+        || (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
       ) {
         container.hide();
         return;
@@ -449,11 +449,11 @@ class AdminModuleController {
     const counter = {};
     const checkTag = (index, value) => {
       newValue = value.toLowerCase();
-      tagExists |=
-        currentModule.name.indexOf(newValue) !== -1 ||
-        currentModule.description.indexOf(newValue) !== -1 ||
-        currentModule.author.indexOf(newValue) !== -1 ||
-        currentModule.techName.indexOf(newValue) !== -1;
+      tagExists
+        |= currentModule.name.indexOf(newValue) !== -1
+        || currentModule.description.indexOf(newValue) !== -1
+        || currentModule.author.indexOf(newValue) !== -1
+        || currentModule.techName.indexOf(newValue) !== -1;
     };
 
     for (let i = 0; i < modulesListLength; i += 1) {
@@ -461,10 +461,9 @@ class AdminModuleController {
       if (currentModule.display === self.currentDisplay) {
         isVisible = true;
 
-        moduleCategory =
-          self.currentRefCategory === self.CATEGORY_RECENTLY_USED
-            ? self.CATEGORY_RECENTLY_USED
-            : currentModule.categories;
+        moduleCategory = self.currentRefCategory === self.CATEGORY_RECENTLY_USED
+          ? self.CATEGORY_RECENTLY_USED
+          : currentModule.categories;
 
         // Check for same category
         if (self.currentRefCategory !== null) {
@@ -495,10 +494,9 @@ class AdminModuleController {
             counter[moduleCategory] = 0;
           }
 
-          defaultMax =
-            moduleCategory === self.CATEGORY_RECENTLY_USED
-              ? self.DEFAULT_MAX_RECENTLY_USED
-              : self.DEFAULT_MAX_PER_CATEGORIES;
+          defaultMax = moduleCategory === self.CATEGORY_RECENTLY_USED
+            ? self.DEFAULT_MAX_RECENTLY_USED
+            : self.DEFAULT_MAX_PER_CATEGORIES;
           if (counter[moduleCategory] >= defaultMax) {
             isVisible &= self.currentCategoryDisplay[moduleCategory];
           }
@@ -532,8 +530,8 @@ class AdminModuleController {
     $(window).on('beforeunload', () => {
       if (self.isUploadStarted === true) {
         return (
-          'It seems some critical operation are running, are you sure you want to change page? ' +
-          'It might cause some unexepcted behaviors.'
+          'It seems some critical operation are running, are you sure you want to change page? '
+          + 'It might cause some unexepcted behaviors.'
         );
       }
 
@@ -591,8 +589,8 @@ class AdminModuleController {
         beforeSend: () => {
           $(self.addonsLoginButtonSelector).show();
           $('button.btn[type="submit"]', self.addonsConnectForm).hide();
-        }
-      }).done(response => {
+        },
+      }).done((response) => {
         if (response.success === 1) {
           window.location.reload();
         } else {
@@ -620,7 +618,7 @@ class AdminModuleController {
     body.on('click', this.moduleImportFailureRetrySelector, () => {
       /* eslint-disable max-len */
       $(
-        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`
+        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`,
       ).fadeOut(() => {
         /**
          * Added timeout for a better render of animation
@@ -659,10 +657,10 @@ class AdminModuleController {
           event.stopPropagation();
           event.preventDefault();
         }
-      }
+      },
     );
 
-    body.on('click', this.moduleImportSelectFileManualSelector, event => {
+    body.on('click', this.moduleImportSelectFileManualSelector, (event) => {
       event.stopPropagation();
       event.preventDefault();
       /**
@@ -716,7 +714,7 @@ class AdminModuleController {
       error: (file, message) => {
         self.displayOnUploadError(message);
       },
-      complete: file => {
+      complete: (file) => {
         if (file.status !== 'error') {
           const responseObject = $.parseJSON(file.xhr.response);
           if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
@@ -726,7 +724,7 @@ class AdminModuleController {
         }
         // State that we have finish the process to unlock some actions
         self.isUploadStarted = false;
-      }
+      },
     };
 
     dropzone.dropzone($.extend(dropzoneOptions));
@@ -817,12 +815,12 @@ class AdminModuleController {
 
         // Install ajax call
         $.post(result.module.attributes.urls.install, {
-          'actionParams[confirmPrestaTrust]': '1'
+          'actionParams[confirmPrestaTrust]': '1',
         })
-          .done(data => {
+          .done((data) => {
             self.displayOnUploadDone(data[moduleName]);
           })
-          .fail(data => {
+          .fail((data) => {
             self.displayOnUploadError(data[moduleName]);
           })
           .always(() => {
@@ -861,10 +859,10 @@ class AdminModuleController {
   updateNotificationsCount(badge) {
     const destinationTabs = {
       to_configure: $('#subtab-AdminModulesNotifications'),
-      to_update: $('#subtab-AdminModulesUpdates')
+      to_update: $('#subtab-AdminModulesUpdates'),
     };
 
-    Object.keys(destinationTabs).forEach(destinationKey => {
+    Object.keys(destinationTabs).forEach((destinationKey) => {
       if (destinationTabs[destinationKey].length !== 0) {
         destinationTabs[destinationKey].find('.notification-counter').text(badge[destinationKey]);
       }
@@ -948,7 +946,7 @@ class AdminModuleController {
       'bulk-enable': 'enable',
       'bulk-disable-mobile': 'disable_mobile',
       'bulk-enable-mobile': 'enable_mobile',
-      'bulk-reset': 'reset'
+      'bulk-reset': 'reset',
     };
 
     // Note no grid selector used yet since we do not needed it at dev time
@@ -956,7 +954,7 @@ class AdminModuleController {
     // use this functionality elsewhere but "manage my module" section
     if (typeof bulkActionToUrl[requestedBulkAction] === 'undefined') {
       $.growl.error({
-        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction)
+        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction),
       });
       return false;
     }
@@ -978,7 +976,7 @@ class AdminModuleController {
         techName: moduleTechName,
         actionMenuObj: $(this)
           .closest('.module-checkbox-bulk-list')
-          .next()
+          .next(),
       });
     });
 
@@ -1025,7 +1023,7 @@ class AdminModuleController {
         actionMenuLink,
         forceDeletion,
         disableCacheClear,
-        requestEndCallback
+        requestEndCallback,
       );
     }
 
@@ -1052,7 +1050,7 @@ class AdminModuleController {
       $.each(actions, (index, moduleData) => {
         actionMenuLink = $(
           self.moduleCardController.moduleActionMenuLinkSelector + bulkModuleAction,
-          moduleData.actionMenuObj
+          moduleData.actionMenuObj,
         );
         if (actionMenuLink.length > 0) {
           menuLinks.push(actionMenuLink);
@@ -1060,7 +1058,7 @@ class AdminModuleController {
           $.growl.error({
             message: window.translate_javascripts['Bulk Action - Request not available for module']
               .replace('[1]', bulkModuleAction)
-              .replace('[2]', moduleData.techName)
+              .replace('[2]', moduleData.techName),
           });
         }
       });
@@ -1081,24 +1079,35 @@ class AdminModuleController {
 
       $.ajax({
         url: $this.data('url'),
-        dataType: 'json'
+        dataType: 'json',
       }).done(() => {
         $next.fadeOut();
       });
     });
 
     // "Upgrade All" button handler
-    $('body').on('click', self.upgradeAllSource, event => {
+    $('body').on('click', self.upgradeAllSource, (event) => {
       event.preventDefault();
+      const isMaintenanceMode = true;
+
+      // Modal body element
+      const maintenanceLink = document.createElement('a');
+      maintenanceLink.classList.add('btn', 'btn-primary', 'btn-lg');
+      maintenanceLink.setAttribute('href', '#');
+      maintenanceLink.innerHTML = 'Go to maintenance page';
 
       const updateAllConfirmModal = new ConfirmModal(
         {
           id: 'confirm-modal',
-          confirmTitle: 'Are you sure you want to upgrade these modules?',
+          confirmTitle: 'Are you sure you want to upgrade this module?',
           closeButtonLabel: 'Cancel',
-          confirmButtonLabel: 'Upgrade',
-          confirmButtonClass: 'btn-primary',
-          closable: true
+          confirmButtonLabel: isMaintenanceMode ? 'Upgrade' : 'Upgrade anyway',
+          confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
+          confirmMessage: isMaintenanceMode
+            ? ''
+            : 'We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues.',
+          closable: true,
+          customButtons: isMaintenanceMode ? [] : [maintenanceLink],
         },
         () => {
           if ($(self.upgradeAllTargets).length <= 0) {
@@ -1113,14 +1122,14 @@ class AdminModuleController {
             moduleTechName = moduleItemList.data('tech-name');
             modulesActions.push({
               techName: moduleTechName,
-              actionMenuObj: $('.module-actions', moduleItemList)
+              actionMenuObj: $('.module-actions', moduleItemList),
             });
           });
 
           this.performModulesAction(modulesActions, 'upgrade');
 
           return true;
-        }
+        },
       );
 
       updateAllConfirmModal.show();
@@ -1158,7 +1167,7 @@ class AdminModuleController {
   initSearchBlock() {
     const self = this;
     self.pstaggerInput = $('#module-search-bar').pstagger({
-      onTagsChanged: tagList => {
+      onTagsChanged: (tagList) => {
         self.currentTagsList = tagList;
         self.updateModuleVisibility();
       },
@@ -1168,10 +1177,10 @@ class AdminModuleController {
       },
       inputPlaceholder: window.translate_javascripts['Search - placeholder'],
       closingCross: true,
-      context: self
+      context: self,
     });
 
-    $('body').on('click', '.module-addons-search-link', event => {
+    $('body').on('click', '.module-addons-search-link', (event) => {
       event.preventDefault();
       event.stopPropagation();
       window.open($(this).attr('href'), '_blank');
@@ -1245,7 +1254,7 @@ class AdminModuleController {
         const $this = $(this);
         replaceFirstWordBy(
           $this.find('.module-search-result-wording'),
-          $this.next('.modules-list').find('.module-item').length
+          $this.next('.modules-list').find('.module-item').length,
         );
       });
 
@@ -1254,6 +1263,7 @@ class AdminModuleController {
       const modulesCount = $('.modules-list').find('.module-item').length;
       replaceFirstWordBy($('.module-search-result-wording'), modulesCount);
 
+      // eslint-disable-next-line
       const selectorToToggle =
         self.currentDisplay === self.DISPLAY_LIST ? this.addonItemListSelector : this.addonItemGridSelector;
       $(selectorToToggle).toggle(modulesCount !== this.modulesList.length / 2);
@@ -1261,7 +1271,7 @@ class AdminModuleController {
       if (modulesCount === 0) {
         $('.module-addons-search-link').attr(
           'href',
-          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`
+          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`,
         );
       }
     }

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -167,7 +167,7 @@ class AdminModuleController {
   initFilterStatusDropdown() {
     const self = this;
     const body = $('body');
-    body.on('click', self.statusItemSelector, function() {
+    body.on('click', self.statusItemSelector, function () {
       // Get data from li DOM input
       self.currentRefStatus = parseInt($(this).data('status-ref'), 10);
       // Change dropdown label to set it to the current status' displayname
@@ -176,7 +176,7 @@ class AdminModuleController {
       self.updateModuleVisibility();
     });
 
-    body.on('click', self.statusResetBtnSelector, function() {
+    body.on('click', self.statusResetBtnSelector, function () {
       $(self.statusSelectorLabelSelector).text($(this).text());
       $(this).hide();
       self.currentRefStatus = null;
@@ -200,7 +200,7 @@ class AdminModuleController {
     body.on('click', self.bulkItemSelector, function initializeBodyChange() {
       if ($(self.getBulkCheckboxesCheckedSelector()).length === 0) {
         $.growl.warning({
-          message: window.translate_javascripts['Bulk Action - One module minimum']
+          message: window.translate_javascripts['Bulk Action - One module minimum'],
         });
         return;
       }
@@ -223,7 +223,7 @@ class AdminModuleController {
       $(self.bulkConfirmModalSelector).modal('show');
     });
 
-    body.on('click', this.bulkConfirmModalAckBtnSelector, event => {
+    body.on('click', this.bulkConfirmModalAckBtnSelector, (event) => {
       event.preventDefault();
       event.stopPropagation();
       $(self.bulkConfirmModalSelector).modal('hide');
@@ -264,9 +264,9 @@ class AdminModuleController {
 
     $.ajax({
       method: 'GET',
-      url: window.moduleURLs.catalogRefresh
+      url: window.moduleURLs.catalogRefresh,
     })
-      .done(response => {
+      .done((response) => {
         if (response.status === true) {
           if (typeof response.domElements === 'undefined') response.domElements = null;
           if (typeof response.msg === 'undefined') response.msg = null;
@@ -302,7 +302,7 @@ class AdminModuleController {
           });
         }
       })
-      .fail(response => {
+      .fail((response) => {
         $(self.placeholderGlobalSelector).fadeOut(800, () => {
           $(self.placeholderFailureMsgSelector).text(response.statusText);
           $(self.placeholderFailureGlobalSelector).fadeIn(800);
@@ -337,7 +337,7 @@ class AdminModuleController {
           active: parseInt($this.data('active'), 10),
           access: $this.data('last-access'),
           display: $this.hasClass('module-item-list') ? self.DISPLAY_LIST : self.DISPLAY_GRID,
-          container
+          container,
         });
 
         if (self.isModulesPage()) {
@@ -406,11 +406,11 @@ class AdminModuleController {
       const container = $(this);
       const nbModulesInContainer = container.find('.module-item').length;
       if (
-        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name'))) ||
-        (self.currentRefStatus !== null && nbModulesInContainer === 0) ||
-        (nbModulesInContainer === 0 &&
-          String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED) ||
-        (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
+        (self.currentRefCategory && self.currentRefCategory !== String(container.find('.modules-list').data('name')))
+        || (self.currentRefStatus !== null && nbModulesInContainer === 0)
+        || (nbModulesInContainer === 0
+          && String(container.find('.modules-list').data('name')) === self.CATEGORY_RECENTLY_USED)
+        || (self.currentTagsList.length > 0 && nbModulesInContainer === 0)
       ) {
         container.hide();
         return;
@@ -449,11 +449,11 @@ class AdminModuleController {
     const counter = {};
     const checkTag = (index, value) => {
       newValue = value.toLowerCase();
-      tagExists |=
-        currentModule.name.indexOf(newValue) !== -1 ||
-        currentModule.description.indexOf(newValue) !== -1 ||
-        currentModule.author.indexOf(newValue) !== -1 ||
-        currentModule.techName.indexOf(newValue) !== -1;
+      tagExists
+        |= currentModule.name.indexOf(newValue) !== -1
+        || currentModule.description.indexOf(newValue) !== -1
+        || currentModule.author.indexOf(newValue) !== -1
+        || currentModule.techName.indexOf(newValue) !== -1;
     };
 
     for (let i = 0; i < modulesListLength; i += 1) {
@@ -461,10 +461,9 @@ class AdminModuleController {
       if (currentModule.display === self.currentDisplay) {
         isVisible = true;
 
-        moduleCategory =
-          self.currentRefCategory === self.CATEGORY_RECENTLY_USED
-            ? self.CATEGORY_RECENTLY_USED
-            : currentModule.categories;
+        moduleCategory = self.currentRefCategory === self.CATEGORY_RECENTLY_USED
+          ? self.CATEGORY_RECENTLY_USED
+          : currentModule.categories;
 
         // Check for same category
         if (self.currentRefCategory !== null) {
@@ -495,10 +494,9 @@ class AdminModuleController {
             counter[moduleCategory] = 0;
           }
 
-          defaultMax =
-            moduleCategory === self.CATEGORY_RECENTLY_USED
-              ? self.DEFAULT_MAX_RECENTLY_USED
-              : self.DEFAULT_MAX_PER_CATEGORIES;
+          defaultMax = moduleCategory === self.CATEGORY_RECENTLY_USED
+            ? self.DEFAULT_MAX_RECENTLY_USED
+            : self.DEFAULT_MAX_PER_CATEGORIES;
           if (counter[moduleCategory] >= defaultMax) {
             isVisible &= self.currentCategoryDisplay[moduleCategory];
           }
@@ -532,8 +530,8 @@ class AdminModuleController {
     $(window).on('beforeunload', () => {
       if (self.isUploadStarted === true) {
         return (
-          'It seems some critical operation are running, are you sure you want to change page? ' +
-          'It might cause some unexepcted behaviors.'
+          'It seems some critical operation are running, are you sure you want to change page? '
+          + 'It might cause some unexepcted behaviors.'
         );
       }
 
@@ -591,8 +589,8 @@ class AdminModuleController {
         beforeSend: () => {
           $(self.addonsLoginButtonSelector).show();
           $('button.btn[type="submit"]', self.addonsConnectForm).hide();
-        }
-      }).done(response => {
+        },
+      }).done((response) => {
         if (response.success === 1) {
           window.location.reload();
         } else {
@@ -620,7 +618,7 @@ class AdminModuleController {
     body.on('click', this.moduleImportFailureRetrySelector, () => {
       /* eslint-disable max-len */
       $(
-        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`
+        `${self.moduleImportSuccessSelector},${self.moduleImportFailureSelector},${self.moduleImportProcessingSelector}`,
       ).fadeOut(() => {
         /**
          * Added timeout for a better render of animation
@@ -659,10 +657,10 @@ class AdminModuleController {
           event.stopPropagation();
           event.preventDefault();
         }
-      }
+      },
     );
 
-    body.on('click', this.moduleImportSelectFileManualSelector, event => {
+    body.on('click', this.moduleImportSelectFileManualSelector, (event) => {
       event.stopPropagation();
       event.preventDefault();
       /**
@@ -716,7 +714,7 @@ class AdminModuleController {
       error: (file, message) => {
         self.displayOnUploadError(message);
       },
-      complete: file => {
+      complete: (file) => {
         if (file.status !== 'error') {
           const responseObject = $.parseJSON(file.xhr.response);
           if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
@@ -726,7 +724,7 @@ class AdminModuleController {
         }
         // State that we have finish the process to unlock some actions
         self.isUploadStarted = false;
-      }
+      },
     };
 
     dropzone.dropzone($.extend(dropzoneOptions));
@@ -817,12 +815,12 @@ class AdminModuleController {
 
         // Install ajax call
         $.post(result.module.attributes.urls.install, {
-          'actionParams[confirmPrestaTrust]': '1'
+          'actionParams[confirmPrestaTrust]': '1',
         })
-          .done(data => {
+          .done((data) => {
             self.displayOnUploadDone(data[moduleName]);
           })
-          .fail(data => {
+          .fail((data) => {
             self.displayOnUploadError(data[moduleName]);
           })
           .always(() => {
@@ -861,10 +859,10 @@ class AdminModuleController {
   updateNotificationsCount(badge) {
     const destinationTabs = {
       to_configure: $('#subtab-AdminModulesNotifications'),
-      to_update: $('#subtab-AdminModulesUpdates')
+      to_update: $('#subtab-AdminModulesUpdates'),
     };
 
-    Object.keys(destinationTabs).forEach(destinationKey => {
+    Object.keys(destinationTabs).forEach((destinationKey) => {
       if (destinationTabs[destinationKey].length !== 0) {
         destinationTabs[destinationKey].find('.notification-counter').text(badge[destinationKey]);
       }
@@ -948,7 +946,7 @@ class AdminModuleController {
       'bulk-enable': 'enable',
       'bulk-disable-mobile': 'disable_mobile',
       'bulk-enable-mobile': 'enable_mobile',
-      'bulk-reset': 'reset'
+      'bulk-reset': 'reset',
     };
 
     // Note no grid selector used yet since we do not needed it at dev time
@@ -956,7 +954,7 @@ class AdminModuleController {
     // use this functionality elsewhere but "manage my module" section
     if (typeof bulkActionToUrl[requestedBulkAction] === 'undefined') {
       $.growl.error({
-        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction)
+        message: window.translate_javascripts['Bulk Action - Request not found'].replace('[1]', requestedBulkAction),
       });
       return false;
     }
@@ -978,7 +976,7 @@ class AdminModuleController {
         techName: moduleTechName,
         actionMenuObj: $(this)
           .closest('.module-checkbox-bulk-list')
-          .next()
+          .next(),
       });
     });
 
@@ -1025,7 +1023,7 @@ class AdminModuleController {
         actionMenuLink,
         forceDeletion,
         disableCacheClear,
-        requestEndCallback
+        requestEndCallback,
       );
     }
 
@@ -1052,7 +1050,7 @@ class AdminModuleController {
       $.each(actions, (index, moduleData) => {
         actionMenuLink = $(
           self.moduleCardController.moduleActionMenuLinkSelector + bulkModuleAction,
-          moduleData.actionMenuObj
+          moduleData.actionMenuObj,
         );
         if (actionMenuLink.length > 0) {
           menuLinks.push(actionMenuLink);
@@ -1060,7 +1058,7 @@ class AdminModuleController {
           $.growl.error({
             message: window.translate_javascripts['Bulk Action - Request not available for module']
               .replace('[1]', bulkModuleAction)
-              .replace('[2]', moduleData.techName)
+              .replace('[2]', moduleData.techName),
           });
         }
       });
@@ -1081,14 +1079,14 @@ class AdminModuleController {
 
       $.ajax({
         url: $this.data('url'),
-        dataType: 'json'
+        dataType: 'json',
       }).done(() => {
         $next.fadeOut();
       });
     });
 
     // "Upgrade All" button handler
-    $('body').on('click', self.upgradeAllSource, event => {
+    $('body').on('click', self.upgradeAllSource, (event) => {
       event.preventDefault();
       const isMaintenanceMode = window.isShopMaintenance;
 
@@ -1109,7 +1107,7 @@ class AdminModuleController {
           confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
           confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
           closable: true,
-          customButtons: isMaintenanceMode ? [] : [maintenanceLink]
+          customButtons: isMaintenanceMode ? [] : [maintenanceLink],
         },
         () => {
           if ($(self.upgradeAllTargets).length <= 0) {
@@ -1124,14 +1122,14 @@ class AdminModuleController {
             moduleTechName = moduleItemList.data('tech-name');
             modulesActions.push({
               techName: moduleTechName,
-              actionMenuObj: $('.module-actions', moduleItemList)
+              actionMenuObj: $('.module-actions', moduleItemList),
             });
           });
 
           this.performModulesAction(modulesActions, 'upgrade');
 
           return true;
-        }
+        },
       );
 
       updateAllConfirmModal.show();
@@ -1169,7 +1167,7 @@ class AdminModuleController {
   initSearchBlock() {
     const self = this;
     self.pstaggerInput = $('#module-search-bar').pstagger({
-      onTagsChanged: tagList => {
+      onTagsChanged: (tagList) => {
         self.currentTagsList = tagList;
         self.updateModuleVisibility();
       },
@@ -1179,10 +1177,10 @@ class AdminModuleController {
       },
       inputPlaceholder: window.translate_javascripts['Search - placeholder'],
       closingCross: true,
-      context: self
+      context: self,
     });
 
-    $('body').on('click', '.module-addons-search-link', event => {
+    $('body').on('click', '.module-addons-search-link', (event) => {
       event.preventDefault();
       event.stopPropagation();
       window.open($(this).attr('href'), '_blank');
@@ -1256,7 +1254,7 @@ class AdminModuleController {
         const $this = $(this);
         replaceFirstWordBy(
           $this.find('.module-search-result-wording'),
-          $this.next('.modules-list').find('.module-item').length
+          $this.next('.modules-list').find('.module-item').length,
         );
       });
 
@@ -1273,7 +1271,7 @@ class AdminModuleController {
       if (modulesCount === 0) {
         $('.module-addons-search-link').attr(
           'href',
-          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`
+          `${this.baseAddonsUrl}search.php?search_query=${encodeURIComponent(this.currentTagsList.join(' '))}`,
         );
       }
     }

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -1103,7 +1103,7 @@ class AdminModuleController {
           closeButtonLabel: window.moduleTranslations.moduleModalUpdateCancel,
           confirmButtonLabel: isMaintenanceMode
             ? window.moduleTranslations.moduleModalUpdateUpgrade
-            : window.moduleTranslations.multipleModuleModalUpdateUpgrade,
+            : window.moduleTranslations.upgradeAnywayButtonText,
           confirmButtonClass: isMaintenanceMode ? 'btn-primary' : 'btn-secondary',
           confirmMessage: isMaintenanceMode ? '' : window.moduleTranslations.moduleModalUpdateConfirmMessage,
           closable: true,

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -36,7 +36,7 @@
     };
 
     var moduleTranslations = {
-      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Feature') }}',
+      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Notification') }}',
       'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Feature') }}',
       'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -38,15 +38,15 @@
     var moduleTranslations = {
       'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Feature') }}',
       'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Feature') }}',
-      'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}', 
-      'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}', 
-      'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}', 
-      'multipleModuleModalUpdateUpgrade': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}', 
-      'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Feature') }}', 
+      'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
+      'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',
+      'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}',
+      'multipleModuleModalUpdateUpgrade': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
+      'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Feature') }}',
     };
 
     // Need to come from the backend
-    var isShopMaintenance = true; 
+    var isShopMaintenance = !{{ 'PS_SHOP_ENABLE'|configuration|intCast }};
   </script>
   <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/module.bundle.js') }}"></script>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -32,7 +32,21 @@
       'configurationPage': '{{ path('admin_module_configure_action', {'module_name': ':number:'})|e('js') }}',
       'moduleImport': '{{ path('admin_module_import')|e('js') }}',
       'notificationsCount': '{{ path('admin_module_notification_count')|e('js') }}',
+      'maintenancePage': '{{ path('admin_maintenance')|e('js') }}',
     };
+
+    var moduleTranslations = {
+      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Feature') }}',
+      'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Feature') }}',
+      'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}', 
+      'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}', 
+      'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}', 
+      'multipleModuleModalUpdateUpgrade': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}', 
+      'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Feature') }}', 
+    };
+
+    // Need to come from the backend
+    var isShopMaintenance = true; 
   </script>
   <script src="{{ asset('themes/default/js/bundle/plugins/jquery.pstagger.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/module.bundle.js') }}"></script>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -41,7 +41,7 @@
       'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}',
-      'multipleModuleModalUpdateUpgrade': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
+      'upgradeAnywayButtonText': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Feature') }}',
     };
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -37,12 +37,12 @@
 
     var moduleTranslations = {
       'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Notification') }}',
-      'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Feature') }}',
+      'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Notification') }}',
       'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
-      'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Feature') }}',
+      'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Notification') }}',
     };
 
     // Need to come from the backend


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Updating module without confirm leads to bugs and problems when updating a module in production
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #14039.
| How to test?  | Go on module page, click on "Update" on a module out of date, also try the "Update All" on the Update tab

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22316)
<!-- Reviewable:end -->
