### PR TITLE
Make root category of a shop non editable

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -2448,8 +2448,8 @@ class CategoryCore extends ObjectModel
      *
      * @return bool
      */
-    public function isRootCategory()
+    public function isRootCategory(): bool
     {
-        return 0 === (int) $this->id_parent || null === $this->id_parent;
+        return 0 === (int) $this->id_parent;
     }
 }

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -2441,4 +2441,15 @@ class CategoryCore extends ObjectModel
 		WHERE `id_category` = ' . (int) $this->id . '
 		AND `id_shop` = ' . (int) $idShop, false);
     }
+
+    /**
+     * Indicates whether a category is ROOT for the shop.
+     * The root category is the one with no parent. It's a virtual category.
+     *
+     * @return bool
+     */
+    public function isRootCategory()
+    {
+        return 0 === (int) $this->id_parent || null === $this->id_parent;
+    }
 }

--- a/src/Adapter/Category/CommandHandler/EditCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/EditCategoryHandler.php
@@ -55,7 +55,6 @@ final class EditCategoryHandler extends AbstractObjectModelHandler implements Ed
             throw new CategoryNotFoundException($command->getCategoryId(), sprintf('Category with id "%s" cannot be found.', $command->getCategoryId()->getValue()));
         }
 
-        // Root category means here REAL ROOT category, not the HOME of the shop
         if ($category->isRootCategory()) {
             throw new CannotEditRootCategoryException();
         }

--- a/src/Adapter/Category/CommandHandler/EditCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/EditCategoryHandler.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\CommandHandler\EditCategoryHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 
 /**
@@ -44,6 +45,7 @@ final class EditCategoryHandler extends AbstractObjectModelHandler implements Ed
      * {@inheritdoc}
      *
      * @throws CategoryNotFoundException
+     * @throws CannotEditRootCategoryException
      */
     public function handle(EditCategoryCommand $command)
     {
@@ -51,6 +53,11 @@ final class EditCategoryHandler extends AbstractObjectModelHandler implements Ed
 
         if (!$category->id) {
             throw new CategoryNotFoundException($command->getCategoryId(), sprintf('Category with id "%s" cannot be found.', $command->getCategoryId()->getValue()));
+        }
+
+        // Root category means here REAL ROOT category, not the HOME of the shop
+        if ($category->isRootCategory()) {
+            throw new CannotEditRootCategoryException();
         }
 
         $this->updateCategoryFromCommandData($category, $command);

--- a/src/Adapter/Category/CommandHandler/EditRootCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/EditRootCategoryHandler.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditRootCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\CommandHandler\EditRootCategoryHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 
@@ -44,6 +45,7 @@ final class EditRootCategoryHandler extends AbstractObjectModelHandler implement
      *
      * @throws CannotEditCategoryException
      * @throws CategoryNotFoundException
+     * @throws CannotEditRootCategoryException
      */
     public function handle(EditRootCategoryCommand $command)
     {
@@ -51,6 +53,11 @@ final class EditRootCategoryHandler extends AbstractObjectModelHandler implement
 
         if (!$category->id) {
             throw new CategoryNotFoundException($command->getCategoryId(), sprintf('Category with id "%s" cannot be found.', $command->getCategoryId()->getValue()));
+        }
+
+        // Root category means here REAL ROOT category, not the HOME of the shop
+        if ($category->isRootCategory()) {
+            throw new CannotEditRootCategoryException();
         }
 
         $this->updateRootCategoryFromCommandData($category, $command);

--- a/src/Adapter/Category/CommandHandler/EditRootCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/EditRootCategoryHandler.php
@@ -55,7 +55,6 @@ final class EditRootCategoryHandler extends AbstractObjectModelHandler implement
             throw new CategoryNotFoundException($command->getCategoryId(), sprintf('Category with id "%s" cannot be found.', $command->getCategoryId()->getValue()));
         }
 
-        // Root category means here REAL ROOT category, not the HOME of the shop
         if ($category->isRootCategory()) {
             throw new CannotEditRootCategoryException();
         }

--- a/src/Adapter/Category/QueryHandler/GetCategoryForEditingHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoryForEditingHandler.php
@@ -31,6 +31,7 @@ use Db;
 use ImageManager;
 use ImageType;
 use PDO;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryHandler\GetCategoryForEditingHandlerInterface;
@@ -62,6 +63,7 @@ final class GetCategoryForEditingHandler implements GetCategoryForEditingHandler
      * {@inheritdoc}
      *
      * @throws CategoryNotFoundException
+     * @throws CannotEditRootCategoryException
      */
     public function handle(GetCategoryForEditing $query)
     {
@@ -69,6 +71,11 @@ final class GetCategoryForEditingHandler implements GetCategoryForEditingHandler
 
         if (!$category->id || (!$category->isAssociatedToShop() && Shop::getContext() == Shop::CONTEXT_SHOP)) {
             throw new CategoryNotFoundException($query->getCategoryId(), sprintf('Category with id "%s" was not found', $query->getCategoryId()->getValue()));
+        }
+
+        // Root category means here REAL ROOT category, not the HOME of the shop
+        if ($category->isRootCategory()) {
+            throw new CannotEditRootCategoryException();
         }
 
         /**

--- a/src/Adapter/Category/QueryHandler/GetCategoryForEditingHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoryForEditingHandler.php
@@ -73,7 +73,6 @@ final class GetCategoryForEditingHandler implements GetCategoryForEditingHandler
             throw new CategoryNotFoundException($query->getCategoryId(), sprintf('Category with id "%s" was not found', $query->getCategoryId()->getValue()));
         }
 
-        // Root category means here REAL ROOT category, not the HOME of the shop
         if ($category->isRootCategory()) {
             throw new CannotEditRootCategoryException();
         }

--- a/src/Core/Domain/Category/Exception/CannotEditRootCategoryException.php
+++ b/src/Core/Domain/Category/Exception/CannotEditRootCategoryException.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Category\Exception;
 
 /**

--- a/src/Core/Domain/Category/Exception/CannotEditRootCategoryException.php
+++ b/src/Core/Domain/Category/Exception/CannotEditRootCategoryException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Category\Exception;
+
+/**
+ * Class CannotEditRootCategoryException is thrown when trying to edit the ROOT category.
+ */
+class CannotEditRootCategoryException extends CategoryException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotAddCategoryExcept
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotDeleteImageException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotDeleteRootCategoryForShopException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotUpdateCategoryStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryException;
@@ -342,6 +343,10 @@ class CategoryController extends FrameworkBundleAdminController
             if (!$editableCategory->isRootCategory()) {
                 return $this->redirectToRoute('admin_categories_edit', ['categoryId' => $categoryId]);
             }
+        } catch (CannotEditRootCategoryException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            return $this->redirectToRoute('admin_categories_index');
         } catch (CategoryNotFoundException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
@@ -811,6 +816,10 @@ class CategoryController extends FrameworkBundleAdminController
             ),
             CannotAddCategoryException::class => $this->trans(
                 'An error occurred while creating the category.',
+                'Admin.Catalog.Notification'
+            ),
+            CannotEditRootCategoryException::class => $this->trans(
+                'The root category of a shop cannot be edited.',
                 'Admin.Catalog.Notification'
             ),
             CannotEditCategoryException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -343,11 +343,7 @@ class CategoryController extends FrameworkBundleAdminController
             if (!$editableCategory->isRootCategory()) {
                 return $this->redirectToRoute('admin_categories_edit', ['categoryId' => $categoryId]);
             }
-        } catch (CannotEditRootCategoryException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
-
-            return $this->redirectToRoute('admin_categories_index');
-        } catch (CategoryNotFoundException $e) {
+        } catch (CannotEditRootCategoryException | CategoryNotFoundException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             return $this->redirectToRoute('admin_categories_index');

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
@@ -28,14 +28,17 @@
     <nav>
       <ol class="breadcrumb">
         {% for category in currentCategoryView.breadcrumb_tree %}
+          {% set isRootCategory = (category.id_parent == 0) %}
           <li class="breadcrumb-item">
-            {% if category.id_parent == 0 and isSingleShopContext %}
+            {% if isRootCategory and isSingleShopContext %}
               {% if category.id_category == currentCategoryView.id %}
                 <span>{{ category.name }}</span>
-                <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
-                  <i style="font-size: 16px;" class="material-icons">edit</i>
-                  {{ 'Edit'|trans({}, 'Admin.Actions') }}
-                </a>
+                  {%  if not isRootCategory %}
+                    <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
+                      <i style="font-size: 16px;" class="material-icons">edit</i>
+                      {{ 'Edit'|trans({}, 'Admin.Actions') }}
+                    </a>
+                  {% endif %}
               {% else %}
                 <a href="{{ path('admin_categories_index') }}">
                   {{ category.name }}
@@ -43,10 +46,12 @@
               {% endif %}
             {% elseif category.id_category == currentCategoryView.id %}
               <span>{{ category.name }}</span>
-              <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
-                <i style="font-size: 16px;" class="material-icons">edit</i>
-                {{ 'Edit'|trans({}, 'Admin.Actions') }}
-              </a>
+                {%  if not isRootCategory %}
+                  <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
+                    <i style="font-size: 16px;" class="material-icons">edit</i>
+                    {{ 'Edit'|trans({}, 'Admin.Actions') }}
+                  </a>
+                {% endif %}
             {% else %}
               <a href="{{ path('admin_categories_index', {'categoryId': category.id_category}) }}">
                 {{ category.name }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
@@ -33,7 +33,7 @@
             {% if isRootCategory and isSingleShopContext %}
               {% if category.id_category == currentCategoryView.id %}
                 <span>{{ category.name }}</span>
-                  {%  if not isRootCategory %}
+                  {% if not isRootCategory %}
                     <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
                       <i style="font-size: 16px;" class="material-icons">edit</i>
                       {{ 'Edit'|trans({}, 'Admin.Actions') }}
@@ -46,7 +46,7 @@
               {% endif %}
             {% elseif category.id_category == currentCategoryView.id %}
               <span>{{ category.name }}</span>
-                {%  if not isRootCategory %}
+                {% if not isRootCategory %}
                   <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
                     <i style="font-size: 16px;" class="material-icons">edit</i>
                     {{ 'Edit'|trans({}, 'Admin.Actions') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
@@ -33,12 +33,6 @@
             {% if isRootCategory and isSingleShopContext %}
               {% if category.id_category == currentCategoryView.id %}
                 <span>{{ category.name }}</span>
-                  {% if not isRootCategory %}
-                    <a href="{{ path('admin_categories_edit', {'categoryId': category.id_category}) }}">
-                      <i style="font-size: 16px;" class="material-icons">edit</i>
-                      {{ 'Edit'|trans({}, 'Admin.Actions') }}
-                    </a>
-                  {% endif %}
               {% else %}
                 <a href="{{ path('admin_categories_index') }}">
                   {{ category.name }}

--- a/tests/Integration/Adapter/Category/QueryHandler/EditRootCategoryHandlerTest.php
+++ b/tests/Integration/Adapter/Category/QueryHandler/EditRootCategoryHandlerTest.php
@@ -1,16 +1,43 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
 
 namespace Tests\Integration\Adapter\Category\QueryHandler;
 
+use PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditRootCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class EditRootCategoryHandlerTest extends KernelTestCase
 {
     /**
-     * @var object|\PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter|null
+     * @var object|TacticianCommandBusAdapter|null
      */
     private $commandBus;
     /**
@@ -18,11 +45,11 @@ class EditRootCategoryHandlerTest extends KernelTestCase
      */
     private $rootCategory;
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+     * @var ContainerInterface|null
      */
     private $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
         $this->container = self::$kernel->getContainer();
@@ -31,7 +58,7 @@ class EditRootCategoryHandlerTest extends KernelTestCase
         $this->rootCategory = (int) $this->container->get('prestashop.adapter.legacy.configuration')->get('PS_ROOT_CATEGORY');
     }
 
-    public function testEditRootCategoryDoesntThrowExceptionIfExists()
+    public function testEditRootCategoryDoesntThrowExceptionIfExists(): void
     {
         $categories = $this->container->get('prestashop.adapter.form.choice_provider.category_tree_choice_provider')->getChoices();
         $existingCategoryId = $categories[0]['id_category'];
@@ -40,14 +67,14 @@ class EditRootCategoryHandlerTest extends KernelTestCase
         $this->assertNull($this->commandBus->handle($command));
     }
 
-    public function testEditRootCategoryThrowsAnExceptionIfCategoryDoesntExist()
+    public function testEditRootCategoryThrowsAnExceptionIfCategoryDoesntExist(): void
     {
         $command = new EditRootCategoryCommand(10000);
         $this->expectException(CategoryNotFoundException::class);
         $this->commandBus->handle($command);
     }
 
-    public function testEditRootCategoryThrowsAnException()
+    public function testEditRootCategoryThrowsAnException(): void
     {
         $command = new EditRootCategoryCommand($this->rootCategory);
         $this->expectException(CannotEditRootCategoryException::class);

--- a/tests/Integration/Adapter/Category/QueryHandler/EditRootCategoryHandlerTest.php
+++ b/tests/Integration/Adapter/Category/QueryHandler/EditRootCategoryHandlerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Integration\Adapter\Category\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditRootCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class EditRootCategoryHandlerTest extends KernelTestCase
+{
+    /**
+     * @var object|\PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter|null
+     */
+    private $commandBus;
+    /**
+     * @var int
+     */
+    private $rootCategory;
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+     */
+    private $container;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+        $this->container = self::$kernel->getContainer();
+
+        $this->commandBus = $this->container->get('prestashop.core.command_bus');
+        $this->rootCategory = (int) $this->container->get('prestashop.adapter.legacy.configuration')->get('PS_ROOT_CATEGORY');
+    }
+
+    public function testEditRootCategoryDoesntThrowExceptionIfExists()
+    {
+        $categories = $this->container->get('prestashop.adapter.form.choice_provider.category_tree_choice_provider')->getChoices();
+        $existingCategoryId = $categories[0]['id_category'];
+        $command = new EditRootCategoryCommand((int) $existingCategoryId);
+
+        $this->assertNull($this->commandBus->handle($command));
+    }
+
+    public function testEditRootCategoryThrowsAnExceptionIfCategoryDoesntExist()
+    {
+        $command = new EditRootCategoryCommand(10000);
+        $this->expectException(CategoryNotFoundException::class);
+        $this->commandBus->handle($command);
+    }
+
+    public function testEditRootCategoryThrowsAnException()
+    {
+        $command = new EditRootCategoryCommand($this->rootCategory);
+        $this->expectException(CannotEditRootCategoryException::class);
+        $this->commandBus->handle($command);
+    }
+}

--- a/tests/Integration/Adapter/Category/QueryHandler/GetCategoryForEditingHandlerTest.php
+++ b/tests/Integration/Adapter/Category/QueryHandler/GetCategoryForEditingHandlerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Integration\Adapter\Category\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GetCategoryForEditingHandlerTest extends KernelTestCase
+{
+    /**
+     * @var object|\PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter|null
+     */
+    private $commandBus;
+    /**
+     * @var int
+     */
+    private $rootCategory;
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+     */
+    private $container;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+        $this->container = self::$kernel->getContainer();
+
+        $this->commandBus = $this->container->get('prestashop.core.command_bus');
+        $this->rootCategory = (int) $this->container->get('prestashop.adapter.legacy.configuration')->get('PS_ROOT_CATEGORY');
+    }
+
+    public function testGetCategoryForEditingReturnsAnEditableCategoryIfExists()
+    {
+        $categories = $this->container->get('prestashop.adapter.form.choice_provider.category_tree_choice_provider')->getChoices();
+        $existingCategoryId = $categories[0]['id_category'];
+        $command = new GetCategoryForEditing((int) $existingCategoryId);
+
+        $editableCategory = $this->commandBus->handle($command);
+        $this->assertInstanceOf(EditableCategory::class, $editableCategory);
+    }
+
+    public function testGetRootCategoryForEditingThrowsAnExceptionIfCategoryDoesntExist()
+    {
+        $command = new GetCategoryForEditing(10000);
+        $this->expectException(CategoryNotFoundException::class);
+        $this->commandBus->handle($command);
+    }
+
+    public function testGetRootCategoryForEditingThrowsAnException()
+    {
+        $command = new GetCategoryForEditing($this->rootCategory);
+        $this->expectException(CannotEditRootCategoryException::class);
+        $this->commandBus->handle($command);
+    }
+}

--- a/tests/Integration/Adapter/Category/QueryHandler/GetCategoryForEditingHandlerTest.php
+++ b/tests/Integration/Adapter/Category/QueryHandler/GetCategoryForEditingHandlerTest.php
@@ -1,17 +1,44 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
 
 namespace Tests\Integration\Adapter\Category\QueryHandler;
 
+use PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotEditRootCategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class GetCategoryForEditingHandlerTest extends KernelTestCase
 {
     /**
-     * @var object|\PrestaShop\PrestaShop\Core\CommandBus\TacticianCommandBusAdapter|null
+     * @var object|TacticianCommandBusAdapter|null
      */
     private $commandBus;
     /**
@@ -19,11 +46,11 @@ class GetCategoryForEditingHandlerTest extends KernelTestCase
      */
     private $rootCategory;
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+     * @var ContainerInterface|null
      */
     private $container;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
         $this->container = self::$kernel->getContainer();
@@ -32,7 +59,7 @@ class GetCategoryForEditingHandlerTest extends KernelTestCase
         $this->rootCategory = (int) $this->container->get('prestashop.adapter.legacy.configuration')->get('PS_ROOT_CATEGORY');
     }
 
-    public function testGetCategoryForEditingReturnsAnEditableCategoryIfExists()
+    public function testGetCategoryForEditingReturnsAnEditableCategoryIfExists(): void
     {
         $categories = $this->container->get('prestashop.adapter.form.choice_provider.category_tree_choice_provider')->getChoices();
         $existingCategoryId = $categories[0]['id_category'];
@@ -42,14 +69,14 @@ class GetCategoryForEditingHandlerTest extends KernelTestCase
         $this->assertInstanceOf(EditableCategory::class, $editableCategory);
     }
 
-    public function testGetRootCategoryForEditingThrowsAnExceptionIfCategoryDoesntExist()
+    public function testGetRootCategoryForEditingThrowsAnExceptionIfCategoryDoesntExist(): void
     {
         $command = new GetCategoryForEditing(10000);
         $this->expectException(CategoryNotFoundException::class);
         $this->commandBus->handle($command);
     }
 
-    public function testGetRootCategoryForEditingThrowsAnException()
+    public function testGetRootCategoryForEditingThrowsAnException(): void
     {
         $command = new GetCategoryForEditing($this->rootCategory);
         $this->expectException(CannotEditRootCategoryException::class);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Root category is the virtual category which is parent of the Home category of a shop. In order to avoid errors due to edition of this category, we avoid his edition
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #20463
| How to test?  | You cannot edit the root category of a shop. A flash message must be displayed and you will be redirected to categories list. <br>Inaccessible URLs : <br><ul><li>/admin-dev/index.php/sell/catalog/categories/1</li><li>/admin-dev/index.php/sell/catalog/categories/1/edit</li><li>/admin-dev/index.php/sell/catalog/categories/1/edit-root</li></ul><br><br>In a multishop context, after creating the Home category of the 2nd shop, you won't see any link in front of Root category. See screenshot<br>![root_category after](https://user-images.githubusercontent.com/7426640/102248793-80959e80-3ef9-11eb-9625-46ee6355eecb.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22438)
<!-- Reviewable:end -->
