### PR TITLE
Make sure the display parameter is properly configured in Webservices

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1328,6 +1328,10 @@ class WebserviceRequestCore
 
     public function getFilteredObjectDetails()
     {
+        if (!$this->setFieldsToDisplay()) {
+            return false;
+        }
+
         $objects = [];
         if (!isset($this->urlFragments['display'])) {
             $this->fieldsToDisplay = 'full';


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The `?display` parameter is not working when fetching an object through the API.
| Type?         | bug fix
| Category?     | WS
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes #22333 
| How to test?  | Follow ticket instruction.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22413)
<!-- Reviewable:end -->
