### PR TITLE
Fixed case where the "Place Order" button is disabled when the order is free and "Terms of service" is disabled

### DIFF
--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -70,13 +70,13 @@ class OrderConfirmationControllerCore extends FrontController
 
         // free order uses -1 as id_module, it has a special check here
         if ($this->id_module == -1) {
-            if ($order->module != 'free_order') {
+            if ($order->module !== 'free_order') {
                 Tools::redirect($redirectLink);
             }
         } else {
             // and the normal check that module matches
             $module = Module::getInstanceById((int) ($this->id_module));
-            if ($order->module != $module->name) {
+            if ($order->module !== $module->name) {
                 Tools::redirect($redirectLink);
             }
         }
@@ -174,7 +174,7 @@ class OrderConfirmationControllerCore extends FrontController
         // note the id_module parameter with value -1
         // it acts as a marker for the module check to use "free_payment"
         // for the check
-        Tools::redirect('index.php?controller=order-confirmation&id_cart=' . (int) $cart->id . '&id_module=-1&id_order=' . $order->currentOrder . '&key=' . $cart->secure_key);
+        Tools::redirect('index.php?controller=order-confirmation&id_cart=' . (int) $cart->id . '&id_module=-1&id_order=' . (int) $order->currentOrder . '&key=' . $cart->secure_key);
     }
 
     public function getBreadcrumbLinks()

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -70,7 +70,7 @@ class OrderConfirmationControllerCore extends FrontController
 
         // free order uses -1 as id_module, it has a special check here
         if ($this->id_module == -1) {
-            if ($order->module != "free_order") {
+            if ($order->module != 'free_order') {
                 Tools::redirect($redirectLink);
             }
         } else {

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -45,6 +45,8 @@ class OrderConfirmationControllerCore extends FrontController
     {
         parent::init();
 
+        // for free orders do extra checks and validations and redirect back here
+        // with bit more data.
         if (true === (bool) Tools::getValue('free_order')) {
             $this->checkFreeOrder();
         }
@@ -65,9 +67,18 @@ class OrderConfirmationControllerCore extends FrontController
         if (!Validate::isLoadedObject($order) || $order->id_customer != $this->context->customer->id || $this->secure_key != $order->secure_key) {
             Tools::redirect($redirectLink);
         }
-        $module = Module::getInstanceById((int) ($this->id_module));
-        if ($order->module != $module->name) {
-            Tools::redirect($redirectLink);
+
+        // free order uses -1 as id_module, it has a special check here
+        if ($this->id_module == -1) {
+            if ($order->module != "free_order") {
+                Tools::redirect($redirectLink);
+            }
+        } else {
+            // and the normal check that module matches
+            $module = Module::getInstanceById((int) ($this->id_module));
+            if ($order->module != $module->name) {
+                Tools::redirect($redirectLink);
+            }
         }
         $this->order_presenter = new OrderPresenter();
     }
@@ -158,6 +169,12 @@ class OrderConfirmationControllerCore extends FrontController
             false,
             $cart->secure_key
         );
+
+        // redirect back to us with rest of the data
+        // note the id_module parameter with value -1
+        // it acts as a marker for the module check to use "free_payment"
+        // for the check
+        Tools::redirect('index.php?controller=order-confirmation&id_cart=' . (int) $cart->id . '&id_module=-1&id_order=' . $order->currentOrder . '&key=' . $cart->secure_key);
     }
 
     public function getBreadcrumbLinks()

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -268,7 +268,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
         .true;
     });
 
-    it("should show no payment needed text", async function () {
+    it("should contain no payment needed text", async function () {
       await testContext.addContextItem(
         this,
         "testIdentifier",
@@ -276,12 +276,11 @@ describe("Create 100% discount with free shipping discount code", async () => {
         baseContext
       );
 
-      // we should have a "no payment needed text" and the button should be enabled
-      const isPaymentNotNeededVisible = await checkoutPage.isPaymentNotNeedNotificationVisible(
-        page
+      const noPaymentNeededText = await checkoutPage.getTextContent(
+        page,
+        checkoutPage.noPaymentNeededElement
       );
-      await expect(isPaymentNotNeededVisible, "No payment needed notification")
-        .to.be.true;
+      await expect(noPaymentNeededText).to.contains(checkoutPage.noPaymentNeededText);
     });
 
     it("complete order button should be enabled", async function () {
@@ -295,10 +294,8 @@ describe("Create 100% discount with free shipping discount code", async () => {
       const confirmButtonVisible = await checkoutPage.paymentConfirmationButton(
         page
       );
-      await expect(confirmButtonVisible, "Confirm button visible")
-        .to.be.true;
+      await expect(confirmButtonVisible, "Confirm button visible").to.be.true;
     });
-
 
     it("should complete the order", async function () {
       await testContext.addContextItem(

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -14,28 +14,15 @@ const cartRulesPage = require("@pages/BO/catalog/discounts");
 const addCartRulePage = require("@pages/BO/catalog/discounts/add");
 const orderSettingsPage = require("@pages/BO/shopParameters/orderSettings");
 
-const localizationPage = require("@pages/BO/international/localization");
-const currenciesPage = require("@pages/BO/international/currencies");
-const addCurrencyPage = require("@pages/BO/international/currencies/add");
-const ordersPage = require("@pages/BO/orders");
-const sqlManagerPage = require("@pages/BO/advancedParameters/database/sqlManager");
-const addSqlQueryPage = require("@pages/BO/advancedParameters/database/sqlManager/add");
-const viewSqlQueryPage = require("@pages/BO/advancedParameters/database/sqlManager/view");
 
 // FO pages
 const homePage = require("@pages/FO/home");
-const searchResultsPage = require("@pages/FO/searchResults");
-const foLoginPage = require("@pages/FO/login");
-const productPage = require("@pages/FO/product");
 const cartPage = require("@pages/FO/cart");
 const checkoutPage = require("@pages/FO/checkout");
 const orderConfirmationPage = require("@pages/FO/checkout/orderConfirmation");
 
 // Import expect from chai
 const { expect } = require("chai");
-
-// Import demo data
-const { PaymentMethods } = require("@data/demo/paymentMethods");
 
 // Import faker data
 const CartRuleFaker = require("@data/faker/cartRule");
@@ -49,6 +36,7 @@ const percentCartRule = new CartRuleFaker({
   discountPercent: 100,
   freeShipping: "on",
 });
+
 const customerData = new CustomerFaker({ password: "" });
 const addressData = new AddressFaker();
 
@@ -135,6 +123,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
           page,
           percentCartRule
         );
+        
         await expect(validationMessage).to.contains(
           addCartRulePage.successfulCreationMessage
         );
@@ -159,7 +148,15 @@ describe("Create 100% discount with free shipping discount code", async () => {
         const pageTitle = await orderSettingsPage.getPageTitle(page);
         await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
       });
+      
       it("Should change the terms and conditions back to disabled", async () => {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          'dissableTermAndConditions',
+          baseContext,
+        );
+        
         const result = await orderSettingsPage.setTermsOfService(page, false);
         await expect(result).to.contains(
           orderSettingsPage.successfulUpdateMessage
@@ -200,7 +197,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
       await expect(pageTitle).to.equal(cartPage.pageTitle);
     });
 
-    it("should add our discount code and check that the grandtotal is 0", async function () {
+    it("should add our discount code and check that the total price is 0", async function () {
       await testContext.addContextItem(
         this,
         "testIdentifier",
@@ -210,11 +207,18 @@ describe("Create 100% discount with free shipping discount code", async () => {
 
       await cartPage.addPromoCode(page, percentCartRule.code);
 
-      const grandTotal = await cartPage.getATIPrice(page);
-      await expect(grandTotal, "Order total price is incorrect").to.equal(0);
+      const totalPrice = await cartPage.getATIPrice(page);
+      await expect(totalPrice, "Order total price is incorrect").to.equal(0);
     });
 
     it("should go to checkout process", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "proceedToCheckout",
+        baseContext
+      );
+      
       await cartPage.clickOnProceedToCheckout(page);
       const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
       await expect(isCheckoutPage).to.be.true;
@@ -250,8 +254,9 @@ describe("Create 100% discount with free shipping discount code", async () => {
         page,
         addressData
       );
-      await expect(isStepAddressComplete, "Step Address is not complete").to.be
-        .true;
+      
+      await expect(isStepAddressComplete, "Step Address is not complete")
+        .to.be.true;
     });
 
     it("should go to last step", async function () {
@@ -264,8 +269,8 @@ describe("Create 100% discount with free shipping discount code", async () => {
 
       // Delivery step - Go to payment step
       const isStepDeliveryComplete = await checkoutPage.goToPaymentStep(page);
-      await expect(isStepDeliveryComplete, "Step Address is not complete").to.be
-        .true;
+      await expect(isStepDeliveryComplete, "Step Address is not complete")
+        .to.be.true;
     });
 
     it("should contain no payment needed text", async function () {
@@ -280,6 +285,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
         page,
         checkoutPage.noPaymentNeededElement
       );
+      
       await expect(noPaymentNeededText).to.contains(checkoutPage.noPaymentNeededText);
     });
 
@@ -294,6 +300,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
       const confirmButtonVisible = await checkoutPage.isPaymentConfirmationButtonVisibleAndEnabled(
         page
       );
+      
       await expect(confirmButtonVisible, "Confirm button visible").to.be.true;
     });
 
@@ -315,6 +322,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
       const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(
         page
       );
+      
       await expect(cardTitle).to.contains(
         orderConfirmationPage.orderConfirmationCardTitle
       );
@@ -399,6 +407,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
           true,
           "Terms and conditions of use"
         );
+        
         await expect(result).to.contains(
           orderSettingsPage.successfulUpdateMessage
         );

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -1,0 +1,367 @@
+require("module-alias/register");
+
+// Helpers to open and close browser
+const helper = require("@utils/helpers");
+
+// Common tests login BO
+const loginCommon = require("@commonTests/loginBO");
+
+// Import pages
+
+// BO pages
+const dashboardPage = require("@pages/BO/dashboard");
+const cartRulesPage = require("@pages/BO/catalog/discounts");
+const addCartRulePage = require("@pages/BO/catalog/discounts/add");
+const orderSettingsPage = require("@pages/BO/shopParameters/orderSettings");
+
+const localizationPage = require("@pages/BO/international/localization");
+const currenciesPage = require("@pages/BO/international/currencies");
+const addCurrencyPage = require("@pages/BO/international/currencies/add");
+const ordersPage = require("@pages/BO/orders");
+const sqlManagerPage = require("@pages/BO/advancedParameters/database/sqlManager");
+const addSqlQueryPage = require("@pages/BO/advancedParameters/database/sqlManager/add");
+const viewSqlQueryPage = require("@pages/BO/advancedParameters/database/sqlManager/view");
+
+// FO pages
+const homePage = require("@pages/FO/home");
+const searchResultsPage = require("@pages/FO/searchResults");
+const foLoginPage = require("@pages/FO/login");
+const productPage = require("@pages/FO/product");
+const cartPage = require("@pages/FO/cart");
+const checkoutPage = require("@pages/FO/checkout");
+const orderConfirmationPage = require("@pages/FO/checkout/orderConfirmation");
+
+// Import expect from chai
+const { expect } = require("chai");
+
+// Import demo data
+const { PaymentMethods } = require("@data/demo/paymentMethods");
+
+// Import faker data
+const CartRuleFaker = require("@data/faker/cartRule");
+const CustomerFaker = require("@data/faker/customer");
+const AddressFaker = require("@data/faker/address");
+
+const percentCartRule = new CartRuleFaker({
+  name: "discount100",
+  code: "discount100",
+  discountType: "Percent",
+  discountPercent: 100,
+  freeShipping: "on",
+});
+const customerData = new CustomerFaker({ password: "" });
+const addressData = new AddressFaker();
+
+// Import test context
+const testContext = require("@utils/testContext");
+
+const baseContext = "regression_checkout_100PercentDiscount_FO";
+
+// Browser and tab
+let browserContext;
+let page;
+
+/**
+ * https://github.com/PrestaShop/PrestaShop/issues/9927
+ *
+ * If order has 100% discount and free shipping AND shop does not ask for
+ * terms and conditions => checkout button will stay disabled even tho it should
+ * not be disabled
+ *
+ * login to BO
+ * add new discount (-100% free shipping)
+ * Change terms and conditions setting
+ */
+describe("Create 100% discount with free shipping discount code", async () => {
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+
+  it("should login in BO", async function () {
+    await loginCommon.loginBO(this, page);
+  });
+
+  /**
+   * Setup, create new 100% discount code with free shipping
+   */
+  describe("SETUP", async () => {
+    it("should go to cart rule page", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "goToCartRulesPageToCreate",
+        baseContext
+      );
+
+      await dashboardPage.goToSubMenu(
+        page,
+        dashboardPage.catalogParentLink,
+        dashboardPage.discountsLink
+      );
+
+      const pageTitle = await cartRulesPage.getPageTitle(page);
+      await expect(pageTitle).to.contains(cartRulesPage.pageTitle);
+    });
+
+    describe("Create a percentage cart rule", async () => {
+      it("should go to new cart rule page", async function () {
+        await testContext.addContextItem(
+          this,
+          "testIdentifier",
+          "goToNewCartRulePage1",
+          baseContext
+        );
+
+        await cartRulesPage.goToAddNewCartRulesPage(page);
+        const pageTitle = await addCartRulePage.getPageTitle(page);
+        await expect(pageTitle).to.contains(addCartRulePage.pageTitle);
+      });
+
+      it("should create new cart rule", async function () {
+        await testContext.addContextItem(
+          this,
+          "testIdentifier",
+          "createPercentCartRule",
+          baseContext
+        );
+
+        const validationMessage = await addCartRulePage.createEditCartRules(
+          page,
+          percentCartRule
+        );
+        await expect(validationMessage).to.contains(
+          addCartRulePage.successfulCreationMessage
+        );
+      });
+    });
+
+    describe("Change terms and conditions setting no", async () => {
+      it("should go to 'Shop Parameters > Order Settings' page", async function () {
+        await testContext.addContextItem(
+          this,
+          "testIdentifier",
+          "goToOrderSettingsPage",
+          baseContext
+        );
+
+        await dashboardPage.goToSubMenu(
+          page,
+          dashboardPage.shopParametersParentLink,
+          dashboardPage.orderSettingsLink
+        );
+
+        const pageTitle = await orderSettingsPage.getPageTitle(page);
+        await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
+      });
+      it("Should change the terms and conditions back to disabled", async () => {
+        const result = await orderSettingsPage.setTermsOfService(page, false);
+        await expect(result).to.contains(
+          orderSettingsPage.successfulUpdateMessage
+        );
+      });
+    });
+  });
+
+  /**
+   * Test case
+   * go through the checkout with out discount code and check the complete order button state
+   */
+  describe("Place an order with discounts in FO", async () => {
+    it("should go to FO page", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "viewMyShop",
+        baseContext
+      );
+
+      page = await cartRulesPage.viewMyShop(page);
+      const isHomePage = await homePage.isHomePage(page);
+      await expect(isHomePage, "Fail to open FO home page").to.be.true;
+    });
+
+    it("should add first product to cart and Proceed to checkout", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "addProductToCart",
+        baseContext
+      );
+
+      await homePage.addProductToCartByQuickView(page, 1, "1");
+      await homePage.proceedToCheckout(page);
+      const pageTitle = await cartPage.getPageTitle(page);
+      await expect(pageTitle).to.equal(cartPage.pageTitle);
+    });
+
+    it("should add our discount code and check that the grandtotal is 0", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "addPercentDiscount",
+        baseContext
+      );
+
+      await cartPage.addPromoCode(page, percentCartRule.code);
+
+      const grandTotal = await cartPage.getATIPrice(page);
+      await expect(grandTotal, "Order total price is incorrect").to.equal(0);
+    });
+
+    it("should go to checkout process", async function () {
+      await cartPage.clickOnProceedToCheckout(page);
+      const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
+      await expect(isCheckoutPage).to.be.true;
+    });
+
+    it("should fill personal information as a guest", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "setPersonalInformation",
+        baseContext
+      );
+
+      const isStepPersonalInfoCompleted = await checkoutPage.setGuestPersonalInformation(
+        page,
+        customerData
+      );
+      await expect(
+        isStepPersonalInfoCompleted,
+        "Step personal information is not completed"
+      ).to.be.true;
+    });
+
+    it("should fill address form and go to delivery step", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "setAddressStep",
+        baseContext
+      );
+
+      const isStepAddressComplete = await checkoutPage.setAddress(
+        page,
+        addressData
+      );
+      await expect(isStepAddressComplete, "Step Address is not complete").to.be
+        .true;
+    });
+
+    it("should validate the order", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "validateOrder",
+        baseContext
+      );
+
+      // Delivery step - Go to payment step
+      const isStepDeliveryComplete = await checkoutPage.goToPaymentStep(page);
+      await expect(isStepDeliveryComplete, "Step Address is not complete").to.be
+        .true;
+
+      // finally test it :)
+      // we should have a "no payment needed text" and the button should be enabled
+
+      // and click on the button should take us to the confirmationpage
+
+      // Check that we got to order confirmation (probably not necessary)
+      const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(page);
+      await expect(cardTitle).to.contains(
+        orderConfirmationPage.orderConfirmationCardTitle
+      );
+    });
+  });
+
+  /**
+   * Cleanup
+   * Remove the discount code and the generated order
+   * Change the terms and conditions setting back to enabled
+   */
+  describe("CLEANUP", async () => {
+    it("should go back to BO", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "BackToBOForCleanup",
+        baseContext
+      );
+
+      page = await checkoutPage.closePage(browserContext, page, 0);
+
+      const pageTitle = await orderSettingsPage.getPageTitle(page);
+      await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
+    });
+
+    describe("Delete created cart rules", async () => {
+      it("should go to cart rules page", async function () {
+        await testContext.addContextItem(
+          this,
+          "testIdentifier",
+          "goToCartRulesPageToDelete",
+          baseContext
+        );
+
+        await cartRulesPage.goToSubMenu(
+          page,
+          cartRulesPage.catalogParentLink,
+          cartRulesPage.discountsLink
+        );
+
+        const pageTitle = await cartRulesPage.getPageTitle(page);
+        await expect(pageTitle).to.contains(cartRulesPage.pageTitle);
+      });
+
+      it("should delete our 100% cart rules", async function () {
+        await testContext.addContextItem(
+          this,
+          "testIdentifier",
+          "deleteCartRules",
+          baseContext
+        );
+
+        const validationMessage = await cartRulesPage.deleteCartRule(page);
+        await expect(validationMessage).to.contains(
+          cartRulesPage.successfulDeleteMessage
+        );
+      });
+    });
+
+    describe("Change terms and conditions setting back to yes", async () => {
+      it("should go to 'Shop Parameters > Order Settings' page", async function () {
+        await testContext.addContextItem(
+          this,
+          "testIdentifier",
+          "goToOrderSettingsPage",
+          baseContext
+        );
+
+        await dashboardPage.goToSubMenu(
+          page,
+          dashboardPage.shopParametersParentLink,
+          dashboardPage.orderSettingsLink
+        );
+
+        const pageTitle = await orderSettingsPage.getPageTitle(page);
+        await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
+      });
+      it("Should change the terms and conditions back to enabled", async () => {
+        const result = await orderSettingsPage.setTermsOfService(
+          page,
+          true,
+          "Terms and conditions of use"
+        );
+        await expect(result).to.contains(
+          orderSettingsPage.successfulUpdateMessage
+        );
+      });
+    });
+  });
+});

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -254,11 +254,11 @@ describe("Create 100% discount with free shipping discount code", async () => {
         .true;
     });
 
-    it("should validate the order", async function () {
+    it("should go to last step", async function () {
       await testContext.addContextItem(
         this,
         "testIdentifier",
-        "validateOrder",
+        "goToLastStep",
         baseContext
       );
 
@@ -266,14 +266,58 @@ describe("Create 100% discount with free shipping discount code", async () => {
       const isStepDeliveryComplete = await checkoutPage.goToPaymentStep(page);
       await expect(isStepDeliveryComplete, "Step Address is not complete").to.be
         .true;
+    });
 
-      // finally test it :)
+    it("should show no payment needed text", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "checkNoPaymentNeededText",
+        baseContext
+      );
+
       // we should have a "no payment needed text" and the button should be enabled
+      const isPaymentNotNeededVisible = await checkoutPage.isPaymentNotNeedNotificationVisible(
+        page
+      );
+      await expect(isPaymentNotNeededVisible, "No payment needed notification")
+        .to.be.true;
+    });
 
-      // and click on the button should take us to the confirmationpage
+    it("complete order button should be enabled", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "checkCompleteIsNotDisabled",
+        baseContext
+      );
+
+      const confirmButtonVisible = await checkoutPage.paymentConfirmationButton(
+        page
+      );
+      await expect(confirmButtonVisible, "Confirm button visible")
+        .to.be.true;
+    });
+
+
+    it("should complete the order", async function () {
+      await testContext.addContextItem(
+        this,
+        "testIdentifier",
+        "completeOrder",
+        baseContext
+      );
+
+      // and click on the confirm button should take us to the confirmationpage
+      await checkoutPage.clickAndWaitForNavigation(
+        page,
+        checkoutPage.paymentConfirmationButton
+      );
 
       // Check that we got to order confirmation (probably not necessary)
-      const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(page);
+      const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(
+        page
+      );
       await expect(cardTitle).to.contains(
         orderConfirmationPage.orderConfirmationCardTitle
       );

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -291,7 +291,7 @@ describe("Create 100% discount with free shipping discount code", async () => {
         baseContext
       );
 
-      const confirmButtonVisible = await checkoutPage.paymentConfirmationButton(
+      const confirmButtonVisible = await checkoutPage.isPaymentConfirmationButtonVisibleAndEnabled(
         page
       );
       await expect(confirmButtonVisible, "Confirm button visible").to.be.true;

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -1,49 +1,49 @@
-require("module-alias/register");
+require('module-alias/register');
 
 // Helpers to open and close browser
-const helper = require("@utils/helpers");
+const helper = require('@utils/helpers');
 
 // Common tests login BO
-const loginCommon = require("@commonTests/loginBO");
+const loginCommon = require('@commonTests/loginBO');
 
 // Import pages
 
 // BO pages
-const dashboardPage = require("@pages/BO/dashboard");
-const cartRulesPage = require("@pages/BO/catalog/discounts");
-const addCartRulePage = require("@pages/BO/catalog/discounts/add");
-const orderSettingsPage = require("@pages/BO/shopParameters/orderSettings");
+const dashboardPage = require('@pages/BO/dashboard');
+const cartRulesPage = require('@pages/BO/catalog/discounts');
+const addCartRulePage = require('@pages/BO/catalog/discounts/add');
+const orderSettingsPage = require('@pages/BO/shopParameters/orderSettings');
 
 
 // FO pages
-const homePage = require("@pages/FO/home");
-const cartPage = require("@pages/FO/cart");
-const checkoutPage = require("@pages/FO/checkout");
-const orderConfirmationPage = require("@pages/FO/checkout/orderConfirmation");
+const homePage = require('@pages/FO/home');
+const cartPage = require('@pages/FO/cart');
+const checkoutPage = require('@pages/FO/checkout');
+const orderConfirmationPage = require('@pages/FO/checkout/orderConfirmation');
 
 // Import expect from chai
-const { expect } = require("chai");
+const {expect} = require('chai');
 
 // Import faker data
-const CartRuleFaker = require("@data/faker/cartRule");
-const CustomerFaker = require("@data/faker/customer");
-const AddressFaker = require("@data/faker/address");
+const CartRuleFaker = require('@data/faker/cartRule');
+const CustomerFaker = require('@data/faker/customer');
+const AddressFaker = require('@data/faker/address');
 
 const percentCartRule = new CartRuleFaker({
-  name: "discount100",
-  code: "discount100",
-  discountType: "Percent",
+  name: 'discount100',
+  code: 'discount100',
+  discountType: 'Percent',
   discountPercent: 100,
-  freeShipping: "on",
+  freeShipping: 'on',
 });
 
-const customerData = new CustomerFaker({ password: "" });
+const customerData = new CustomerFaker({password: ''});
 const addressData = new AddressFaker();
 
 // Import test context
-const testContext = require("@utils/testContext");
+const testContext = require('@utils/testContext');
 
-const baseContext = "regression_checkout_100PercentDiscount_FO";
+const baseContext = 'regression_checkout_100PercentDiscount_FO';
 
 // Browser and tab
 let browserContext;
@@ -60,7 +60,7 @@ let page;
  * add new discount (-100% free shipping)
  * Change terms and conditions setting
  */
-describe("Create 100% discount with free shipping discount code", async () => {
+describe('Create 100% discount with free shipping discount code', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -71,39 +71,39 @@ describe("Create 100% discount with free shipping discount code", async () => {
     await helper.closeBrowserContext(browserContext);
   });
 
-  it("should login in BO", async function () {
+  it('should login in BO', async function () {
     await loginCommon.loginBO(this, page);
   });
 
   /**
    * Setup, create new 100% discount code with free shipping
    */
-  describe("SETUP", async () => {
-    it("should go to cart rule page", async function () {
+  describe('SETUP', async () => {
+    it('should go to cart rule page', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "goToCartRulesPageToCreate",
-        baseContext
+        'testIdentifier',
+        'goToCartRulesPageToCreate',
+        baseContext,
       );
 
       await dashboardPage.goToSubMenu(
         page,
         dashboardPage.catalogParentLink,
-        dashboardPage.discountsLink
+        dashboardPage.discountsLink,
       );
 
       const pageTitle = await cartRulesPage.getPageTitle(page);
       await expect(pageTitle).to.contains(cartRulesPage.pageTitle);
     });
 
-    describe("Create a percentage cart rule", async () => {
-      it("should go to new cart rule page", async function () {
+    describe('Create a percentage cart rule', async () => {
+      it('should go to new cart rule page', async function () {
         await testContext.addContextItem(
           this,
-          "testIdentifier",
-          "goToNewCartRulePage1",
-          baseContext
+          'testIdentifier',
+          'goToNewCartRulePage1',
+          baseContext,
         );
 
         await cartRulesPage.goToAddNewCartRulesPage(page);
@@ -111,55 +111,55 @@ describe("Create 100% discount with free shipping discount code", async () => {
         await expect(pageTitle).to.contains(addCartRulePage.pageTitle);
       });
 
-      it("should create new cart rule", async function () {
+      it('should create new cart rule', async function () {
         await testContext.addContextItem(
           this,
-          "testIdentifier",
-          "createPercentCartRule",
-          baseContext
+          'testIdentifier',
+          'createPercentCartRule',
+          baseContext,
         );
 
         const validationMessage = await addCartRulePage.createEditCartRules(
           page,
-          percentCartRule
+          percentCartRule,
         );
-        
+
         await expect(validationMessage).to.contains(
-          addCartRulePage.successfulCreationMessage
+          addCartRulePage.successfulCreationMessage,
         );
       });
     });
 
-    describe("Change terms and conditions setting no", async () => {
+    describe('Change terms and conditions setting no', async () => {
       it("should go to 'Shop Parameters > Order Settings' page", async function () {
         await testContext.addContextItem(
           this,
-          "testIdentifier",
-          "goToOrderSettingsPage",
-          baseContext
+          'testIdentifier',
+          'goToOrderSettingsPage',
+          baseContext,
         );
 
         await dashboardPage.goToSubMenu(
           page,
           dashboardPage.shopParametersParentLink,
-          dashboardPage.orderSettingsLink
+          dashboardPage.orderSettingsLink,
         );
 
         const pageTitle = await orderSettingsPage.getPageTitle(page);
         await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
       });
-      
-      it("Should change the terms and conditions back to disabled", async () => {
+
+      it('Should change the terms and conditions back to disabled', async () => {
         await testContext.addContextItem(
           this,
           'testIdentifier',
           'dissableTermAndConditions',
           baseContext,
         );
-        
+
         const result = await orderSettingsPage.setTermsOfService(page, false);
         await expect(result).to.contains(
-          orderSettingsPage.successfulUpdateMessage
+          orderSettingsPage.successfulUpdateMessage,
         );
       });
     });
@@ -169,162 +169,162 @@ describe("Create 100% discount with free shipping discount code", async () => {
    * Test case
    * go through the checkout with out discount code and check the complete order button state
    */
-  describe("Place an order with discounts in FO", async () => {
-    it("should go to FO page", async function () {
+  describe('Place an order with discounts in FO', async () => {
+    it('should go to FO page', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "viewMyShop",
-        baseContext
+        'testIdentifier',
+        'viewMyShop',
+        baseContext,
       );
 
       page = await cartRulesPage.viewMyShop(page);
       const isHomePage = await homePage.isHomePage(page);
-      await expect(isHomePage, "Fail to open FO home page").to.be.true;
+      await expect(isHomePage, 'Fail to open FO home page').to.be.true;
     });
 
-    it("should add first product to cart and Proceed to checkout", async function () {
+    it('should add first product to cart and Proceed to checkout', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "addProductToCart",
-        baseContext
+        'testIdentifier',
+        'addProductToCart',
+        baseContext,
       );
 
-      await homePage.addProductToCartByQuickView(page, 1, "1");
+      await homePage.addProductToCartByQuickView(page, 1, '1');
       await homePage.proceedToCheckout(page);
       const pageTitle = await cartPage.getPageTitle(page);
       await expect(pageTitle).to.equal(cartPage.pageTitle);
     });
 
-    it("should add our discount code and check that the total price is 0", async function () {
+    it('should add our discount code and check that the total price is 0', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "addPercentDiscount",
-        baseContext
+        'testIdentifier',
+        'addPercentDiscount',
+        baseContext,
       );
 
       await cartPage.addPromoCode(page, percentCartRule.code);
 
       const totalPrice = await cartPage.getATIPrice(page);
-      await expect(totalPrice, "Order total price is incorrect").to.equal(0);
+      await expect(totalPrice, 'Order total price is incorrect').to.equal(0);
     });
 
-    it("should go to checkout process", async function () {
+    it('should go to checkout process', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "proceedToCheckout",
-        baseContext
+        'testIdentifier',
+        'proceedToCheckout',
+        baseContext,
       );
-      
+
       await cartPage.clickOnProceedToCheckout(page);
       const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
       await expect(isCheckoutPage).to.be.true;
     });
 
-    it("should fill personal information as a guest", async function () {
+    it('should fill personal information as a guest', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "setPersonalInformation",
-        baseContext
+        'testIdentifier',
+        'setPersonalInformation',
+        baseContext,
       );
 
       const isStepPersonalInfoCompleted = await checkoutPage.setGuestPersonalInformation(
         page,
-        customerData
+        customerData,
       );
       await expect(
         isStepPersonalInfoCompleted,
-        "Step personal information is not completed"
+        'Step personal information is not completed',
       ).to.be.true;
     });
 
-    it("should fill address form and go to delivery step", async function () {
+    it('should fill address form and go to delivery step', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "setAddressStep",
-        baseContext
+        'testIdentifier',
+        'setAddressStep',
+        baseContext,
       );
 
       const isStepAddressComplete = await checkoutPage.setAddress(
         page,
-        addressData
+        addressData,
       );
-      
-      await expect(isStepAddressComplete, "Step Address is not complete")
+
+      await expect(isStepAddressComplete, 'Step Address is not complete')
         .to.be.true;
     });
 
-    it("should go to last step", async function () {
+    it('should go to last step', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "goToLastStep",
-        baseContext
+        'testIdentifier',
+        'goToLastStep',
+        baseContext,
       );
 
       // Delivery step - Go to payment step
       const isStepDeliveryComplete = await checkoutPage.goToPaymentStep(page);
-      await expect(isStepDeliveryComplete, "Step Address is not complete")
+      await expect(isStepDeliveryComplete, 'Step Address is not complete')
         .to.be.true;
     });
 
-    it("should contain no payment needed text", async function () {
+    it('should contain no payment needed text', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "checkNoPaymentNeededText",
-        baseContext
+        'testIdentifier',
+        'checkNoPaymentNeededText',
+        baseContext,
       );
 
       const noPaymentNeededText = await checkoutPage.getTextContent(
         page,
-        checkoutPage.noPaymentNeededElement
+        checkoutPage.noPaymentNeededElement,
       );
-      
+
       await expect(noPaymentNeededText).to.contains(checkoutPage.noPaymentNeededText);
     });
 
-    it("complete order button should be enabled", async function () {
+    it('complete order button should be enabled', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "checkCompleteIsNotDisabled",
-        baseContext
+        'testIdentifier',
+        'checkCompleteIsNotDisabled',
+        baseContext,
       );
 
       const confirmButtonVisible = await checkoutPage.isPaymentConfirmationButtonVisibleAndEnabled(
-        page
+        page,
       );
-      
-      await expect(confirmButtonVisible, "Confirm button visible").to.be.true;
+
+      await expect(confirmButtonVisible, 'Confirm button visible').to.be.true;
     });
 
-    it("should complete the order", async function () {
+    it('should complete the order', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "completeOrder",
-        baseContext
+        'testIdentifier',
+        'completeOrder',
+        baseContext,
       );
 
       // and click on the confirm button should take us to the confirmationpage
       await checkoutPage.clickAndWaitForNavigation(
         page,
-        checkoutPage.paymentConfirmationButton
+        checkoutPage.paymentConfirmationButton,
       );
 
       // Check that we got to order confirmation (probably not necessary)
       const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(
-        page
+        page,
       );
-      
+
       await expect(cardTitle).to.contains(
-        orderConfirmationPage.orderConfirmationCardTitle
+        orderConfirmationPage.orderConfirmationCardTitle,
       );
     });
   });
@@ -334,13 +334,13 @@ describe("Create 100% discount with free shipping discount code", async () => {
    * Remove the discount code and the generated order
    * Change the terms and conditions setting back to enabled
    */
-  describe("CLEANUP", async () => {
-    it("should go back to BO", async function () {
+  describe('CLEANUP', async () => {
+    it('should go back to BO', async function () {
       await testContext.addContextItem(
         this,
-        "testIdentifier",
-        "BackToBOForCleanup",
-        baseContext
+        'testIdentifier',
+        'BackToBOForCleanup',
+        baseContext,
       );
 
       page = await checkoutPage.closePage(browserContext, page, 0);
@@ -349,67 +349,67 @@ describe("Create 100% discount with free shipping discount code", async () => {
       await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
     });
 
-    describe("Delete created cart rules", async () => {
-      it("should go to cart rules page", async function () {
+    describe('Delete created cart rules', async () => {
+      it('should go to cart rules page', async function () {
         await testContext.addContextItem(
           this,
-          "testIdentifier",
-          "goToCartRulesPageToDelete",
-          baseContext
+          'testIdentifier',
+          'goToCartRulesPageToDelete',
+          baseContext,
         );
 
         await cartRulesPage.goToSubMenu(
           page,
           cartRulesPage.catalogParentLink,
-          cartRulesPage.discountsLink
+          cartRulesPage.discountsLink,
         );
 
         const pageTitle = await cartRulesPage.getPageTitle(page);
         await expect(pageTitle).to.contains(cartRulesPage.pageTitle);
       });
 
-      it("should delete our 100% cart rules", async function () {
+      it('should delete our 100% cart rules', async function () {
         await testContext.addContextItem(
           this,
-          "testIdentifier",
-          "deleteCartRules",
-          baseContext
+          'testIdentifier',
+          'deleteCartRules',
+          baseContext,
         );
 
         const validationMessage = await cartRulesPage.deleteCartRule(page);
         await expect(validationMessage).to.contains(
-          cartRulesPage.successfulDeleteMessage
+          cartRulesPage.successfulDeleteMessage,
         );
       });
     });
 
-    describe("Change terms and conditions setting back to yes", async () => {
+    describe('Change terms and conditions setting back to yes', async () => {
       it("should go to 'Shop Parameters > Order Settings' page", async function () {
         await testContext.addContextItem(
           this,
-          "testIdentifier",
-          "goToOrderSettingsPage",
-          baseContext
+          'testIdentifier',
+          'goToOrderSettingsPage',
+          baseContext,
         );
 
         await dashboardPage.goToSubMenu(
           page,
           dashboardPage.shopParametersParentLink,
-          dashboardPage.orderSettingsLink
+          dashboardPage.orderSettingsLink,
         );
 
         const pageTitle = await orderSettingsPage.getPageTitle(page);
         await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
       });
-      it("Should change the terms and conditions back to enabled", async () => {
+      it('Should change the terms and conditions back to enabled', async () => {
         const result = await orderSettingsPage.setTermsOfService(
           page,
           true,
-          "Terms and conditions of use"
+          'Terms and conditions of use',
         );
-        
+
         await expect(result).to.contains(
-          orderSettingsPage.successfulUpdateMessage
+          orderSettingsPage.successfulUpdateMessage,
         );
       });
     });

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -149,11 +149,11 @@ describe('Create 100% discount with free shipping discount code', async () => {
         await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
       });
 
-      it('Should change the terms and conditions back to disabled', async () => {
+      it('should change the terms and conditions back to disabled', async function () {
         await testContext.addContextItem(
           this,
           'testIdentifier',
-          'dissableTermAndConditions',
+          'disableTermAndConditions',
           baseContext,
         );
 
@@ -289,7 +289,7 @@ describe('Create 100% discount with free shipping discount code', async () => {
       await expect(noPaymentNeededText).to.contains(checkoutPage.noPaymentNeededText);
     });
 
-    it('complete order button should be enabled', async function () {
+    it('should check that complete order button is enabled', async function () {
       await testContext.addContextItem(
         this,
         'testIdentifier',
@@ -388,7 +388,7 @@ describe('Create 100% discount with free shipping discount code', async () => {
         await testContext.addContextItem(
           this,
           'testIdentifier',
-          'goToOrderSettingsPage',
+          'goToOrderSettingsPageToReset',
           baseContext,
         );
 
@@ -401,6 +401,7 @@ describe('Create 100% discount with free shipping discount code', async () => {
         const pageTitle = await orderSettingsPage.getPageTitle(page);
         await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
       });
+
       it('Should change the terms and conditions back to enabled', async () => {
         const result = await orderSettingsPage.setTermsOfService(
           page,

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -399,7 +399,14 @@ describe('Create 100% discount with free shipping discount code', async () => {
         await expect(pageTitle).to.contains(orderSettingsPage.pageTitle);
       });
 
-      it('Should change the terms and conditions back to enabled', async () => {
+      it('should change the terms and conditions back to enabled', async function () {
+        await testContext.addContextItem(
+          this,
+          'testIdentifier',
+          'resetTermsAndConditionsValue',
+          baseContext,
+        );
+
         const result = await orderSettingsPage.setTermsOfService(
           page,
           true,

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -281,10 +281,7 @@ describe('Create 100% discount with free shipping discount code', async () => {
         baseContext,
       );
 
-      const noPaymentNeededText = await checkoutPage.getTextContent(
-        page,
-        checkoutPage.noPaymentNeededElement,
-      );
+      const noPaymentNeededText = await checkoutPage.getNoPaymentNeededBlockContent(page);
 
       await expect(noPaymentNeededText).to.contains(checkoutPage.noPaymentNeededText);
     });

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -312,11 +312,8 @@ describe('Create 100% discount with free shipping discount code', async () => {
         baseContext,
       );
 
-      // and click on the confirm button should take us to the confirmationpage
-      await checkoutPage.clickAndWaitForNavigation(
-        page,
-        checkoutPage.paymentConfirmationButton,
-      );
+      // complete the order
+      await checkoutPage.orderWithoutPaymentMethod(page);
 
       // Check that we got to order confirmation (probably not necessary)
       const cardTitle = await orderConfirmationPage.getOrderConfirmationCardTitle(

--- a/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
+++ b/tests/UI/campaigns/regression/checkout/100PercentDiscount_FO.js
@@ -34,7 +34,7 @@ const percentCartRule = new CartRuleFaker({
   code: 'discount100',
   discountType: 'Percent',
   discountPercent: 100,
-  freeShipping: 'on',
+  freeShipping: true,
 });
 
 const customerData = new CustomerFaker({password: ''});

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -25,7 +25,7 @@ class Checkout extends FOBasePage {
     this.termsOfServiceModalDiv = '#modal div.js-modal-content';
     this.paymentConfirmationButton = `${this.paymentStepSection} #payment-confirmation button:not([disabled])`;
     this.shippingValueSpan = '#cart-subtotal-shipping span.value';
-    this.noPaymentNeededElement = `${this.paymentStepSection} div.content > p`;
+    this.noPaymentNeededElement = `${this.paymentStepSection} div.content > p.cart-payment-step-not-needed-info`;
     this.noPaymentNeededText = 'No payment needed for this order';
 
     // Personal information form

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -26,6 +26,7 @@ class Checkout extends FOBasePage {
     this.paymentConfirmationButton = `${this.paymentStepSection} #payment-confirmation button:not([disabled])`;
     this.shippingValueSpan = '#cart-subtotal-shipping span.value';
     this.noPaymentNeededElement = `${this.paymentStepSection} div.content > p`;
+    this.noPaymentNeededText = 'No payment needed for this order';
 
     // Personal information form
     this.personalInformationStepForm = '#checkout-personal-information-step';

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -223,6 +223,24 @@ class Checkout extends FOBasePage {
   }
 
   /**
+   * Order when no payment is needed
+   * @param page
+   * @returns {Promise<void>}
+   */
+   async orderWithoutPaymentMethod(page) {
+    // Click on terms of services checkbox if visible
+    if (await this.elementVisible(page, this.conditionToApproveLabel, 500)) {
+      await Promise.all([
+        this.waitForVisibleSelector(page, this.paymentConfirmationButton),
+        page.click(this.conditionToApproveLabel),
+      ]);
+    }
+
+    // Validate the order
+    await this.clickAndWaitForNavigation(page, this.paymentConfirmationButton);
+  }
+
+  /**
    * Check payment method existence
    * @param page {Page} Browser tab
    * @param paymentModuleName {string} The payment module name

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -136,6 +136,16 @@ class Checkout extends FOBasePage {
   }
 
   /**
+   * Is confirm button visible and enabled
+   * @param page
+   * @returns {Promise<boolean>}
+   */
+  isPaymentConfirmationButtonVisibleAndEnabled(page) {
+    // small side effect note, the selector is the one that checks for disabled
+    return this.elementVisible(page, this.paymentConfirmationButton, 1000);
+  }
+
+  /**
    * Get selected shipping method name
    * @param page {Page} Browser tab
    * @return {Promise<string>}

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -146,6 +146,15 @@ class Checkout extends FOBasePage {
   }
 
   /**
+   * Get No payment needed block content
+   * @param page
+   * @returns {string}
+   */
+   getNoPaymentNeededBlockContent(page) {
+    return this.getTextContent(page, this.noPaymentNeededElement);
+  }
+
+  /**
    * Get selected shipping method name
    * @param page {Page} Browser tab
    * @return {Promise<string>}

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -150,7 +150,7 @@ class Checkout extends FOBasePage {
    * @param page
    * @returns {string}
    */
-   getNoPaymentNeededBlockContent(page) {
+  getNoPaymentNeededBlockContent(page) {
     return this.getTextContent(page, this.noPaymentNeededElement);
   }
 
@@ -236,7 +236,7 @@ class Checkout extends FOBasePage {
    * @param page
    * @returns {Promise<void>}
    */
-   async orderWithoutPaymentMethod(page) {
+  async orderWithoutPaymentMethod(page) {
     // Click on terms of services checkbox if visible
     if (await this.elementVisible(page, this.conditionToApproveLabel, 500)) {
       await Promise.all([

--- a/tests/UI/pages/FO/checkout/index.js
+++ b/tests/UI/pages/FO/checkout/index.js
@@ -25,6 +25,7 @@ class Checkout extends FOBasePage {
     this.termsOfServiceModalDiv = '#modal div.js-modal-content';
     this.paymentConfirmationButton = `${this.paymentStepSection} #payment-confirmation button:not([disabled])`;
     this.shippingValueSpan = '#cart-subtotal-shipping span.value';
+    this.noPaymentNeededElement = `${this.paymentStepSection} div.content > p`;
 
     // Personal information form
     this.personalInformationStepForm = '#checkout-personal-information-step';

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -40,7 +40,8 @@ class Payment {
 
     $body.on('change', `${this.conditionsSelector} input[type="checkbox"]`, $.proxy(this.toggleOrderButton, this));
     $body.on('change', 'input[name="payment-option"]', $.proxy(this.toggleOrderButton, this));
-    // call toggle once on init to handle situation where evertyhing is already ok (0 price order, payment preselected etc)
+    // call toggle once on init to handle situation where everything
+    // is already ok (like 0 price order, payment already preselected and so on)
     this.toggleOrderButton();
 
     $body.on('click', `${this.confirmationSelector} button`, $.proxy(this.confirm, this));

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -40,6 +40,9 @@ class Payment {
 
     $body.on('change', `${this.conditionsSelector} input[type="checkbox"]`, $.proxy(this.toggleOrderButton, this));
     $body.on('change', 'input[name="payment-option"]', $.proxy(this.toggleOrderButton, this));
+    // call toggle once on init to handle situation where evertyhing is already ok (0 price order, payment preselected etc)
+    this.toggleOrderButton();
+
     $body.on('click', `${this.confirmationSelector} button`, $.proxy(this.confirm, this));
 
     this.collapseOptions();

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -14,7 +14,7 @@
   {/if}
 
   {if $is_free}
-    <p>{l s='No payment needed for this order' d='Shop.Theme.Checkout'}</p>
+    <p class="cart-payment-step-not-needed-info">{l s='No payment needed for this order' d='Shop.Theme.Checkout'}</p>
   {/if}
   <div class="payment-options {if $is_free}hidden-xs-up{/if}">
     {foreach from=$payment_options item="module_options"}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | Test case for #9927 (FO - Checkout - The "Place Order" button is disabled when the order is free and "Terms of service" is disabled)
| Type?         | bug fix
| Category?     | FO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #9927.
| How to test?  | ```docker-compose up``` and run ```HEADLESS=false TEST_PATH="regression/checkout/100PercentDiscount_FO.js" URL_FO="http://localhost:8001/" npm run specific-test```

While writing this I think I found few more problems:

* checkout button selector in the test case uses [disabled] but the button is not actually disabled it only has a class disabled (at least in this scenario)
* clicking the confirm button goes to login page (should go to order confirmation page)

This was done as an exercise of howto use your test suite :) so it might not be up to all the testing standards you have, improvement suggestions are welcome :) (like, I guessed that this should probably be a regresssion test ;)

I will probably continue on this branch to add the fix also but wanted to get this out here to get some feedback if this is even the correct way to start fixing things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22389)
<!-- Reviewable:end -->
