### PR TITLE
Hide gamification icon on header on mobile responsive view

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -48,7 +48,7 @@ $search-border-color: #bbcdd2
 			right: 0.5rem
 
 		// hide on very small screens
-		&.hide-mobile-sm
+		&.hide-mobile-sm, #gamification_notif
 			@media (max-width: breakpoint-max('sm'))
 				display: none
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -287,6 +287,14 @@ $header-text-color: #4e6167 !default;
         left: 0.3125rem;
       }
     }
+
+    &.gamification-component {
+      @include media-breakpoint-down("sm") {
+        // stylelint-disable-next-line
+        display: none !important;
+      }
+    }
+
     > .stores .ps-dropdown-menu {
       right: 0;
       left: auto;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Gamification icon is not usefull on mobile as you focus on quick actions
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22357.
| How to test?  | go on BO, see if on legacy and migrated page the gamification icon is hidden in the header when using a mobile 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22359)
<!-- Reviewable:end -->
