### PR TITLE
Fix errors when viewing an order in BackOffice when the language of the order no longer exists

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -497,7 +497,7 @@ class CartCore extends ObjectModel
                 LEFT JOIN `' . _DB_PREFIX_ . 'cart_rule` cr ON cd.`id_cart_rule` = cr.`id_cart_rule`
                 LEFT JOIN `' . _DB_PREFIX_ . 'cart_rule_lang` crl ON (
                     cd.`id_cart_rule` = crl.`id_cart_rule`
-                    AND crl.id_lang = ' . (int) $this->id_lang . '
+                    AND crl.id_lang = ' . (int) $this->getAssociatedLanguage()->getId() . '
                 )
                 WHERE `id_cart` = ' . (int) $this->id . '
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
@@ -567,7 +567,7 @@ class CartCore extends ObjectModel
                 LEFT JOIN `' . _DB_PREFIX_ . 'cart_rule` cr ON cd.`id_cart_rule` = cr.`id_cart_rule`
                 LEFT JOIN `' . _DB_PREFIX_ . 'cart_rule_lang` crl ON (
                     cd.`id_cart_rule` = crl.`id_cart_rule`
-                    AND crl.id_lang = ' . (int) $this->id_lang . '
+                    AND crl.id_lang = ' . (int) $this->getAssociatedLanguage()->getId() . '
                 )
                 WHERE `id_cart` = ' . (int) $this->id . '
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1656,6 +1656,24 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Returns the language related to the cart or the default one if deleted
+     *
+     * @return Language
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public function getLanguage(): Language
+    {
+        $language = new Language($this->id_lang);
+        if (null === $language->id) {
+            $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
+        }
+
+        return $language;
+    }
+
+    /**
      * Customization management.
      *
      * @param int $quantity Quantity value to add or subtract

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1656,24 +1656,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Returns the language related to the cart or the default one if deleted
-     *
-     * @return Language
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function getLanguage(): Language
-    {
-        $language = new Language($this->id_lang);
-        if (null === $language->id) {
-            $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
-        }
-
-        return $language;
-    }
-
-    /**
      * Customization management.
      *
      * @param int $quantity Quantity value to add or subtract

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -261,7 +261,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         if ($id) {
             $entity_mapper = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\EntityMapper');
-            $entity_mapper->load($id, $id_lang, $this, $this->def, $this->id_shop, self::$cache_objects);
+            $entity_mapper->load($id, $this->id_lang, $this, $this->def, $this->id_shop, self::$cache_objects);
         }
     }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -364,6 +364,24 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     }
 
     /**
+     * Returns the language related to the object or the default one if it doesn't exists
+     *
+     * @return Language
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public function getAssociatedLanguage(): Language
+    {
+        $language = new Language($this->id_lang);
+        if (null === $language->id) {
+            $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
+        }
+
+        return $language;
+    }
+
+    /**
      * Formats values of each fields.
      *
      * @since 1.5.0.1

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -231,7 +231,7 @@ abstract class PaymentModuleCore extends Module
         // The tax cart is loaded before the customer so re-cache the tax calculation method
         $this->context->cart->setTaxCalculationMethod();
 
-        $this->context->language = new Language((int) $this->context->cart->id_lang);
+        $this->context->language = $this->context->cart->getAssociatedLanguage();
         $this->context->shop = ($shop ? $shop : new Shop((int) $this->context->cart->id_shop));
         ShopUrl::resetMainDomainCache();
         $id_currency = $currency_special ? (int) $currency_special : (int) $this->context->cart->id_currency;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -691,24 +691,6 @@ class OrderCore extends ObjectModel
         ');
     }
 
-    /**
-     * Returns the language related to the order or the default one if deleted
-     *
-     * @return Language
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function getLanguage(): Language
-    {
-        $language = new Language($this->id_lang);
-        if (null === $language->id) {
-            $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
-        }
-
-        return $language;
-    }
-
     protected function setProductCustomizedDatas(&$product, $customized_datas)
     {
         $product['customizedDatas'] = null;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -691,6 +691,24 @@ class OrderCore extends ObjectModel
         ');
     }
 
+    /**
+     * Returns the language related to the order or the default one if deleted
+     *
+     * @return Language
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public function getLanguage(): Language
+    {
+        $language = new Language($this->id_lang);
+        if (null === $language->id) {
+            $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
+        }
+
+        return $language;
+    }
+
     protected function setProductCustomizedDatas(&$product, $customized_datas)
     {
         $product['customizedDatas'] = null;

--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -85,8 +85,9 @@ class OrderCarrierCore extends ObjectModel
      */
     public function sendInTransitEmail($order)
     {
+        $orderLanguageId = (int) $order->getAssociatedLanguage()->getId();
         $customer = new Customer((int) $order->id_customer);
-        $carrier = new Carrier((int) $order->id_carrier, $order->id_lang);
+        $carrier = new Carrier((int) $order->id_carrier, $orderLanguageId);
         $address = new Address((int) $order->id_address_delivery);
 
         if (!Validate::isLoadedObject($customer)) {
@@ -107,8 +108,8 @@ class OrderCarrierCore extends ObjectModel
             $prod_obj = new Product((int) $product['product_id']);
 
             //try to get the first image for the purchased combination
-            $img = $prod_obj->getCombinationImages($order->id_lang);
-            $link_rewrite = $prod_obj->link_rewrite[$order->id_lang];
+            $img = $prod_obj->getCombinationImages($orderLanguageId);
+            $link_rewrite = $prod_obj->link_rewrite[$orderLanguageId];
             $combination_img = $img[$product['product_attribute_id']][0]['id_image'];
             if ($combination_img != null) {
                 $img_url = $link->getImageLink($link_rewrite, $combination_img, 'large_default');
@@ -126,7 +127,7 @@ class OrderCarrierCore extends ObjectModel
             $metadata .= "\n" . '</div>';
         }
 
-        $orderLanguage = new Language((int) $order->id_lang);
+        $orderLanguage = new Language((int) $orderLanguageId);
         $templateVars = [
             '{followup}' => str_replace('@', $this->tracking_number, $carrier->url),
             '{firstname}' => $customer->firstname,
@@ -143,7 +144,7 @@ class OrderCarrierCore extends ObjectModel
         ];
 
         if (@Mail::Send(
-            (int) $order->id_lang,
+            $orderLanguageId,
             'in_transit',
             $this->trans(
                 'Package in transit',

--- a/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
@@ -32,7 +32,6 @@ use CartRule;
 use Context;
 use Currency;
 use Customer;
-use Language;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddCartRuleToCartCommand;
@@ -80,7 +79,7 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCustomer(new Customer($cart->id_customer))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddCartRuleToCartHandler.php
@@ -79,7 +79,7 @@ final class AddCartRuleToCartHandler extends AbstractCartHandler implements AddC
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCustomer(new Customer($cart->id_customer))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/CommandHandler/RemoveProductFromCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/RemoveProductFromCartHandler.php
@@ -66,7 +66,7 @@ final class RemoveProductFromCartHandler extends AbstractCartHandler implements 
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCustomer(new Customer($cart->id_customer))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/CommandHandler/RemoveProductFromCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/RemoveProductFromCartHandler.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
 use Currency;
 use Customer;
-use Language;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\RemoveProductFromCartCommand;
@@ -67,7 +66,7 @@ final class RemoveProductFromCartHandler extends AbstractCartHandler implements 
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCustomer(new Customer($cart->id_customer))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php
+++ b/src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 use Cart;
 use Context;
 use Customer;
-use Language;
 use Mail;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\SendCartToCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\SendCartToCustomerHanlderInterface;
@@ -57,10 +56,10 @@ final class SendCartToCustomerHandler implements SendCartToCustomerHanlderInterf
             '{lastname}' => $customer->lastname,
         ];
 
-        $cartLanguage = new Language((int) $cart->id_lang);
+        $cartLanguage = $cart->getAssociatedLanguage();
 
         $emailWasSent = Mail::send(
-            (int) $cart->id_lang,
+            (int) $cartLanguage->getId(),
             'backoffice_order',
             Context::getContext()->getTranslator()->trans(
                 'Process the payment of your order',
@@ -131,7 +130,7 @@ final class SendCartToCustomerHandler implements SendCartToCustomerHanlderInterf
         return Context::getContext()->link->getPageLink(
             'order',
             false,
-            (int) $cart->id_lang,
+            (int) $cart->getAssociatedLanguage()->getId(),
             [
                 'step' => 3,
                 'recover_cart' => $cart->id,

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 use Carrier;
 use Currency;
 use Customer;
-use Language;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateCartCarrierCommand;
@@ -67,7 +66,7 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCustomer(new Customer($cart->id_customer))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateCartCarrierHandler.php
@@ -66,7 +66,7 @@ final class UpdateCartCarrierHandler extends AbstractCartHandler implements Upda
         $this->contextStateManager
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCustomer(new Customer($cart->id_customer))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -33,7 +33,6 @@ use Cart;
 use CartRule;
 use Currency;
 use Customer;
-use Language;
 use Link;
 use Message;
 use PrestaShop\Decimal\Number;
@@ -121,7 +120,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
     {
         $cart = $this->getCart($query->getCartId());
         $currency = new Currency($cart->id_currency);
-        $language = new Language($cart->id_lang);
+        $language = $cart->getLanguage();
 
         $this->contextStateManager
             ->setCart($cart)

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -134,10 +134,10 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             $addresses = $this->getAddresses($cart);
 
             if ($query->hideDiscounts()) {
-                $legacySummary = $cart->getSummaryDetails($cart->id_lang, true);
+                $legacySummary = $cart->getSummaryDetails($cart->getAssociatedLanguage()->getId(), true);
                 $products = $this->extractProductsWithGiftSplitFromLegacySummary($cart, $legacySummary, $currency);
             } else {
-                $legacySummary = $cart->getRawSummaryDetails($cart->id_lang, true);
+                $legacySummary = $cart->getRawSummaryDetails($cart->getAssociatedLanguage()->getId(), true);
                 $products = $this->extractProductsFromLegacySummary($cart, $legacySummary, $currency);
             }
 
@@ -170,7 +170,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
         $customer = new Customer($cart->id_customer);
         $cartAddresses = [];
 
-        foreach ($customer->getAddresses($cart->id_lang) as $data) {
+        foreach ($customer->getAddresses($cart->getAssociatedLanguage()->getId()) as $data) {
             $addressId = (int) $data['id_address'];
             $cartAddresses[$addressId] = $this->buildCartAddress($addressId, $cart);
         }
@@ -442,7 +442,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             $this->contextLink->getPageLink(
                 'order',
                 false,
-                (int) $cart->id_lang,
+                (int) $cart->getAssociatedLanguage()->getId(),
                 http_build_query([
                     'step' => 3,
                     'recover_cart' => $cartId,

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -470,7 +470,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
 
         $customizations = Product::getAllCustomizedDatas(
             $cart->id,
-            $cart->id_lang,
+            $cart->getAssociatedLanguage()->getId(),
             true,
             null,
             $customizationId

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -120,7 +120,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
     {
         $cart = $this->getCart($query->getCartId());
         $currency = new Currency($cart->id_currency);
-        $language = $cart->getLanguage();
+        $language = $cart->getAssociatedLanguage();
 
         $this->contextStateManager
             ->setCart($cart)

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -136,8 +136,10 @@ final class ContextStateManager
      */
     public function setLanguage(?Language $language): self
     {
-        $this->saveContextField('language');
-        $this->context->language = $language;
+        if (null !== $language->id) {
+            $this->saveContextField('language');
+            $this->context->language = $language;
+        }
 
         return $this;
     }

--- a/src/Adapter/ContextStateManager.php
+++ b/src/Adapter/ContextStateManager.php
@@ -136,10 +136,8 @@ final class ContextStateManager
      */
     public function setLanguage(?Language $language): self
     {
-        if (null !== $language->id) {
-            $this->saveContextField('language');
-            $this->context->language = $language;
-        }
+        $this->saveContextField('language');
+        $this->context->language = $language;
 
         return $this;
     }

--- a/src/Adapter/CustomerService/CommandHandler/AddOrderCustomerMessageHandler.php
+++ b/src/Adapter/CustomerService/CommandHandler/AddOrderCustomerMessageHandler.php
@@ -30,7 +30,6 @@ use Configuration;
 use Customer;
 use CustomerMessage;
 use CustomerThread;
-use Language;
 use Mail;
 use Order;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
@@ -231,7 +230,7 @@ final class AddOrderCustomerMessageHandler implements AddOrderCustomerMessageHan
             $message = Tools::nl2br(Tools::htmlentitiesUTF8($command->getMessage()));
         }
 
-        $orderLanguage = new Language((int) $order->id_lang);
+        $orderLanguage = $order->getAssociatedLanguage();
         $varsTpl = [
             '{lastname}' => $customer->lastname,
             '{firstname}' => $customer->firstname,
@@ -241,7 +240,7 @@ final class AddOrderCustomerMessageHandler implements AddOrderCustomerMessageHan
         ];
 
         return Mail::Send(
-            (int) $order->id_lang,
+            (int) $orderLanguage->getId(),
             'order_merchant_comment',
             $this->translator->trans(
                 'New message regarding your order',

--- a/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
+++ b/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
@@ -33,7 +33,6 @@ use Context;
 use Country;
 use Currency;
 use Customer;
-use Language;
 use Order;
 use OrderDetail;
 use Pack;
@@ -189,7 +188,7 @@ abstract class AbstractOrderCommandHandler extends AbstractOrderHandler
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCountry($this->getCartTaxCountry($cart))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
+++ b/src/Adapter/Order/CommandHandler/AbstractOrderCommandHandler.php
@@ -188,7 +188,7 @@ abstract class AbstractOrderCommandHandler extends AbstractOrderHandler
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCountry($this->getCartTaxCountry($cart))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -88,7 +88,7 @@ final class AddOrderFromBackOfficeHandler implements AddOrderFromBackOfficeHandl
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCountry($this->getTaxCountry($cart))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddOrderFromBackOfficeHandler.php
@@ -88,7 +88,7 @@ final class AddOrderFromBackOfficeHandler implements AddOrderFromBackOfficeHandl
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCountry($this->getTaxCountry($cart))
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -141,7 +141,7 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
             throw new OrderException('Cart linked to the order cannot be found.');
         }
 
-        $product = $this->getProduct($command->getProductId(), (int) $order->id_lang);
+        $product = $this->getProduct($command->getProductId(), (int) $order->getAssociatedLanguage()->getId());
         $combination = null !== $command->getCombinationId() ? $this->getCombination($command->getCombinationId()->getValue()) : null;
         $combinationId = null !== $combination ? (int) $combination->id : 0;
 

--- a/src/Adapter/Order/CommandHandler/BulkChangeOrderStatusHandler.php
+++ b/src/Adapter/Order/CommandHandler/BulkChangeOrderStatusHandler.php
@@ -77,7 +77,7 @@ final class BulkChangeOrderStatusHandler implements BulkChangeOrderStatusHandler
             $useExistingPayment = !$order->hasInvoice();
             $history->changeIdOrderState((int) $orderState->id, $order, $useExistingPayment);
 
-            $carrier = new Carrier($order->id_carrier, $order->id_lang);
+            $carrier = new Carrier($order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
             $templateVars = [];
 
             if ($history->id_order_state == Configuration::get('PS_OS_SHIPPING') && $order->shipping_number) {

--- a/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
+++ b/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
@@ -65,7 +65,7 @@ final class DuplicateOrderCartHandler implements DuplicateOrderCartHandlerInterf
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setShop(new Shop($cart->id_shop))
         ;
         $result = $cart->duplicate();

--- a/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
+++ b/src/Adapter/Order/CommandHandler/DuplicateOrderCartHandler.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Order\CommandHandler;
 use Cart;
 use Currency;
 use Customer;
-use Language;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\DuplicateOrderCartCommand;
@@ -66,7 +65,7 @@ final class DuplicateOrderCartHandler implements DuplicateOrderCartHandlerInterf
             ->setCart($cart)
             ->setCustomer(new Customer($cart->id_customer))
             ->setCurrency(new Currency($cart->id_currency))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setShop(new Shop($cart->id_shop))
         ;
         $result = $cart->duplicate();

--- a/src/Adapter/Order/CommandHandler/ResendOrderEmailHandler.php
+++ b/src/Adapter/Order/CommandHandler/ResendOrderEmailHandler.php
@@ -55,7 +55,7 @@ final class ResendOrderEmailHandler extends AbstractOrderCommandHandler implemen
 
         $history = new OrderHistory($command->getOrderHistoryId());
 
-        $carrier = new Carrier($order->id_carrier, $order->id_lang);
+        $carrier = new Carrier($order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
         $templateVars = [];
 
         if ($orderState->id == Configuration::get('PS_OS_SHIPPING') && $order->shipping_number) {

--- a/src/Adapter/Order/CommandHandler/SendProcessOrderEmailHandler.php
+++ b/src/Adapter/Order/CommandHandler/SendProcessOrderEmailHandler.php
@@ -75,8 +75,8 @@ class SendProcessOrderEmailHandler implements SendProcessOrderEmailHandlerInterf
         try {
             $cart = $this->getCart($cartId);
             $customer = $this->getCustomer(new CustomerId((int) $cart->id_customer));
-            $langId = (int) $cart->id_lang;
-            $cartLanguage = new Language($langId);
+            $cartLanguage = $cart->getAssociatedLanguage();
+            $langId = (int) $cartLanguage->getId();
 
             if (!Mail::send(
                 $langId,

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -114,7 +114,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
             }
 
             $customer = new Customer((int) $order->id_customer);
-            $carrier = new Carrier((int) $order->id_carrier, $order->id_lang);
+            $carrier = new Carrier((int) $order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
 
             Hook::exec('actionAdminOrdersTrackingNumberUpdate', [
                 'order' => $order,

--- a/src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderStatusHandler.php
@@ -69,7 +69,7 @@ final class UpdateOrderStatusHandler extends AbstractOrderHandler implements Upd
 
         $history->changeIdOrderState((int) $orderState->id, $order, $useExistingPayments);
 
-        $carrier = new Carrier($order->id_carrier, $order->id_lang);
+        $carrier = new Carrier($order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
         $templateVars = [];
 
         if ($history->id_order_state == Configuration::get('PS_OS_SHIPPING') && $order->shipping_number) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -116,7 +116,7 @@ class OrderAmountUpdater
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCountry($cart->getTaxCountry())
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -35,7 +35,6 @@ use Cart;
 use CartRule;
 use Currency;
 use Customer;
-use Language;
 use Order;
 use OrderCarrier;
 use OrderCartRule;
@@ -117,7 +116,7 @@ class OrderAmountUpdater
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCountry($cart->getTaxCountry())
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -226,7 +226,7 @@ class OrderDetailUpdater
             ->saveCurrentContext()
             ->setCart(new Cart($order->id_cart))
             ->setCustomer(new Customer($order->id_customer))
-            ->setLanguage($order->getLanguage())
+            ->setLanguage($order->getAssociatedLanguage())
             ->setCurrency($currency)
             ->setCountry($country)
             ->setShop($shop)

--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -34,7 +34,6 @@ use Country;
 use Currency;
 use Customer;
 use Db;
-use Language;
 use Order;
 use OrderDetail;
 use PrestaShop\Decimal\Number;
@@ -227,7 +226,7 @@ class OrderDetailUpdater
             ->saveCurrentContext()
             ->setCart(new Cart($order->id_cart))
             ->setCustomer(new Customer($order->id_customer))
-            ->setLanguage(new Language($order->id_lang))
+            ->setLanguage($order->getLanguage())
             ->setCurrency($currency)
             ->setCountry($country)
             ->setShop($shop)

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -111,7 +111,7 @@ class OrderProductQuantityUpdater
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage($cart->getLanguage())
+            ->setLanguage($cart->getAssociatedLanguage())
             ->setCountry($cart->getTaxCountry())
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -35,7 +35,6 @@ use Currency;
 use Customer;
 use Customization;
 use Db;
-use Language;
 use Order;
 use OrderDetail;
 use OrderInvoice;
@@ -112,7 +111,7 @@ class OrderProductQuantityUpdater
             ->setCart($cart)
             ->setCurrency(new Currency($cart->id_currency))
             ->setCustomer(new Customer($cart->id_customer))
-            ->setLanguage(new Language($cart->id_lang))
+            ->setLanguage($cart->getLanguage())
             ->setCountry($cart->getTaxCountry())
             ->setShop(new Shop($cart->id_shop))
         ;

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -230,7 +230,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $genderName = '';
 
         if (Validate::isLoadedObject($gender)) {
-            $genderName = $gender->name[$order->id_lang];
+            $genderName = $gender->name[$order->id_lang] ?? $gender->name[$this->contextLanguageId];
         }
 
         $customerStats = $customer->getStats();
@@ -280,7 +280,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $address->address2,
             $stateName,
             $address->city,
-            $country->name[$order->id_lang],
+            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
             $address->postcode,
             $address->phone,
             $address->phone_mobile,
@@ -314,7 +314,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $address->address2,
             $stateName,
             $address->city,
-            $country->name[$order->id_lang],
+            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
             $address->postcode,
             $address->phone,
             $address->phone_mobile,

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -230,7 +230,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $genderName = '';
 
         if (Validate::isLoadedObject($gender)) {
-            $genderName = $gender->name[$order->id_lang] ?? $gender->name[$this->contextLanguageId];
+            $genderName = $gender->name[(int) $order->getAssociatedLanguage()->getId()];
         }
 
         $customerStats = $customer->getStats();
@@ -280,7 +280,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $address->address2,
             $stateName,
             $address->city,
-            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
+            $country->name[(int) $order->getAssociatedLanguage()->getId()],
             $address->postcode,
             $address->phone,
             $address->phone_mobile,
@@ -314,7 +314,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $address->address2,
             $stateName,
             $address->city,
-            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
+            $country->name[(int) $order->getAssociatedLanguage()->getId()],
             $address->postcode,
             $address->phone,
             $address->phone_mobile,

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -31,7 +31,6 @@ use Country;
 use Currency;
 use Customer;
 use Group;
-use Language;
 use Order;
 use OrderCarrier;
 use PrestaShop\Decimal\Number;
@@ -65,23 +64,15 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     private $locale;
 
     /**
-     * @var int|false|null
-     */
-    private $contextLanguageId;
-
-    /**
      * @param LocaleRepository $localeRepository
      * @param string $locale
-     * @param int|null $contextLanguageId
      */
     public function __construct(
         LocaleRepository $localeRepository,
-        string $locale,
-        ?int $contextLanguageId = null
+        string $locale
     ) {
         $this->localeRepository = $localeRepository;
         $this->locale = $locale;
-        $this->contextLanguageId = $contextLanguageId ?? Language::getIdByLocale($this->locale);
     }
 
     /**
@@ -141,7 +132,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
             $address->city,
             $address->postcode,
             $stateName,
-            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
+            $country->name[(int) $order->getAssociatedLanguage()->getId()],
             $customer ? $customer->email : null,
             $address->phone
         );
@@ -177,7 +168,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
             $address->city,
             $address->postcode,
             $stateName,
-            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
+            $country->name[(int) $order->getAssociatedLanguage()->getId()],
             $address->phone,
             $carrierName,
             $orderCarrier->tracking_number ?: null

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -72,14 +72,16 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     /**
      * @param LocaleRepository $localeRepository
      * @param string $locale
+     * @param int|null $contextLanguageId
      */
     public function __construct(
         LocaleRepository $localeRepository,
-        string $locale
+        string $locale,
+        ?int $contextLanguageId
     ) {
         $this->localeRepository = $localeRepository;
         $this->locale = $locale;
-        $this->contextLanguageId = Language::getIdByLocale($this->locale);
+        $this->contextLanguageId = $contextLanguageId ?? Language::getIdByLocale($this->locale);
     }
 
     /**

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -65,7 +65,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     private $locale;
 
     /**
-     * @var int
+     * @var int|false|null
      */
     private $contextLanguageId;
 

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -31,6 +31,7 @@ use Country;
 use Currency;
 use Customer;
 use Group;
+use Language;
 use Order;
 use OrderCarrier;
 use PrestaShop\Decimal\Number;
@@ -64,6 +65,11 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     private $locale;
 
     /**
+     * @var int
+     */
+    private $contextLanguageId;
+
+    /**
      * @param LocaleRepository $localeRepository
      * @param string $locale
      */
@@ -73,6 +79,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     ) {
         $this->localeRepository = $localeRepository;
         $this->locale = $locale;
+        $this->contextLanguageId = Language::getIdByLocale($this->locale);
     }
 
     /**
@@ -132,7 +139,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
             $address->city,
             $address->postcode,
             $stateName,
-            $country->name[$order->id_lang],
+            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
             $customer ? $customer->email : null,
             $address->phone
         );
@@ -168,7 +175,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
             $address->city,
             $address->postcode,
             $stateName,
-            $country->name[$order->id_lang],
+            $country->name[$order->id_lang] ?? $country->name[$this->contextLanguageId],
             $address->phone,
             $carrierName,
             $orderCarrier->tracking_number ?: null

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -77,7 +77,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
     public function __construct(
         LocaleRepository $localeRepository,
         string $locale,
-        ?int $contextLanguageId
+        ?int $contextLanguageId = null
     ) {
         $this->localeRepository = $localeRepository;
         $this->locale = $locale;

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -265,7 +265,9 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 (string) $product['displayed_max_refundable'],
                 $product['location'],
                 !empty($product['id_order_invoice']) ? $product['id_order_invoice'] : null,
-                !empty($product['id_order_invoice']) ? $orderInvoice->getInvoiceNumberFormatted($order->id_lang) : '',
+                !empty($product['id_order_invoice'])
+                    ? $orderInvoice->getInvoiceNumberFormatted((int) $order->getAssociatedLanguage()->getId())
+                    : '',
                 $productType,
                 (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product['product_id'])),
                 $packItems,

--- a/src/Adapter/Order/Refund/OrderSlipCreator.php
+++ b/src/Adapter/Order/Refund/OrderSlipCreator.php
@@ -32,7 +32,6 @@ use Currency;
 use Customer;
 use Db;
 use Hook;
-use Language;
 use Mail;
 use Order;
 use OrderDetail;
@@ -121,12 +120,12 @@ class OrderSlipCreator
                 '{order_name}' => $order->getUniqReference(),
             ];
 
-            $orderLanguage = new Language((int) $order->id_lang);
+            $orderLanguage = $order->getAssociatedLanguage();
 
             // @todo: use a dedicated Mail class (see #13945)
             // @todo: remove this @and have a proper error handling
             @Mail::Send(
-                (int) $order->id_lang,
+                (int) $orderLanguage->getId(),
                 'credit_slip',
                 $this->translator->trans(
                     'New credit slip regarding your order',

--- a/src/Adapter/Order/Refund/VoucherGenerator.php
+++ b/src/Adapter/Order/Refund/VoucherGenerator.php
@@ -141,10 +141,10 @@ class VoucherGenerator
         ];
 
         // @todo: use private method to send mail and later a decoupled mail sender
-        $orderLanguage = new Language((int) $order->id_lang);
+        $orderLanguage = $order->getAssociatedLanguage();
 
         @Mail::Send(
-            (int) $order->id_lang,
+            (int) $orderLanguage->getId(),
             'voucher',
             $this->translator->trans(
                 'New voucher for your order #%s',

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -350,7 +350,7 @@ class OrderLazyArray extends AbstractLazyArray
     {
         $order = $this->order;
 
-        $carrier = new Carrier((int) $order->id_carrier, (int) $order->id_lang);
+        $carrier = new Carrier((int) $order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
         $orderCarrier = $this->objectPresenter->present($carrier);
         $orderCarrier['name'] = ($carrier->name == '0') ? Configuration::get('PS_SHOP_NAME') : $carrier->name;
         $orderCarrier['delay'] = $carrier->delay;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -229,7 +229,6 @@ services:
     arguments:
       - '@prestashop.core.localization.locale.repository'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.getLocale()"
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderPreview'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -229,6 +229,7 @@ services:
     arguments:
       - '@prestashop.core.localization.locale.repository'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.getLocale()"
+      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderPreview'

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -155,7 +155,7 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I add :quantity products :productName to the cart :cartReference
+     * @When /^I add (\d+) product(?:s)? "(.+)" to the cart "(.+)"$/
      *
      * @param int $quantity
      * @param string $productName

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderCartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderCartFeatureContext.php
@@ -39,13 +39,15 @@ use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 class OrderCartFeatureContext extends AbstractDomainFeatureContext
 {
     /**
-     * @Given order :orderId has customer :customerId
+     * @Given order :orderReference has customer :customerReference
      *
-     * @param int $orderId
-     * @param int $customerId
+     * @param string $orderId
+     * @param string $customerId
      */
-    public function orderHasCustomer(int $orderId, int $customerId)
+    public function orderHasCustomer(string $orderReference, string $customerReference)
     {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        $customerId = SharedStorage::getStorage()->get($customerReference);
         /** @var OrderForViewing $orderForViewing */
         $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
         /** @var OrderCustomerForViewing $orderCustomerForViewing */

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderCartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderCartFeatureContext.php
@@ -41,8 +41,8 @@ class OrderCartFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Given order :orderReference has customer :customerReference
      *
-     * @param string $orderId
-     * @param string $customerId
+     * @param string $orderReference
+     * @param string $customerReference
      */
     public function orderHasCustomer(string $orderReference, string $customerReference)
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -58,6 +58,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCom
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderPreview;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderDiscountForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderInvoiceAddressForViewing;
@@ -1405,6 +1406,40 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
         );
         Assert::assertEquals('amount', $specificPrice->reduction_type);
         Assert::assertTrue((bool) $specificPrice->reduction_tax);
+    }
+
+    /**
+     * @Then order :orderReference preview shipping address should have the following details:
+     */
+    public function getOrderPreviewShippingAddress(string $orderReference, TableNode $table)
+    {
+        $orderId = $this->getSharedStorage()->get($orderReference);
+        $orderPreview = $this->getQueryBus()->handle(new GetOrderPreview($orderId));
+        $shippingAddress = $orderPreview->getShippingDetails();
+
+        $address = [
+            'firstName' => $shippingAddress->getFirstName(),
+            'lastName' => $shippingAddress->getLastName(),
+            'company' => $shippingAddress->getCompany(),
+            'vatNumber' => $shippingAddress->getVatNumber(),
+            'address1' => $shippingAddress->getAddress1(),
+            'address2' => $shippingAddress->getAddress2(),
+            'city' => $shippingAddress->getCity(),
+            'postalCode' => $shippingAddress->getPostalCode(),
+            'stateName' => $shippingAddress->getStateName(),
+            'country' => $shippingAddress->getCountry(),
+            'phone' => $shippingAddress->getPhone(),
+            'carrierName' => $shippingAddress->getCarrierName(),
+            'trackingNumber' => $shippingAddress->getTrackingNumber(),
+        ];
+
+        $expectedDetails = $table->getRowsHash();
+        foreach ($expectedDetails as $key => $value) {
+            Assert::assertEquals(
+                $value,
+                $address[$key]
+            );
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -43,7 +43,7 @@ class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
             throw new RuntimeException(sprintf('Iso code %s does not exist', $isoCode));
         }
 
-        Configuration::updateValue('PS_LANG_DEFAULT', $languageId);
+        Configuration::updateValue('PS_LANG_DEFAULT', (string) $languageId);
 
         SharedStorage::getStorage()->set('default_language_id', $languageId);
     }
@@ -72,6 +72,15 @@ class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
         }
 
         SharedStorage::getStorage()->set($reference, $language);
+    }
+
+    /**
+     * @When I delete language :reference
+     */
+    public function deleteLanguage($reference)
+    {
+        $language = SharedStorage::getStorage()->get($reference);
+        $language->delete();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -699,7 +699,7 @@ Feature: Order from Back Office (BO)
       | total_tax_excl | rate | total_amount |
       | 7              | 6.00 | 0.42         |
 
-  Scenario: View order passed with a now deleted language
+  Scenario: View order created on a currently deleted language
     Given language "Spanish" with locale "es-ES" exists
     And language with iso code "es" is the default one
     When I create an empty cart "dummy_cart-ES" for customer "testCustomer"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -713,6 +713,7 @@ Feature: Order from Back Office (BO)
     And I change order "bo_order-ES" shipping address to "test-address"
     Then order "bo_order-ES" shipping address should be "test-address"
     And order "bo_order-ES" preview shipping address should have the following details:
+      # country is not translated here but should be on the develop branch (https://github.com/PrestaShop/PrestaShop/pull/19818)
       | country | United States |
     When language with iso code "en" is the default one
     And I delete language "Spanish"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -698,3 +698,24 @@ Feature: Order from Back Office (BO)
     And the first invoice from order "bo_order1" should have following shipping tax details:
       | total_tax_excl | rate | total_amount |
       | 7              | 6.00 | 0.42         |
+
+  Scenario: View order passed with a now deleted language
+    Given language "Spanish" with locale "es-ES" exists
+    And language with iso code "es" is the default one
+    When I create an empty cart "dummy_cart-ES" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart-ES"
+    And I add 1 product "Mug The best is yet to come" to the cart "dummy_cart-ES"
+    And I add order "bo_order-ES" with the following details:
+      | cart                | dummy_cart-ES               |
+      | message             |                             |
+      | payment module name | dummy_payment               |
+      | status              | Awaiting bank wire payment  |
+    And I change order "bo_order-ES" shipping address to "test-address"
+    Then order "bo_order-ES" shipping address should be "test-address"
+    And order "bo_order-ES" preview shipping address should have the following details:
+      | country | United States |
+    When language with iso code "en" is the default one
+    And I delete language "Spanish"
+    Then order "bo_order-ES" shipping address should be "test-address"
+    And order "bo_order-ES" preview shipping address should have the following details:
+      | country | United States |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When showing invoice/shipping address of a customer, we used the order lang but if we remove that lang from the store, no fallback was used. This PR aims to use the default store language when the order's one is not available.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22611
| How to test?      | Please see #22611
| Possible impacts? | /


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22677)
<!-- Reviewable:end -->
