### PR TITLE
Fix missing itemListElement on single nav element (like homepage)

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -22,6 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
+{if $breadcrumb.count > 1}
 <nav data-depth="{$breadcrumb.count}" class="breadcrumb hidden-sm-down">
   <ol itemscope itemtype="https://schema.org/BreadcrumbList">
     {block name='breadcrumb'}
@@ -42,3 +43,4 @@
     {/block}
   </ol>
 </nav>
+{/if}

--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -23,24 +23,24 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 {if $breadcrumb.count > 1}
-<nav data-depth="{$breadcrumb.count}" class="breadcrumb hidden-sm-down">
-  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
-    {block name='breadcrumb'}
-      {foreach from=$breadcrumb.links item=path name=breadcrumb}
-        {block name='breadcrumb_item'}
-          {if not $smarty.foreach.breadcrumb.last}
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-              <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
-              <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
-            </li>
-          {elseif isset($path.title)}
-            <li>
-              <span>{$path.title}</span>
-            </li>
-          {/if}
-        {/block}
-      {/foreach}
-    {/block}
-  </ol>
-</nav>
+  <nav data-depth="{$breadcrumb.count}" class="breadcrumb hidden-sm-down">
+    <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+      {block name='breadcrumb'}
+        {foreach from=$breadcrumb.links item=path name=breadcrumb}
+          {block name='breadcrumb_item'}
+            {if not $smarty.foreach.breadcrumb.last}
+              <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
+                <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
+              </li>
+            {elseif isset($path.title)}
+              <li>
+                <span>{$path.title}</span>
+              </li>
+            {/if}
+          {/block}
+        {/foreach}
+      {/block}
+    </ol>
+  </nav>
 {/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This error occurs on Google search console which asks for a itemListElement but this breadcrumb is only one item, and can be removed.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22416
| How to test?      | Check in google search console.
| Possible impacts? | Theme classic, on homepage


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22607)
<!-- Reviewable:end -->
