### PR TITLE
Remove padding left on label on mobile responsive view

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -49,6 +49,10 @@
         padding-right: 25px;
         text-align: right;
       }
+
+      @include media-breakpoint-down("sm") {
+        padding-left: 0;
+      }
     }
 
     &.type-hidden {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Labels have some padding which cause alignment issue on forms
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22370.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22371)
<!-- Reviewable:end -->
