### PR TITLE
Hide recommended modules and help on mobile view in the BO

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -77,9 +77,11 @@
         justify-content: flex-start;
       }
 
-      #recommended-modules-button,
-      .btn-help {
-        display: none;
+      @include media-breakpoint-down(sm) {
+        #recommended-modules-button,
+        .btn-help {
+          display: none;
+        }
       }
 
       a + a {

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -77,6 +77,11 @@
         justify-content: flex-start;
       }
 
+      #recommended-modules-button,
+      .btn-help {
+        display: none;
+      }
+
       a + a {
         margin-left: $grid-gutter-width / 2;
       }

--- a/admin-dev/themes/new-theme/scss/pages/product/products_catalog.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/products_catalog.scss
@@ -16,6 +16,11 @@
 
     .row {
       align-items: center;
+
+      @include media-breakpoint-down(sm) {
+        margin-right: 0;
+        margin-left: 0;
+      }
     }
   }
 

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -75,7 +75,7 @@
                   {l s='Help' d='Admin.Global'}
                 </a>
               {else}
-                <a class="btn btn-outline-secondary" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
+                <a class="btn btn-outline-secondary btn-help" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
                   {l s='Help' d='Admin.Global'}
                 </a>
               {/if}

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -151,7 +151,6 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $isProductPage = ('AdminProducts' === $this->controller_name);
 
         $vars = [
-            'viewport_scale' => '1',
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'headerTabContent' => $this->headerTabContent,

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -151,7 +151,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $isProductPage = ('AdminProducts' === $this->controller_name);
 
         $vars = [
-            'viewport_scale' => $isProductPage ? '0.75' : '1',
+            'viewport_scale' => '1',
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'headerTabContent' => $this->headerTabContent,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | These buttons are not needed on mobile, and they increase height of header which is bad in term of UX
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22344.
| How to test?  | Build assets, open any migrated pages on mobile, recommended modules and help buttons should not be shown

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22349)
<!-- Reviewable:end -->
