### PR TITLE
Create Order - Cart details modal - Fix refresh for cart total

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -5312,4 +5312,27 @@ class CartCore extends ObjectModel
 
         return $summary;
     }
+
+    /**
+     * @param Cart $cart
+     *
+     * @return float
+     */
+    public function getCartTotalPrice()
+    {
+        $summary = $this->getSummaryDetails();
+
+        $id_order = (int) Order::getIdByCartId($this->id);
+        $order = new Order($id_order);
+
+        if (Validate::isLoadedObject($order)) {
+            $taxCalculationMethod = $order->getTaxCalculationMethod();
+        } else {
+            $taxCalculationMethod = Group::getPriceDisplayMethod(Group::getCurrent()->id);
+        }
+
+        return $taxCalculationMethod == PS_TAX_EXC ?
+            $summary['total_price_without_tax'] :
+            $summary['total_price'];
+    }
 }

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -1025,6 +1025,17 @@ class AdminStatsControllerCore extends AdminStatsTabController
 
                 break;
 
+            case 'shopping_cart_total':
+                $cartId = Tools::getValue('cartId');
+                $cart = new Cart((int) $cartId);
+                if (Validate::isLoadedObject($cart)) {
+                    $value = $this->context->getCurrentLocale()->formatPrice(
+                        $cart->getCartTotalPrice(),
+                        Currency::getIsoCodeById((int) $cart->id_currency)
+                    );
+                }
+                break;
+
             default:
                 $value = false;
         }

--- a/src/Adapter/Kpi/ShoppingCartTotalKpi.php
+++ b/src/Adapter/Kpi/ShoppingCartTotalKpi.php
@@ -74,6 +74,7 @@ final class ShoppingCartTotalKpi implements KpiInterface
             $cart->getCartTotalPrice(),
             Currency::getIsoCodeById((int) $cart->id_currency)
         );
+        $helper->source = Context::getContext()->link->getAdminLink('AdminStats') . '&ajax=1&action=getKpi&kpi=shopping_cart_total&cartId=' . $cart->id;
 
         return $helper->generate();
     }

--- a/src/Adapter/Kpi/ShoppingCartTotalKpi.php
+++ b/src/Adapter/Kpi/ShoppingCartTotalKpi.php
@@ -71,10 +71,9 @@ final class ShoppingCartTotalKpi implements KpiInterface
         $helper->title = $translator->trans('Total Cart', [], 'Admin.Orderscustomers.Feature');
         $helper->subtitle = $translator->trans('Cart #%ID%', ['%ID%' => $cart->id], 'Admin.Orderscustomers.Feature');
         $helper->value = $this->locale->formatPrice(
-            $this->getCartTotalPrice($cart),	            $cart->getCartTotalPrice(),
-            Currency::getIsoCodeById((int) $cart->id_currency)	            Currency::getIsoCodeById((int) $cart->id_currency)
-        );	        );
-        $helper->source = Context::getContext()->link->getAdminLink('AdminStats') . '&ajax=1&action=getKpi&kpi=shopping_cart_total&cartId=' . $cart->id;
+            $cart->getCartTotalPrice(),
+            Currency::getIsoCodeById((int) $cart->id_currency)
+        );
 
         return $helper->generate();
     }

--- a/src/Adapter/Kpi/ShoppingCartTotalKpi.php
+++ b/src/Adapter/Kpi/ShoppingCartTotalKpi.php
@@ -29,12 +29,9 @@ namespace PrestaShop\PrestaShop\Adapter\Kpi;
 use Cart;
 use Context;
 use Currency;
-use Group;
 use HelperKpi;
-use Order;
 use PrestaShop\PrestaShop\Core\Kpi\KpiInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
-use Validate;
 
 /**
  * {@inheritdoc}
@@ -74,9 +71,10 @@ final class ShoppingCartTotalKpi implements KpiInterface
         $helper->title = $translator->trans('Total Cart', [], 'Admin.Orderscustomers.Feature');
         $helper->subtitle = $translator->trans('Cart #%ID%', ['%ID%' => $cart->id], 'Admin.Orderscustomers.Feature');
         $helper->value = $this->locale->formatPrice(
-            $this->getCartTotalPrice($cart),
-            Currency::getIsoCodeById((int) $cart->id_currency)
-        );
+            $this->getCartTotalPrice($cart),	            $cart->getCartTotalPrice(),
+            Currency::getIsoCodeById((int) $cart->id_currency)	            Currency::getIsoCodeById((int) $cart->id_currency)
+        );	        );
+        $helper->source = Context::getContext()->link->getAdminLink('AdminStats') . '&ajax=1&action=getKpi&kpi=shopping_cart_total&cartId=' . $cart->id;
 
         return $helper->generate();
     }
@@ -89,30 +87,5 @@ final class ShoppingCartTotalKpi implements KpiInterface
     public function setOptions(array $options)
     {
         $this->options = $options;
-    }
-
-    /**
-     * @param Cart $cart
-     *
-     * @return float
-     */
-    private function getCartTotalPrice(Cart $cart)
-    {
-        $summary = $cart->getSummaryDetails();
-
-        $id_order = (int) Order::getIdByCartId($cart->id);
-        $order = new Order($id_order);
-
-        if (Validate::isLoadedObject($order)) {
-            $taxCalculationMethod = $order->getTaxCalculationMethod();
-        } else {
-            $taxCalculationMethod = Group::getPriceDisplayMethod(Group::getCurrent()->id);
-        }
-
-        $totalPrice = $taxCalculationMethod == PS_TAX_EXC ?
-            $summary['total_price_without_tax'] :
-            $summary['total_price'];
-
-        return $totalPrice;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -86,13 +86,15 @@ class CartController extends FrameworkBundleAdminController
         $kpiRowFactory->setOptions([
             'cart_id' => $cartId,
         ]);
+        $kpiRow = $kpiRowFactory->build();
+        $kpiRow->setAllowRefresh(false);
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Cart/view.html.twig', [
             'cartView' => $cartView,
             'layoutTitle' => $this->trans('View', 'Admin.Actions'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-            'cartKpi' => $kpiRowFactory->build(),
+            'cartKpi' => $kpiRow,
             'createOrderFromCartLink' => $this->generateUrl('admin_orders_create', [
                 'cartId' => $cartId,
             ]),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | Fix missing source attribute for the KPIHelper to fix JS error. Do not show the refresh button
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #22105 
| How to test?  | In BO > Orders > Add new Order page > Search a customer > choose it > Open the details for a cart > You will see the amount of the cart and no *Refresh* button<br><br>In Orders > Shopping carts > choose a cart and hit View > You will see the total amount of the cart and no *Refresh* button

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22249)
<!-- Reviewable:end -->
