### PR TITLE
Remove breadcrumb on responsive mobile

### DIFF
--- a/admin-dev/themes/default/sass/partials/_content.sass
+++ b/admin-dev/themes/default/sass/partials/_content.sass
@@ -18,7 +18,7 @@ body
 				h4.page-subtitle
 					@include left($paddingLeftMobile)
 				ul.page-breadcrumb
-					@include left($paddingLeftMobile)
+          display: none
 
 #main
 	z-index: 10

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -57,10 +57,15 @@
   }
 
   // breadcrumb
-  nav > ol {
-    padding-left: 0;
-  }
+  nav {
+    @include media-breakpoint-down(sm) {
+      display: none;
+    }
 
+    > ol {
+      padding-left: 0;
+    }
+  }
   // toolbar buttons
   .toolbar-icons {
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Breadcrumb on mobile is useless and increase height of header which is too big
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22355.
| How to test?  | Go on any page in the BO on mobile, see if breadcrumb is hidden

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22356)
<!-- Reviewable:end -->
