### PR TITLE
Fix order view pan overflow

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -351,7 +351,7 @@
   #order-view-page {
     padding: 0 10px;
 
-    #historyTabContent,
+    .right-column .tab-content,
     #orderProductsPanel {
       table {
         overflow: scroll;

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -349,6 +349,15 @@
   }
 
   #order-view-page {
+    padding: 0 10px;
+
+    #historyTabContent,
+    #orderProductsPanel {
+      table {
+        overflow: scroll;
+      }
+    }
+
     .card-details {
       &-form {
         width: 100%;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Pans on order view were too wide on mobile screen, causing an oveflow
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22364
| How to test?  | Go on order view, see if tables on order view are not overflowing content, they should be scrollable

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22365)
<!-- Reviewable:end -->
