### PR TITLE
Get rid of empty string of redirect type from database structure

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1649,7 +1649,7 @@ CREATE TABLE `PREFIX_product` (
   `redirect_type` ENUM(
     '404', '301-product', '302-product',
     '301-category', '302-category'
-  ) NOT NULL DEFAULT '',
+  ) NOT NULL DEFAULT '404',
   `id_type_redirected` int(10) unsigned NOT NULL DEFAULT '0',
   `available_for_order` tinyint(1) NOT NULL DEFAULT '1',
   `available_date` date DEFAULT NULL,

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1647,7 +1647,7 @@ CREATE TABLE `PREFIX_product` (
   `text_fields` tinyint(4) NOT NULL DEFAULT '0',
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `redirect_type` ENUM(
-    '', '404', '301-product', '302-product',
+    '404', '301-product', '302-product',
     '301-category', '302-category'
   ) NOT NULL DEFAULT '',
   `id_type_redirected` int(10) unsigned NOT NULL DEFAULT '0',

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -45,3 +45,9 @@ UPDATE `PREFIX_product` SET `location` = '' WHERE `location` IS NULL;
 ALTER TABLE `PREFIX_product` MODIFY COLUMN `location` VARCHAR(255) NOT NULL DEFAULT '';
 UPDATE `PREFIX_product_attribute` SET `location` = '' WHERE `location` IS NULL;
 ALTER TABLE `PREFIX_product_attribute` MODIFY COLUMN `location` VARCHAR(255) NOT NULL DEFAULT '';
+
+UPDATE `PREFIX_product` SET `redirect_type` = '404' WHERE `redirect_type` = '';
+ALTER TABLE `PREFIX_product` MODIFY COLUMN `redirect_type` ENUM(
+    '404', '301-product', '302-product', '301-category', '302-category'
+) NOT NULL DEFAULT '404';
+


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Related to PR - https://github.com/PrestaShop/PrestaShop/pull/20473. We did get rid of empty string as redirect_type in code, this PR takes care of sql upgrade and sql structure. We didn't discuss it yet, but it's also an option to leave it unchanged to avoid BC breaks and maybe remove it in some later versions :man_shrugging: 
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | part of #14776
| How to test?  | Needs to perform version upgrade from to from 1.7.7 to 1.7.8

**BC BREAKS**
removes EVAL `''` from product.redirect_type
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22378)
<!-- Reviewable:end -->
