### PR TITLE
Add more data to actionProductCancel hook

### DIFF
--- a/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php
@@ -241,7 +241,7 @@ final class CancelOrderProductHandler extends AbstractOrderCommandHandler implem
                 $newQuantity = max((int) $orderDetail->product_quantity - (int) $qty_cancel_product, 0);
                 $orderInvoice = $orderDetail->id_order_invoice != 0 ? new OrderInvoice($orderDetail->id_order_invoice) : null;
                 $this->orderProductQuantityUpdater->update($order, $orderDetail, $newQuantity, $orderInvoice);
-                Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetail->id_order_detail, 'action' => CancellationActionType::CANCEL_PRODUCT], null, false, true, false, $order->id_shop);
+                Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetail->id_order_detail, 'cancel_quantity' => $qty_cancel_product, 'action' => CancellationActionType::CANCEL_PRODUCT], null, false, true, false, $order->id_shop);
             }
         }
     }

--- a/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
@@ -146,7 +146,7 @@ final class IssuePartialRefundHandler extends AbstractOrderCommandHandler implem
             if ($shouldReinjectProducts) {
                 $this->reinjectQuantity($orderDetail, $productRefund['quantity']);
             }
-            Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetailId, 'action' => CancellationActionType::PARTIAL_REFUND], null, false, true, false, $order->id_shop);
+            Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetailId, 'cancel_quantity' => $productRefund['quantity'], 'cancel_amount' => $productRefund['amount'], 'action' => CancellationActionType::PARTIAL_REFUND], null, false, true, false, $order->id_shop);
         }
 
         // Update order carrier weight

--- a/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueReturnProductHandler.php
@@ -147,7 +147,7 @@ class IssueReturnProductHandler extends AbstractOrderCommandHandler implements I
             if ($command->restockRefundedProducts()) {
                 $this->reinjectQuantity($orderDetail, $productRefund['quantity']);
             }
-            Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetailId, 'action' => CancellationActionType::RETURN_PRODUCT], null, false, true, false, $order->id_shop);
+            Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetailId, 'cancel_quantity' => $productRefund['quantity'], 'action' => CancellationActionType::RETURN_PRODUCT], null, false, true, false, $order->id_shop);
         }
 
         // Update order carrier weight

--- a/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssueStandardRefundHandler.php
@@ -156,7 +156,7 @@ class IssueStandardRefundHandler extends AbstractOrderCommandHandler implements 
             $orderDetail = $orderRefundSummary->getOrderDetailById($orderDetailId);
             // For standard refund the order is necessarily NOT delivered yet, so reinjection is automatic
             $this->reinjectQuantity($orderDetail, $productRefund['quantity']);
-            Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetailId, 'action' => CancellationActionType::STANDARD_REFUND], null, false, true, false, $order->id_shop);
+            Hook::exec('actionProductCancel', ['order' => $order, 'id_order_detail' => (int) $orderDetailId, 'cancel_quantity' => $productRefund['quantity'], 'action' => CancellationActionType::STANDARD_REFUND], null, false, true, false, $order->id_shop);
         }
 
         // Update order carrier weight


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I added more data to actionProductCancel hook. Mainly in order to fix https://github.com/PrestaShop/ps_googleanalytics/issues/84.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/22569, https://github.com/PrestaShop/ps_googleanalytics/issues/84
| How to test?      | Dump data of actionProductCancel, do a partial refund of an order.
| Possible impacts? | Not likely, it only provides additional data to an array.

**Resources**
https://devdocs.prestashop.com/1.7/development/page-reference/back-office/order/refunds/

**Screenshots**
![Výstřižek](https://user-images.githubusercontent.com/6097524/103764522-e61e0c00-501b-11eb-8157-07ace89ea52e.JPG)

ping @PierreRambaud and @matks
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22686)
<!-- Reviewable:end -->
