### PR TITLE
Fix Tax Total is wrong in "Order Conf" mail when a Voucher is used.

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -631,7 +631,7 @@ abstract class PaymentModuleCore extends Module
                             '{total_shipping_tax_excl}' => Tools::displayPrice($order->total_shipping_tax_excl, $this->context->currency, false),
                             '{total_shipping_tax_incl}' => Tools::displayPrice($order->total_shipping_tax_incl, $this->context->currency, false),
                             '{total_wrapping}' => Tools::displayPrice($order->total_wrapping, $this->context->currency, false),
-                            '{total_tax_paid}' => Tools::displayPrice(($order->total_products_wt - $order->total_products) + ($order->total_shipping_tax_incl - $order->total_shipping_tax_excl), $this->context->currency, false),
+                            '{total_tax_paid}' => Tools::displayPrice((($order->total_products_wt - $order->total_products) - ($order->total_discounts_tax_incl - $order->total_discounts_tax_excl)) + ($order->total_shipping_tax_incl - $order->total_shipping_tax_excl), $this->context->currency, false),
                         );
 
                         if (is_array($extra_vars)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.6
| Description?      | fix the issue #22558, the total tax in wrong in order conf email when using a discount voucher.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #22558.
| How to test?      | make an order using a voucher ex 10% on order total.
| Possible impacts? | check total tax is right in the order confirmation email where a voucher is used.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22559)
<!-- Reviewable:end -->
