### PR TITLE
Show help message for PageNotFound for ajax calls

### DIFF
--- a/controllers/front/PageNotFoundController.php
+++ b/controllers/front/PageNotFoundController.php
@@ -60,4 +60,10 @@ class PageNotFoundControllerCore extends FrontController
 
         return $page;
     }
+
+    public function displayAjax()
+    {
+        header('Content-Type: application/json');
+        echo json_encode($this->trans('The page you are looking for was not found.', [], 'Shop.Theme.Global'));
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Show help message for PageNotFound for ajax calls instead of nothing
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/22538
| How to test?      | See ticket. Instead of blank page, the ajax route that does not exist will return message `The page you are looking for was not found.` in JSON
| Possible impacts? | Only the ticket scope is concerned.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22539)
<!-- Reviewable:end -->
