### PR TITLE
Simplify cms forms

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -34,6 +34,7 @@ import GeneratableInput from '@js/components/generatable-input.js';
 import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
 import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
 import TextWithLengthCounter from '@components/form/text-with-length-counter';
+import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field.js';
 import {EventEmitter} from '@components/event-emitter';
 
@@ -91,6 +92,7 @@ const initPrestashopComponents = () => {
     CountryDniRequiredToggler,
     TextWithLengthCounter,
     MultistoreConfigField,
+    PreviewOpener,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
@@ -53,6 +53,7 @@ $(() => {
     $('#serp-app').data('cms-url'),
   );
 
+  /** @todo do with components */
   new TranslatableField();
   new TinyMCEEditor();
 

--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.js
@@ -23,13 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import PreviewOpener from '@components/form/preview-opener';
 import ChoiceTree from '@components/form/choice-tree';
-import TaggableField from '@components/taggable-field';
-import TranslatableInput from '@components/translatable-input';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
-import TranslatableField from '@components/translatable-field';
-import TinyMCEEditor from '@components/tinymce-editor';
 import Serp from '@app/utils/serp/index';
 
 const {$} = window;
@@ -37,7 +32,15 @@ const {$} = window;
 $(() => {
   new ChoiceTree('#cms_page_page_category_id');
 
-  const translatorInput = new TranslatableInput();
+  window.prestashop.component.initComponents(
+    [
+      'TranslatableInput',
+      'TranslatableField',
+      'TinyMCEEditor',
+    ],
+  );
+
+  const translatorInput = window.prestashop.instance.translatableInput;
 
   new Serp(
     {
@@ -53,18 +56,14 @@ $(() => {
     $('#serp-app').data('cms-url'),
   );
 
-  /** @todo do with components */
-  new TranslatableField();
-  new TinyMCEEditor();
-
-  new TaggableField({
+  new window.prestashop.component.TaggableField({
     tokenFieldSelector: 'input.js-taggable-field',
     options: {
       createTokensOnBlur: true,
     },
   });
 
-  new PreviewOpener('.js-preview-url');
+  new window.prestashop.component.PreviewOpener('.js-preview-url');
 
   textToLinkRewriteCopier({
     sourceElementSelector: 'input.js-copier-source-title',

--- a/src/Core/ConstraintValidator/CleanHtmlValidator.php
+++ b/src/Core/ConstraintValidator/CleanHtmlValidator.php
@@ -37,7 +37,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 final class CleanHtmlValidator extends ConstraintValidator
 {
-    private const IFRAME_PATTERN = '/<[\s]*(i?frame|form|input|embed|object)/ims';
+    private const EMBEDDABLE_HTML_PATTERN = '/<[\s]*(i?frame|form|input|embed|object)/ims';
 
     /**
      * @var bool
@@ -69,7 +69,7 @@ final class CleanHtmlValidator extends ConstraintValidator
         $containsScriptTags = preg_match('/<[\s]*script/ims', $value) || preg_match('/.*script\:/ims', $value);
         $containsJavascriptEvents = preg_match('/(' . $this->getJavascriptEvents() . ')[\s]*=/ims', $value);
 
-        $iframe = !$this->allowIframe && preg_match(self::IFRAME_PATTERN, $value);
+        $iframe = !$this->allowIframe && preg_match(self::EMBEDDABLE_HTML_PATTERN, $value);
         if ($containsScriptTags || $containsJavascriptEvents || $iframe) {
             $this->context->buildViolation($constraint->message)
                 ->setTranslationDomain('Admin.Notifications.Error')

--- a/src/Core/ConstraintValidator/CleanHtmlValidator.php
+++ b/src/Core/ConstraintValidator/CleanHtmlValidator.php
@@ -42,11 +42,11 @@ final class CleanHtmlValidator extends ConstraintValidator
     /**
      * @var bool
      */
-    private $allowIframe;
+    private $allowEmbeddableHtml;
 
-    public function __construct(bool $allowIframe)
+    public function __construct(bool $allowEmbeddableHtml)
     {
-        $this->allowIframe = $allowIframe;
+        $this->allowEmbeddableHtml = $allowEmbeddableHtml;
     }
 
     /**
@@ -69,7 +69,7 @@ final class CleanHtmlValidator extends ConstraintValidator
         $containsScriptTags = preg_match('/<[\s]*script/ims', $value) || preg_match('/.*script\:/ims', $value);
         $containsJavascriptEvents = preg_match('/(' . $this->getJavascriptEvents() . ')[\s]*=/ims', $value);
 
-        $iframe = !$this->allowIframe && preg_match(self::EMBEDDABLE_HTML_PATTERN, $value);
+        $iframe = !$this->allowEmbeddableHtml && preg_match(self::EMBEDDABLE_HTML_PATTERN, $value);
         if ($containsScriptTags || $containsJavascriptEvents || $iframe) {
             $this->context->buildViolation($constraint->message)
                 ->setTranslationDomain('Admin.Notifications.Error')

--- a/src/Core/ConstraintValidator/CleanHtmlValidator.php
+++ b/src/Core/ConstraintValidator/CleanHtmlValidator.php
@@ -38,6 +38,16 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 final class CleanHtmlValidator extends ConstraintValidator
 {
     /**
+     * @var bool
+     */
+    private $allowIframe;
+
+    public function __construct(bool $allowIframe)
+    {
+        $this->allowIframe = $allowIframe;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
@@ -57,7 +67,8 @@ final class CleanHtmlValidator extends ConstraintValidator
         $containsScriptTags = preg_match('/<[\s]*script/ims', $value) || preg_match('/.*script\:/ims', $value);
         $containsJavascriptEvents = preg_match('/(' . $this->getJavascriptEvents() . ')[\s]*=/ims', $value);
 
-        if ($containsScriptTags || $containsJavascriptEvents) {
+        $iframe = !$this->allowIframe && preg_match('/<[\s]*(i?frame|form|input|embed|object)/ims', $value);
+        if ($containsScriptTags || $containsJavascriptEvents || $iframe) {
             $this->context->buildViolation($constraint->message)
                 ->setTranslationDomain('Admin.Notifications.Error')
                 ->setParameter('%s', $this->formatValue($value))

--- a/src/Core/ConstraintValidator/CleanHtmlValidator.php
+++ b/src/Core/ConstraintValidator/CleanHtmlValidator.php
@@ -37,6 +37,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 final class CleanHtmlValidator extends ConstraintValidator
 {
+    private const IFRAME_PATTERN = '/<[\s]*(i?frame|form|input|embed|object)/ims';
+
     /**
      * @var bool
      */
@@ -67,7 +69,7 @@ final class CleanHtmlValidator extends ConstraintValidator
         $containsScriptTags = preg_match('/<[\s]*script/ims', $value) || preg_match('/.*script\:/ims', $value);
         $containsJavascriptEvents = preg_match('/(' . $this->getJavascriptEvents() . ')[\s]*=/ims', $value);
 
-        $iframe = !$this->allowIframe && preg_match('/<[\s]*(i?frame|form|input|embed|object)/ims', $value);
+        $iframe = !$this->allowIframe && preg_match(self::IFRAME_PATTERN, $value);
         if ($containsScriptTags || $containsJavascriptEvents || $iframe) {
             $this->context->buildViolation($constraint->message)
                 ->setTranslationDomain('Admin.Notifications.Error')

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -352,6 +352,8 @@ class CmsPageController extends FrameworkBundleAdminController
             '@PrestaShop/Admin/Improve/Design/Cms/create_category.html.twig',
             [
                 'cmsPageCategoryForm' => $cmsPageCategoryForm->createView(),
+                'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             ]
         );
     }
@@ -415,6 +417,8 @@ class CmsPageController extends FrameworkBundleAdminController
             [
                 'cmsPageCategoryForm' => $cmsPageCategoryForm->createView(),
                 'cmsCategoryParentId' => $cmsCategoryParentId,
+                'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             ]
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\IsUrlRewrite;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -79,8 +80,8 @@ class CmsPageCategoryType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>;=#{}';
-        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>={}';
+        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . TypedRegexValidator::CATALOG_CHARS;
+        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . TypedRegexValidator::GENERIC_NAME_CHARS;
         $builder
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -74,7 +74,7 @@ class CmsPageCategoryType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') .  '<>;=#{}';
+        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>;=#{}';
         $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>={}';
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -189,7 +189,7 @@ class CmsPageCategoryType extends TranslatorAwareType
             ])
             ->add('friendly_url', TranslatableType::class, [
                 'label' => $this->trans('Friendly URL', 'Admin.Global'),
-                'help' => $this->trans('Only letters and the minus (-) character are allowed.', 'Admin.Catalog.Help'),
+                'help' => $this->trans('Unless the \'Accented URL\' option is enabled (in Shop parameters > Traffic & SEO), only letters, numbers, underscores (_), and hyphens (-) are allowed.', 'Admin.Catalog.Help'),
                 'constraints' => [
                     new DefaultLanguage(),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -46,6 +46,12 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class CmsPageCategoryType extends TranslatorAwareType
 {
+    private const NAME_MAX_LENGTH = 64;
+    private const FRIENDLY_URL_MAX_LENGTH = 64;
+    private const META_TITLE_MAX_LENGTH = 255;
+    private const META_KEYWORDS_MAX_LENGTH = 255;
+    private const META_DESCRIPTION_MAX_LENGTH = 512;
+
     /**
      * @var array
      */
@@ -89,11 +95,11 @@ class CmsPageCategoryType extends TranslatorAwareType
                             'type' => 'catalog_name',
                         ]),
                         new Length([
-                            'max' => 64,
+                            'max' => self::NAME_MAX_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 64]
+                                ['%limit%' => self::NAME_MAX_LENGTH]
                             ),
                         ]),
                     ],
@@ -129,11 +135,11 @@ class CmsPageCategoryType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 255,
+                            'max' => self::META_TITLE_MAX_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 255]
+                                ['%limit%' => self::META_TITLE_MAX_LENGTH]
                             ),
                         ]),
                     ],
@@ -149,11 +155,11 @@ class CmsPageCategoryType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 512,
+                            'max' => self::META_DESCRIPTION_MAX_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 512]
+                                ['%limit%' => self::META_DESCRIPTION_MAX_LENGTH]
                             ),
                         ]),
                     ],
@@ -169,11 +175,11 @@ class CmsPageCategoryType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 255,
+                            'max' => self::META_KEYWORDS_MAX_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 255]
+                                ['%limit%' => self::META_KEYWORDS_MAX_LENGTH]
                             ),
                         ]),
                     ],
@@ -192,11 +198,11 @@ class CmsPageCategoryType extends TranslatorAwareType
                     'constraints' => [
                         new IsUrlRewrite(),
                         new Length([
-                            'max' => 64,
+                            'max' => self::FRIENDLY_URL_MAX_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 64]
+                                ['%limit%' => self::FRIENDLY_URL_MAX_LENGTH]
                             ),
                         ]),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -34,20 +34,18 @@ use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Translation\TranslatorAwareTrait;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * Defines form for Improve > Design > Pages > Categories create/edit actions
  */
-class CmsPageCategoryType extends AbstractType
+class CmsPageCategoryType extends TranslatorAwareType
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var array
      */
@@ -59,11 +57,14 @@ class CmsPageCategoryType extends AbstractType
     private $isShopFeatureEnabled;
 
     /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
      * @param array $allCmsCategories
      * @param bool $isShopFeatureEnabled
      */
-    public function __construct(array $allCmsCategories, $isShopFeatureEnabled)
+    public function __construct(TranslatorInterface $translator, array $locales, array $allCmsCategories, $isShopFeatureEnabled)
     {
+        parent::__construct($translator, $locales);
         $this->allCmsCategories = $allCmsCategories;
         $this->isShopFeatureEnabled = $isShopFeatureEnabled;
     }
@@ -73,8 +74,12 @@ class CmsPageCategoryType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Notifications.Info') .  '<>;=#{}';
+        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Notifications.Info') . '<>={}';
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->trans('Name', 'Admin.Global'),
+                'help' => $invalidCharactersForCatalogLabel,
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
@@ -85,24 +90,27 @@ class CmsPageCategoryType extends AbstractType
                         ]),
                         new Length([
                             'max' => 64,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 64],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 64]
                             ),
                         ]),
                     ],
                 ],
             ])
             ->add('is_displayed', SwitchType::class, [
+                'label' => $this->trans('Displayed', 'Admin.Global'),
                 'required' => false,
             ])
             ->add('parent_category', MaterialChoiceTreeType::class, [
+                'label' => $this->trans('Parent category', 'Admin.Design.Feature'),
                 'required' => false,
                 'choices_tree' => $this->allCmsCategories,
                 'choice_value' => 'id_cms_category',
             ])
             ->add('description', TranslatableType::class, [
+                'label' => $this->trans('Description', 'Admin.Global'),
                 'required' => false,
                 'type' => TextareaType::class,
                 'options' => [
@@ -112,7 +120,9 @@ class CmsPageCategoryType extends AbstractType
                 ],
             ])
             ->add('meta_title', TranslatableType::class, [
+                'label' => $this->trans('Meta title', 'Admin.Global'),
                 'required' => false,
+                'help' => $invalidCharactersForNameLabel,
                 'options' => [
                     'constraints' => [
                         new TypedRegex([
@@ -120,16 +130,18 @@ class CmsPageCategoryType extends AbstractType
                         ]),
                         new Length([
                             'max' => 255,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 255],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 255]
                             ),
                         ]),
                     ],
                 ],
             ])
             ->add('meta_description', TranslatableType::class, [
+                'label' => $this->trans('Meta description', 'Admin.Global'),
+                'help' => $invalidCharactersForNameLabel,
                 'required' => false,
                 'options' => [
                     'constraints' => [
@@ -138,16 +150,18 @@ class CmsPageCategoryType extends AbstractType
                         ]),
                         new Length([
                             'max' => 512,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 512],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 512]
                             ),
                         ]),
                     ],
                 ],
             ])
             ->add('meta_keywords', TranslatableType::class, [
+                'label' => $this->trans('Meta keywords', 'Admin.Global'),
+                'help' => $invalidCharactersForNameLabel,
                 'required' => false,
                 'options' => [
                     'constraints' => [
@@ -156,19 +170,21 @@ class CmsPageCategoryType extends AbstractType
                         ]),
                         new Length([
                             'max' => 255,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 255],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 255]
                             ),
                         ]),
                     ],
                     'attr' => [
-                        'placeholder' => $this->trans('Add tag', [], 'Admin.Actions'),
+                        'placeholder' => $this->trans('Add tag', 'Admin.Actions'),
                     ],
                 ],
             ])
             ->add('friendly_url', TranslatableType::class, [
+                'label' => $this->trans('Friendly URL', 'Admin.Global'),
+                'help' => $this->trans('Only letters and the minus (-) character are allowed.', 'Admin.Catalog.Help'),
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
@@ -177,10 +193,10 @@ class CmsPageCategoryType extends AbstractType
                         new IsUrlRewrite(),
                         new Length([
                             'max' => 64,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 64],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 64]
                             ),
                         ]),
                     ],
@@ -190,14 +206,15 @@ class CmsPageCategoryType extends AbstractType
 
         if ($this->isShopFeatureEnabled) {
             $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global'),
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->trans(
                             'The %s field is required.',
+                            'Admin.Notifications.Error',
                             [
-                                sprintf('"%s"', $this->trans('Shop association', [], 'Admin.Global')),
-                            ],
-                            'Admin.Notifications.Error'
+                                sprintf('"%s"', $this->trans('Shop association', 'Admin.Global')),
+                            ]
                         ),
                     ]),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -74,7 +74,7 @@ class CmsPageCategoryType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Notifications.Info') .  '<>;=#{}';
+        $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') .  '<>;=#{}';
         $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Notifications.Info') . '<>={}';
         $builder
             ->add('name', TranslatableType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -46,10 +46,10 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class CmsPageCategoryType extends TranslatorAwareType
 {
-    private const NAME_MAX_LENGTH = 64;
-    private const META_TITLE_MAX_LENGTH = 255;
-    private const META_KEYWORDS_MAX_LENGTH = 255;
-    private const META_DESCRIPTION_MAX_LENGTH = 512;
+    public const NAME_MAX_LENGTH = 64;
+    public const META_TITLE_MAX_LENGTH = 255;
+    public const META_KEYWORDS_MAX_LENGTH = 255;
+    public const META_DESCRIPTION_MAX_LENGTH = 512;
 
     /**
      * @var array

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -75,7 +75,7 @@ class CmsPageCategoryType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $invalidCharactersForCatalogLabel = $this->trans('Invalid characters:', 'Admin.Global') .  '<>;=#{}';
-        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Notifications.Info') . '<>={}';
+        $invalidCharactersForNameLabel = $this->trans('Invalid characters:', 'Admin.Global') . '<>={}';
         $builder
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageCategoryType.php
@@ -47,7 +47,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class CmsPageCategoryType extends TranslatorAwareType
 {
     private const NAME_MAX_LENGTH = 64;
-    private const FRIENDLY_URL_MAX_LENGTH = 64;
     private const META_TITLE_MAX_LENGTH = 255;
     private const META_KEYWORDS_MAX_LENGTH = 255;
     private const META_DESCRIPTION_MAX_LENGTH = 512;
@@ -198,11 +197,11 @@ class CmsPageCategoryType extends TranslatorAwareType
                     'constraints' => [
                         new IsUrlRewrite(),
                         new Length([
-                            'max' => self::FRIENDLY_URL_MAX_LENGTH,
+                            'max' => self::NAME_MAX_LENGTH,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => self::FRIENDLY_URL_MAX_LENGTH]
+                                ['%limit%' => self::NAME_MAX_LENGTH]
                             ),
                         ]),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -36,7 +36,6 @@ use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -238,12 +237,9 @@ class CmsPageType extends TranslatorAwareType
                     ],
                 ],
             ])
-            /** @todo change to TranslatableType once it works with formatted form area */
-            ->add('content', TranslateType::class, [
+            ->add('content', TranslatableType::class, [
                 'label' => $this->trans('Page content', 'Admin.Design.Feature'),
                 'type' => FormattedTextareaType::class,
-                'locales' => $this->locales,
-                'hideTabs' => false,
                 'required' => false,
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -171,6 +171,14 @@ class CmsPageType extends TranslatorAwareType
                         new TypedRegex([
                             'type' => 'generic_name',
                         ]),
+                        new Length([
+                            'max' => 512,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 512]
+                            ),
+                        ]),
                     ],
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -49,6 +49,11 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class CmsPageType extends TranslatorAwareType
 {
+    private const TITLE_MAX_CHARS = 255;
+    private const META_DESCRIPTION_MAX_CHARS = 512;
+    private const META_KEYWORD_MAX_CHARS = 512;
+    private const FRIENDLY_URL_MAX_CHARS = 128;
+
     /**
      * @var array
      */
@@ -121,11 +126,11 @@ class CmsPageType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 255,
+                            'max' => self::TITLE_MAX_CHARS,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 255]
+                                ['%limit%' => self::TITLE_MAX_CHARS]
                             ),
                         ]),
                     ],
@@ -152,11 +157,11 @@ class CmsPageType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 255,
+                            'max' => self::TITLE_MAX_CHARS,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 255]
+                                ['%limit%' => self::TITLE_MAX_CHARS]
                             ),
                         ]),
                     ],
@@ -172,11 +177,11 @@ class CmsPageType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 512,
+                            'max' => self::META_DESCRIPTION_MAX_CHARS,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 512]
+                                ['%limit%' => self::META_DESCRIPTION_MAX_CHARS]
                             ),
                         ]),
                     ],
@@ -201,11 +206,11 @@ class CmsPageType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 512,
+                            'max' => self::META_KEYWORD_MAX_CHARS,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 512]
+                                ['%limit%' => self::META_KEYWORD_MAX_CHARS]
                             ),
                         ]),
                     ],
@@ -235,11 +240,11 @@ class CmsPageType extends TranslatorAwareType
                     'constraints' => [
                         new IsUrlRewrite(),
                         new Length([
-                            'max' => 128,
+                            'max' => self::FRIENDLY_URL_MAX_CHARS,
                             'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 'Admin.Notifications.Error',
-                                ['%limit%' => 128]
+                                ['%limit%' => self::FRIENDLY_URL_MAX_CHARS]
                             ),
                         ]),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -238,6 +238,7 @@ class CmsPageType extends TranslatorAwareType
                     ],
                 ],
             ])
+            /** @todo change to TranslatableType once it works with formatted form area */
             ->add('content', TranslateType::class, [
                 'label' => $this->trans('Page content', 'Admin.Design.Feature'),
                 'type' => FormattedTextareaType::class,

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -49,10 +49,10 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class CmsPageType extends TranslatorAwareType
 {
-    private const TITLE_MAX_CHARS = 255;
-    private const META_DESCRIPTION_MAX_CHARS = 512;
-    private const META_KEYWORD_MAX_CHARS = 512;
-    private const FRIENDLY_URL_MAX_CHARS = 128;
+    public const TITLE_MAX_CHARS = 255;
+    public const META_DESCRIPTION_MAX_CHARS = 512;
+    public const META_KEYWORD_MAX_CHARS = 512;
+    public const FRIENDLY_URL_MAX_CHARS = 128;
 
     /**
      * @var array

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -884,11 +884,11 @@ services:
 
     form.type.cms_page_category:
         class: 'PrestaShopBundle\Form\Admin\Improve\Design\Pages\CmsPageCategoryType'
+        parent: 'form.type.translatable.aware'
+        public: true
         arguments:
             - '@=service("prestashop.core.form.choice_provider.cms_categories").getChoices()'
             - '@=service("prestashop.adapter.multistore_feature").isUsed()'
-        calls:
-            - { method: setTranslator, arguments: ['@translator'] }
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
@@ -58,3 +58,11 @@ services:
       - '@prestashop.adapter.country.country_required_fields_provider'
     tags:
       - { name: validator.constraint_validator }
+
+  prestashop.core.constraint_validator.clean_html_validator:
+      class: 'PrestaShop\PrestaShop\Core\ConstraintValidator\CleanHtmlValidator'
+      arguments:
+        - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_ALLOW_HTML_IFRAME')"
+      tags:
+        - { name: validator.constraint_validator }
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/category_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/category_form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme cmsPageCategoryForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block category_form %}
   {{ form_start(cmsPageCategoryForm) }}
@@ -34,53 +34,7 @@
     </div>
     <div class="card-block row">
       <div class="card-text">
-
-        {% set invalidCharactersForCatalogLabel = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>;=#{}' %}
-        {% set invalidCharactersForNameLabel = 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ '<>={}' %}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.name, {}, {
-          'label': 'Name'|trans({}, 'Admin.Global'),
-          'help': invalidCharactersForCatalogLabel
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.is_displayed, {}, {
-          'label': 'Displayed'|trans({}, 'Admin.Global'),
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.parent_category, {}, {
-          'label': 'Parent category'|trans({}, 'Admin.Design.Feature'),
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.description, {}, {
-          'label': 'Description'|trans({}, 'Admin.Global'),
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.meta_title, {}, {
-          'label': 'Meta title'|trans({}, 'Admin.Global'),
-          'help': invalidCharactersForNameLabel
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.meta_description, {}, {
-          'label': 'Meta description'|trans({}, 'Admin.Global'),
-          'help': invalidCharactersForNameLabel
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.meta_keywords, {}, {
-          'label': 'Meta keywords'|trans({}, 'Admin.Global'),
-          'help': invalidCharactersForNameLabel
-        }) }}
-
-        {{ ps.form_group_row(cmsPageCategoryForm.friendly_url, {}, {
-          'label': 'Friendly URL'|trans({}, 'Admin.Global'),
-          'help': 'Only letters and the minus (-) character are allowed.'|trans({}, 'Admin.Catalog.Help')
-        }) }}
-
-        {% if cmsPageCategoryForm.shop_association is defined %}
-          {{ ps.form_group_row(cmsPageCategoryForm.shop_association, {}, {
-            'label': 'Shop association'|trans({}, 'Admin.Global')
-          }) }}
-        {% endif %}
-
+        {{ form_widget(cmsPageCategoryForm) }}
       </div>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -32,9 +32,7 @@
     </div>
     <div class="card-block row">
       <div class="card-text">
-        {% block cms_page_form_rest %}
-          {{ form_widget(cmsPageForm) }}
-        {% endblock %}
+        {{ form_widget(cmsPageForm) }}
       </div>
     </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme cmsPageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(cmsPageForm) }}
   <div class="card">
@@ -33,7 +33,7 @@
     <div class="card-block row">
       <div class="card-text">
         {% block cms_page_form_rest %}
-          {{ form_rest(cmsPageForm) }}
+          {{ form_widget(cmsPageForm) }}
         {% endblock %}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -115,6 +115,11 @@
   {{ block('form_help') }}
 {% endblock switch_widget %}
 
+{% block custom_content_widget %}
+  {% include template with data %}
+  {{ block('form_help') }}
+{% endblock %}
+
 {% block text_with_length_counter_widget %}
   <div class="input-group js-text-with-length-counter">
     {% set current_length = form.vars.max_length - form.vars.value|length %}

--- a/tests/Unit/Core/ConstraintValidator/CleanHtmlValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CleanHtmlValidatorTest.php
@@ -68,6 +68,18 @@ class CleanHtmlValidatorTest extends ConstraintValidatorTestCase
         ;
     }
 
+    public function testItFailsWhenIframeWithSpacesIsGiven()
+    {
+        $htmlTag = '< iframe >';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->buildViolation((new CleanHtml())->message)
+            ->setParameter('%s', '"' . $htmlTag . '"')
+            ->assertRaised()
+        ;
+    }
+
     public function testItFailsWhenFormIsGiven()
     {
         $htmlTag = '<form>';

--- a/tests/Unit/Core/ConstraintValidator/CleanHtmlValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CleanHtmlValidatorTest.php
@@ -68,6 +68,64 @@ class CleanHtmlValidatorTest extends ConstraintValidatorTestCase
         ;
     }
 
+    public function testItFailsWhenFormIsGiven()
+    {
+        $htmlTag = '<form> <input name="your-card-number"> </form>';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->buildViolation((new CleanHtml())->message)
+            ->setParameter('%s', '"' . $htmlTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    public function testItFailsWhenInputIsGiven()
+    {
+        $htmlTag = '<input name="your-card-number">';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->buildViolation((new CleanHtml())->message)
+            ->setParameter('%s', '"' . $htmlTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    public function testItFailsWhenEmbedIsGiven()
+    {
+        $htmlTag = '<embed type="image/jpg" src="funny_cat.jpg" width="300" height="200">';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->buildViolation((new CleanHtml())->message)
+            ->setParameter('%s', '"' . $htmlTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    public function testItFailsWhenObjectIsGiven()
+    {
+        $htmlTag = '<object data="funny_cat.jpg" width="300" height="200"></object> ';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->buildViolation((new CleanHtml())->message)
+            ->setParameter('%s', '"' . $htmlTag . '"')
+            ->assertRaised()
+        ;
+    }
+
+    public function testSucceedsWithPlainWords()
+    {
+        $htmlTag = '/form input > embed object iframe';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->assertNoViolation();
+        $this->context->getViolations();
+    }
+
     protected function createValidator()
     {
         return new CleanHtmlValidator(false);

--- a/tests/Unit/Core/ConstraintValidator/CleanHtmlValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CleanHtmlValidatorTest.php
@@ -70,7 +70,7 @@ class CleanHtmlValidatorTest extends ConstraintValidatorTestCase
 
     public function testItFailsWhenFormIsGiven()
     {
-        $htmlTag = '<form> <input name="your-card-number"> </form>';
+        $htmlTag = '<form>';
 
         $this->validator->validate($htmlTag, new CleanHtml());
 

--- a/tests/Unit/Core/ConstraintValidator/CleanHtmlWithIframeValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CleanHtmlWithIframeValidatorTest.php
@@ -70,7 +70,7 @@ class CleanHtmlWithIframeValidatorTest extends ConstraintValidatorTestCase
 
     public function testItSucceedsWhenFormIsGiven()
     {
-        $htmlTag = '<form> <input name="your-card-number"> </form>';
+        $htmlTag = '<form>';
 
         $this->validator->validate($htmlTag, new CleanHtml());
 

--- a/tests/Unit/Core/ConstraintValidator/CleanHtmlWithIframeValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CleanHtmlWithIframeValidatorTest.php
@@ -24,13 +24,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Core\ConstraintValidator;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\CleanHtmlValidator;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
-class CleanHtmlValidatorTest extends ConstraintValidatorTestCase
+class CleanHtmlWithIframeValidatorTest extends ConstraintValidatorTestCase
 {
     public function testItFailsWhenScriptTagsAreGiven()
     {
@@ -56,20 +58,18 @@ class CleanHtmlValidatorTest extends ConstraintValidatorTestCase
         ;
     }
 
-    public function testItFailsWhenIframeIsGiven()
+    public function testItSucceedsWhenIframeIsGiven()
     {
         $htmlTag = '<iframe src="catvideo.html" /></iframe>';
 
         $this->validator->validate($htmlTag, new CleanHtml());
 
-        $this->buildViolation((new CleanHtml())->message)
-            ->setParameter('%s', '"' . $htmlTag . '"')
-            ->assertRaised()
-        ;
+        $this->assertNoViolation();
+        $this->context->getViolations();
     }
 
     protected function createValidator()
     {
-        return new CleanHtmlValidator(false);
+        return new CleanHtmlValidator(true);
     }
 }

--- a/tests/Unit/Core/ConstraintValidator/CleanHtmlWithIframeValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CleanHtmlWithIframeValidatorTest.php
@@ -68,6 +68,46 @@ class CleanHtmlWithIframeValidatorTest extends ConstraintValidatorTestCase
         $this->context->getViolations();
     }
 
+    public function testItSucceedsWhenFormIsGiven()
+    {
+        $htmlTag = '<form> <input name="your-card-number"> </form>';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->assertNoViolation();
+        $this->context->getViolations();
+    }
+
+    public function testItSucceedsWhenInputIsGiven()
+    {
+        $htmlTag = '<input name="your-card-number">';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->assertNoViolation();
+        $this->context->getViolations();
+    }
+
+    public function testItSucceedsWhenEmbedIsGiven()
+    {
+        $htmlTag = '<embed type="image/jpg" src="funny_cat.jpg" width="300" height="200">';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->assertNoViolation();
+        $this->context->getViolations();
+    }
+
+    public function testItSucceedsWhenObjectIsGiven()
+    {
+        $htmlTag = '<object data="funny_cat.jpg" width="300" height="200"></object> ';
+
+        $this->validator->validate($htmlTag, new CleanHtml());
+
+        $this->assertNoViolation();
+        $this->context->getViolations();
+    }
+
     protected function createValidator()
     {
         return new CleanHtmlValidator(true);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplifies cms forms
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Improve -> Design -> Pages. Everything must look the same aside from help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by CmsPageCategoryType. This means if any module extends this type they will get an exception upon upgrading to PS version containing changes in this PR.

CleanHtmlValidator now has one dependancy. This means if any module extends this class they will get an exception upon upgrading to PS version containing changes in this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
