### PR TITLE
Hook keys must be in lowercase

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -145,7 +145,7 @@ class HookCore extends ObjectModel
 
     public static function isDisplayHookName($hook_name)
     {
-        $hook_name = strtolower(self::normalizeHookName($hook_name));
+        $hook_name = strtolower(static::normalizeHookName($hook_name));
 
         if ($hook_name === 'header' || $hook_name === 'displayheader') {
             // this hook is to add resources to the <head> section of the page
@@ -174,7 +174,7 @@ class HookCore extends ObjectModel
 
         if ($only_display_hooks) {
             return array_filter($hooks, function ($hook) {
-                return self::isDisplayHookName($hook['name']);
+                return static::isDisplayHookName($hook['name']);
             });
         } else {
             return $hooks;
@@ -202,7 +202,7 @@ class HookCore extends ObjectModel
             return false;
         }
 
-        $hook_ids = self::getAllHookIds($withAliases, $refreshCache);
+        $hook_ids = static::getAllHookIds($withAliases, $refreshCache);
 
         return isset($hook_ids[$hookName]) ? $hook_ids[$hookName] : false;
     }
@@ -249,7 +249,7 @@ class HookCore extends ObjectModel
             E_USER_DEPRECATED
         );
 
-        return self::getCanonicalHookNames();
+        return static::getCanonicalHookNames();
     }
 
     /**
@@ -263,7 +263,7 @@ class HookCore extends ObjectModel
      */
     public static function isAlias(string $hookName): bool
     {
-        $aliases = self::getCanonicalHookNames();
+        $aliases = static::getCanonicalHookNames();
 
         return isset($aliases[strtolower($hookName)]);
     }
@@ -381,7 +381,7 @@ class HookCore extends ObjectModel
         $hooksToCheck = (!$strict) ? static::getAllKnownNames($hookName) : [$hookName];
 
         foreach ($hooksToCheck as $currentHookName) {
-            if (is_callable([$module, self::getMethodName($currentHookName)])) {
+            if (is_callable([$module, static::getMethodName($currentHookName)])) {
                 return true;
             }
         }
@@ -407,14 +407,14 @@ class HookCore extends ObjectModel
         // Since is_callable() will always return true when __call() is available,
         // if the module was expecting an aliased hook name to be invoked, but we send
         // the canonical hook name instead, the hook will never be acknowledged by the module.
-        $methodName = self::getMethodName($hookName);
+        $methodName = static::getMethodName($hookName);
         if (is_callable([$module, $methodName])) {
             return static::coreCallHook($module, $methodName, $hookArgs);
         }
 
         // fall back to all other names
         foreach (static::getAllKnownNames($hookName) as $hook) {
-            $methodName = self::getMethodName($hook);
+            $methodName = static::getMethodName($hook);
             if (is_callable([$module, $methodName])) {
                 return static::coreCallHook($module, $methodName, $hookArgs);
             }
@@ -709,7 +709,7 @@ class HookCore extends ObjectModel
      */
     public static function getHookModuleExecList($hookName = null)
     {
-        $allHookRegistrations = self::getAllHookRegistrations(Context::getContext(), $hookName);
+        $allHookRegistrations = static::getAllHookRegistrations(Context::getContext(), $hookName);
 
         // If no hook_name is given, return all registered hooks
         if (null === $hookName) {
@@ -768,7 +768,7 @@ class HookCore extends ObjectModel
             return null;
         }
 
-        $hookRegistry = self::getHookRegistry();
+        $hookRegistry = static::getHookRegistry();
         $isRegistryEnabled = null !== $hookRegistry;
 
         if ($isRegistryEnabled) {
@@ -810,8 +810,8 @@ class HookCore extends ObjectModel
             return ($array_return) ? [] : false;
         }
 
-        if (array_key_exists($hook_name, self::$deprecated_hooks)) {
-            $deprecVersion = self::$deprecated_hooks[$hook_name]['from'] ?? _PS_VERSION_;
+        if (array_key_exists($hook_name, static::$deprecated_hooks)) {
+            $deprecVersion = static::$deprecated_hooks[$hook_name]['from'] ?? _PS_VERSION_;
             Tools::displayAsDeprecated('The hook ' . $hook_name . ' is deprecated in PrestaShop v.' . $deprecVersion);
         }
 
@@ -1174,7 +1174,7 @@ class HookCore extends ObjectModel
         if ($useCache) {
             Cache::store($cache_id, $allHookRegistrations);
             // @todo remove this in 1.6, we keep it in 1.5 for backward compatibility
-            self::$_hook_modules_cache_exec = $allHookRegistrations;
+            static::$_hook_modules_cache_exec = $allHookRegistrations;
         }
 
         return $allHookRegistrations;

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -222,7 +222,9 @@ class HookCore extends ObjectModel
 							WHERE `id_hook` = ' . (int) $hook_id);
 
             if (false === $result) {
-                throw new PrestaShopObjectNotFoundException('The hook id #%s does not exist in database', $hook_id);
+                throw new PrestaShopObjectNotFoundException(
+                    sprintf('The hook id #%d does not exist in database', $hook_id)
+                );
             }
 
             Cache::store($cache_id, $result);

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -283,7 +283,7 @@ class HookCore extends ObjectModel
             $hookAliases = [];
             if ($hookAliasList) {
                 foreach ($hookAliasList as $ha) {
-                    $hookAliases[$ha['name']][] = $ha['alias'];
+                    $hookAliases[strtolower($ha['name'])][] = $ha['alias'];
                 }
             }
             Cache::store($cacheId, $hookAliases);
@@ -312,7 +312,7 @@ class HookCore extends ObjectModel
 
         $allAliases = Hook::getAllHookAliases();
 
-        $aliases = $allAliases[$canonicalHookName] ?? [];
+        $aliases = $allAliases[strtolower($canonicalHookName)] ?? [];
 
         Cache::store($cacheId, $aliases);
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -204,7 +204,7 @@ class HookCore extends ObjectModel
 
         $hook_ids = static::getAllHookIds($withAliases, $refreshCache);
 
-        return isset($hook_ids[$hookName]) ? $hook_ids[$hookName] : false;
+        return $hook_ids[$hookName] ?? false;
     }
 
     /**
@@ -1032,8 +1032,8 @@ class HookCore extends ObjectModel
         $customer = $context->customer;
 
         $cache_id = self::MODULE_LIST_BY_HOOK_KEY
-            . ($shop instanceof Shop && isset($shop->id) ? '_' . $shop->id : '')
-            . ($customer instanceof Customer ? '_' . $customer->id : '');
+            . (isset($shop->id) ? '_' . $shop->id : '')
+            . (isset($customer->id) ? '_' . $customer->id : '');
 
         $useCache = (
             !in_array(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Hooks must be stored with strtolower in `getAllHookAliases` because all check are done in lowercase elsewhere.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22527
| How to test?      | Follow ticket instruction.
| Possible impacts? | The whole Hook part is impacted, make sure all hooks are still rendered and called.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22532)
<!-- Reviewable:end -->
