### PR TITLE
Fix buttons height on mobile on order view page

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -349,8 +349,6 @@
   }
 
   #order-view-page {
-    padding: 0 10px;
-
     .right-column .tab-content,
     #orderProductsPanel {
       table {
@@ -400,34 +398,21 @@
     }
 
     .order-actions {
-      #update_order_status_action_form {
-        .select-status {
-          margin-bottom: 0.9375rem;
-        }
-      }
+      justify-content: center;
 
       .select-status {
-        width: 100%;
-        max-width: inherit;
+        max-width: 206px;
 
         .select-status-colored {
           max-width: inherit;
-          /* stylelint-disable-next-line */
-          margin-right: 0 !important;
+          padding-right: 2.5rem;
+          text-overflow: ellipsis;
         }
       }
 
       > * {
         &:not(:last-child) {
           margin-right: 0;
-        }
-
-        a,
-        button,
-        & {
-          width: 100%;
-          /* stylelint-disable-next-line */
-          margin-left: 0 !important;
         }
       }
 
@@ -437,6 +422,21 @@
 
         i {
           margin-right: 20px;
+        }
+      }
+
+      &-print {
+        width: 100%;
+        max-width: 242px;
+
+        > .input-group,
+        button {
+          width: 100%;
+          text-align: center;
+
+          i {
+            margin-right: .5rem;
+          }
         }
       }
     }

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -435,7 +435,7 @@
           text-align: center;
 
           i {
-            margin-right: .5rem;
+            margin-right: 0.5rem;
           }
         }
       }
@@ -559,5 +559,19 @@ input#partial_refund_shipping {
 .discountList {
   &-name {
     max-width: 400px;
+  }
+}
+
+@media (max-width: 374px) {
+  #order-view-page {
+    .order-actions {
+      &-print {
+        max-width: 186px;
+      }
+
+      .select-status {
+        max-width: 150px;
+      }
+    }
   }
 }

--- a/admin-dev/themes/new-theme/scss/pages/partials/_order-navigation.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_order-navigation.scss
@@ -19,7 +19,7 @@
       justify-content: space-between;
       width: 100%;
       max-width: 88px;
-      margin-left: .8rem;
+      margin-left: 0.8rem;
 
       &-left,
       &-right {

--- a/admin-dev/themes/new-theme/scss/pages/partials/_order-navigation.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_order-navigation.scss
@@ -17,6 +17,9 @@
   #order-view-page {
     .order-navigation {
       justify-content: space-between;
+      width: 100%;
+      max-width: 88px;
+      margin-left: .8rem;
 
       &-left,
       &-right {
@@ -25,7 +28,8 @@
 
         a {
           display: block;
-          width: 100%;
+          width: 38px;
+          height: 38px;
         }
       }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Buttons were strange on 375px, now it's correctly aligned
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22660.
| How to test?      | Go on order view page and see on 375px


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22662)
<!-- Reviewable:end -->
