### PR TITLE
Fix border radius on kpis pan

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -1,11 +1,12 @@
 .kpi-container {
   position: relative;
   display: block;
-  padding-top: .9375rem;
-  padding-bottom: .9375rem;
+  padding-top: 0.9375rem;
+  padding-bottom: 0.9375rem;
   text-align: center;
   text-decoration: none;
   background: #fff;
+  @include border-radius($card-border-radius);
 
   &:hover {
     text-decoration: none;
@@ -49,8 +50,8 @@
   .title,
   .subtitle,
   .value {
-    padding-left: .125rem;
-    font-size: .75rem;
+    padding-left: 0.125rem;
+    font-size: 0.75rem;
     color: $gray-dark;
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Border radius on this part was not the same than everything else, I added a border radius 5px to it
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22452
| How to test?  | Go on order page and look at kpis border

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22453)
<!-- Reviewable:end -->
