### PR TITLE
Fixed case where saving virtual product attachment is modifying product price if a specific price is set on the product

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
@@ -54,7 +54,7 @@ class VirtualProductController extends FrameworkBundleAdminController
         $router = $this->get('router');
 
         //get product
-        $product = $productAdapter->getProduct((int) $idProduct, true);
+        $product = $productAdapter->getProduct((int) $idProduct);
 
         if (!$product || !$request->isXmlHttpRequest()) {
             return $response;


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Fixes #22069 - no need to instantiate "full" product here - otherwise price is getting recalculated on subsequential product->save() if there's a specific price on the product itself- this causes price lowering after any virtual product attachment save. looks like quite major issue to me as it scrambled many prices of customer shop.
| Type?         | bug fix 
| Category?     | BO
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes #22069
| How to test?  | See #22069

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22376)
<!-- Reviewable:end -->
