### PR TITLE
Wait to fill inputs before hiding modal in create currency form

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
@@ -122,12 +122,12 @@ export default class CurrencyForm {
     }
   }
 
-  onCurrencySelectorChange() {
+  async onCurrencySelectorChange() {
     const selectedISOCode = this.$currencySelector.val();
     if (selectedISOCode !== '') {
       this.$isUnofficialCheckbox.prop('checked', false);
       this.$isoCodeInput.prop('readonly', true);
-      this.resetCurrencyData(selectedISOCode);
+      await this.resetCurrencyData(selectedISOCode);
     } else {
       this.$isUnofficialCheckbox.prop('checked', true);
       this.$isoCodeInput.prop('readonly', false);
@@ -177,7 +177,7 @@ export default class CurrencyForm {
     this.$resetDefaultSettingsButton.addClass('spinner');
 
     this.state.currencyData = await this.fetchCurrency(selectedISOCode);
-    await this.fillCurrencyData(this.state.currencyData);
+    this.fillCurrencyData(this.state.currencyData);
 
     // Reset languages
     this.originalLanguages.forEach((language) => {

--- a/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
@@ -177,7 +177,7 @@ export default class CurrencyForm {
     this.$resetDefaultSettingsButton.addClass('spinner');
 
     this.state.currencyData = await this.fetchCurrency(selectedISOCode);
-    this.fillCurrencyData(this.state.currencyData);
+    await this.fillCurrencyData(this.state.currencyData);
 
     // Reset languages
     this.originalLanguages.forEach((language) => {

--- a/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.js
@@ -122,12 +122,12 @@ export default class CurrencyForm {
     }
   }
 
-  async onCurrencySelectorChange() {
+  onCurrencySelectorChange() {
     const selectedISOCode = this.$currencySelector.val();
     if (selectedISOCode !== '') {
       this.$isUnofficialCheckbox.prop('checked', false);
       this.$isoCodeInput.prop('readonly', true);
-      await this.resetCurrencyData(selectedISOCode);
+      this.resetCurrencyData(selectedISOCode);
     } else {
       this.$isUnofficialCheckbox.prop('checked', true);
       this.$isoCodeInput.prop('readonly', false);

--- a/tests/UI/pages/BO/international/currencies/add.js
+++ b/tests/UI/pages/BO/international/currencies/add.js
@@ -48,6 +48,18 @@ class AddCurrency extends BOBasePage {
       await page.waitForTimeout(200);
     }
 
+    // Wait for input to have value
+    let inputHasValue = false;
+    for (let i = 0; i < 50 && !inputHasValue; i++) {
+      /* eslint-env browser */
+      inputHasValue = await page.evaluate(
+        selector => document.querySelector(selector).value !== "",
+        this.currencyNameInput(1),
+      );
+
+      await page.waitForTimeout(200);
+    }
+
     await page.check(this.statusToggleInput(currencyData.enabled ? 1 : 0));
     await this.clickAndWaitForNavigation(page, this.saveButton);
     return this.getTextContent(page, this.alertSuccessBlockParagraph);

--- a/tests/UI/pages/BO/international/currencies/add.js
+++ b/tests/UI/pages/BO/international/currencies/add.js
@@ -53,7 +53,7 @@ class AddCurrency extends BOBasePage {
     for (let i = 0; i < 50 && !inputHasValue; i++) {
       /* eslint-env browser */
       inputHasValue = await page.evaluate(
-        selector => document.querySelector(selector).value !== "",
+        selector => document.querySelector(selector).value !== '',
         this.currencyNameInput(1),
       );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | In nightly, create official currency test fail because modal in hiding before inputs have value, so to avoid that, We should wait for this action before hiding modal
| Type?         | refacto
| Category?     | TE
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | `TEST_PATH="functional/BO/11_international/01_localization/currencies/04_updateExchangeRate.js" URL_FO=shopUrl/  npm run specific-test`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22363)
<!-- Reviewable:end -->
