### PR TITLE
Add scroll on kpis on mobile and adjust some sizes

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -1,11 +1,26 @@
 .kpi-container {
   position: relative;
   display: block;
-  padding-top: .9375rem;
-  padding-bottom: .9375rem;
+  padding-top: 0.9375rem;
+  padding-bottom: 0.9375rem;
   text-align: center;
   text-decoration: none;
   background: #fff;
+
+  @include media-breakpoint-down(sm) {
+    > .row {
+      display: flex;
+      flex-wrap: nowrap;
+      // stylelint-disable-next-line
+      justify-content: flex-start !important;
+      overflow: scroll;
+
+      > div {
+        min-width: 10rem;
+        margin: 0 1rem;
+      }
+    }
+  }
 
   &:hover {
     text-decoration: none;
@@ -17,6 +32,13 @@
   top: 0;
   right: 0;
   z-index: 1;
+
+  @include media-breakpoint-down(sm) {
+    button {
+      padding: 0.3rem;
+      font-size: 0.75rem;
+    }
+  }
 }
 
 .kpi-content {
@@ -49,8 +71,8 @@
   .title,
   .subtitle,
   .value {
-    padding-left: .125rem;
-    font-size: .75rem;
+    padding-left: 0.125rem;
+    font-size: 0.75rem;
     color: $gray-dark;
   }
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -8,16 +8,53 @@
   background: #fff;
 
   @include media-breakpoint-down(sm) {
+    background: none;
+
+    &:not(.box-stats) {
+      padding: 0;
+    }
+
+    &.box-stats {
+      min-width: 13rem;
+      padding: 1rem;
+      background-color: #fff;
+      box-shadow: 0 8px 16px 0 rgba(#000, .1);
+      @include border-radius($card-border-radius);
+    }
+
+    .kpi-content {
+      padding-left: 35px;
+
+      .title {
+        font-size: .875rem;
+      }
+
+      .kpi-description {
+
+        .value {
+          font-size: .875rem;
+        }
+      }
+    }
+
     > .row {
       display: flex;
       flex-wrap: nowrap;
-      // stylelint-disable-next-line
+      align-items: center;
+      // stylelint-disable
       justify-content: flex-start !important;
+      // stylelint-enable
+      padding: 1.1rem 0;
+      padding-top: .5rem;
+      margin: 0 -0.5rem !important;
       overflow: scroll;
 
       > div {
-        min-width: 10rem;
-        margin: 0 1rem;
+        margin: 0 .5rem;
+
+        i {
+          font-size: 1.5rem;
+        }
       }
     }
   }
@@ -35,8 +72,7 @@
 
   @include media-breakpoint-down(sm) {
     button {
-      padding: 0.3rem;
-      font-size: 0.75rem;
+      display: none;
     }
   }
 }
@@ -113,5 +149,13 @@
   > .kpi-container {
     padding-right: 1rem;
     padding-left: 1rem;
+  }
+}
+
+.card-kpis {
+  @include media-breakpoint-down(sm) {
+    background-color: inherit;
+    border: none;
+    box-shadow: inherit;
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -18,7 +18,7 @@
       min-width: 13rem;
       padding: 1rem;
       background-color: #fff;
-      box-shadow: 0 8px 16px 0 rgba(#000, .1);
+      box-shadow: 0 8px 16px 0 rgba(#000, 0.1);
       @include border-radius($card-border-radius);
     }
 
@@ -26,13 +26,12 @@
       padding-left: 35px;
 
       .title {
-        font-size: .875rem;
+        font-size: 0.875rem;
       }
 
       .kpi-description {
-
         .value {
-          font-size: .875rem;
+          font-size: 0.875rem;
         }
       }
     }
@@ -43,14 +42,14 @@
       align-items: center;
       // stylelint-disable
       justify-content: flex-start !important;
-      // stylelint-enable
       padding: 1.1rem 0;
-      padding-top: .5rem;
+      padding-top: 0.5rem;
       margin: 0 -0.5rem !important;
       overflow: scroll;
+      // stylelint-enable
 
       > div {
-        margin: 0 .5rem;
+        margin: 0 0.5rem;
 
         i {
           font-size: 1.5rem;

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -24,11 +24,11 @@
 // Components
 @import "components/layout/content_div";
 @import "components/layout/header_toolbar";
-@import "components/layout/kpi";
 @import "components/layout/main_header";
 @import "components/layout/nav_bar";
 @import "components/layout/non_responsive";
 @import "components/cards";
+@import "components/layout/kpi";
 @import "components/category_tree";
 @import "components/dropzone";
 @import "components/modulescards";

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -29,7 +29,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col-xl-10">
-      <div class="card">
+      <div class="card card-kpis">
         {% block translations_kpis_row %}
           <div class="row">
             {{ render(controller(

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
@@ -41,7 +41,7 @@
   {% block categories_kpis %}
     <div class="row">
       <div class="col">
-        <div class="card">
+        <div class="card card-kpis">
           <div class="row">
             {{ render(controller(
               'PrestaShopBundle:Admin\\Common:renderKpiRow',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
@@ -50,7 +50,7 @@
   {% block customers_kpis %}
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
+        <div class="card card-kpis">
           <div class="row">
             {{ render(controller(
               'PrestaShopBundle:Admin\\Common:renderKpiRow',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/view.html.twig
@@ -29,7 +29,7 @@
   {% block cart_kpis %}
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
+        <div class="card card-kpis">
           <div class="row">
             {{ render(controller(
               'PrestaShopBundle:Admin\\Common:renderKpiRow',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -35,7 +35,7 @@
   {% block orders_kpi %}
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
+        <div class="card card-kpis">
           <div class="row orders-kpi">
             {{ render(controller(
               'PrestaShopBundle:Admin\\Common:renderKpiRow',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | KPIs were taking too much height on mobile
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22422.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22427)
<!-- Reviewable:end -->
