### PR TITLE
Added form theme to the address required fields

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
@@ -45,8 +45,7 @@
           </p>
         </div>
       </div>
-      {{ form_widget(requiredFieldsForm.required_fields) }}
-      {{ form_rest(requiredFieldsForm) }}
+      {{ form_widget(requiredFieldsForm) }}
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
@@ -45,7 +45,7 @@
           </p>
         </div>
       </div>
-      {{ form_widget(requiredFieldsForm) }}
+      {{ form_widget(requiredFieldsForm.required_fields) }}
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/required_fields.html.twig
@@ -23,6 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme requiredFieldsForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
+
 <div class="collapse" id="addressRequiredFieldsContainer">
   {{ form_start(requiredFieldsForm, {'action': path('admin_addresses_save_required_fields')}) }}
   <div class="card" >


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Now address required fields uses form theme.
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Address required fields must look and work exactly the same
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21243)
<!-- Reviewable:end -->
