### PR TITLE
[WIP] Simplify product preferences

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product-preferences/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/index.js
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import TranslatableInput from '@components/translatable-input';
 import StockManagementOptionHandler from '@pages/product-preferences/stock-management-option-handler';
 import CatalogModeOptionHandler from '@pages/product-preferences/catalog-mode-option-handler';
 import * as pageMap from '@pages/product-preferences/product-preferences-page-map';
@@ -31,7 +30,12 @@ import * as pageMap from '@pages/product-preferences/product-preferences-page-ma
 const {$} = window;
 
 $(() => {
-  new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+    ],
+  );
+
   new StockManagementOptionHandler();
   new CatalogModeOptionHandler(pageMap);
 });

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -228,7 +228,7 @@
     <value>1</value>
   </configuration>
   <configuration id="PS_ATTRIBUTE_CATEGORY_DISPLAY" name="PS_ATTRIBUTE_CATEGORY_DISPLAY">
-    <value>1</value>
+    <value>0</value>
   </configuration>
   <configuration id="PS_CUSTOMER_SERVICE_FILE_UPLOAD" name="PS_CUSTOMER_SERVICE_FILE_UPLOAD">
     <value>1</value>

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -213,7 +213,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
         switch ($error->getErrorCode()) {
             case GeneralFormDataProvider::ERROR_MUST_BE_NUMERIC_EQUAL_TO_ZERO_OR_HIGHER:
                 return $this->trans(
-                    '%s is invalid. Please enter an integer greater or equal to 0.',
+                    '%s is invalid. Please enter an integer greater than or equal to 0.',
                     'Admin.Notifications.Error',
                     [$this->getFieldLabel($error->getFieldName())]
                 );

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -47,12 +47,131 @@ class ProductPreferencesController extends FrameworkBundleAdminController
      */
     public function indexAction(Request $request)
     {
-        $legacyController = $request->attributes->get('_legacy_controller');
-
         $generalForm = $this->getGeneralFormHandler()->getForm();
         $pageForm = $this->getPageFormHandler()->getForm();
         $paginationForm = $this->getPaginationFormHandler()->getForm();
         $stockForm = $this->getStockFormHandler()->getForm();
+
+        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function processGeneralFormAction(Request $request)
+    {
+        $pageForm = $this->getPageFormHandler()->getForm();
+        $paginationForm = $this->getPaginationFormHandler()->getForm();
+        $stockForm = $this->getStockFormHandler()->getForm();
+
+        $generalForm = $this->processForm(
+            $request,
+            $this->getGeneralFormHandler(),
+            'General'
+        );
+
+        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function processPageFormAction(Request $request)
+    {
+        $generalForm = $this->getGeneralFormHandler()->getForm();
+        $paginationForm = $this->getPaginationFormHandler()->getForm();
+        $stockForm = $this->getStockFormHandler()->getForm();
+
+        $pageForm = $this->processForm(
+            $request,
+            $this->getPageFormHandler(),
+            'Page'
+        );
+
+        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function processPaginationFormAction(Request $request)
+    {
+        $generalForm = $this->getGeneralFormHandler()->getForm();
+        $pageForm = $this->getPageFormHandler()->getForm();
+        $stockForm = $this->getStockFormHandler()->getForm();
+
+        $paginationForm = $this->processForm(
+            $request,
+            $this->getPaginationFormHandler(),
+            'Pagination'
+        );
+
+        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function processStockFormAction(Request $request)
+    {
+        $generalForm = $this->getGeneralFormHandler()->getForm();
+        $pageForm = $this->getPageFormHandler()->getForm();
+        $paginationForm = $this->getPaginationFormHandler()->getForm();
+
+        $stockForm = $this->processForm(
+            $request,
+            $this->getStockFormHandler(),
+            'Stock'
+        );
+
+        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
+    }
+
+    /**
+     * @param Request $request
+     * @param FormInterface $generalForm
+     * @param FormInterface $pageForm
+     * @param FormInterface $paginationForm
+     * @param FormInterface $stockForm
+     *
+     * @return Response
+     */
+    protected function renderForm(
+        Request $request,
+        FormInterface $generalForm,
+        FormInterface $pageForm,
+        FormInterface $paginationForm,
+        FormInterface $stockForm
+    ): Response {
+        $legacyController = $request->attributes->get('_legacy_controller');
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/product_preferences.html.twig', [
             'layoutHeaderToolbarBtn' => [],
@@ -71,91 +190,15 @@ class ProductPreferencesController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function processGeneralFormAction(Request $request)
-    {
-        return $this->processForm(
-            $request,
-            $this->getGeneralFormHandler(),
-            'General'
-        );
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function processPageFormAction(Request $request)
-    {
-        return $this->processForm(
-            $request,
-            $this->getPageFormHandler(),
-            'Page'
-        );
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function processPaginationFormAction(Request $request)
-    {
-        return $this->processForm(
-            $request,
-            $this->getPaginationFormHandler(),
-            'Pagination'
-        );
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function processStockFormAction(Request $request)
-    {
-        return $this->processForm(
-            $request,
-            $this->getStockFormHandler(),
-            'Stock'
-        );
-    }
-
-    /**
      * Process the Product Preferences configuration form.
      *
      * @param Request $request
      * @param FormHandlerInterface $formHandler
      * @param string $hookName
      *
-     * @return RedirectResponse
+     * @return FormInterface
      */
-    protected function processForm(Request $request, FormHandlerInterface $formHandler, string $hookName)
+    protected function processForm(Request $request, FormHandlerInterface $formHandler, string $hookName): FormInterface
     {
         $this->dispatchHook(
             'actionAdminShopParametersProductPreferencesControllerPostProcess' . $hookName . 'Before',
@@ -167,7 +210,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
         $form = $formHandler->getForm();
         $form->handleRequest($request);
 
-        if ($form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $saveErrors = $formHandler->save($data);
 
@@ -178,7 +221,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->redirectToRoute('admin_product_preferences');
+        return $form;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -47,131 +47,12 @@ class ProductPreferencesController extends FrameworkBundleAdminController
      */
     public function indexAction(Request $request)
     {
-        $generalForm = $this->getGeneralFormHandler()->getForm();
-        $pageForm = $this->getPageFormHandler()->getForm();
-        $paginationForm = $this->getPaginationFormHandler()->getForm();
-        $stockForm = $this->getStockFormHandler()->getForm();
-
-        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function processGeneralFormAction(Request $request)
-    {
-        $pageForm = $this->getPageFormHandler()->getForm();
-        $paginationForm = $this->getPaginationFormHandler()->getForm();
-        $stockForm = $this->getStockFormHandler()->getForm();
-
-        $generalForm = $this->processForm(
-            $request,
-            $this->getGeneralFormHandler(),
-            'General'
-        );
-
-        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function processPageFormAction(Request $request)
-    {
-        $generalForm = $this->getGeneralFormHandler()->getForm();
-        $paginationForm = $this->getPaginationFormHandler()->getForm();
-        $stockForm = $this->getStockFormHandler()->getForm();
-
-        $pageForm = $this->processForm(
-            $request,
-            $this->getPageFormHandler(),
-            'Page'
-        );
-
-        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function processPaginationFormAction(Request $request)
-    {
-        $generalForm = $this->getGeneralFormHandler()->getForm();
-        $pageForm = $this->getPageFormHandler()->getForm();
-        $stockForm = $this->getStockFormHandler()->getForm();
-
-        $paginationForm = $this->processForm(
-            $request,
-            $this->getPaginationFormHandler(),
-            'Pagination'
-        );
-
-        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
-    }
-
-    /**
-     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
-     *     message="You do not have permission to update this.",
-     *     redirectRoute="admin_product_preferences"
-     * )
-     *
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function processStockFormAction(Request $request)
-    {
-        $generalForm = $this->getGeneralFormHandler()->getForm();
-        $pageForm = $this->getPageFormHandler()->getForm();
-        $paginationForm = $this->getPaginationFormHandler()->getForm();
-
-        $stockForm = $this->processForm(
-            $request,
-            $this->getStockFormHandler(),
-            'Stock'
-        );
-
-        return $this->renderForm($request, $generalForm, $pageForm, $paginationForm, $stockForm);
-    }
-
-    /**
-     * @param Request $request
-     * @param FormInterface $generalForm
-     * @param FormInterface $pageForm
-     * @param FormInterface $paginationForm
-     * @param FormInterface $stockForm
-     *
-     * @return Response
-     */
-    protected function renderForm(
-        Request $request,
-        FormInterface $generalForm,
-        FormInterface $pageForm,
-        FormInterface $paginationForm,
-        FormInterface $stockForm
-    ): Response {
         $legacyController = $request->attributes->get('_legacy_controller');
+
+        $generalForm = $this->getGeneralFormHandler()->getForm();
+        $pageForm = $this->getPageFormHandler()->getForm();
+        $paginationForm = $this->getPaginationFormHandler()->getForm();
+        $stockForm = $this->getStockFormHandler()->getForm();
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/product_preferences.html.twig', [
             'layoutHeaderToolbarBtn' => [],
@@ -190,15 +71,91 @@ class ProductPreferencesController extends FrameworkBundleAdminController
     }
 
     /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function processGeneralFormAction(Request $request)
+    {
+        return $this->processForm(
+            $request,
+            $this->getGeneralFormHandler(),
+            'General'
+        );
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function processPageFormAction(Request $request)
+    {
+        return $this->processForm(
+            $request,
+            $this->getPageFormHandler(),
+            'Page'
+        );
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function processPaginationFormAction(Request $request)
+    {
+        return $this->processForm(
+            $request,
+            $this->getPaginationFormHandler(),
+            'Pagination'
+        );
+    }
+
+    /**
+     * @AdminSecurity("is_granted(['update', 'create', 'delete'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to update this.",
+     *     redirectRoute="admin_product_preferences"
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function processStockFormAction(Request $request)
+    {
+        return $this->processForm(
+            $request,
+            $this->getStockFormHandler(),
+            'Stock'
+        );
+    }
+
+    /**
      * Process the Product Preferences configuration form.
      *
      * @param Request $request
      * @param FormHandlerInterface $formHandler
      * @param string $hookName
      *
-     * @return FormInterface
+     * @return RedirectResponse
      */
-    protected function processForm(Request $request, FormHandlerInterface $formHandler, string $hookName): FormInterface
+    protected function processForm(Request $request, FormHandlerInterface $formHandler, string $hookName)
     {
         $this->dispatchHook(
             'actionAdminShopParametersProductPreferencesControllerPostProcess' . $hookName . 'Before',
@@ -210,7 +167,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
         $form = $formHandler->getForm();
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted()) {
             $data = $form->getData();
             $saveErrors = $formHandler->save($data);
 
@@ -221,7 +178,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
             }
         }
 
-        return $form;
+        return $this->redirectToRoute('admin_product_preferences');
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -69,7 +69,7 @@ class GeneralType extends TranslatorAwareType
                     new Type(
                         [
                             'value' => 'numeric',
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                     new GreaterThanOrEqual(

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -33,6 +33,8 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class generates "General" form
@@ -46,16 +48,61 @@ class GeneralType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('catalog_mode', SwitchType::class)
-            ->add('catalog_mode_with_prices', SwitchType::class)
+            ->add('catalog_mode', SwitchType::class,
+            [
+                'label' => $this->trans('Catalog mode', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.', 'Admin.Shopparameters.Help')
+                    . '<br>' .
+                    $this->trans('Have specific needs? Edit particular groups to let them see prices or not.', 'Admin.Shopparameters.Help'),
+            ])
+            ->add('catalog_mode_with_prices', SwitchType::class, [
+                'row_attr' => [
+                    'class' => 'catalog-mode-option',
+                ],
+                'label' => $this->trans('Show prices', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Display product prices when in catalog mode.', 'Admin.Shopparameters.Help'),
+            ])
             ->add('new_days_number', IntegerType::class, [
                 'required' => false,
+                'label' => $this->trans('Number of days for which the product is considered \'new\'', 'Admin.Shopparameters.Feature'),
+                'constraints' => [
+                    new Type(
+                        [
+                            'value' => 'numeric',
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                    new GreaterThanOrEqual(
+                        [
+                            'value' => 0,
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                ],
             ])
             ->add('short_description_limit', TextWithUnitType::class, [
+                'label' => $this->trans('Max size of product summary', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Set the maximum size of the summary of your product description (in characters).', 'Admin.Shopparameters.Help'),
+                'constraints' => [
+                    new Type(
+                        [
+                            'value' => 'numeric',
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                    new GreaterThanOrEqual(
+                        [
+                            'value' => 0,
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                ],
                 'required' => false,
                 'unit' => $this->trans('characters', 'Admin.Shopparameters.Help'),
             ])
             ->add('quantity_discount', ChoiceType::class, [
+                'label' => $this->trans('Quantity discounts based on', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('How to calculate quantity discounts.', 'Admin.Shopparameters.Help'),
                 'choices' => [
                     'Products' => 0,
                     'Combinations' => 1,
@@ -63,8 +110,14 @@ class GeneralType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ])
-            ->add('force_friendly_url', SwitchType::class)
-            ->add('default_status', SwitchType::class);
+            ->add('force_friendly_url', SwitchType::class, [
+                'label' => $this->trans('Force update of friendly URL', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('When active, friendly URL will be updated on every save.', 'Admin.Shopparameters.Help'),
+            ])
+            ->add('default_status', SwitchType::class, [
+                'label' => $this->trans('Default activation status', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('When active, new products will be activated by default during creation.', 'Admin.Shopparameters.Help'),
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -75,7 +75,7 @@ class GeneralType extends TranslatorAwareType
                     new GreaterThanOrEqual(
                         [
                             'value' => 0,
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -87,7 +87,7 @@ class GeneralType extends TranslatorAwareType
                     new Type(
                         [
                             'value' => 'numeric',
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                     new GreaterThanOrEqual(

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -42,27 +42,35 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class GeneralType extends TranslatorAwareType
 {
+    public const FIELD_CATALOG_MODE = 'catalog_mode';
+    public const FIELD_CATALOG_MODE_WITH_PRICES = 'catalog_mode_with_prices';
+    public const FIELD_NEW_DAYS_NUMBER = 'new_days_number';
+    public const FIELD_SHORT_DESCRIPTION_LIMIT = 'short_description_limit';
+    public const FIELD_QUANTITY_DISCOUNT = 'quantity_discount';
+    public const FIELD_FORCE_FRIENDLY_URL = 'force_friendly_url';
+    public const FIELD_DEFAULT_STATUS = 'default_status';
+
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('catalog_mode', SwitchType::class,
+            ->add(static::FIELD_CATALOG_MODE, SwitchType::class,
             [
                 'label' => $this->trans('Catalog mode', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.', 'Admin.Shopparameters.Help')
                     . '<br>' .
                     $this->trans('Have specific needs? Edit particular groups to let them see prices or not.', 'Admin.Shopparameters.Help'),
             ])
-            ->add('catalog_mode_with_prices', SwitchType::class, [
+            ->add(static::FIELD_CATALOG_MODE_WITH_PRICES, SwitchType::class, [
                 'row_attr' => [
                     'class' => 'catalog-mode-option',
                 ],
                 'label' => $this->trans('Show prices', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Display product prices when in catalog mode.', 'Admin.Shopparameters.Help'),
             ])
-            ->add('new_days_number', IntegerType::class, [
+            ->add(static::FIELD_NEW_DAYS_NUMBER, IntegerType::class, [
                 'required' => false,
                 'label' => $this->trans('Number of days for which the product is considered \'new\'', 'Admin.Shopparameters.Feature'),
                 'constraints' => [
@@ -80,7 +88,7 @@ class GeneralType extends TranslatorAwareType
                     ),
                 ],
             ])
-            ->add('short_description_limit', TextWithUnitType::class, [
+            ->add(static::FIELD_SHORT_DESCRIPTION_LIMIT, TextWithUnitType::class, [
                 'label' => $this->trans('Max size of product summary', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Set the maximum size of the summary of your product description (in characters).', 'Admin.Shopparameters.Help'),
                 'constraints' => [
@@ -100,7 +108,7 @@ class GeneralType extends TranslatorAwareType
                 'required' => false,
                 'unit' => $this->trans('characters', 'Admin.Shopparameters.Help'),
             ])
-            ->add('quantity_discount', ChoiceType::class, [
+            ->add(static::FIELD_QUANTITY_DISCOUNT, ChoiceType::class, [
                 'label' => $this->trans('Quantity discounts based on', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('How to calculate quantity discounts.', 'Admin.Shopparameters.Help'),
                 'choices' => [
@@ -110,11 +118,11 @@ class GeneralType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'required' => true,
             ])
-            ->add('force_friendly_url', SwitchType::class, [
+            ->add(static::FIELD_FORCE_FRIENDLY_URL, SwitchType::class, [
                 'label' => $this->trans('Force update of friendly URL', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('When active, friendly URL will be updated on every save.', 'Admin.Shopparameters.Help'),
             ])
-            ->add('default_status', SwitchType::class, [
+            ->add(static::FIELD_DEFAULT_STATUS, SwitchType::class, [
                 'label' => $this->trans('Default activation status', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('When active, new products will be activated by default during creation.', 'Admin.Shopparameters.Help'),
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -93,7 +93,7 @@ class GeneralType extends TranslatorAwareType
                     new GreaterThanOrEqual(
                         [
                             'value' => 0,
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -74,12 +74,7 @@ class PageType extends TranslatorAwareType
             ])
             ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
                 'label' => $this->trans('Display the "%add_to_cart_label%" button when a product has attributes', 'Admin.Shopparameters.Help'),
-                'help' => $this->trans('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.',
-                    'Admin.Shopparameters.Help',
-                    [
-                        '%add_to_cart_label%' => $this->trans('Add to cart', 'Shop.Theme.Actions'),
-                    ]
-                ),
+                'help' => $this->trans('Note that this setting does not work with the default theme anymore', 'Admin.Shopparameters.Help'),
             ])
             ->add('attribute_anchor_separator', ChoiceType::class, [
                 'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -63,7 +63,7 @@ class PageType extends TranslatorAwareType
                     new GreaterThanOrEqual(
                         [
                             'value' => 0,
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -73,7 +73,13 @@ class PageType extends TranslatorAwareType
                 'help' => $this->trans('If an attribute is not available in every product combination, it will not be displayed.', 'Admin.Shopparameters.Help'),
             ])
             ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
-                'label' => $this->trans('Display the "%add_to_cart_label%" button when a product has attributes', 'Admin.Shopparameters.Help'),
+                'label' => $this->trans(
+                    'Display the "%add_to_cart_label%" button when a product has attributes',
+                    'Admin.Shopparameters.Feature',
+                    [
+                        '%add_to_cart_label%' => $this->trans('Add to cart', 'Shop.Theme.Actions'),
+                    ]
+                ),
                 'help' => $this->trans('Note that this setting does not work with the default theme anymore', 'Admin.Shopparameters.Help'),
             ])
             ->add('attribute_anchor_separator', ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -57,7 +57,7 @@ class PageType extends TranslatorAwareType
                     new Type(
                         [
                             'value' => 'numeric',
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                     new GreaterThanOrEqual(

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -80,7 +80,7 @@ class PageType extends TranslatorAwareType
                         '%add_to_cart_label%' => $this->trans('Add to cart', 'Shop.Theme.Actions'),
                     ]
                 ),
-                'help' => $this->trans('Note that this setting does not work with the default theme anymore', 'Admin.Shopparameters.Help'),
+                'help' => $this->trans('Note that this setting does not work with the default theme anymore.', 'Admin.Shopparameters.Help'),
             ])
             ->add('attribute_anchor_separator', ChoiceType::class, [
                 'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -27,17 +27,19 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class generates "Product page" form
  * in "Configure > Shop Parameters > Product Settings" page.
  */
-class PageType extends AbstractType
+class PageType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -45,10 +47,40 @@ class PageType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('display_quantities', SwitchType::class)
-            ->add('display_last_quantities', IntegerType::class)
-            ->add('display_unavailable_attributes', SwitchType::class)
-            ->add('allow_add_variant_to_cart_from_listing', SwitchType::class)
+            ->add('display_quantities', SwitchType::class, [
+                'label' => $this->trans('Display available quantities on the product page', 'Admin.Shopparameters.Feature'),
+            ])
+            ->add('display_last_quantities', IntegerType::class, [
+                'label' => $this->trans('Display remaining quantities when the quantity is lower than', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Set to "0" to disable this feature.', 'Admin.Shopparameters.Help'),
+                'constraints' => [
+                    new Type(
+                        [
+                            'value' => 'numeric',
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                    new GreaterThanOrEqual(
+                        [
+                            'value' => 0,
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                ],
+            ])
+            ->add('display_unavailable_attributes', SwitchType::class, [
+                'label' => $this->trans('Display unavailable attributes on the product page', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('If an attribute is not available in every product combination, it will not be displayed.', 'Admin.Shopparameters.Help'),
+            ])
+            ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
+                'label' => $this->trans('Display the "%add_to_cart_label%" button when a product has attributes', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.',
+                    'Admin.Shopparameters.Help',
+                    [
+                        '%add_to_cart_label%' => $this->trans('Add to cart', 'Shop.Theme.Actions'),
+                    ]
+                ),
+            ])
             ->add('attribute_anchor_separator', ChoiceType::class, [
                 'choices' => [
                     '-' => '-',
@@ -56,8 +88,12 @@ class PageType extends AbstractType
                 ],
                 'required' => true,
                 'choice_translation_domain' => 'Admin.Global',
+                'label' => $this->trans('Separator of attribute anchor on the product links', 'Admin.Shopparameters.Feature'),
             ])
-            ->add('display_discount_price', SwitchType::class);
+            ->add('display_discount_price', SwitchType::class, [
+                'label' => $this->trans('Display discounted price', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").', 'Admin.Shopparameters.Help'),
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -73,7 +73,7 @@ class PageType extends TranslatorAwareType
                 'help' => $this->trans('If an attribute is not available in every product combination, it will not be displayed.', 'Admin.Shopparameters.Help'),
             ])
             ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
-                'label' => $this->trans('Display the "%add_to_cart_label%" button when a product has attributes', 'Admin.Shopparameters.Feature'),
+                'label' => $this->trans('Display the "%add_to_cart_label%" button when a product has attributes', 'Admin.Shopparameters.Help'),
                 'help' => $this->trans('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.',
                     'Admin.Shopparameters.Help',
                     [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -41,16 +41,24 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class PageType extends TranslatorAwareType
 {
+    public const FIELD_DISPLAY_QUANTITIES = 'display_quantities';
+    public const FIELD_DISPLAY_LAST_QUANTITIES = 'display_last_quantities';
+    public const FIELD_DISPLAY_UNAVAILABLE_ATTRIBUTES = 'display_unavailable_attributes';
+    public const FIELD_ALLOW_ADD_VARIANT_TO_CART_FROM_LISTING = 'allow_add_variant_to_cart_from_listing';
+    public const FIELD_ATTRIBUTE_ANCHOR_SEPARATOR = 'attribute_anchor_separator';
+    public const FIELD_DISPLAY_DISCOUNT_PRICE = 'display_discount_price';
+
+
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('display_quantities', SwitchType::class, [
+            ->add(static::FIELD_DISPLAY_QUANTITIES, SwitchType::class, [
                 'label' => $this->trans('Display available quantities on the product page', 'Admin.Shopparameters.Feature'),
             ])
-            ->add('display_last_quantities', IntegerType::class, [
+            ->add(static::FIELD_DISPLAY_LAST_QUANTITIES, IntegerType::class, [
                 'label' => $this->trans('Display remaining quantities when the quantity is lower than', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Set to "0" to disable this feature.', 'Admin.Shopparameters.Help'),
                 'constraints' => [
@@ -68,11 +76,11 @@ class PageType extends TranslatorAwareType
                     ),
                 ],
             ])
-            ->add('display_unavailable_attributes', SwitchType::class, [
+            ->add(static::FIELD_DISPLAY_UNAVAILABLE_ATTRIBUTES, SwitchType::class, [
                 'label' => $this->trans('Display unavailable attributes on the product page', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('If an attribute is not available in every product combination, it will not be displayed.', 'Admin.Shopparameters.Help'),
             ])
-            ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
+            ->add(static::FIELD_ALLOW_ADD_VARIANT_TO_CART_FROM_LISTING, SwitchType::class, [
                 'label' => $this->trans(
                     'Display the "%add_to_cart_label%" button when a product has attributes',
                     'Admin.Shopparameters.Feature',
@@ -82,7 +90,7 @@ class PageType extends TranslatorAwareType
                 ),
                 'help' => $this->trans('Note that this setting does not work with the default theme anymore.', 'Admin.Shopparameters.Help'),
             ])
-            ->add('attribute_anchor_separator', ChoiceType::class, [
+            ->add(static::FIELD_ATTRIBUTE_ANCHOR_SEPARATOR, ChoiceType::class, [
                 'choices' => [
                     '-' => '-',
                     ',' => ',',
@@ -91,7 +99,7 @@ class PageType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'label' => $this->trans('Separator of attribute anchor on the product links', 'Admin.Shopparameters.Feature'),
             ])
-            ->add('display_discount_price', SwitchType::class, [
+            ->add(static::FIELD_DISPLAY_DISCOUNT_PRICE, SwitchType::class, [
                 'label' => $this->trans('Display discounted price', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").', 'Admin.Shopparameters.Help'),
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -26,17 +26,19 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class generates "Pagination" form
  * in "Configure > Shop Parameters > Product Settings" page.
  */
-class PaginationType extends AbstractType
+class PaginationType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -44,8 +46,27 @@ class PaginationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('products_per_page', IntegerType::class)
+            ->add('products_per_page', IntegerType::class, [
+                'label' => $this->trans('Products per page', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Number of products displayed per page. Default is 10.', 'Admin.Shopparameters.Help'),
+                'constraints' => [
+                    new Type(
+                        [
+                            'value' => 'numeric',
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                    new GreaterThanOrEqual(
+                        [
+                            'value' => 0,
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                ],
+            ])
             ->add('default_order_by', ChoiceType::class, [
+                'label' => $this->trans('Default order by', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('The order in which products are displayed in the product list.', 'Admin.Shopparameters.Help'),
                 'choices' => [
                     'Product name' => 0,
                     'Product price' => 1,
@@ -59,6 +80,8 @@ class PaginationType extends AbstractType
                 'required' => true,
             ])
             ->add('default_order_way', ChoiceType::class, [
+                'label' => $this->trans('Default order method', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Default order method for product list.', 'Admin.Shopparameters.Help'),
                 'choices' => [
                     'Ascending' => 0,
                     'Descending' => 1,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -53,7 +53,7 @@ class PaginationType extends TranslatorAwareType
                     new Type(
                         [
                             'value' => 'numeric',
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                     new GreaterThanOrEqual(

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -40,13 +40,16 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class PaginationType extends TranslatorAwareType
 {
+    public const FIELD_PRODUCTS_PER_PAGE = 'products_per_page';
+    public const FIELD_DEFAULT_ORDER_BY = 'default_order_by';
+    public const FIELD_DEFAULT_ORDER_WAY = 'default_order_way';
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('products_per_page', IntegerType::class, [
+            ->add(static::FIELD_PRODUCTS_PER_PAGE, IntegerType::class, [
                 'label' => $this->trans('Products per page', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Number of products displayed per page. Default is 10.', 'Admin.Shopparameters.Help'),
                 'constraints' => [
@@ -64,7 +67,7 @@ class PaginationType extends TranslatorAwareType
                     ),
                 ],
             ])
-            ->add('default_order_by', ChoiceType::class, [
+            ->add(static::FIELD_DEFAULT_ORDER_BY, ChoiceType::class, [
                 'label' => $this->trans('Default order by', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('The order in which products are displayed in the product list.', 'Admin.Shopparameters.Help'),
                 'choices' => [
@@ -79,7 +82,7 @@ class PaginationType extends TranslatorAwareType
                 ],
                 'required' => true,
             ])
-            ->add('default_order_way', ChoiceType::class, [
+            ->add(static::FIELD_DEFAULT_ORDER_WAY, ChoiceType::class, [
                 'label' => $this->trans('Default order method', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Default order method for product list.', 'Admin.Shopparameters.Help'),
                 'choices' => [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -59,7 +59,7 @@ class PaginationType extends TranslatorAwareType
                     new GreaterThanOrEqual(
                         [
                             'value' => 0,
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer number.', 'Admin.Notifications.Error'),
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
                         ]
                     ),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -46,29 +46,51 @@ class StockType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('allow_ordering_oos', SwitchType::class)
-            ->add('stock_management', SwitchType::class)
+            ->add('allow_ordering_oos', SwitchType::class, [
+                'label' => $this->trans('Allow ordering of out-of-stock products', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans(
+                    'By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.',
+                    'Admin.Shopparameters.Help',
+                    [
+                        '%add_to_cart_label%' => $this->trans('Add to cart', 'Shop.Theme.Actions'),
+                    ]
+                ),
+            ])
+            ->add('stock_management', SwitchType::class, [
+                'label' => $this->trans('Enable stock management', 'Admin.Shopparameters.Feature'),
+            ])
             ->add('in_stock_label', TranslatableType::class, [
+                'label' => $this->trans('Label of in-stock products', 'Admin.Shopparameters.Feature'),
                 'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])
             ->add('oos_allowed_backorders', TranslatableType::class, [
+                'label' => $this->trans('Label of out-of-stock products with allowed backorders', 'Admin.Shopparameters.Feature'),
                 'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])
             ->add('oos_denied_backorders', TranslatableType::class, [
+                'label' => $this->trans('Label of out-of-stock products with denied backorders', 'Admin.Shopparameters.Feature'),
                 'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])
             ->add('delivery_time', TranslatableType::class, [
-                'type' => TextType::class,
+                'label' => $this->trans('Delivery time of in-stock products', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans(
+                        'Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)',
+                        'Admin.Shopparameters.Help'
+                    ) . '</br>' . $this->trans('Leave empty to disable.', 'Admin.Shopparameters.Feature'),                'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])
             ->add('oos_delivery_time', TranslatableType::class, [
+                'label' => $this->trans('Delivery time of out-of-stock products with allowed backorders', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)', 'Admin.Shopparameters.Help'),
                 'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])
             ->add('pack_stock_management', ChoiceType::class, [
+                'label' => $this->trans('Default pack stock management', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('When selling packs of products, how do you want your stock to be calculated?', 'Admin.Shopparameters.Help'),
                 'choices' => [
                     'Decrement pack only.' => 0,
                     'Decrement products in pack only.' => 1,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -77,7 +77,7 @@ class StockType extends TranslatorAwareType
             ->add('delivery_time', TranslatableType::class, [
                 'label' => $this->trans('Delivery time of in-stock products', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans(
-                        'Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)',
+                        'Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days).',
                         'Admin.Shopparameters.Help'
                     ) . '</br>' . $this->trans('Leave empty to disable.', 'Admin.Shopparameters.Help'),
                 'type' => TextType::class,
@@ -85,7 +85,7 @@ class StockType extends TranslatorAwareType
             ])
             ->add('oos_delivery_time', TranslatableType::class, [
                 'label' => $this->trans('Delivery time of out-of-stock products with allowed backorders', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)', 'Admin.Shopparameters.Help'),
+                'help' => $this->trans('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days).', 'Admin.Shopparameters.Help'),
                 'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -79,7 +79,8 @@ class StockType extends TranslatorAwareType
                 'help' => $this->trans(
                         'Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)',
                         'Admin.Shopparameters.Help'
-                    ) . '</br>' . $this->trans('Leave empty to disable.', 'Admin.Shopparameters.Feature'),                'type' => TextType::class,
+                    ) . '</br>' . $this->trans('Leave empty to disable.', 'Admin.Shopparameters.Help'),
+                'type' => TextType::class,
                 'only_enabled_locales' => false,
             ])
             ->add('oos_delivery_time', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -52,6 +52,7 @@ class SwitchType extends AbstractType
             'multiple' => false,
             'expanded' => false,
             'disabled' => false,
+            'required' => false,
             'choice_translation_domain' => self::TRANS_DOMAIN,
         ]);
         $resolver->setAllowedTypes('disabled', 'bool');

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -415,8 +415,23 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.product_preferences.page:
+        class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\PageType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.product_preferences.stock:
         class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\StockType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
+
+    form.type.product_preferences.pagination:
+        class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\PaginationType'
         parent: 'form.type.translatable.aware'
         public: true
         tags:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme generalForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_general %}
 <div class="row justify-content-center">
@@ -35,62 +35,7 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Catalog mode'|trans), ('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.catalog_mode) }}
-              {{ form_widget(generalForm.catalog_mode) }}
-              <small class="form-text">{{ 'Have specific needs? Edit particular groups to let them see prices or not.'|trans({}, 'Admin.Shopparameters.Help') }}</small>
-            </div>
-          </div>
-          <div class="form-group row catalog-mode-option">
-            {{ ps.label_with_help(('Show prices'|trans), ('Display product prices when in catalog mode.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.catalog_mode_with_prices) }}
-              {{ form_widget(generalForm.catalog_mode_with_prices) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Number of days for which the product is considered \'new\''|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generalForm.new_days_number) }}
-              {{ form_widget(generalForm.new_days_number) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Max size of product summary'|trans), ('Set the maximum size of the summary of your product description (in characters).'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.short_description_limit) }}
-              {{ form_widget(generalForm.short_description_limit) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Quantity discounts based on'|trans), ('How to calculate quantity discounts.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.quantity_discount) }}
-              {{ form_widget(generalForm.quantity_discount) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Force update of friendly URL'|trans), ('When active, friendly URL will be updated on every save.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.force_friendly_url) }}
-              {{ form_widget(generalForm.force_friendly_url) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default activation status'|trans), ('When active, new products will be activated by default during creation.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.default_status) }}
-              {{ form_widget(generalForm.default_status) }}
-            </div>
-          </div>
-
-          {% block product_general_preferences_form_rest %}
-            {{ form_rest(generalForm) }}
-          {% endblock %}
+          {{ form_widget(generalForm) }}
         </div>
       </div>
       <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme pageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_page %}
 <div class="row justify-content-center">
@@ -35,60 +35,8 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Display available quantities on the product page'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_quantities) }}
-              {{ form_widget(pageForm.display_quantities) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Display remaining quantities when the quantity is lower than'|trans), ('Set to "0" to disable this feature.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_last_quantities) }}
-              {{ form_widget(pageForm.display_last_quantities) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Display unavailable attributes on the product page'|trans), ('If an attribute is not available in every product combination, it will not be displayed.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_unavailable_attributes) }}
-              {{ form_widget(pageForm.display_unavailable_attributes) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Display the "%add_to_cart_label%" button when a product has attributes'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help')), ('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pageForm.allow_add_variant_to_cart_from_listing) }}
-              {{ form_widget(pageForm.allow_add_variant_to_cart_from_listing) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Separator of attribute anchor on the product links'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(pageForm.attribute_anchor_separator) }}
-              {{ form_widget(pageForm.attribute_anchor_separator) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Display discounted price'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_discount_price) }}
-              {{ form_widget(pageForm.display_discount_price) }}
-              <small class="form-text">{{ 'In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").'|trans({}, 'Admin.Shopparameters.Help') }}</small>
-            </div>
-          </div>
+          {{ form_widget(pageForm) }}
         </div>
-
-        {% block product_page_preferences_form_rest %}
-          {{ form_rest(pageForm) }}
-        {% endblock %}
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme paginationForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_pagination %}
 <div class="row justify-content-center">
@@ -35,31 +35,7 @@
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Products per page'|trans), ('Number of products displayed per page. Default is 10.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(paginationForm.products_per_page) }}
-              {{ form_widget(paginationForm.products_per_page) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default order by'|trans), ('The order in which products are displayed in the product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(paginationForm.default_order_by) }}
-              {{ form_widget(paginationForm.default_order_by) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default order method'|trans), ('Default order method for product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(paginationForm.default_order_way) }}
-              {{ form_widget(paginationForm.default_order_way) }}
-            </div>
-          </div>
-
-          {% block product_pagination_preferences_form_rest %}
-            {{ form_rest(paginationForm) }}
-          {% endblock %}
+          {{ form_widget(paginationForm) }}
         </div>
       </div>
       <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -24,95 +24,26 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme stockForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_stock %}
-<div class="row justify-content-center">
-  <div class="col">
-    <div class="card" id="configuration_fieldset_stock">
-      <h3 class="card-header">
-        <i class="material-icons">shop</i> {{ 'Products stock'|trans }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Allow ordering of out-of-stock products'|trans), ('By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.allow_ordering_oos) }}
-              {{ form_widget(stockForm.allow_ordering_oos) }}
-            </div>
+  <div class="row justify-content-center">
+    <div class="col">
+      <div class="card" id="configuration_fieldset_stock">
+        <h3 class="card-header">
+          <i class="material-icons">shop</i> {{ 'Products stock'|trans }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_widget(stockForm) }}
           </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Enable stock management'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.stock_management) }}
-              {{ form_widget(stockForm.stock_management) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Label of in-stock products'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.stock_management) }}
-              {{ form_widget(stockForm.in_stock_label) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Label of out-of-stock products with allowed backorders'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.oos_allowed_backorders) }}
-              {{ form_widget(stockForm.oos_allowed_backorders) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Label of out-of-stock products with denied backorders'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.oos_denied_backorders) }}
-              {{ form_widget(stockForm.oos_denied_backorders) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Delivery time of in-stock products'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.delivery_time) }}
-              {{ form_widget(stockForm.delivery_time) }}
-              <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Delivery time of out-of-stock products with allowed backorders'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.oos_delivery_time) }}
-              {{ form_widget(stockForm.oos_delivery_time) }}
-              <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default pack stock management'|trans), ('When selling packs of products, how do you want your stock to be calculated?'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.pack_stock_management) }}
-              {{ form_widget(stockForm.pack_stock_management) }}
-            </div>
-          </div>
-
-          {% block product_stock_preferences_form_rest %}
-            {{ form_rest(stockForm) }}
-          {% endblock %}
         </div>
-      </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="form-stock-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary" id="form-stock-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -149,5 +149,11 @@
         <span class="input-group-text js-countable-text">{{ current_length }}</span>
       </div>
     {% endif %}
+
+    {%- block integer_widget -%}
+      {%- set type = type|default('number') -%}
+      {{ block('form_widget_simple') }}
+      {{- block('form_help') -}}
+    {%- endblock integer_widget -%}
   </div>
 {% endblock text_with_length_counter_widget %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies product preferences form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Configuration -> Shop Parameters -> Product Preferences. Everything must look the same aside for help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by PageType and PaginationType. This means if any module extends those types they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
