### PR TITLE
Method assertCmsCategoryExists doesn't return anything, it throws an exception

### DIFF
--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -77,12 +77,11 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
     private function createCmsFromCommand(EditCmsPageCommand $command)
     {
         $cms = $this->getCmsPageIfExistsById($command->getCmsPageId()->getValue());
-        $cmsCategoryId = null !== $command->getCmsPageCategoryId() ? $command->getCmsPageCategoryId()->getValue() : null;
 
-        if (null !== $cmsCategoryId) {
-            $this->assertCmsCategoryExists($cmsCategoryId);
+        if (null !== $command->getCmsPageCategoryId()) {
+            $this->assertCmsCategoryExists($command->getCmsPageCategoryId()->getValue());
 
-            $cms->id_cms_category = $cmsCategoryId;
+            $cms->id_cms_category = $command->getCmsPageCategoryId()->getValue();
         }
 
         if (null !== $command->getLocalizedTitle()) {

--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -79,7 +79,9 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
         $cms = $this->getCmsPageIfExistsById($command->getCmsPageId()->getValue());
         $cmsCategoryId = null === $command->getCmsPageCategoryId() ?: $command->getCmsPageCategoryId()->getValue();
 
-        if (null !== $cmsCategoryId && $this->assertCmsCategoryExists($cmsCategoryId)) {
+        if (null !== $cmsCategoryId) {
+            $this->assertCmsCategoryExists($cmsCategoryId);
+
             $cms->id_cms_category = $cmsCategoryId;
         }
 

--- a/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/EditCmsPageHandler.php
@@ -77,7 +77,7 @@ final class EditCmsPageHandler extends AbstractCmsPageHandler implements EditCms
     private function createCmsFromCommand(EditCmsPageCommand $command)
     {
         $cms = $this->getCmsPageIfExistsById($command->getCmsPageId()->getValue());
-        $cmsCategoryId = null === $command->getCmsPageCategoryId() ?: $command->getCmsPageCategoryId()->getValue();
+        $cmsCategoryId = null !== $command->getCmsPageCategoryId() ? $command->getCmsPageCategoryId()->getValue() : null;
 
         if (null !== $cmsCategoryId) {
             $this->assertCmsCategoryExists($cmsCategoryId);

--- a/tests/Integration/Behaviour/Features/Context/Domain/CmsPageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CmsPageFeatureContext.php
@@ -132,9 +132,16 @@ class CmsPageFeatureContext extends AbstractDomainFeatureContext
         if (isset($data['active'])) {
             $command->setIsDisplayed(PrimitiveUtils::castStringBooleanIntoBoolean($data['active']));
         }
+        if (isset($data['id_cms_category'])) {
+            $command->setCmsPageCategoryId((int) $data['id_cms_category']);
+        }
 
-        $this->getCommandBus()->handle($command);
-        SharedStorage::getStorage()->set($cmsPageReference, new CMS($cmsId));
+        try {
+            $this->getCommandBus()->handle($command);
+            SharedStorage::getStorage()->set($cmsPageReference, new CMS($cmsId));
+        } catch (Exception $e) {
+            $this->latestException = $e;
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/CmsPage/cms_page_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CmsPage/cms_page_management.feature
@@ -1,11 +1,11 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cms_page
 @reset-database-before-feature
 Feature: CmsPage Management
-  PrestaShop allows BO users to manage cms pages
+  PrestaShop allows BO users to manage CMS pages
   As a BO user
   I must be able to create, edit and delete CMS page in my shop
 
-  Scenario: Adding new cms page
+  Scenario: Adding new CMS page
     When I add new CMS page "cmspage-1" with following properties:
       | id_cms_category      | 1                                        |
       | meta_title           | Special delivery options                 |
@@ -30,7 +30,7 @@ Feature: CmsPage Management
     When I create CMS page "cmspage-3" with cms category id "5000"
     Then I should get error message 'Cms page category with id "5000" not found'
 
-  Scenario: Editing cms page
+  Scenario: Editing CMS page
     When I edit CMS page "cmspage-1" with following properties:
       | meta_title           | Unusual delivery options              |
       | meta_description     | Our unusual delivery options          |
@@ -46,6 +46,12 @@ Feature: CmsPage Management
     And CMS page "cmspage-1" indexation for search engines should be enabled
     And CMS page "cmspage-1" should be not displayed
 
+  Scenario: Editing CMS page with wrong CMS category id
+    Given cms category with id "60274513" does not exist
+    When I edit CMS page "cmspage-1" with following properties:
+      | id_cms_category | 60274513   |
+    Then I should get error message 'Cms page category with id "60274513" not found'
+
   Scenario: Editing CMS page single field should be allowed
     When I edit CMS page "cmspage-1" with following properties:
       | content              | <span style="color:#0000FF;"> <a href="www.special.test">Check options</a></span> |
@@ -58,7 +64,7 @@ Feature: CmsPage Management
     When I toggle CMS page "cmspage-1" display status
     Then CMS page "cmspage-1" should be not displayed
 
-  Scenario: Enabling and disabling cms pages in bulk action
+  Scenario: Enabling and disabling CMS pages in bulk action
     Given CMS pages: "cmspage-2,cmspage-3,cms-page-4" exists
     Then CMS pages: "cmspage-2,cmspage-3,cms-page-4" should be not displayed
     When I enable CMS pages: "cmspage-2,cmspage-3,cms-page-4" in bulk action
@@ -66,9 +72,8 @@ Feature: CmsPage Management
     And CMS pages: "cmspage-2,cmspage-3,cms-page-4" should be displayed
     When I disable CMS pages: "cmspage-2,cmspage-3,cms-page-4" in bulk action
 
-  Scenario: Deleting cms pages
+  Scenario: Deleting CMS pages
     When I delete CMS page "cmspage-1"
     Then CMS page "cmspage-1" should be deleted
     When I delete CMS pages: "cmspage-2,cmspage-3,cms-page-4" using bulk action
     Then CMS pages: "cmspage-2,cmspage-3,cms-page-4" should be deleted
-


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Method assertCmsCategoryExists doesn't return anything, it throws an exception.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22340
| How to test?  | Follow ticket instruction

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22407)
<!-- Reviewable:end -->
