### PR TITLE
Fix tooltip position on grid items

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -227,7 +227,7 @@ table .column-filters td:last-child .grid-reset-button {
           &.action-type {
             .inline-dropdown-item {
               &:only-child {
-                margin-left: auto;
+                flex: 0 0 auto;
               }
 
               width: inherit;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Tooltip was badly positionned when grid contain only one btn in one column
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22314.
| How to test?  | See issue
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22411)
<!-- Reviewable:end -->
