### PR TITLE
Change some alerts on improve translations to helpbox

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -133,16 +133,20 @@
         <div class="card" id="configuration_fieldset_notifications">
           <h3 class="card-header">
             <i class="material-icons">priority_high</i> {{ 'Notifications'|trans }}
+
+            <span
+              class="help-box"
+              data-container="body"
+              data-toggle="popover"
+              data-trigger="hover"
+              data-placement="right"
+              data-content="{{ "Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them."|trans({}, 'Admin.Advparameters.Help') }}"
+              title
+            >
+            </span>
           </h3>
           <div class="card-block row">
             <div class="card-text">
-
-              <div class="row">
-                <div class="col">
-                  {{ ps.infotip("Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them."|trans({}, 'Admin.Advparameters.Help')) }}
-                </div>
-              </div>
-
               <div class="form-group row">
                 {{ ps.label_with_help(('Show notifications for new orders'|trans), ("This will display notifications when new orders are made in your shop."|trans({}, 'Admin.Advparameters.Help'))) }}
                 <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -141,7 +141,7 @@
               data-trigger="hover"
               data-placement="right"
               data-content="{{ "Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them."|trans({}, 'Admin.Advparameters.Help') }}"
-              title
+              title=""
             >
             </span>
           </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -92,16 +92,20 @@
           <div class="card" id="optional_features">
             <h3 class="card-header">
               <i class="material-icons">extension</i> {{ 'Optional features'|trans }}
+
+              <span
+                class="help-box"
+                data-container="body"
+                data-toggle="popover"
+                data-trigger="hover"
+                data-placement="right"
+                data-content="{{ 'Some features can be disabled in order to improve performance.'|trans({}, 'Admin.Advparameters.Help') }}"
+                title
+              >
+              </span>
             </h3>
             <div class="card-block row">
               <div class="card-text">
-
-                <div class="row">
-                  <div class="col">
-                    {{ ps.infotip('Some features can be disabled in order to improve performance.'|trans({}, 'Admin.Advparameters.Help')) }}
-                  </div>
-                </div>
-
                 {% block perfs_form_optional_features_form %}
                   {{ form_widget(optionalFeaturesForm) }}
                 {% endblock %}
@@ -125,15 +129,21 @@
           <div class="card">
             <h3 class="card-header">
               <i class="material-icons">zoom_out_map</i> {{ 'CCC (Combine, Compress and Cache)'|trans }}
+
+
+            <span
+              class="help-box"
+              data-container="body"
+              data-toggle="popover"
+              data-trigger="hover"
+              data-placement="right"
+              data-content="{{ 'CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.7+. Otherwise, CCC will cause problems.'|trans({}, 'Admin.Advparameters.Help') }}"
+              title
+            >
+            </span>
             </h3>
             <div class="card-block row">
               <div class="card-text">
-                <div class="row">
-                  <div class="col">
-                    {{ ps.infotip('CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.7+. Otherwise, CCC will cause problems.'|trans({}, 'Admin.Advparameters.Help')) }}
-                  </div>
-                </div>
-
                 {% block perfs_form_ccc_form %}
                   {{ form_widget(combineCompressCacheForm) }}
                 {% endblock %}
@@ -157,15 +167,20 @@
           <div class="card">
             <h3 class="card-header">
               <i class="material-icons">link</i> {{ 'Media servers (use only with CCC)'|trans }}
+
+              <span
+                class="help-box"
+                data-container="body"
+                data-toggle="popover"
+                data-trigger="hover"
+                data-placement="right"
+                data-content="{{ 'You must enter another domain, or subdomain, in order to use cookieless static content.'|trans({}, 'Admin.Advparameters.Feature') }}"
+                title
+              >
+              </span>
             </h3>
             <div class="card-block row">
               <div class="card-text">
-                <div class="row">
-                  <div class="col">
-                    {{ ps.infotip('You must enter another domain, or subdomain, in order to use cookieless static content.'|trans({}, 'Admin.Advparameters.Feature')) }}
-                  </div>
-                </div>
-
                 {% block perfs_form_media_servers_form %}
                   {{ form_widget(mediaServersForm) }}
                 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -100,7 +100,7 @@
                 data-trigger="hover"
                 data-placement="right"
                 data-content="{{ 'Some features can be disabled in order to improve performance.'|trans({}, 'Admin.Advparameters.Help') }}"
-                title
+                title=""
               >
               </span>
             </h3>
@@ -138,7 +138,7 @@
               data-trigger="hover"
               data-placement="right"
               data-content="{{ 'CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.7+. Otherwise, CCC will cause problems.'|trans({}, 'Admin.Advparameters.Help') }}"
-              title
+              title=""
             >
             </span>
             </h3>
@@ -175,7 +175,7 @@
                 data-trigger="hover"
                 data-placement="right"
                 data-content="{{ 'You must enter another domain, or subdomain, in order to use cookieless static content.'|trans({}, 'Admin.Advparameters.Feature') }}"
-                title
+                title=""
               >
               </span>
             </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -61,7 +61,7 @@
           data-trigger="hover"
           data-placement="right"
           data-content="{{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}"
-          title
+          title=""
         >
         </span>
       </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -53,19 +53,20 @@
     <div class="card">
       <h3 class="card-header">
         <i class="material-icons">settings</i> {{ cardHeaderLabel }}
+
+        <span
+          class="help-box"
+          data-container="body"
+          data-toggle="popover"
+          data-trigger="hover"
+          data-placement="right"
+          data-content="{{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}"
+          title
+        >
+        </span>
       </h3>
       <div class="card-block row">
         <div class="card-text">
-            <div class="row">
-              <div class="col-sm">
-                <div class="alert alert-info" role="alert">
-                  <div class="alert-text">
-                    {{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}
-                  </div>
-                </div>
-              </div>
-            </div>
-
             <div class="form-group row">
               <label class="form-control-label">
                 {{ 'Shop domain'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -37,7 +37,7 @@
         data-trigger="hover"
         data-placement="right"
         data-content="{{ 'This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop\'s "Friendly URL" option must be enabled, and Apache\'s URL rewriting module (mod_rewrite) must be activated on your web server.'|trans({}, 'Admin.Shopparameters.Notification') }}{{ 'There are several available keywords for each route listed below; note that keywords with * are required!'|trans({}, 'Admin.Shopparameters.Notification') }} {{ 'To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.'|trans({}, 'Admin.Shopparameters.Notification') }}"
-        title
+        title=""
       >
       </span>
     </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -29,21 +29,20 @@
   <div class="card">
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'Schema of URLs'|trans }}
+
+      <span
+        class="help-box"
+        data-container="body"
+        data-toggle="popover"
+        data-trigger="hover"
+        data-placement="right"
+        data-content="{{ 'This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop\'s "Friendly URL" option must be enabled, and Apache\'s URL rewriting module (mod_rewrite) must be activated on your web server.'|trans({}, 'Admin.Shopparameters.Notification') }}{{ 'There are several available keywords for each route listed below; note that keywords with * are required!'|trans({}, 'Admin.Shopparameters.Notification') }} {{ 'To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.'|trans({}, 'Admin.Shopparameters.Notification') }}"
+        title
+      >
+      </span>
     </h3>
     <div class="card-block row">
       <div class="card-text">
-        <div class="row">
-          <div class="col-sm">
-            <div class="alert alert-info" role="alert">
-              <div class="alert-text">
-                {{ 'This section enables you to change the default pattern of your links. In order to use this functionality, PrestaShop\'s "Friendly URL" option must be enabled, and Apache\'s URL rewriting module (mod_rewrite) must be activated on your web server.'|trans({}, 'Admin.Shopparameters.Notification') }}<br>
-                {{ 'There are several available keywords for each route listed below; note that keywords with * are required!'|trans({}, 'Admin.Shopparameters.Notification') }} <br>
-                {{ 'To add a keyword in your URL, use the {keyword} syntax. If the keyword is not empty, you can add text before or after the keyword with syntax {prepend:keyword:append}. For example {-hey-:meta_title} will add "-hey-my-title" in the URL if the meta title is set.'|trans({}, 'Admin.Shopparameters.Notification') }}
-              </div>
-            </div>
-          </div>
-        </div>
-
         <div class="form-group row">
           <label class="form-control-label">
             {{ 'Route to products'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
@@ -38,7 +38,7 @@
         data-trigger="hover"
         data-placement="right"
         data-content="{{ 'You can add IP addresses that will always be allowed to access your shop (e.g. Google bots\' IP).'|trans({}, 'Admin.International.Help') }}"
-        title
+        title=""
       >
       </span>
     </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
@@ -30,18 +30,20 @@
   <div class="card">
     <h3 class="card-header">
       {{ 'IP address whitelist'|trans }}
+
+      <span
+        class="help-box"
+        data-container="body"
+        data-toggle="popover"
+        data-trigger="hover"
+        data-placement="right"
+        data-content="{{ 'You can add IP addresses that will always be allowed to access your shop (e.g. Google bots\' IP).'|trans({}, 'Admin.International.Help') }}"
+        title
+      >
+      </span>
     </h3>
     <div class="card-block row">
       <div class="card-text">
-        <div class="row">
-          <div class="col">
-            <div class="alert alert-info" role="alert">
-              <span class="alert-text">
-                {{ 'You can add IP addresses that will always be allowed to access your shop (e.g. Google bots\' IP).'|trans({}, 'Admin.International.Help') }}
-              </span>
-            </div>
-          </div>
-        </div>
         {{ form_widget(geolocationIpAddressWhitelistForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
@@ -30,18 +30,20 @@
   <div class="card">
     <h3 class="card-header">
       {{ 'Options'|trans({}, 'Admin.Global') }}
+
+      <span
+        class="help-box"
+        data-container="body"
+        data-toggle="popover"
+        data-trigger="hover"
+        data-placement="right"
+        data-content="{{ 'The following features are only available if you enable the Geolocation by IP address feature.'|trans }}"
+        title
+      >
+      </span>
     </h3>
     <div class="card-block row">
       <div class="card-text">
-        <div class="row">
-          <div class="col">
-            <div class="alert alert-info" role="alert">
-              <span class="alert-text">
-                {{ 'The following features are only available if you enable the Geolocation by IP address feature.'|trans }}
-              </span>
-            </div>
-          </div>
-        </div>
         {{ form_widget(geolocationOptionsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
@@ -38,7 +38,7 @@
         data-trigger="hover"
         data-placement="right"
         data-content="{{ 'The following features are only available if you enable the Geolocation by IP address feature.'|trans }}"
-        title
+        title=""
       >
       </span>
     </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
@@ -37,8 +37,8 @@
       data-toggle="popover"
       data-trigger="hover"
       data-placement="right"
-      title="Dismissible popover"
       data-content="{{ 'You can add or update a language directly from the PrestaShop website here.'|trans({}, 'Admin.International.Help') }}"
+      title
     >
     </span>
   </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
@@ -30,19 +30,21 @@
 <div class="card">
   <h3 class="card-header">
     <div class="material-icons">arrow_drop_down_circle</div> {{ 'Add / Update a language'|trans }}
+
+    <span
+      class="help-box"
+      data-container="body"
+      data-toggle="popover"
+      data-trigger="hover"
+      data-placement="right"
+      title="Dismissible popover"
+      data-content="{{ 'You can add or update a language directly from the PrestaShop website here.'|trans({}, 'Admin.International.Help') }}"
+    >
+    </span>
   </h3>
 
   <div class="card-block row">
     <div class="card-text">
-      <div class="row">
-        <div class="col-sm">
-          <div class="alert alert-info" role="alert">
-            <div class="alert-text">
-              {{ 'You can add or update a language directly from the PrestaShop website here.'|trans({}, 'Admin.International.Help') }}
-            </div>
-          </div>
-        </div>
-      </div>
       <div class="form-group row">
         <label class="form-control-label">
           {{ 'Please select the language you want to add or update'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
@@ -38,7 +38,7 @@
       data-trigger="hover"
       data-placement="right"
       data-content="{{ 'You can add or update a language directly from the PrestaShop website here.'|trans({}, 'Admin.International.Help') }}"
-      title
+      title=""
     >
     </span>
   </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -30,14 +30,15 @@
 <div class="card">
   <h3 class="card-header">
     <i class="material-icons">cloud_upload</i> {{ 'Export a language'|trans }}
+
     <span
       class="help-box"
       data-container="body"
       data-toggle="popover"
       data-trigger="hover"
       data-placement="right"
-      title="Dismissible popover"
       data-content="{{ 'Export data from one language to a file (language pack).'|trans({}, 'Admin.International.Help') }}{{ 'Select which theme you would like to export your translations to.'|trans({}, 'Admin.International.Help') }}"
+      title
     >
     </span>
   </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -38,7 +38,7 @@
       data-trigger="hover"
       data-placement="right"
       data-content="{{ 'Export data from one language to a file (language pack).'|trans({}, 'Admin.International.Help') }}{{ 'Select which theme you would like to export your translations to.'|trans({}, 'Admin.International.Help') }}"
-      title
+      title=""
     >
     </span>
   </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -30,20 +30,19 @@
 <div class="card">
   <h3 class="card-header">
     <i class="material-icons">cloud_upload</i> {{ 'Export a language'|trans }}
+    <span
+      class="help-box"
+      data-container="body"
+      data-toggle="popover"
+      data-trigger="hover"
+      data-placement="right"
+      title="Dismissible popover"
+      data-content="{{ 'Export data from one language to a file (language pack).'|trans({}, 'Admin.International.Help') }}{{ 'Select which theme you would like to export your translations to.'|trans({}, 'Admin.International.Help') }}"
+    >
+    </span>
   </h3>
   <div class="card-block row">
     <div class="card-text">
-      <div class="row">
-        <div class="col-sm">
-          <div class="alert alert-info" role="alert">
-            <div class="alert-text">
-              {{ 'Export data from one language to a file (language pack).'|trans({}, 'Admin.International.Help') }} <br>
-              {{ 'Select which theme you would like to export your translations to.'|trans({}, 'Admin.International.Help') }}
-            </div>
-          </div>
-        </div>
-      </div>
-
       <div class="form-group row">
         <label class="form-control-label">
           {{ 'Language'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -31,14 +31,15 @@
   <div class="card">
     <h3 class="card-header">
       <i class="material-icons">description</i> {{ 'Modify translations'|trans }}
+
       <span
         class="help-box"
         data-container="body"
         data-toggle="popover"
         data-trigger="hover"
         data-placement="right"
-        title="Dismissible popover"
         data-content="{{ 'Here you can modify translations for every line of text inside PrestaShop.'|trans({}, 'Admin.International.Help') }}{{ 'First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.'|trans({}, 'Admin.International.Help') }}"
+        title
       >
       </span>
     </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -31,22 +31,20 @@
   <div class="card">
     <h3 class="card-header">
       <i class="material-icons">description</i> {{ 'Modify translations'|trans }}
+      <span
+        class="help-box"
+        data-container="body"
+        data-toggle="popover"
+        data-trigger="hover"
+        data-placement="right"
+        title="Dismissible popover"
+        data-content="{{ 'Here you can modify translations for every line of text inside PrestaShop.'|trans({}, 'Admin.International.Help') }}{{ 'First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.'|trans({}, 'Admin.International.Help') }}"
+      >
+      </span>
     </h3>
 
     <div class="card-block row">
       <div class="card-text">
-        <div class="row">
-          <div class="col-sm">
-            <div class="alert alert-info" role="alert">
-              <div class="alert-text">
-                {{ 'Here you can modify translations for every line of text inside PrestaShop.'|trans({}, 'Admin.International.Help') }}
-                <br>
-                {{ 'First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.'|trans({}, 'Admin.International.Help') }}
-              </div>
-            </div>
-          </div>
-        </div>
-
         <div class="form-group row">
           <label class="form-control-label">
             {{ 'Type of translation'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -39,7 +39,7 @@
         data-trigger="hover"
         data-placement="right"
         data-content="{{ 'Here you can modify translations for every line of text inside PrestaShop.'|trans({}, 'Admin.International.Help') }}{{ 'First, select a type of translation (such as "Back office" or "Installed modules"), and then select the language you want to translate strings in.'|trans({}, 'Admin.International.Help') }}"
-        title
+        title=""
       >
       </span>
     </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
@@ -39,7 +39,7 @@
           data-trigger="hover"
           data-placement="right"
           data-content="{{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }} {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}"
-          title
+          title=""
         >
         </span>
       </h3>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
@@ -31,23 +31,20 @@
     <div class="card">
       <h3 class="card-header">
         <i class="material-icons">filter_none</i> {{ 'Handling'|trans }}
+
+        <span
+          class="help-box"
+          data-container="body"
+          data-toggle="popover"
+          data-trigger="hover"
+          data-placement="right"
+          data-content="{{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }} {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}"
+          title
+        >
+        </span>
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="row">
-            <div class="col">
-              <div class="alert alert-info" role="alert">
-                <ul>
-                  <li>
-                    {{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }}
-                  </li>
-                  <li>
-                    {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
           {{ form_widget(handlingForm) }}
         </div>
       </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Alert infos are not the component that should be used sometimes, it needs to be replaced into helpbox in the header of cards
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22193.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22373)
<!-- Reviewable:end -->
