### PR TITLE
Fix Persian install fixtures (missing 2 carrier entries)

### DIFF
--- a/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
@@ -7,6 +7,6 @@
     <delay>بیشتر بخرید تا هزینه کمتری بپردازید!</delay>
   </carrier>
   <carrier id="My_light_carrier" id_shop="1">
-    <delay>سبک تر ارزان تر!</delay>
+    <delay>هرچه سبک تر ارزان تر!</delay>
   </carrier>
 </entity_carrier>

--- a/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
@@ -3,4 +3,10 @@
   <carrier id="My_carrier" id_shop="1">
     <delay>تحویل روز بعد!</delay>
   </carrier>
+  <carrier id="My_cheap_carrier" id_shop="1">
+    <delay>یشتر بخرید تا هزینه کمتری بپردازید!</delay>
+  </carrier>
+  <carrier id="My_light_carrier" id_shop="1">
+    <delay>سبک تر ارزان تر!</delay>
+  </carrier>
 </entity_carrier>

--- a/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
+++ b/install-dev/fixtures/fashion/langs/fa/data/carrier.xml
@@ -4,7 +4,7 @@
     <delay>تحویل روز بعد!</delay>
   </carrier>
   <carrier id="My_cheap_carrier" id_shop="1">
-    <delay>یشتر بخرید تا هزینه کمتری بپردازید!</delay>
+    <delay>بیشتر بخرید تا هزینه کمتری بپردازید!</delay>
   </carrier>
   <carrier id="My_light_carrier" id_shop="1">
     <delay>سبک تر ارزان تر!</delay>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete them:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | IN: Fix installation - carrier delay empty (Error for Persian Language). On the installation process in Persian (Farsi) language, one error happened about carrier->delay is empty and installation with demo data can't be succeeded
| Type?             | bug fix
| Category?         | IN 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #22657
| How to test?      | just install PrestaShop with Persian (Farsi) language
| Possible impacts? | Installation process.

<img width="960" alt="image_2020-12-24_13-47-09" src="https://user-images.githubusercontent.com/9982451/103082647-d2bc7b00-45ef-11eb-8090-5d732484a541.png">

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22564)
<!-- Reviewable:end -->
