### PR TITLE
Improve multiple choice table : Add option to keep table heads fixed

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_choice_table.scss
+++ b/admin-dev/themes/new-theme/scss/components/_choice_table.scss
@@ -10,7 +10,7 @@
       @extend .choice-table;
     }
 
-    thead, 
+    thead,
     tbody tr {
       display: table;
       width: 100%;

--- a/admin-dev/themes/new-theme/scss/components/_choice_table.scss
+++ b/admin-dev/themes/new-theme/scss/components/_choice_table.scss
@@ -10,7 +10,8 @@
       @extend .choice-table;
     }
 
-    thead, tbody tr {
+    thead, 
+    tbody tr {
       display: table;
       width: 100%;
       table-layout: fixed;

--- a/admin-dev/themes/new-theme/scss/components/_choice_table.scss
+++ b/admin-dev/themes/new-theme/scss/components/_choice_table.scss
@@ -3,3 +3,17 @@
   overflow-y: auto;
 }
 
+.choice-table-headers-fixed {
+  table {
+    tbody {
+      display: block;
+      @extend .choice-table;
+    }
+
+    thead, tbody tr {
+      display: table;
+      width: 100%;
+      table-layout: fixed;
+    }
+  }
+}

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -124,6 +124,7 @@ class WebserviceKeyType extends TranslatorAwareType
                 'multiple_choices' => $this->getPermissionChoicesForResources(),
                 'scrollable' => false,
                 'headers_to_disable' => ['all'],
+                'headers_fixed' => true,
             ])
         ;
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
@@ -107,25 +107,25 @@ class PaymentModulePreferencesType extends TranslatorAwareType
                 'label' => $this->trans('Currency restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->getCurrencyChoices(),
                 'multiple_choices' => $this->getCurrencyChoicesForPaymentModules(),
-                'headers_fixed' => true
+                'headers_fixed' => true,
             ])
             ->add('country_restrictions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Country restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->countryChoices,
                 'multiple_choices' => $this->getCountryChoicesForPaymentModules(),
-                'headers_fixed' => true
+                'headers_fixed' => true,
             ])
             ->add('group_restrictions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Group restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->groupChoices,
                 'multiple_choices' => $this->getGroupChoicesForPaymentModules(),
-                'headers_fixed' => true
+                'headers_fixed' => true,
             ])
             ->add('carrier_restrictions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Carrier restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->carrierChoices,
                 'multiple_choices' => $this->getCarrierChoicesForPaymentModules(),
-                'headers_fixed' => true
+                'headers_fixed' => true,
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Payment/Preferences/PaymentModulePreferencesType.php
@@ -107,21 +107,25 @@ class PaymentModulePreferencesType extends TranslatorAwareType
                 'label' => $this->trans('Currency restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->getCurrencyChoices(),
                 'multiple_choices' => $this->getCurrencyChoicesForPaymentModules(),
+                'headers_fixed' => true
             ])
             ->add('country_restrictions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Country restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->countryChoices,
                 'multiple_choices' => $this->getCountryChoicesForPaymentModules(),
+                'headers_fixed' => true
             ])
             ->add('group_restrictions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Group restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->groupChoices,
                 'multiple_choices' => $this->getGroupChoicesForPaymentModules(),
+                'headers_fixed' => true
             ])
             ->add('carrier_restrictions', MaterialMultipleChoiceTableType::class, [
                 'label' => $this->trans('Carrier restrictions', 'Admin.Payment.Feature'),
                 'choices' => $this->carrierChoices,
                 'multiple_choices' => $this->getCarrierChoicesForPaymentModules(),
+                'headers_fixed' => true
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/Material/MaterialMultipleChoiceTableType.php
@@ -74,6 +74,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
         $view->vars['choices'] = $options['choices'];
         $view->vars['scrollable'] = $options['scrollable'];
         $view->vars['headers_to_disable'] = $options['headers_to_disable'];
+        $view->vars['headers_fixed'] = $options['headers_fixed'];
         $view->vars['table_label'] = $options['table_label'];
     }
 
@@ -109,6 +110,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
             ->setDefaults([
                 'scrollable' => true,
                 'headers_to_disable' => [],
+                'headers_fixed' => false,
                 'table_label' => false,
             ])
         ;
@@ -117,6 +119,7 @@ class MaterialMultipleChoiceTableType extends AbstractType
         $resolver->setAllowedTypes('multiple_choices', 'array');
         $resolver->setAllowedTypes('scrollable', 'bool');
         $resolver->setAllowedTypes('headers_to_disable', 'array');
+        $resolver->setAllowedTypes('headers_fixed', 'bool');
         $resolver->setAllowedTypes('table_label', ['bool', 'string']);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -600,7 +600,7 @@
 
 {% block material_multiple_choice_table_widget %}
   {% spaceless %}
-    <div class="choice-table table-responsive">
+    <div class="choice-table{% if headers_fixed %}-headers-fixed{% endif %} table-responsive">
       <table class="table">
         <thead>
           <tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -654,7 +654,7 @@
 
 {% block material_multiple_choice_table_widget %}
   {% spaceless %}
-    <div class="choice-table table-responsive">
+    <div class="choice-table{% if headers_fixed %}-headers-fixed{% endif %} table-responsive">
       <table class="table">
         <thead>
         <tr>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | When we have very large tables, we have to scroll to see the last options, except that the headers are no longer visible, so it becomes difficult to know how to choose an option. For more details see https://github.com/PrestaShop/PrestaShop/issues/22461
| Type?         | improvement
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22461
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/22461

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22462)
<!-- Reviewable:end -->
