### PR TITLE
Prevent HookDataCollector unserialize() to throw an exception

### DIFF
--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -62,6 +62,15 @@ final class HookDataCollector extends DataCollector
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function unserialize($data)
+    {
+        // it seems that php 7.3 has a bug with unserialize: https://bugs.php.net/bug.php?id=77302
+        $this->data = is_array($data) ? $data : @unserialize($data);
+    }
+
+    /**
      * Return the list of every dispatched legacy hooks during one request.
      *
      * @return array


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | It seems that php 7.3 [introduced a bug](https://bugs.php.net/bug.php?id=77302) in the `unserialize()` function that can throw an exception. This PR aims to prevent that exception to happen.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22231
| How to test?      | Please see #22231
| Possible impacts? | This should only impact the debug toolbar that should be available in every **migrated** page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22579)
<!-- Reviewable:end -->
