### PR TITLE
Update php-cs-fixer to 2.17.2

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -43,6 +43,7 @@ return PhpCsFixer\Config::create()
         'self_accessor' => false,
         'yoda_style' => null,
         'single_line_throw' => false,
+        'no_alias_language_construct_call' => false,
     ])
     ->setFinder($finder)
     ->setCacheFile(__DIR__.'/var/.php_cs.cache');

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -278,7 +278,7 @@ abstract class DbCore
 
         // Add here your slave(s) server(s) in this file
         if (file_exists(_PS_ROOT_DIR_ . '/config/db_slave_server.inc.php')) {
-            self::$_servers = array_merge(self::$_servers, require(_PS_ROOT_DIR_ . '/config/db_slave_server.inc.php'));
+            self::$_servers = array_merge(self::$_servers, require (_PS_ROOT_DIR_ . '/config/db_slave_server.inc.php'));
         }
 
         self::$_slave_servers_loaded = true;

--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -238,6 +238,6 @@ abstract class AbstractFormCore implements FormInterface
     {
         $error = $field->getMaxLength() != null && strlen($field->getValue()) > (int) $field->getMaxLength();
 
-        return  !$error;
+        return !$error;
     }
 }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1108,7 +1108,7 @@ abstract class ModuleCore implements ModuleInterface
                 }
 
                 $file = _PS_MODULE_DIR_ . self::$classInModule[$current_class] . '/' . Context::getContext()->language->iso_code . '.php';
-                if (Tools::file_exists_cache($file) && include_once($file)) {
+                if (Tools::file_exists_cache($file) && include_once ($file)) {
                     $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
                 }
             } else {
@@ -1238,7 +1238,7 @@ abstract class ModuleCore implements ModuleInterface
         // Find translations
         global $_MODULES;
         $file = _PS_MODULE_DIR_ . $module . '/' . Context::getContext()->language->iso_code . '.php';
-        if (Tools::file_exists_cache($file) && include_once($file)) {
+        if (Tools::file_exists_cache($file) && include_once ($file)) {
             if (isset($_MODULE) && is_array($_MODULE)) {
                 $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
             }
@@ -1337,7 +1337,7 @@ abstract class ModuleCore implements ModuleInterface
                 // If no errors in Xml, no need instand and no need new config.xml file, we load only translations
                 if (!count($module_errors) && (int) $xml_module->need_instance == 0) {
                     $file = _PS_MODULE_DIR_ . $module . '/' . Context::getContext()->language->iso_code . '.php';
-                    if (Tools::file_exists_cache($file) && include_once($file)) {
+                    if (Tools::file_exists_cache($file) && include_once ($file)) {
                         if (isset($_MODULE) && is_array($_MODULE)) {
                             $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
                         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a73079487d679518abd2315f102b619",
+    "content-hash": "2a30571d9a8b17340cf72e71cb77f2cd",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -8645,27 +8645,27 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.16.4",
+            "version": "v2.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13"
+                "reference": "aaee4f3d16a996fc0b570be0c69d3b80c909c507"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1023c3458137ab052f6ff1e09621a721bfdeca13",
-                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/aaee4f3d16a996fc0b570be0c69d3b80c909c507",
+                "reference": "aaee4f3d16a996fc0b570be0c69d3b80c909c507",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^1.2",
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0",
+                "php": "^5.6 || ^7.0 || ^8.0",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
                 "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
                 "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
                 "symfony/finder": "^3.0 || ^4.0 || ^5.0",
@@ -8678,14 +8678,17 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.2",
+                "keradus/cli-executor": "^1.4",
                 "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.1",
+                "php-coveralls/php-coveralls": "^2.4.1",
                 "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
-                "phpunitgoodpractices/traits": "^1.8",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
+                "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.4.4 <9.5",
+                "phpunitgoodpractices/polyfill": "^1.5",
+                "phpunitgoodpractices/traits": "^1.9.1",
+                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
                 "symfony/phpunit-bridge": "^5.1",
                 "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
@@ -8734,7 +8737,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.17.2"
             },
             "funding": [
                 {
@@ -8742,7 +8745,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-27T23:57:46+00:00"
+            "time": "2020-12-17T16:41:55+00:00"
         },
         {
             "name": "johnkary/phpunit-speedtrap",
@@ -10427,6 +10430,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-simplexml": "*",
         "ext-zip": "*"
     },
     "platform-dev": [],

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -274,7 +274,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
      */
     public function combinationIsActive()
     {
-        return  Combination::isFeatureActive();
+        return Combination::isFeatureActive();
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/AddressFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/AddressFormDataHandler.php
@@ -61,7 +61,7 @@ final class AddressFormDataHandler implements FormDataHandlerInterface
     }
 
     /**
-     * {@inheritdoc}]
+     * {@inheritdoc}
      *
      * @throws CountryConstraintException
      * @throws StateConstraintException

--- a/src/Core/Form/IdentifiableObject/DataHandler/AddressFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/AddressFormDataHandler.php
@@ -61,7 +61,7 @@ final class AddressFormDataHandler implements FormDataHandlerInterface
     }
 
     /**
-     * {@inheritdoc]
+     * {@inheritdoc}]
      *
      * @throws CountryConstraintException
      * @throws StateConstraintException

--- a/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerAddressFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerAddressFormDataHandler.php
@@ -51,7 +51,7 @@ final class ManufacturerAddressFormDataHandler implements FormDataHandlerInterfa
     }
 
     /**
-     * {@inheritdoc}]
+     * {@inheritdoc}
      */
     public function create(array $data)
     {

--- a/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerAddressFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerAddressFormDataHandler.php
@@ -51,7 +51,7 @@ final class ManufacturerAddressFormDataHandler implements FormDataHandlerInterfa
     }
 
     /**
-     * {@inheritdoc]
+     * {@inheritdoc}]
      */
     public function create(array $data)
     {

--- a/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AttributeGroupGridDefinitionFactory.php
@@ -51,7 +51,6 @@ final class AttributeGroupGridDefinitionFactory extends AbstractFilterableGridDe
     const GRID_ID = 'attribute_group';
 
     use BulkDeleteActionTrait;
-
     use DeleteActionTrait;
 
     /**

--- a/src/PrestaShopBundle/Api/QueryParamsCollection.php
+++ b/src/PrestaShopBundle/Api/QueryParamsCollection.php
@@ -764,7 +764,7 @@ abstract class QueryParamsCollection
     {
         $check = (is_int($timestamp) || is_float($timestamp)) ? $timestamp : (string) (int) $timestamp;
 
-        return  ($check === $timestamp)
+        return ($check === $timestamp)
             && ((int) $timestamp <= PHP_INT_MAX)
             && ((int) $timestamp >= ~PHP_INT_MAX);
     }

--- a/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
+++ b/src/PrestaShopBundle/Command/UpdateSchemaCommand.php
@@ -213,7 +213,7 @@ class UpdateSchemaCommand extends ContainerAwareCommand
             } catch (\Exception $e) {
                 $conn->rollBack();
 
-                throw($e);
+                throw ($e);
             }
         }
         $conn->commit();

--- a/tests/Integration/Behaviour/Features/Context/Util/PrimitiveUtils.php
+++ b/tests/Integration/Behaviour/Features/Context/Util/PrimitiveUtils.php
@@ -74,7 +74,6 @@ class PrimitiveUtils
                 break;
 
             case self::TYPE_ARRAY:
-
                 if ('empty' === $element) {
                     return [];
                 }
@@ -130,7 +129,6 @@ class PrimitiveUtils
                 return $element1 === $element2;
                 break;
             case self::TYPE_DOUBLE:
-
                 // see http://php.net/manual/en/language.types.float.php#language.types.float.comparison
                 $epsilon = 0.00001;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update php-cs-fixer to 2.17.2. This brings some improved rules, so the PR fixes the code when it's relevant. I also disable one new option of PHP-CS-Fixer. I'm not against enabling it but it means a very big PR. One thing at a time 😄 .
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22549)
<!-- Reviewable:end -->
