### PR TITLE
Fix problem in editing or deleting old addresses after DNI has been set to "mandatory" for that country

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -234,9 +234,13 @@ class AddressCore extends ObjectModel
 
             return parent::delete();
         } else {
-            $this->deleted = true;
-
-            return $this->update();
+            return Db::getInstance()->update(
+                $this->def['table'],
+                [
+                    'deleted' => 1,
+                ],
+                ' ' . $this->def['primary'] . ' = ' . (int)$this->id
+            );
         }
     }
 
@@ -443,8 +447,8 @@ class AddressCore extends ObjectModel
     public static function addressExists($id_address)
     {
         return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
-            'SELECT `id_address` 
-            FROM ' . _DB_PREFIX_ . 'address a 
+            'SELECT `id_address`
+            FROM ' . _DB_PREFIX_ . 'address a
             WHERE a.`id_address` = ' . (int) $id_address,
             false
         );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.8.0
| Description?  | FIX for the issue 22480 described here https://github.com/PrestaShop/PrestaShop/issues/22480. Problem to edit or delete address once the "require dni" is activated for that country.
| Type?         | bug fix 
| Category?     | FO
| BC breaks?    | 
| Deprecations? |  no
| Fixed ticket? | Fixes #22480
| How to test?  | Like described here https://github.com/PrestaShop/PrestaShop/issues/22480. Register and complete an order. Activate DNI mandatory for the country of the address of the order, go in customer account in front office and try do delete the old address without dni.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22483)
<!-- Reviewable:end -->
