### PR TITLE
Don't redirect to http from https if it is homepage (Fix Chrome security alert when customer register)

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -197,10 +197,7 @@ class ToolsCore
             }
 
             $explode = explode('?', $url);
-            // don't use ssl if url is home page
-            // used when logout for example
-            $use_ssl = !empty($url);
-            $url = $link->getPageLink($explode[0], $use_ssl);
+            $url = $link->getPageLink($explode[0]);
             if (isset($explode[1])) {
                 $url .= '?' . $explode[1];
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | when creating a customer account, after POST on https://<domain>/connexion?create_account=1 server respond with 302 and redirect to http://domain/ which display an alert with the last Chrome browser version
| Type?         | bug fix 
| Category?     |  CO
| BC breaks?    | Unknown
| Deprecations? | no
| Fixed ticket? | Fixes #22430
| How to test?  | 1. Install the last version of Google Chrome, install PrestaShop 1.7.7 with HTTPS enabled<br/>2. Go to https://shop_url/connexion?create_account=1 => you're on HTTPS<br/>3. Fill the form and submit<br/>4. You are redirected to homepage and you're on http

![image](https://user-images.githubusercontent.com/1206153/102214118-0dc7fb80-3ed8-11eb-882f-4e182393a199.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22432)
<!-- Reviewable:end -->
