### PR TITLE
Configuration should be a twig function and not a twig filter

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
@@ -61,7 +61,7 @@
             <a href="{{ product.url|default('') }}#tab-step2">{{ product.price_final|default('N/A'|trans({}, 'Admin.Global')) }}</a>
         </td>
 
-        {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+        {% if configuration('PS_STOCK_MANAGEMENT') %}
             <td class="product-sav-quantity text-center" data-product-quantity-value="{{ product.sav_quantity|default('') }}">
                 <a href="{{ product.url|default('') }}#tab-step3">
                     {% if product.sav_quantity is defined and product.sav_quantity > 0 %}
@@ -75,8 +75,8 @@
             <td></td>
         {% endif %}
         <td class="text-center">
-          
-          <div 
+
+          <div
             class="ps-switch ps-switch-sm ps-switch-nolabel ps-switch-center"
             onclick="unitProductAction(this, {% if product.active|default(0) == 0 %}'activate'{% else %}'deactivate'{% endif %});"
           >

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list_quicknav.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list_quicknav.html.twig
@@ -40,7 +40,7 @@
                     <th class="hidden-xs hidden-sm">
                         {{ "Price"|trans({}, 'Admin.Global') }}
                     </th>
-                    {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+                    {% if configuration('PS_STOCK_MANAGEMENT') %}
                         <th class="hidden-xs">
                             {{ "Quantity"|trans({}, 'Admin.Catalog.Feature') }}
                         </th>
@@ -59,7 +59,7 @@
                         <td class="hidden-xs hidden-sm">
                             <a href="{{ product.url|default('') }}#tab-step2">{{ product.price|default('N/A'|trans({}, 'Admin.Global')) }}</a>
                         </td>
-                        {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+                        {% if configuration('PS_STOCK_MANAGEMENT') %}
                             <td class="hidden-xs product-sav-quantity"
                                 productquantityvalue="{{ product.sav_quantity|default('') }}">
                                 <a href="{{ product.url|default('') }}#tab-step3">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -60,7 +60,7 @@
             {{ "Price (tax incl.)"|trans({}, 'Admin.Catalog.Feature') }}
           </th>
 
-          {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+          {% if configuration('PS_STOCK_MANAGEMENT') %}
           <th scope="col" class="text-center" style="width: 9%">
             {{ ps.sortable_column_header("Quantity"|trans({}, 'Admin.Catalog.Feature'), 'sav_quantity', orderBy, sortOrder) }}
           </th>
@@ -139,7 +139,7 @@
             } %}
           </th>
           <th class="text-center"></th>
-          {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+          {% if configuration('PS_STOCK_MANAGEMENT') %}
           <th class="text-center">
             {% include '@PrestaShop/Admin/Helpers/range_inputs.html.twig' with {
               'input_name': "filter_column_sav_quantity",

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig
@@ -34,7 +34,7 @@
 
     <div class="col-xxl-10">
       <div class="row">
-        <div class="col-md-7 big-input {{ 'PS_FORCE_FRIENDLY_PRODUCT'|configuration == 1 ? 'friendly-url-force-update' : '' }}" id="form_step1_names">
+        <div class="col-md-7 big-input {{ configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 ? 'friendly-url-force-update' : '' }}" id="form_step1_names">
           {{ form_widget(formName) }}
         </div>
         <div class="col-sm-7 col-md-2 form_step1_type_product">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
@@ -37,7 +37,7 @@
     <td class="attribute-finalprice text-sm-right">
       <span data-price="{{ form.vars.value.final_price }}" data-uniqid="{{ form.vars.value.id_product_attribute }}">{{ form.vars.value.final_price }}</span> {{ default_currency_symbol }}
     </td>
-    {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+    {% if configuration('PS_STOCK_MANAGEMENT') %}
       <td class="attribute-quantity">
           <div>
               <input type="text" value="{{ form.vars.value.attribute_quantity }}" class="form-control text-sm-right">
@@ -65,7 +65,7 @@
                 </h2>
                 {{ form_widget(form.attribute_default) }}
                 <div class="row">
-                  {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+                  {% if configuration('PS_STOCK_MANAGEMENT') %}
                     <div class="col-md-2">
                       <fieldset class="form-group">
                           <label class="form-control-label">
@@ -165,7 +165,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-3 {% if 'PS_USE_ECOTAX'|configuration != 1 %}hide{% endif %}">
+                    <div class="col-md-3 {% if configuration('PS_USE_ECOTAX') != 1 %}hide{% endif %}">
                         <fieldset class="form-group">
                             <label class="form-control-label">{{ form.attribute_ecotax.vars.label }}</label>
                             {{ form_errors(form.attribute_ecotax) }}
@@ -188,7 +188,7 @@
                             <label class="form-control-label">{{ form.attribute_weight.vars.label }}</label>
                             <div class="input-group">
                                 <div class="input-group-prepend">
-                                    <span class="input-group-text">{{ 'PS_WEIGHT_UNIT'|configuration }}</span>
+                                    <span class="input-group-text">{{ configuration('PS_WEIGHT_UNIT') }}</span>
                                 </div>
                                 {{ form_errors(form.attribute_weight) }}
                                 {{ form_widget(form.attribute_weight) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -87,13 +87,13 @@
             <th>{{ 'Combinations'|trans({}, 'Admin.Catalog.Feature') }}</th>
             <th>{{ 'Impact on price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
             <th>{{ 'Final price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
-            {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+            {% if configuration('PS_STOCK_MANAGEMENT') %}
                 <th>{{ 'Quantity'|trans({}, 'Admin.Catalog.Feature') }}</th>
             {% endif %}
             <th colspan="3" class="text-sm-right">{{ 'Default combination'|trans({}, 'Admin.Catalog.Feature') }}</th>
           </tr>
         </thead>
-        <tbody class="js-combinations-list panel-group accordion" id="accordion_combinations" data-action-delete-all="{{ path('admin_delete_all_attributes', { 'idProduct': 1 }) }}" data-weight-unit="{{ 'PS_WEIGHT_UNIT'|configuration }}" data-action-refresh-images="{{ path('admin_get_form_images_combination', { 'idProduct': 1 }) }}"  data-id-product= {{ id_product }} data-ids-product-attribute="{{ ids_product_attribute }}" data-combinations-url="{{ path('admin_combination_generate_form', { 'combinationIds': ':numbers' }) }}">
+        <tbody class="js-combinations-list panel-group accordion" id="accordion_combinations" data-action-delete-all="{{ path('admin_delete_all_attributes', { 'idProduct': 1 }) }}" data-weight-unit="{{ configuration('PS_WEIGHT_UNIT') }}" data-action-refresh-images="{{ path('admin_get_form_images_combination', { 'idProduct': 1 }) }}"  data-id-product= {{ id_product }} data-ids-product-attribute="{{ ids_product_attribute }}" data-combinations-url="{{ path('admin_combination_generate_form', { 'combinationIds': ':numbers' }) }}">
           {% if has_combinations %}
             <tr class="combination loading timeline-wrapper" id="loading-attribute">
               <td class="timeline-item" width="1%">
@@ -110,7 +110,7 @@
               <td class="attribute-finalprice">
                 <div class="animated-background"></div>
               </td>
-              {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+              {% if configuration('PS_STOCK_MANAGEMENT') %}
                 <td class="attribute-quantity">
                   <div class="animated-background"></div>
                 </td>
@@ -171,7 +171,7 @@
     <div class="col-md-12">
       <h2>{{ 'Availability preferences'|trans({}, 'Admin.Catalog.Feature') }}</h2>
     </div>
-    {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+    {% if configuration('PS_STOCK_MANAGEMENT') %}
       <div class="col-md-12">
         <label class="form-control-label">{{ 'Behavior when out of stock'|trans({}, 'Admin.Catalog.Feature') }}</label>
         {{ form_errors(form.out_of_stock) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div class="row" id="bulk-combinations-container-fields">
-  {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+  {% if configuration('PS_STOCK_MANAGEMENT') %}
     <div class="col-lg-4 col-md-3 col-sm-6">
       <label class="form-control-label">{{ form.quantity.vars.label }}</label>
       {{ form_errors(form.quantity) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
@@ -73,7 +73,7 @@
     <div class="col-md-9">
       <div class="alert alert-info" role="alert">
         <p class="alert-text">
-          {% if 'PS_REWRITING_SETTINGS'|configuration == 0 %}
+          {% if configuration('PS_REWRITING_SETTINGS') == 0 %}
             <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
             {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
           {% else %}
@@ -82,7 +82,7 @@
           {% endif %}
         </p>
         <p class="alert-text">
-          {% if 'PS_FORCE_FRIENDLY_PRODUCT'|configuration == 1 %}
+          {% if configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 %}
             <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
             {# "It" refers to the option "Force update of friendly URL" #}
             {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{% set dimension_unit, weight_unit = 'PS_DIMENSION_UNIT'|configuration, 'PS_WEIGHT_UNIT'|configuration %}
+{% set dimension_unit, weight_unit = configuration('PS_DIMENSION_UNIT'), configuration('PS_WEIGHT_UNIT') %}
 
 <div class="col-md-12 pb-1">
   <h2>{{ 'Package dimension'|trans({}, 'Admin.Catalog.Feature') }}</h2>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig
@@ -34,7 +34,7 @@
               <h2>{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</h2>
               <fieldset class="form-group">
                 <div class="row">
-                  {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+                  {% if configuration('PS_STOCK_MANAGEMENT') %}
                     <div class="col-md-4">
                       <label class="form-control-label">{{ formStockQuantity.vars.label }}</label>
                       {{ form_errors(formStockQuantity) }}
@@ -168,7 +168,7 @@
                 </div>
               </div>
             {% endif %}
-            {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+            {% if configuration('PS_STOCK_MANAGEMENT') %}
               <div id="pack_stock_type">
                 <h2>{{ formPackStockType.vars.label }}</h2>
                 <div class="row col-md-4">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
@@ -40,7 +40,7 @@
               <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12"
                   url-upload="{{ path('admin_product_image_upload', {'idProduct': productId}) }}"
                   url-position="{{ path('admin_product_image_positions') }}"
-                  data-max-size="{{ 'PS_LIMIT_UPLOAD_IMAGE_VALUE'|configuration }}"
+                  data-max-size="{{ configuration('PS_LIMIT_UPLOAD_IMAGE_VALUE') }}"
               >
                 <div id="product-images-dropzone-error" class="text-danger"></div>
                 <div class="dz-default dz-message openfilemanager">
@@ -186,7 +186,7 @@
                     </div>
                   </div>
 
-                  {% if 'PS_STOCK_MANAGEMENT'|configuration %}
+                  {% if configuration('PS_STOCK_MANAGEMENT') %}
                     <div class="form-group mb-4" id="product_qty_0_shortcut_div">
                       <h2>
                         {{ "Quantity"|trans({}, 'Admin.Catalog.Feature') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
@@ -66,7 +66,7 @@
                   </div>
                 </div>
               </div>
-              <div class="col-md-2 col-md-offset-1 {% if 'PS_USE_ECOTAX'|configuration != 1 %}hide{% endif %}">
+              <div class="col-md-2 col-md-offset-1 {% if configuration('PS_USE_ECOTAX') != 1 %}hide{% endif %}">
                 <label class="form-control-label">{{ pricingForm.ecotax.vars.label }}</label>
                 {{ form_errors(pricingForm.ecotax) }}
                 {{ form_widget(pricingForm.ecotax) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
@@ -36,7 +36,7 @@
         </button>
       </div>
       <div class="modal-body">
-        {% if not 'PS_ORDER_RECALCULATE_SHIPPING'|configuration %}
+        {% if not configuration('PS_ORDER_RECALCULATE_SHIPPING') %}
           <div class="alert alert-info" role="alert">
             <p class="alert-text">
               {{ 'Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings'|trans({}, 'Admin.Orderscustomers.Notification') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -230,7 +230,7 @@
                   '[/1]': '</strong>'
                   }, 'Admin.Orderscustomers.Notification')|raw }}.
 
-                {% if not 'PS_ORDER_RETURN'|configuration %}
+                {% if not configuration('PS_ORDER_RETURN') %}
                   <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
                 {% endif %}
               </small>

--- a/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/layout.html.twig
@@ -49,7 +49,7 @@
 {% block translate_javascripts %}
   <script>
     var translate_javascripts = {{ js_translatable|json_encode()|raw }};
-    var PS_ALLOW_ACCENTED_CHARS_URL = {{ 'PS_ALLOW_ACCENTED_CHARS_URL'|configuration|intCast }};
+    var PS_ALLOW_ACCENTED_CHARS_URL = {{ configuration('PS_ALLOW_ACCENTED_CHARS_URL')|intCast }};
   </script>
 {% endblock %}
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -31,8 +31,8 @@ use Exception;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
-use Twig\Extension\GlobalsInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Twig\Extension\GlobalsInterface;
 
 /**
  * This class is used by Twig_Environment and provide layout methods callable from a twig template.

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use Twig\Extension\GlobalsInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * This class is used by Twig_Environment and provide layout methods callable from a twig template.
@@ -112,7 +113,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('configuration', [$this, 'getConfiguration']),
+            new \Twig_SimpleFilter('configuration', [$this, 'getConfiguration'], ['deprecated' => true]),
         ];
     }
 
@@ -127,6 +128,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
             new \Twig_SimpleFunction('getLegacyLayout', [$this, 'getLegacyLayout']),
             new \Twig_SimpleFunction('getAdminLink', [$this, 'getAdminLink']),
             new \Twig_SimpleFunction('youtube_link', [$this, 'getYoutubeLink']),
+            new \Twig_SimpleFunction('configuration', [$this, 'getConfiguration']),
         ];
     }
 
@@ -134,12 +136,14 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
      * Returns a legacy configuration key.
      *
      * @param string $key
+     * @param mixed $default Default value is null
+     * @param ShopConstraint $shopConstraint Default value is null
      *
-     * @return array An array of functions
+     * @return mixed
      */
-    public function getConfiguration($key)
+    public function getConfiguration($key, $default = null, ShopConstraint $shopConstraint = null)
     {
-        return $this->configuration->get($key);
+        return $this->configuration->get($key, $default, $shopConstraint);
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Configuration should be a twig function and not a twig filter. And allow user to use the default and shopConstraint parameters.
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | yes
| How to test?  | No need QA, tests are green.

This is what you get when calling `'PS_SHOP_ENABLE'|configuration` instead of `configuration('PS_SHOP_ENABLE')`
![image](https://user-images.githubusercontent.com/1462701/101765012-07551080-3ae1-11eb-8d01-282aaaa66148.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22331)
<!-- Reviewable:end -->
