### PR TITLE
Dont apply discount on the product price including ecotax

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3788,33 +3788,6 @@ class ProductCore extends ObjectModel
             $price = $product_tax_calculator->addTaxes($price);
         }
 
-        // Eco Tax
-        if (($result['ecotax'] || isset($result['attribute_ecotax'])) && $with_ecotax) {
-            $ecotax = $result['ecotax'];
-            if (isset($result['attribute_ecotax']) && $result['attribute_ecotax'] > 0) {
-                $ecotax = $result['attribute_ecotax'];
-            }
-
-            if ($id_currency) {
-                $ecotax = Tools::convertPrice($ecotax, $id_currency);
-            }
-            if ($use_tax) {
-                static $psEcotaxTaxRulesGroupId = null;
-                if ($psEcotaxTaxRulesGroupId === null) {
-                    $psEcotaxTaxRulesGroupId = (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID');
-                }
-                // reinit the tax manager for ecotax handling
-                $tax_manager = TaxManagerFactory::getManager(
-                    $address,
-                    $psEcotaxTaxRulesGroupId
-                );
-                $ecotax_tax_calculator = $tax_manager->getTaxCalculator();
-                $price += $ecotax_tax_calculator->addTaxes($ecotax);
-            } else {
-                $price += $ecotax;
-            }
-        }
-
         // Reduction
         $specific_price_reduction = 0;
         if (($only_reduc || $use_reduc) && $specific_price) {
@@ -3858,6 +3831,33 @@ class ProductCore extends ObjectModel
 
         if ($only_reduc) {
             return Tools::ps_round($specific_price_reduction, $decimals);
+        }
+
+        // Eco Tax
+        if (($result['ecotax'] || isset($result['attribute_ecotax'])) && $with_ecotax) {
+            $ecotax = $result['ecotax'];
+            if (isset($result['attribute_ecotax']) && $result['attribute_ecotax'] > 0) {
+                $ecotax = $result['attribute_ecotax'];
+            }
+
+            if ($id_currency) {
+                $ecotax = Tools::convertPrice($ecotax, $id_currency);
+            }
+            if ($use_tax) {
+                static $psEcotaxTaxRulesGroupId = null;
+                if ($psEcotaxTaxRulesGroupId === null) {
+                    $psEcotaxTaxRulesGroupId = (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID');
+                }
+                // reinit the tax manager for ecotax handling
+                $tax_manager = TaxManagerFactory::getManager(
+                    $address,
+                    $psEcotaxTaxRulesGroupId
+                );
+                $ecotax_tax_calculator = $tax_manager->getTaxCalculator();
+                $price += $ecotax_tax_calculator->addTaxes($ecotax);
+            } else {
+                $price += $ecotax;
+            }
         }
 
         $price = Tools::ps_round($price, $decimals);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix the price calculation of a product when the product has an ecotax and has a promotion. The calculation must first apply the promotion and then add the ecotax to the price after the promotion. 
| Type?             | bug fix
| Category?         | FO / BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9600
| How to test?      | Explain in #9600.
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22694)
<!-- Reviewable:end -->
