### PR TITLE
Fix invisible input in SEO Options

### DIFF
--- a/src/Adapter/Meta/SEOOptionsDataConfiguration.php
+++ b/src/Adapter/Meta/SEOOptionsDataConfiguration.php
@@ -51,7 +51,7 @@ class SEOOptionsDataConfiguration implements DataConfigurationInterface
     public function getConfiguration()
     {
         return [
-            'product_attributes_in_title' => $this->configuration->get('PS_PRODUCT_ATTRIBUTES_IN_TITLE'),
+            'product_attributes_in_title' => (bool) $this->configuration->get('PS_PRODUCT_ATTRIBUTES_IN_TITLE'),
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The form input is invisible.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      |  After a fresh install in the BO => Shop Parameters => SEO & URLs page => Display attributes in the product meta title. <br>Without the PR: ![image](https://user-images.githubusercontent.com/1462701/103292267-c53b3280-49ed-11eb-9ff5-96a8ce4185a0.png)<br>With the PR: ![image](https://user-images.githubusercontent.com/1462701/103292238-bb193400-49ed-11eb-893a-5d832df45cc9.png) Can be done by a dev.
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22619)
<!-- Reviewable:end -->
