### PR TITLE
Fix Attributes on the product page when combinations are different

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7355,7 +7355,7 @@ class ProductCore extends ObjectModel
             FROM
                 `' . _DB_PREFIX_ . 'product_attribute_combination` pac
                 INNER JOIN `' . _DB_PREFIX_ . 'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
-				INNER JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
+                INNER JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
             WHERE
                 pa.id_product = ' . $idProduct . '
                 AND pac.id_attribute IN (' . $idAttributesImploded . ')
@@ -7365,7 +7365,7 @@ class ProductCore extends ObjectModel
                     FROM  
                         `' . _DB_PREFIX_ . 'product_attribute_combination` pac 
                         INNER JOIN `' . _DB_PREFIX_ . 'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
-						INNER JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
+                        INNER JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
                     WHERE  
                         pa.id_product = ' . $idProduct . ' ' . $subQueryAdditionalWhere . '
                 )

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7343,10 +7343,9 @@ class ProductCore extends ObjectModel
         }
 
         $idAttributesImploded = implode(',', array_map('intval', $idAttributes));
-        $notInAdditionalWhere = ' AND pac.id_attribute NOT IN (' . $idAttributesImploded . ')';
+        $subQueryAdditionalWhere = ' AND pac.id_attribute NOT IN (' . $idAttributesImploded . ')';
         if (!empty($emptyAttributeGroups)) {
-            $emptyGroupsImploded = implode(',', array_map('intval', $emptyAttributeGroups));
-            $notInAdditionalWhere = ' AND a.id_attribute_group IN (' . $emptyGroupsImploded . ')';
+            $subQueryAdditionalWhere = ' AND a.id_attribute_group IN (' . implode(',', $emptyAttributeGroups) . ')';
         }
 
         $idProductAttribute = Db::getInstance()->getValue(
@@ -7368,7 +7367,7 @@ class ProductCore extends ObjectModel
                         INNER JOIN `' . _DB_PREFIX_ . 'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
 						INNER JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
                     WHERE  
-                        pa.id_product = ' . $idProduct . ' ' . $notInAdditionalWhere . '
+                        pa.id_product = ' . $idProduct . ' ' . $subQueryAdditionalWhere . '
                 )
             GROUP BY
                 pac.`id_product_attribute`

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7355,7 +7355,6 @@ class ProductCore extends ObjectModel
             FROM
                 `' . _DB_PREFIX_ . 'product_attribute_combination` pac
                 INNER JOIN `' . _DB_PREFIX_ . 'product_attribute` pa ON pa.id_product_attribute = pac.id_product_attribute
-                INNER JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
             WHERE
                 pa.id_product = ' . $idProduct . '
                 AND pac.id_attribute IN (' . $idAttributesImploded . ')

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7332,7 +7332,7 @@ class ProductCore extends ObjectModel
         $emptyAttributeGroups = [];
         foreach ($idAttributes as $idAttributeGroup => $idAttribute) {
             if (is_numeric($idAttributeGroup) && empty($idAttribute)) {
-                $emptyAttributeGroups[] = (int)$idAttributeGroup;
+                $emptyAttributeGroups[] = (int) $idAttributeGroup;
             }
         }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -725,7 +725,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                             );
                         }
                     }
-					
+
                     // Added empty attribute if current group attributes are irregular!
                     // Irregular means when we have Product Attributes with and without
                     // current group related attributes at the same time. for example:
@@ -782,7 +782,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         }
                     }
                 }
-				
+
                 //find selected attribute or first of group
                 $index = 0;
                 $current_selected_attribute = 0;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -775,7 +775,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                                         'name' => '-',
                                         'html_color_code' => '',
                                         'texture' => '',
-                                        'selected' => empty($currentAttributes[$idAttributeGroup]) ? true : false,
+                                        'selected' => empty($currentAttributes[$idAttributeGroup]),
                                     ],
                                 ] + $group['attributes'];
                             }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -756,7 +756,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                             !empty($independentIdAttribute) &&
                             !empty($product_for_template['attributes'])
                         ) {
-                            $currentAttributes = array();
+                            $currentAttributes = [];
                             foreach ($product_for_template['attributes'] as $attribute) {
                                 if (!empty($attribute['id_attribute'])) {
                                     $currentAttributes[$attribute['id_attribute_group']] = $attribute['id_attribute'];
@@ -776,7 +776,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                                         'html_color_code' => '',
                                         'texture' => '',
                                         'selected' => empty($currentAttributes[$idAttributeGroup]) ? true : false,
-                                    ]
+                                    ],
                                 ] + $group['attributes'];
                             }
                         }

--- a/themes/classic/templates/catalog/_partials/product-variants.tpl
+++ b/themes/classic/templates/catalog/_partials/product-variants.tpl
@@ -51,9 +51,16 @@
                   {if $group_attribute.texture}
                     class="color texture" style="background-image: url({$group_attribute.texture})"
                   {elseif $group_attribute.html_color_code}
-                    class="color" style="background-color: {$group_attribute.html_color_code}" 
+                    class="color" style="background-color: {$group_attribute.html_color_code}"
+                  {else}
+                    class="color"
                   {/if}
-                ><span class="sr-only">{$group_attribute.name}</span></span>
+                >
+                  {if !$group_attribute.texture && !$group_attribute.html_color_code}
+                    <span class="no-color" style="display: flex;justify-content: center;">-</span>
+                  {/if}
+                  <span class="sr-only">{$group_attribute.name}</span>
+                </span>
               </label>
             </li>
           {/foreach}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When product combinations are asymmetric and irregular. Usually, the combinations are not displayed correctly and even the prices may not be displayed incorrectly.   On the other hand, when you want to add a new combination that has a new attribute, may you have many problems because u need to edit older combinations or even deleted and create a new one to make sure everything is alright on the product page. To better understand, I upload two images that show a bug that has fixed. (you can see in other cases.)
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22661
| How to test?      | create a product with different combinations
| Possible impacts? | Product page


|<img width="350" alt="Fix-Attribute" src="https://user-images.githubusercontent.com/9982451/103472114-9a126380-4d9e-11eb-8d26-a12301779567.png">| <img width="350" alt="Fix-Attribute2" src="https://user-images.githubusercontent.com/9982451/103472115-9e3e8100-4d9e-11eb-8c08-9e4a2adcebd3.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22639)
<!-- Reviewable:end -->
