### PR TITLE
Ecotax and Cost price decimals are truncated on BO when the product has combinations

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2231,6 +2231,7 @@ class ProductCore extends ObjectModel
 
         $price = str_replace(',', '.', $price);
         $weight = str_replace(',', '.', $weight);
+        $ecotax = str_replace(',', '.', $ecotax);
 
         $combination = new Combination();
         $combination->id_product = (int) $this->id;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When we add an ecotax or a cost price with decimals to a product with combinations, it is truncated. By @itroom-agence
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/14093.
| How to test?      | See please https://github.com/PrestaShop/PrestaShop/issues/14093
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22631)
<!-- Reviewable:end -->
