### PR TITLE
Fix warning/errors from upgrade scripts

### DIFF
--- a/install-dev/upgrade/php/add_new_tab.php
+++ b/install-dev/upgrade/php/add_new_tab.php
@@ -145,7 +145,7 @@ function add_new_tab_17($className, $name, $id_parent, $returnId = false, $paren
         if (!empty($parentClassName) && !empty($newID)) {
             $parentRole = strtoupper('ROLE_MOD_TAB_'.pSQL($parentClassName).'_'.$role);
             Db::getInstance()->execute(
-                'INSERT INTO `'._DB_PREFIX_.'access` (`id_profile`, `id_authorization_role`)
+                'INSERT IGNORE INTO `'._DB_PREFIX_.'access` (`id_profile`, `id_authorization_role`)
                 SELECT a.`id_profile`, '. (int)$newID .' as `id_authorization_role`
                 FROM `'._DB_PREFIX_.'access` a join `'._DB_PREFIX_.'authorization_role` ar on a.`id_authorization_role` = ar.`id_authorization_role`
                 WHERE ar.`slug` = "'.pSQL($parentRole).'"'

--- a/install-dev/upgrade/php/add_quick_access_tab.php
+++ b/install-dev/upgrade/php/add_quick_access_tab.php
@@ -27,7 +27,7 @@
 function add_quick_access_tab()
 {
     include_once _PS_INSTALL_PATH_.'upgrade/php/add_new_tab.php';
-    add_new_tab(
+    add_new_tab_17(
         'AdminQuickAccesses',
         'en:Quick access|fr:Accès rapide|es:Quick access|de:Quick access|it:Quick access',
         -1

--- a/install-dev/upgrade/php/delete_hook.php
+++ b/install-dev/upgrade/php/delete_hook.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+function delete_hook($hook)
+{
+    $modules = Hook::getHookModuleExecList($hook);
+    if (is_array($modules)) {
+        foreach ($modules as $module) {
+            $moduleInstance = Module::getInstanceByName($module['module']);
+            if ($moduleInstance instanceof  Module) {
+                Hook::unregisterHook($moduleInstance, $hook);
+            }
+        }
+    }
+
+    return (bool) Db::getInstance()->execute(
+        'DELETE FROM `' . _DB_PREFIX_ . 'hook` WHERE `name` = "' . pSQL($hook) . '"'
+    );
+}

--- a/install-dev/upgrade/php/delete_hook.php
+++ b/install-dev/upgrade/php/delete_hook.php
@@ -30,7 +30,7 @@ function delete_hook($hook)
     if (is_array($modules)) {
         foreach ($modules as $module) {
             $moduleInstance = Module::getInstanceByName($module['module']);
-            if ($moduleInstance instanceof  Module) {
+            if ($moduleInstance instanceof Module) {
                 Hook::unregisterHook($moduleInstance, $hook);
             }
         }

--- a/install-dev/upgrade/php/migrate_tabs_17.php
+++ b/install-dev/upgrade/php/migrate_tabs_17.php
@@ -66,8 +66,10 @@ function migrate_tabs_17()
 
     /* update remaining idParent */
     foreach($moduleParents as $idParent => $className) {
-        $idTab = Db::getInstance()->getValue('SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name='.pSQL($className));
-        Db::getInstance()->execute('UPDATE '._DB_PREFIX_.'tab SET id_parent='.(int)$idTab.' WHERE id_parent='.(int)$idParent);
+        if (!empty($className)) {
+            $idTab = Db::getInstance()->getValue('SELECT id_tab FROM '._DB_PREFIX_.'tab WHERE class_name="'.pSQL($className).'"');
+            Db::getInstance()->execute('UPDATE '._DB_PREFIX_.'tab SET id_parent='.(int)$idTab.' WHERE id_parent='.(int)$idParent);
+        }
     }
 
     return true;

--- a/install-dev/upgrade/php/ps_1761_update_currencies.php
+++ b/install-dev/upgrade/php/ps_1761_update_currencies.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
  * On PrestaShop 1.7.6.0, two new columns have been introduced in the PREFIX_currency table: precision & numeric_iso_code
  * A fresh install would add the proper data in these columns, however an upgraded shop to 1.7.6.0 would not get the
  * corresponding values of each currency.
- * 
+ *
  * This upgrade script will cover this need by loading the CLDR data and update the currency if it still has the default table values.
  */
 function ps_1761_update_currencies()
@@ -62,10 +62,12 @@ function ps_1761_update_currencies()
             $currency->precision = (int) $cldrCurrency->getDecimalDigits();
             $currency->numeric_iso_code = $cldrCurrency->getNumericIsoCode();
         }
-        $currency->save();
+        Db::getInstance()->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'currency`
+            SET `precision` = ' . $currency->precision . ', `numeric_iso_code` = ' . $currency->numeric_iso_code . '
+            WHERE `id_currency` = ' . $currency->id
+        );
     }
 
     ObjectModel::enableCache();
-    
-    
 }

--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -78,8 +78,6 @@ ALTER TABLE  `PREFIX_product_lang` ADD  `social_sharing_description` VARCHAR( 25
 ALTER TABLE `PREFIX_hook` DROP `live_edit`;
 
 /* Remove comparator feature */
-DELETE FROM `PREFIX_hook_alias` WHERE `name` = 'displayProductComparison';
-DELETE FROM `PREFIX_hook` WHERE `name` = 'displayProductComparison';
 DELETE FROM `PREFIX_meta` WHERE `page` = 'products-comparison';
 DROP TABLE IF EXISTS `PREFIX_compare`;
 DROP TABLE IF EXISTS `PREFIX_compare_product`;
@@ -156,19 +154,18 @@ INSERT INTO `PREFIX_hook` (`name`, `title`, `description`, `position`) VALUES
   ('displayAfterBodyOpeningTag', 'Very top of pages', 'Use this hook for advertisement or modals you want to load first.', '1'),
   ('displayBeforeBodyClosingTag', 'Very bottom of pages', 'Use this hook for your modals or any content you want to load at the very end.', '1');
 
-
-DELETE FROM `PREFIX_hook` WHERE `name` IN (
-  'displayProductTab',
-  'displayProductTabContent',
-  'displayBeforePayment',
-  'actionBeforeAuthentication',
-  'actionOrderDetail',
-  'actionProductListOverride',
-  'actionSearch',
-  'displayCustomerIdentityForm',
-  'displayHomeTab',
-  'displayHomeTabContent',
-  'displayPayment');
+/* PHP:delete_hook(displayProductTab); */;
+/* PHP:delete_hook(displayProductTabContent); */;
+/* PHP:delete_hook(displayBeforePayment); */;
+/* PHP:delete_hook(actionBeforeAuthentication); */;
+/* PHP:delete_hook(actionOrderDetail); */;
+/* PHP:delete_hook(actionProductListOverride); */;
+/* PHP:delete_hook(actionSearch); */;
+/* PHP:delete_hook(displayCustomerIdentityForm); */;
+/* PHP:delete_hook(displayHomeTab); */;
+/* PHP:delete_hook(displayHomeTabContent); */;
+/* PHP:delete_hook(displayPayment); */;
+/* PHP:delete_hook(displayProductComparison); */;
 
 DELETE FROM `PREFIX_hook_alias` WHERE `name` IN (
   'beforeAuthentication',
@@ -178,7 +175,8 @@ DELETE FROM `PREFIX_hook_alias` WHERE `name` IN (
   'orderDetail',
   'payment',
   'productListAssign',
-  'search');
+  'search',
+  'displayProductComparison');
 
 DELETE FROM `PREFIX_configuration` WHERE `name` IN (
   '_MEDIA_SERVER_2_',

--- a/install-dev/upgrade/sql/1.7.6.2.sql
+++ b/install-dev/upgrade/sql/1.7.6.2.sql
@@ -31,12 +31,6 @@ FROM `PREFIX_customization_field_lang` entity
 LEFT JOIN `PREFIX_customization_field_lang` entity2 ON `entity2`.`id_shop` = 1 AND `entity`.`id_customization_field` = `entity2`.`id_customization_field`
 WHERE `entity2`.`id_shop` IS NULL;
 
-INSERT INTO `PREFIX_info_lang` SELECT
-`entity`.`id_info`, 1, `entity`.`id_lang`, `entity`.`text`
-FROM `PREFIX_info_lang` entity
-LEFT JOIN `PREFIX_info_lang` entity2 ON `entity2`.`id_shop` = 1 AND `entity`.`id_info` = `entity2`.`id_info`
-WHERE `entity2`.`id_shop` IS NULL;
-
 INSERT INTO `PREFIX_meta_lang` SELECT
 `entity`.`id_meta`, 1, `entity`.`id_lang`, `entity`.title, `entity`.`description`, `entity`.`keywords`, `entity`.`url_rewrite`
 FROM `PREFIX_meta_lang` entity


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Because during the upgrade process of 1.7.6.2 we try to upgrade a table belongings to a module, that can throw errors when that module is not present during the process.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially #22668
| How to test?      | Upgrade from 1.6.1.24 to a version >= 1.7.6.2 with the autoupgrade module and the option "Switch to the default theme" checked (as this option is checked by default when we select the channel *major*), you should not have the following warning: ![Capture d’écran 2021-01-06 à 10 52 03](https://user-images.githubusercontent.com/2168836/103754955-596c5180-500d-11eb-8433-2fec7935bd28.png)
| Possible impacts? | /


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22682)
<!-- Reviewable:end -->
