### PR TITLE
Update HookRepository.php

### DIFF
--- a/src/Core/Module/HookRepository.php
+++ b/src/Core/Module/HookRepository.php
@@ -72,7 +72,7 @@ class HookRepository
      */
     public function createHook($hook_name, $title = '', $description = '', $position = 1)
     {
-        $id_hook = (int) $this->getIdByName($hook_name);
+        $id_hook = $this->getIdByName($hook_name);
         if ($id_hook > 0) {
             return $id_hook;
         }
@@ -84,7 +84,7 @@ class HookRepository
             'position' => $this->db->escape($position),
         ], false, true, Db::INSERT);
 
-        return $this->getIdByName($hook_name);
+        return $this->db->Insert_ID();
     }
 
     private function getIdModule($module_name)

--- a/src/Core/Module/HookRepository.php
+++ b/src/Core/Module/HookRepository.php
@@ -60,8 +60,23 @@ class HookRepository
         return (int) $id_hook;
     }
 
+    /**
+     * Creates a new hook if not already existing and returns the hook id.
+     *
+     * @param string $hook_name The name of the hook
+     * @param string $title The title for the hook
+     * @param string $description The description for the hook
+     * @param int $position if the modules in the hook can be positioned
+     *
+     * @return int Hook ID
+     */
     public function createHook($hook_name, $title = '', $description = '', $position = 1)
     {
+        $id_hook = (int) $this->getIdByName($hook_name);
+        if ($id_hook > 0) {
+            return $id_hook;
+        }
+
         $this->db->insert('hook', [
             'name' => $this->db->escape($hook_name),
             'title' => $this->db->escape($title),

--- a/src/Core/Module/HookRepository.php
+++ b/src/Core/Module/HookRepository.php
@@ -67,7 +67,7 @@ class HookRepository
             'title' => $this->db->escape($title),
             'description' => $this->db->escape($description),
             'position' => $this->db->escape($position),
-        ], false, true, Db::REPLACE);
+        ], false, true, Db::INSERT);
 
         return $this->getIdByName($hook_name);
     }


### PR DESCRIPTION
Fix for issue 9941 where custom_hooks: in theme.yml will get new IDS if theme is installed again causing issues if the same custom hooks are used in another multishop.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This will fix theme.yml issue white custom hooks being assigned new id (id_hook) each time a theme is activated. If the same theme or a childtheme with the same custom hooks is used in another multistore, then all module hooked to these hooks loose their positions since the id is changed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9941.
| How to test?      | create a new theme, add a customhook to the theme.yml, install the theme and make a note of the id_hook in hook table, change back to classic theme and then change to the new theme again. Custom hook now has a new id.
| Possible impacts? | Create custom hooks from other locations than theme.yml.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22520)
<!-- Reviewable:end -->
