### PR TITLE
Allow extending Order-create form summary 

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/CartSummaryFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CartSummaryFormDataHandler.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddOrderFromBackOfficeCommand;
+
+/**
+ * Handles cart summary data
+ */
+class CartSummaryFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @var int
+     */
+    private $contextEmployeeId;
+
+    /**
+     * @param CommandBusInterface $commandBus
+     * @param int $contextEmployeeId
+     */
+    public function __construct(
+        CommandBusInterface $commandBus,
+        int $contextEmployeeId
+    ) {
+        $this->commandBus = $commandBus;
+        $this->contextEmployeeId = $contextEmployeeId;
+    }
+
+    /**
+     * Creates new Order from cart summary
+     *
+     * {@inheritdoc}
+     */
+    public function create(array $data)
+    {
+        return $this->commandBus->handle(new AddOrderFromBackOfficeCommand(
+            (int) $data['cart_id'],
+            (int) $this->contextEmployeeId,
+            $data['order_message'],
+            $data['payment_module'],
+            (int) $data['order_state']
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($id, array $data)
+    {
+        // not used for edition, only creation
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -165,3 +165,9 @@ services:
     arguments:
       - '@prestashop.core.command_bus'
       - '@prestashop.core.query_bus'
+
+  prestashop.core.form.identifiable_object.data_handler.cart_summary_form_data_handler:
+      class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CartSummaryFormDataHandler'
+      arguments:
+          - '@prestashop.core.command_bus'
+          - '@=service("prestashop.adapter.legacy.context").getContext().employee.id'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -177,3 +177,9 @@ services:
     factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
     arguments:
       - '@prestashop.core.form.identifiable_object.cancellation_form_data_handler'
+
+  prestashop.core.form.identifiable_object.handler.cart_summary_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: 'prestashop.core.form.identifiable_object.handler.form_handler_factory:create'
+    arguments:
+      - '@prestashop.core.form.identifiable_object.data_handler.cart_summary_form_data_handler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -110,7 +110,9 @@
             'label': 'Order status'|trans({}, 'Admin.Orderscustomers.Feature'),
           }) }}
 
-          {{ form_rest(summaryForm) }}
+          {% block cart_summary_form_rest %}
+            {{ form_rest(summaryForm) }}
+          {% endblock %}
 
           <div class="form-group row mt-4">
             <div class="col-sm offset-sm-4">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -110,6 +110,8 @@
             'label': 'Order status'|trans({}, 'Admin.Orderscustomers.Feature'),
           }) }}
 
+          {{ form_rest(summaryForm) }}
+
           <div class="form-group row mt-4">
             <div class="col-sm offset-sm-4">
               <button class="btn btn-primary" type="submit" id="create-order-button">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  1.7.7.x
| Description?  | see bellow
| Type?         | improvement/bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #22321
| How to test?  | Open Sell > Catalog> Orders > add new Order page and check that after filling information order is created as usual. Additional tests can be done to assure extendability by using FormBuilder and FormHandler from module hooks as usual.

**DESCRIPTION**
* Use FormHandler in OrderController::placeOrderAction to take advantage of handler hooks
* Add missing form_rest in summary.html.twig just before the save button (that fixes broken field rendering when its extended using formbuilder (screenshot1))

**Screenshots:**
1. 
![Screenshot from 2020-12-09 18-52-09](https://user-images.githubusercontent.com/31609858/101675069-f913df80-3a61-11eb-904a-b64474339996.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22320)
<!-- Reviewable:end -->
