### PR TITLE
Integrate product options form and related command

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -34,7 +34,11 @@ use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
 use PrestaShop\PrestaShop\Core\Product\ProductInterface;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 
@@ -421,7 +425,7 @@ class ProductCore extends ObjectModel
             'id_shop_default' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'id_manufacturer' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'id_supplier' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
-            'reference' => ['type' => self::TYPE_STRING, 'validate' => 'isReference', 'size' => 64],
+            'reference' => ['type' => self::TYPE_STRING, 'validate' => 'isReference', 'size' => Reference::MAX_LENGTH],
             'supplier_reference' => ['type' => self::TYPE_STRING, 'validate' => 'isReference', 'size' => 64],
             'location' => ['type' => self::TYPE_STRING, 'validate' => 'isString', 'size' => 255],
             'width' => ['type' => self::TYPE_FLOAT, 'validate' => 'isUnsignedFloat'],
@@ -429,10 +433,10 @@ class ProductCore extends ObjectModel
             'depth' => ['type' => self::TYPE_FLOAT, 'validate' => 'isUnsignedFloat'],
             'weight' => ['type' => self::TYPE_FLOAT, 'validate' => 'isUnsignedFloat'],
             'quantity_discount' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
-            'ean13' => ['type' => self::TYPE_STRING, 'validate' => 'isEan13', 'size' => 13],
-            'isbn' => ['type' => self::TYPE_STRING, 'validate' => 'isIsbn', 'size' => 32],
-            'upc' => ['type' => self::TYPE_STRING, 'validate' => 'isUpc', 'size' => 12],
-            'mpn' => ['type' => self::TYPE_STRING, 'validate' => 'isMpn', 'size' => 40],
+            'ean13' => ['type' => self::TYPE_STRING, 'validate' => 'isEan13', 'size' => Ean13::MAX_LENGTH],
+            'isbn' => ['type' => self::TYPE_STRING, 'validate' => 'isIsbn', 'size' => Isbn::MAX_LENGTH],
+            'upc' => ['type' => self::TYPE_STRING, 'validate' => 'isUpc', 'size' => Upc::MAX_LENGTH],
+            'mpn' => ['type' => self::TYPE_STRING, 'validate' => 'isMpn', 'size' => ProductSettings::MAX_MPN_LENGTH],
             'cache_is_pack' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'cache_has_attachments' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'is_virtual' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
@@ -6272,7 +6276,7 @@ class ProductCore extends ObjectModel
      *
      * @return bool
      *
-     * @throws \PrestaShopDatabaseException
+     * @throws PrestaShopDatabaseException
      */
     public function hasActivatedRequiredCustomizableFields()
     {
@@ -6429,7 +6433,7 @@ class ProductCore extends ObjectModel
      */
     public static function getOldTempProducts()
     {
-        $sql = 'SELECT id_product FROM `' . _DB_PREFIX_ . 'product` WHERE state=' . \Product::STATE_TEMP . ' AND date_upd < NOW() - INTERVAL 1 DAY';
+        $sql = 'SELECT id_product FROM `' . _DB_PREFIX_ . 'product` WHERE state=' . Product::STATE_TEMP . ' AND date_upd < NOW() - INTERVAL 1 DAY';
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql, true, false);
     }

--- a/src/Core/ConstraintValidator/Constraints/TypedRegex.php
+++ b/src/Core/ConstraintValidator/Constraints/TypedRegex.php
@@ -50,6 +50,9 @@ class TypedRegex extends Constraint
     const TYPE_CURRENCY_ISO_CODE = 'currency_iso_code';
     const TYPE_FILE_NAME = 'file_name';
     const TYPE_DNI_LITE = 'dni_lite';
+    const TYPE_UPC = 'upc';
+    const TYPE_EAN_13 = 'ean_13';
+    const TYPE_ISBN = 'isbn';
 
     /**
      * @var string
@@ -75,5 +78,13 @@ class TypedRegex extends Constraint
     public function validatedBy()
     {
         return TypedRegexValidator::class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'type';
     }
 }

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -30,6 +30,9 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Address\Configuration\AddressConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\AlphaIsoCode;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\IsoCode;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
 use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -111,6 +114,9 @@ class TypedRegexValidator extends ConstraintValidator
             TypedRegex::TYPE_CURRENCY_ISO_CODE => AlphaIsoCode::PATTERN,
             TypedRegex::TYPE_FILE_NAME => '/^[a-zA-Z0-9_.-]+$/',
             TypedRegex::TYPE_DNI_LITE => AddressConstraint::DNI_LITE_PATTERN,
+            TypedRegex::TYPE_UPC => Upc::VALID_PATTERN,
+            TypedRegex::TYPE_EAN_13 => Ean13::VALID_PATTERN,
+            TypedRegex::TYPE_ISBN => Isbn::VALID_PATTERN,
         ];
 
         if (isset($typePatterns[$type])) {

--- a/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
@@ -294,6 +294,7 @@ class UpdateProductShippingCommand
 
     /**
      * @todo: dimensions deserves dedicated VO and might be worth reusing in Carriers page.
+     *
      * @todo Check https://github.com/PrestaShop/PrestaShop/issues/19666#issuecomment-756088706
      *
      * @param DecimalNumber $value

--- a/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
@@ -293,6 +293,9 @@ class UpdateProductShippingCommand
     }
 
     /**
+     * @todo: dimensions deserves dedicated VO and might be worth reusing in Carriers page.
+     * @todo Check https://github.com/PrestaShop/PrestaShop/issues/19666#issuecomment-756088706
+     *
      * @param DecimalNumber $value
      * @param string $dimensionName
      *

--- a/src/Core/Domain/Product/ProductSettings.php
+++ b/src/Core/Domain/Product/ProductSettings.php
@@ -29,12 +29,22 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product;
 
 /**
- * Defines settings for product
+ * Defines settings for product.
+ * If related Value Object does not exist, then various settings (e.g. regex, length constraints) are saved here
  */
 class ProductSettings
 {
     /**
-     * Maximum length of product name
+     * Class not supposed to be initialized, it only serves as static storage
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Bellow constants define maximum allowed length of product properties
      */
     const MAX_NAME_LENGTH = 128;
+    const MAX_MPN_LENGTH = 40;
+    //@todo: finish up with properties that doesn't have related ValueObjects like description, meta_description etc. (see Product.php)
 }

--- a/src/Core/Form/ChoiceProvider/ProductConditionChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ProductConditionChoiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class ProductConditionChoiceProvider implements FormChoiceProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(
+        TranslatorInterface $translator
+    ) {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChoices()
+    {
+        return [
+            $this->translator->trans('New', [], 'Shop.Theme.Catalog') => ProductCondition::NEW,
+            $this->translator->trans('Used', [], 'Shop.Theme.Catalog') => ProductCondition::USED,
+            $this->translator->trans('Refurbished', [], 'Shop.Theme.Catalog') => ProductCondition::REFURBISHED,
+        ];
+    }
+}

--- a/src/Core/Form/ChoiceProvider/ProductVisibilityChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ProductVisibilityChoiceProvider.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class ProductVisibilityChoiceProvider implements FormChoiceProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(
+        TranslatorInterface $translator
+    ) {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getChoices()
+    {
+        return [
+            $this->translator->trans('Everywhere', [], 'Admin.Catalog.Feature') => ProductVisibility::VISIBLE_EVERYWHERE,
+            $this->translator->trans('Catalog only', [], 'Admin.Catalog.Feature') => ProductVisibility::VISIBLE_IN_CATALOG,
+            $this->translator->trans('Search only', [], 'Admin.Catalog.Feature') => ProductVisibility::VISIBLE_IN_SEARCH,
+            $this->translator->trans('Nowhere', [], 'Admin.Catalog.Feature') => ProductVisibility::INVISIBLE,
+        ];
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandBuilder.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+final class OptionsCommandBuilder implements ProductCommandBuilderInterface
+{
+    /**
+     * @param ProductId $productId
+     * @param array $formData
+     *
+     * @return UpdateProductOptionsCommand|null
+     */
+    public function buildCommand(ProductId $productId, array $formData)
+    {
+        if (!isset($formData['options'])) {
+            return null;
+        }
+
+        $options = $formData['options'];
+        $command = new UpdateProductOptionsCommand($productId->getValue());
+
+        if (isset($options['active'])) {
+            $command->setActive((bool) $options['active']);
+        }
+        if (isset($options['visibility'])) {
+            $command->setVisibility($options['visibility']);
+        }
+        if (isset($options['available_for_order'])) {
+            $command->setAvailableForOrder((bool) $options['available_for_order']);
+        }
+        if (isset($options['show_price'])) {
+            $command->setShowPrice((bool) $options['show_price']);
+        }
+        if (isset($options['online_only'])) {
+            $command->setOnlineOnly((bool) $options['online_only']);
+        }
+        if (isset($options['show_condition'])) {
+            $command->setShowCondition((bool) $options['show_condition']);
+        }
+        if (isset($options['condition'])) {
+            $command->setCondition($options['condition']);
+        }
+        if (isset($options['manufacturer_id'])) {
+            $command->setManufacturerId((int) $options['manufacturer_id']);
+        }
+
+        return $command;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 
@@ -64,6 +65,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
             'basic' => $this->extractBasicData($productForEditing),
             'price' => $this->extractPriceData($productForEditing),
             'shipping' => $this->extractShippingData($productForEditing),
+            'options' => $this->extractOptionsData($productForEditing),
         ];
     }
 
@@ -146,5 +148,42 @@ final class ProductFormDataProvider implements FormDataProviderInterface
             'delivery_time_out_stock_note' => $shipping->getLocalizedDeliveryTimeOutOfStockNotes(),
             'carriers' => $shipping->getCarrierReferences(),
         ];
+    }
+
+    private function extractOptionsData(ProductForEditing $productForEditing): array
+    {
+        $options = $productForEditing->getOptions();
+        $details = $productForEditing->getDetails();
+
+        return [
+            'active' => $options->isActive(),
+            'visibility' => $options->getVisibility(),
+            'available_for_order' => $options->isAvailableForOrder(),
+            'show_price' => $options->showPrice(),
+            'online_only' => $options->isOnlineOnly(),
+            'show_condition' => $options->showCondition(),
+            'condition' => $options->getCondition(),
+            'tags' => $this->presentTags($productForEditing->getBasicInformation()->getLocalizedTags()),
+            'mpn' => $details->getMpn(),
+            'upc' => $details->getUpc(),
+            'ean_13' => $details->getEan13(),
+            'isbn' => $details->getIsbn(),
+            'reference' => $details->getReference(),
+        ];
+    }
+
+    /**
+     * @param LocalizedTags[] $localizedTagsList
+     *
+     * @return array<int, string>
+     */
+    private function presentTags(array $localizedTagsList): array
+    {
+        $tags = [];
+        foreach ($localizedTagsList as $localizedTags) {
+            $tags[$localizedTags->getLanguageId()] = implode(',', $localizedTags->getTags());
+        }
+
+        return $tags;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -34,6 +35,7 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\Regex;
 
@@ -43,40 +45,54 @@ use Symfony\Component\Validator\Constraints\Regex;
 class OptionsType extends TranslatorAwareType
 {
     /**
+     * @var FormChoiceProviderInterface
+     */
+    private $productVisibilityChoiceProvider;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param FormChoiceProviderInterface $productVisibilityChoiceProvider
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        FormChoiceProviderInterface $productVisibilityChoiceProvider
+    ) {
+        parent::__construct($translator, $locales);
+        $this->productVisibilityChoiceProvider = $productVisibilityChoiceProvider;
+    }
+
+    /**
      * {@inheritdoc}
-     *
-     * Builds form
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('visibility', ChoiceType::class, [
-            'choices' => [
-                $this->trans('Everywhere', 'Admin.Catalog.Feature') => 'both',
-                $this->trans('Catalog only', 'Admin.Catalog.Feature') => 'catalog',
-                $this->trans('Search only', 'Admin.Catalog.Feature') => 'search',
-                $this->trans('Nowhere', 'Admin.Catalog.Feature') => 'none',
-            ],
-            'attr' => [
-                'class' => 'custom-select',
-            ],
-            'required' => true,
-            'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
-        ])->add('meta_keyword', TranslatableType::class, [
-            'required' => false,
-            'options' => [
-                'constraints' => [
-                    new TypedRegex([
-                        'type' => TypedRegex::TYPE_GENERIC_NAME,
-                        //                        'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
-                    ]),
-                ],
+        $builder
+            ->add('visibility', ChoiceType::class, [
+                'choices' => $this->productVisibilityChoiceProvider->getChoices(),
                 'attr' => [
-                    'class' => 'js-taggable-field',
-                    //                    'placeholder' => $this->trans('Add tag', 'Admin.Actions'),
+                    'class' => 'custom-select',
                 ],
+                'required' => true,
+                'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
+            ])
+            ->add('meta_keyword', TranslatableType::class, [
                 'required' => false,
-            ],
-        ])
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex([
+                            'type' => TypedRegex::TYPE_GENERIC_NAME,
+                            //                        'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
+                        ]),
+                    ],
+                    'attr' => [
+                        'class' => 'js-taggable-field',
+                        //                    'placeholder' => $this->trans('Add tag', 'Admin.Actions'),
+                    ],
+                    'required' => false,
+                ],
+            ])
             ->add('tags', TranslateType::class, [
                 'type' => TextType::class,
                 'options' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -29,9 +29,9 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -68,13 +68,26 @@ class OptionsType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('active', SwitchType::class, [
+                'label' => $this->trans('Online', 'Admin.Catalog.Feature'),
+            ])
             ->add('visibility', ChoiceType::class, [
                 'choices' => $this->productVisibilityChoiceProvider->getChoices(),
                 'attr' => [
                     'class' => 'custom-select',
                 ],
-                'required' => true,
                 'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
+            ])
+            ->add('available_for_order', SwitchType::class, [
+                'label' => $this->trans('Available for order', 'Admin.Catalog.Feature'),
+            ])
+            ->add('show_price', SwitchType::class, [
+                'label' => $this->trans('Show price', 'Admin.Catalog.Feature'),
+                'required' => false,
+            ])
+            ->add('online_only', SwitchType::class, [
+                'label' => $this->trans('Web only (not sold in your retail store)', 'Admin.Catalog.Feature'),
+                'required' => false,
             ])
             ->add('tags', TranslatableType::class, [
                 'required' => false,
@@ -128,7 +141,7 @@ class OptionsType extends TranslatorAwareType
                 'label' => $this->trans('Reference', 'Admin.Global'),
                 'empty_data' => '',
             ])
-            ->add('show_condition', CheckboxType::class, [
+            ->add('show_condition', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
             ])
@@ -165,15 +178,5 @@ class OptionsType extends TranslatorAwareType
 //                'label' => $this->trans('Default suppliers', 'Admin.Catalog.Feature'),
 //            ])
         ;
-    }
-
-    /**
-     * Returns the block prefix of this type.
-     *
-     * @return string The prefix name
-     */
-    public function getBlockPrefix()
-    {
-        return 'product_options';
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslateType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
+
+/**
+ * This form class is responsible to generate the product options form.
+ */
+class OptionsType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     *
+     * Builds form
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('visibility', ChoiceType::class, [
+            'choices' => [
+                $this->trans('Everywhere', 'Admin.Catalog.Feature') => 'both',
+                $this->trans('Catalog only', 'Admin.Catalog.Feature') => 'catalog',
+                $this->trans('Search only', 'Admin.Catalog.Feature') => 'search',
+                $this->trans('Nowhere', 'Admin.Catalog.Feature') => 'none',
+            ],
+            'attr' => [
+                'class' => 'custom-select',
+            ],
+            'required' => true,
+            'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
+        ])->add('meta_keyword', TranslatableType::class, [
+            'required' => false,
+            'options' => [
+                'constraints' => [
+                    new TypedRegex([
+                        'type' => TypedRegex::TYPE_GENERIC_NAME,
+                        //                        'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
+                    ]),
+                ],
+                'attr' => [
+                    'class' => 'js-taggable-field',
+                    //                    'placeholder' => $this->trans('Add tag', 'Admin.Actions'),
+                ],
+                'required' => false,
+            ],
+        ])
+            ->add('tags', TranslateType::class, [
+                'type' => TextType::class,
+                'options' => [
+                    'attr' => [
+                        'class' => 'tokenfield',
+                        'placeholder' => $this->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', 'Admin.Catalog.Help'),
+                    ],
+                ],
+                'locales' => $this->locales,
+                'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
+            ])
+            ->add('mpn', TextType::class, [
+                'required' => false,
+                'label' => $this->trans('MPN', 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    new Length(['max' => 40]),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('upc', TextType::class, [
+                'required' => false,
+                'label' => $this->trans('UPC barcode', 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    //@todo: adjust TypedRegex use UPC VO
+                    new Regex('/^[0-9]{0,12}$/'),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('ean13', TextType::class, [
+                'required' => false,
+                'error_bubbling' => true,
+                'label' => $this->trans('EAN-13 or JAN barcode', 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    //@todo: adjust TypedRegex
+                    new Regex('/^[0-9]{0,13}$/'),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('isbn', TextType::class, [
+                'required' => false,
+                'label' => $this->trans('ISBN', 'Admin.Catalog.Feature'),
+                'constraints' => [
+                    //@todo: adjust TypedRegex
+                    new Regex('/^[0-9-]{0,32}$/'),
+                ],
+                'empty_data' => '',
+            ])
+            ->add('reference', TextType::class, [
+                'required' => false,
+                'label' => $this->trans('Reference', 'Admin.Global'),
+                'empty_data' => '',
+            ])
+            ->add('show_condition', CheckboxType::class, [
+                'required' => false,
+                'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
+            ])
+            ->add('condition', ChoiceType::class, [
+                'choices' => [
+                    $this->trans('New', 'Shop.Theme.Catalog') => 'new',
+                    $this->trans('Used', 'Shop.Theme.Catalog') => 'used',
+                    $this->trans('Refurbished', 'Shop.Theme.Catalog') => 'refurbished',
+                ],
+                'attr' => [
+                    'class' => 'custom-select',
+                ],
+                'required' => true,
+                'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
+            ])
+//            ->add('suppliers', ChoiceType::class, [
+//                'choices' => $this->suppliers,
+//                'expanded' => true,
+//                'multiple' => true,
+//                'required' => false,
+//                'attr' => [
+//                    'class' => 'custom-select',
+//                ],
+//                'label' => $this->trans('Suppliers', 'Admin.Global'),
+//            ])
+//            ->add('default_supplier', ChoiceType::class, [
+//                'choices' => $this->suppliers,
+//                'expanded' => true,
+//                'multiple' => false,
+//                'required' => true,
+//                'attr' => [
+//                    'class' => 'custom-select',
+//                ],
+//                'label' => $this->trans('Default suppliers', 'Admin.Catalog.Feature'),
+//            ])
+        ;
+    }
+
+    /**
+     * Returns the block prefix of this type.
+     *
+     * @return string The prefix name
+     */
+    public function getBlockPrefix()
+    {
+        return 'product_options';
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -37,7 +37,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
-use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * This form class is responsible to generate the product options form.
@@ -82,9 +81,7 @@ class OptionsType extends TranslatorAwareType
                 'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
                 'options' => [
                     'constraints' => [
-                        new TypedRegex([
-                            'type' => TypedRegex::TYPE_GENERIC_NAME,
-                        ]),
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
                     ],
                     'attr' => [
                         'class' => 'js-taggable-field',
@@ -105,8 +102,7 @@ class OptionsType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('UPC barcode', 'Admin.Catalog.Feature'),
                 'constraints' => [
-                    //@todo: adjust TypedRegex use UPC VO
-                    new Regex('/^[0-9]{0,12}$/'),
+                    new TypedRegex(TypedRegex::TYPE_UPC),
                 ],
                 'empty_data' => '',
             ])
@@ -115,8 +111,7 @@ class OptionsType extends TranslatorAwareType
                 'error_bubbling' => true,
                 'label' => $this->trans('EAN-13 or JAN barcode', 'Admin.Catalog.Feature'),
                 'constraints' => [
-                    //@todo: adjust TypedRegex
-                    new Regex('/^[0-9]{0,13}$/'),
+                    new TypedRegex(TypedRegex::TYPE_EAN_13),
                 ],
                 'empty_data' => '',
             ])
@@ -124,8 +119,7 @@ class OptionsType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('ISBN', 'Admin.Catalog.Feature'),
                 'constraints' => [
-                    //@todo: adjust TypedRegex
-                    new Regex('/^[0-9-]{0,32}$/'),
+                    new TypedRegex(TypedRegex::TYPE_ISBN),
                 ],
                 'empty_data' => '',
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -85,7 +85,7 @@ class OptionsType extends TranslatorAwareType
     {
         $builder
             ->add('active', SwitchType::class, [
-                'label' => $this->trans('Online', 'Admin.Catalog.Feature'),
+                'label' => $this->trans('Online', 'Admin.Global'),
             ])
             ->add('visibility', ChoiceType::class, [
                 'choices' => $this->productVisibilityChoiceProvider->getChoices(),
@@ -171,7 +171,7 @@ class OptionsType extends TranslatorAwareType
             ])
             ->add('manufacturer_id', ChoiceType::class, [
                 'choices' => $this->manufacturerNameByIdChoiceProvider->getChoices(),
-                'label' => $this->trans('Manufacturer', 'Admin.Catalog.Feature'),
+                'label' => $this->trans('Brand', 'Admin.Catalog.Feature'),
             ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -54,20 +54,28 @@ class OptionsType extends TranslatorAwareType
     private $productConditionChoiceProvider;
 
     /**
+     * @var FormChoiceProviderInterface
+     */
+    private $manufacturerNameByIdChoiceProvider;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param FormChoiceProviderInterface $productVisibilityChoiceProvider
      * @param FormChoiceProviderInterface $productConditionChoiceProvider
+     * @param FormChoiceProviderInterface $manufacturerNameByIdChoiceProvider
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
         FormChoiceProviderInterface $productVisibilityChoiceProvider,
-        FormChoiceProviderInterface $productConditionChoiceProvider
+        FormChoiceProviderInterface $productConditionChoiceProvider,
+        FormChoiceProviderInterface $manufacturerNameByIdChoiceProvider
     ) {
         parent::__construct($translator, $locales);
         $this->productVisibilityChoiceProvider = $productVisibilityChoiceProvider;
         $this->productConditionChoiceProvider = $productConditionChoiceProvider;
+        $this->manufacturerNameByIdChoiceProvider = $manufacturerNameByIdChoiceProvider;
     }
 
     /**
@@ -161,6 +169,8 @@ class OptionsType extends TranslatorAwareType
                 'required' => true,
                 'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
             ])
-        ;
+            ->add('manufacturer_id', ChoiceType::class, [
+                'choices' => $this->manufacturerNameByIdChoiceProvider->getChoices(),
+            ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -171,6 +171,7 @@ class OptionsType extends TranslatorAwareType
             ])
             ->add('manufacturer_id', ChoiceType::class, [
                 'choices' => $this->manufacturerNameByIdChoiceProvider->getChoices(),
+                'label' => $this->trans('Manufacturer', 'Admin.Catalog.Feature'),
             ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -27,9 +27,9 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Form\Admin\Type\TranslateType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -77,38 +77,27 @@ class OptionsType extends TranslatorAwareType
                 'required' => true,
                 'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
             ])
-            ->add('meta_keyword', TranslatableType::class, [
+            ->add('tags', TranslatableType::class, [
                 'required' => false,
+                'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
                 'options' => [
                     'constraints' => [
                         new TypedRegex([
                             'type' => TypedRegex::TYPE_GENERIC_NAME,
-                            //                        'message' => $this->trans('%s is invalid.', 'Admin.Notifications.Error'),
                         ]),
                     ],
                     'attr' => [
                         'class' => 'js-taggable-field',
-                        //                    'placeholder' => $this->trans('Add tag', 'Admin.Actions'),
+                        'placeholder' => $this->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', 'Admin.Catalog.Help'),
                     ],
                     'required' => false,
                 ],
-            ])
-            ->add('tags', TranslateType::class, [
-                'type' => TextType::class,
-                'options' => [
-                    'attr' => [
-                        'class' => 'tokenfield',
-                        'placeholder' => $this->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', 'Admin.Catalog.Help'),
-                    ],
-                ],
-                'locales' => $this->locales,
-                'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
             ])
             ->add('mpn', TextType::class, [
                 'required' => false,
                 'label' => $this->trans('MPN', 'Admin.Catalog.Feature'),
                 'constraints' => [
-                    new Length(['max' => 40]),
+                    new Length(['max' => ProductSettings::MAX_MPN_LENGTH]),
                 ],
                 'empty_data' => '',
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -49,17 +49,25 @@ class OptionsType extends TranslatorAwareType
     private $productVisibilityChoiceProvider;
 
     /**
+     * @var FormChoiceProviderInterface
+     */
+    private $productConditionChoiceProvider;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param FormChoiceProviderInterface $productVisibilityChoiceProvider
+     * @param FormChoiceProviderInterface $productConditionChoiceProvider
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        FormChoiceProviderInterface $productVisibilityChoiceProvider
+        FormChoiceProviderInterface $productVisibilityChoiceProvider,
+        FormChoiceProviderInterface $productConditionChoiceProvider
     ) {
         parent::__construct($translator, $locales);
         $this->productVisibilityChoiceProvider = $productVisibilityChoiceProvider;
+        $this->productConditionChoiceProvider = $productConditionChoiceProvider;
     }
 
     /**
@@ -119,7 +127,7 @@ class OptionsType extends TranslatorAwareType
                 ],
                 'empty_data' => '',
             ])
-            ->add('ean13', TextType::class, [
+            ->add('ean_13', TextType::class, [
                 'required' => false,
                 'error_bubbling' => true,
                 'label' => $this->trans('EAN-13 or JAN barcode', 'Admin.Catalog.Feature'),
@@ -146,37 +154,13 @@ class OptionsType extends TranslatorAwareType
                 'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
             ])
             ->add('condition', ChoiceType::class, [
-                'choices' => [
-                    $this->trans('New', 'Shop.Theme.Catalog') => 'new',
-                    $this->trans('Used', 'Shop.Theme.Catalog') => 'used',
-                    $this->trans('Refurbished', 'Shop.Theme.Catalog') => 'refurbished',
-                ],
+                'choices' => $this->productConditionChoiceProvider->getChoices(),
                 'attr' => [
                     'class' => 'custom-select',
                 ],
                 'required' => true,
                 'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
             ])
-//            ->add('suppliers', ChoiceType::class, [
-//                'choices' => $this->suppliers,
-//                'expanded' => true,
-//                'multiple' => true,
-//                'required' => false,
-//                'attr' => [
-//                    'class' => 'custom-select',
-//                ],
-//                'label' => $this->trans('Suppliers', 'Admin.Global'),
-//            ])
-//            ->add('default_supplier', ChoiceType::class, [
-//                'choices' => $this->suppliers,
-//                'expanded' => true,
-//                'multiple' => false,
-//                'required' => true,
-//                'attr' => [
-//                    'class' => 'custom-select',
-//                ],
-//                'label' => $this->trans('Default suppliers', 'Admin.Catalog.Feature'),
-//            ])
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -51,6 +51,7 @@ class ProductType extends TranslatorAwareType
             ->add('basic', BasicInformationType::class)
             ->add('price', PriceType::class)
             ->add('shipping', ShippingType::class)
+            ->add('options', OptionsType::class)
             ->add('save', SubmitType::class, [
                 'label' => $this->trans('Save', 'Admin.Actions'),
                 'attr' => [

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1267,6 +1267,8 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Sell\Product\OptionsType'
         parent: 'form.type.translatable.aware'
         public: true
+        arguments:
+            - '@prestashop.core.form.choice_provider.product_visibility_choice_provider'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1263,6 +1263,13 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.sell.product.options_type:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\OptionsType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     prestashop.bundle.form.admin.configure.shop_parameters.order_states.order_state:
       class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderStates\OrderStateType'
       parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1270,6 +1270,7 @@ services:
         arguments:
             - '@prestashop.core.form.choice_provider.product_visibility_choice_provider'
             - '@prestashop.core.form.choice_provider.product_condition_choice_provider'
+            - '@prestashop.adapter.form.choice_provider.manufacturer_name_by_id'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1269,6 +1269,7 @@ services:
         public: true
         arguments:
             - '@prestashop.core.form.choice_provider.product_visibility_choice_provider'
+            - '@prestashop.core.form.choice_provider.product_condition_choice_provider'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -255,3 +255,8 @@ services:
       class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
       arguments:
           - '@translator'
+
+  prestashop.core.form.choice_provider.product_condition_choice_provider:
+      class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductConditionChoiceProvider'
+      arguments:
+          - '@translator'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -250,3 +250,8 @@ services:
       class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\DeliveryTimeNoteTypesProvider'
       arguments:
           - '@translator'
+
+  prestashop.core.form.choice_provider.product_visibility_choice_provider:
+      class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductVisibilityChoiceProvider'
+      arguments:
+          - '@translator'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -9,6 +9,7 @@ services:
                 - '@prestashop.core.form.command_builder.product.basic_information'
                 - '@prestashop.core.form.command_builder.product.prices'
                 - '@prestashop.core.form.command_builder.product.shipping'
+                - '@prestashop.core.form.command_builder.product.options_command_builder'
 
     prestashop.core.form.command_builder.product.basic_information:
         class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\BasicInformationCommandBuilder
@@ -18,3 +19,6 @@ services:
 
     prestashop.core.form.command_builder.product.shipping:
         class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ShippingCommandBuilder
+
+    prestashop.core.form.command_builder.product.options_command_builder:
+        class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\OptionsCommandBuilder

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -25,6 +25,7 @@
 {% set isBasicTabValid = productForm.basic.description.vars.valid and productForm.basic.description_short.vars.valid %}
 {% set isPriceTabValid = productForm.price.vars.valid %}
 {% set isShippingTabValid = productForm.shipping.vars.valid %}
+{% set isOptionsTabValid = productForm.options.vars.valid %}
 
 <div class="tabs js-tabs">
   <div class="arrow d-xl-none js-arrow left-arrow float-left">
@@ -42,9 +43,16 @@
         {{ 'Pricing'|trans({}, 'Admin.Catalog.Feature') }}
       </a>
     </li>
+
     <li id="shipping-tab-nav" class="nav-item{% if not isShippingTabValid %} has-error{% endif %}">
       <a href="#shipping-tab" role="tab" data-toggle="tab" class="nav-link">
         {{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+
+    <li id="options-tab-nav" class="nav-item{% if not isOptionsTabValid %} has-error{% endif %}">
+      <a href="#options-tab" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'Options'|trans({}, 'Admin.Catalog.Feature') }}
       </a>
     </li>
   </ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -52,7 +52,7 @@
 
     <li id="options-tab-nav" class="nav-item{% if not isOptionsTabValid %} has-error{% endif %}">
       <a href="#options-tab" role="tab" data-toggle="tab" class="nav-link">
-        {{ 'Options'|trans({}, 'Admin.Catalog.Feature') }}
+        {{ 'Options'|trans({}, 'Admin.Global') }}
       </a>
     </li>
   </ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -70,6 +70,12 @@
         </div>
       {% endblock %}
 
+      {% block product_tab_options %}
+        <div role="tabpanel" class="form-contenttab tab-pane" id="options-tab">
+          {{ form_widget(productForm.options) }}
+        </div>
+      {% endblock %}
+
       {% block product_extra_tabs %}
       {% endblock %}
     </div>

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -26,15 +26,17 @@
 
 namespace Tests\Unit\Core\ConstraintValidator;
 
+use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 {
-    public function testItSucceedsForNameTypeWhenValidCharactersGiven()
+    public function testItSucceedsForNameTypeWhenValidCharactersGiven(): void
     {
         $value = 'goodname';
         $this->validator->validate($value, new TypedRegex(['type' => 'name']));
@@ -44,15 +46,12 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForNameType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForNameTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForNameTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'name']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'name']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'name']), $invalidChar);
     }
 
     public function testItSucceedsForCatalogNameTypeWhenValidCharactersGiven()
@@ -65,15 +64,12 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForCatalogNameType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForCatalogNameTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForCatalogNameTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'catalog_name']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'catalog_name']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'catalog_name']), $invalidChar);
     }
 
     public function testItSucceedsForGenericNameTypeWhenValidCharactersGiven()
@@ -86,18 +82,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForGenericNameType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForGenericNameTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForGenericNameTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'generic_name']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'catalog_name']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'generic_name']), $invalidChar);
     }
 
-    public function testItSucceedsForCityNameTypeWhenValidCharactersGiven()
+    public function testItSucceedsForCityNameTypeWhenValidCharactersGiven(): void
     {
         $value = 'London';
         $this->validator->validate($value, new TypedRegex(['type' => 'city_name']));
@@ -107,18 +100,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForCityNameType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForCityNameTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForCityNameTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'city_name']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'city_name']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'city_name']), $invalidChar);
     }
 
-    public function testItSucceedsForAddressTypeWhenValidCharactersGiven()
+    public function testItSucceedsForAddressTypeWhenValidCharactersGiven(): void
     {
         $value = '3197 Hillview Drive';
         $this->validator->validate($value, new TypedRegex(['type' => 'address']));
@@ -128,18 +118,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForAddressType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForAddressTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForAddressTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'address']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'address']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'address']), $invalidChar);
     }
 
-    public function testItSucceedsForPostCodeTypeWhenValidCharactersGiven()
+    public function testItSucceedsForPostCodeTypeWhenValidCharactersGiven(): void
     {
         $value = '94103';
         $this->validator->validate($value, new TypedRegex(['type' => 'post_code']));
@@ -149,18 +136,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForPostCodeType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForPostCodeTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForPostCodeTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'post_code']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'post_code']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'post_code']), $invalidChar);
     }
 
-    public function testItSucceedsForPhoneNumberTypeWhenValidCharactersGiven()
+    public function testItSucceedsForPhoneNumberTypeWhenValidCharactersGiven(): void
     {
         $value = '707-216-7924';
         $this->validator->validate($value, new TypedRegex(['type' => 'phone_number']));
@@ -170,18 +154,19 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForPhoneNumberType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForPhoneNumberTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForPhoneNumberTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'phone_number']));
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'phone_number']), $invalidChar);
 
         $this->buildViolation((new TypedRegex(['type' => 'phone_number']))->message)
             ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+            ->assertRaised();
     }
 
-    public function testItSucceedsForMessageTypeWhenValidCharactersGiven()
+    public function testItSucceedsForMessageTypeWhenValidCharactersGiven(): void
     {
         $value = 'some random message #)F@$. ';
         $this->validator->validate($value, new TypedRegex(['type' => 'message']));
@@ -191,18 +176,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForMessageType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForMessageTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForMessageTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'message']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'message']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'message']), $invalidChar);
     }
 
-    public function testItSucceedsForLanguageIsoCodeTypeWhenValidCharactersGiven()
+    public function testItSucceedsForLanguageIsoCodeTypeWhenValidCharactersGiven(): void
     {
         $value = 'US';
         $this->validator->validate($value, new TypedRegex(['type' => 'language_iso_code']));
@@ -212,18 +194,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForLanguageIsoCodeType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForLanguageIsoCodeTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForLanguageIsoCodeTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'language_iso_code']));
-
-        $this->buildViolation((new TypedRegex(['type' => 'language_iso_code']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'language_iso_code']), $invalidChar);
     }
 
-    public function testItSucceedsForLanguageCodeTypeWhenValidCharactersGiven()
+    public function testItSucceedsForLanguageCodeTypeWhenValidCharactersGiven(): void
     {
         $value = 'lt-LT';
         $this->validator->validate($value, new TypedRegex(['type' => 'language_code']));
@@ -233,21 +212,69 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidCharactersForLanguageCodeType
+     *
+     * @param string $invalidChar
      */
-    public function testItFailsForLanguageCodeTypeWhenInvalidCharacterGiven($invalidChar)
+    public function testItFailsForLanguageCodeTypeWhenInvalidCharacterGiven(string $invalidChar): void
     {
-        $this->validator->validate($invalidChar, new TypedRegex(['type' => 'language_code']));
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'language_code']), $invalidChar);
+    }
 
-        $this->buildViolation((new TypedRegex(['type' => 'language_code']))->message)
-            ->setParameter('%s', '"' . $invalidChar . '"')
-            ->assertRaised()
-        ;
+    public function testItSucceedsForUpcTypeWhenValidCharactersGiven(): void
+    {
+        $this->validator->validate('12345678901', new TypedRegex('upc'));
+
+        $this->assertNoViolation();
     }
 
     /**
-     * @return array
+     * @dataProvider getInvalidCharactersForUpc
+     *
+     * @param string $invalidChar
      */
-    public function getInvalidCharactersForNameType()
+    public function testItFailsForUpcTypeWhenInvalidCharacterGiven(string $invalidChar): void
+    {
+        $this->assertViolationIsRaised(new TypedRegex('upc'), $invalidChar);
+    }
+
+    public function testItSucceedsForEan13TypeWhenValidCharactersGiven(): void
+    {
+        $this->validator->validate('1780201379629', new TypedRegex('ean_13'));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getInvalidCharactersForEan13
+     *
+     * @param string $invalidChar
+     */
+    public function testItFailsForEan13TypeWhenInvalidCharacterGiven(string $invalidChar): void
+    {
+        $this->assertViolationIsRaised(new TypedRegex('ean_13'), $invalidChar);
+    }
+
+    public function testItSucceedsForIsbnTypeWhenValidCharactersGiven(): void
+    {
+        $this->validator->validate('-1780', new TypedRegex('isbn'));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getInvalidCharactersForIsbn
+     *
+     * @param string $invalidChar
+     */
+    public function testItFailsForIsbnTypeWhenInvalidCharacterGiven(string $invalidChar): void
+    {
+        $this->assertViolationIsRaised(new TypedRegex('isbn'), $invalidChar);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function getInvalidCharactersForNameType(): array
     {
         return [
             ['0'], ['2'], ['<'], ['>'], ['?'], ['#'], ['%'], [','], [';'], ['+'], ['¤'], [':'], ['!'], ['='], ['#'],
@@ -256,9 +283,9 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
-    public function getInvalidCharactersForCatalogNameType()
+    public function getInvalidCharactersForCatalogNameType(): array
     {
         return [
             ['<'], ['>'], [';'], ['='], ['#'], ['{'], ['}'],
@@ -266,9 +293,9 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
-    public function getInvalidCharactersForGenericNameType()
+    public function getInvalidCharactersForGenericNameType(): array
     {
         return [
             ['<'], ['>'], ['='], ['{'], ['}'],
@@ -276,9 +303,9 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
-    public function getInvalidCharactersForCityNameType()
+    public function getInvalidCharactersForCityNameType(): array
     {
         return [
             ['!'], ['>'], ['<'], [';'], ['?'], ['='], ['+'], ['@'], ['#'], ['"'], ['°'], ['{'], ['}'], ['_'],
@@ -287,9 +314,9 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
-    public function getInvalidCharactersForAddressType()
+    public function getInvalidCharactersForAddressType(): array
     {
         return [
             ['!'], ['>'], ['<'], ['?'], ['='], ['+'], ['@'], ['{'], ['}'], ['_'], ['$'], ['%'],
@@ -297,9 +324,9 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
-    public function getInvalidCharactersForPostCodeType()
+    public function getInvalidCharactersForPostCodeType(): array
     {
         return [
             ['<'], ['>'], ['?'], ['#'], ['%'], [','], [';'], ['+'], ['¤'], [':'], ['!'], ['='], ['#'],
@@ -308,9 +335,9 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
-    public function getInvalidCharactersForPhoneNumberType()
+    public function getInvalidCharactersForPhoneNumberType(): array
     {
         return [
             ['<'], ['>'], ['?'], ['#'], ['%'], [','], [';'], ['¤'], [':'], ['!'], ['='], ['#'],
@@ -318,28 +345,144 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    public function getInvalidCharactersForMessageType()
+    /**
+     * @return string[][]
+     */
+    public function getInvalidCharactersForMessageType(): array
     {
         return [
             ['<'], ['>'], ['{'], ['}'],
         ];
     }
 
-    public function getInvalidCharactersForLanguageIsoCodeType()
+    /**
+     * @return string[][]
+     */
+    public function getInvalidCharactersForLanguageIsoCodeType(): array
     {
         return [
             ['a'], ['ž'], ['abcd'], ['2'], ['26'], ['ABCE'],
         ];
     }
 
-    public function getInvalidCharactersForLanguageCodeType()
+    /**
+     * @return string[][]
+     */
+    public function getInvalidCharactersForLanguageCodeType(): array
     {
         return [
             ['az-acc'], ['1'], ['12-22'], ['ži-as'],
         ];
     }
 
-    protected function createValidator()
+    /**
+     * @return Generator
+     */
+    public function getInvalidCharactersForUpc(): Generator
+    {
+        yield ['1234567890013'];
+        yield ['what'];
+        yield ['!'];
+        yield ['@'];
+        yield ['$'];
+        yield ['%s'];
+        yield ['^'];
+        yield ['&'];
+        yield ['*'];
+        yield ['('];
+        yield [')'];
+        yield ['-'];
+        yield ['+'];
+        yield ['='];
+        yield ['{'];
+        yield ['}'];
+        yield ['['];
+        yield ['['];
+        yield ['<'];
+        yield ['>'];
+        yield ['?'];
+        yield ['/'];
+        yield ['\\'];
+        yield ['\''];
+        yield [';'];
+        yield [':'];
+        yield ['.'];
+        yield [','];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getInvalidCharactersForEan13(): Generator
+    {
+        yield ['10000000000014'];
+        yield ['what'];
+        yield ['!'];
+        yield ['@'];
+        yield ['$'];
+        yield ['%s'];
+        yield ['^'];
+        yield ['&'];
+        yield ['*'];
+        yield ['('];
+        yield [')'];
+        yield ['-'];
+        yield ['+'];
+        yield ['='];
+        yield ['{'];
+        yield ['}'];
+        yield ['['];
+        yield ['['];
+        yield ['<'];
+        yield ['>'];
+        yield ['?'];
+        yield ['/'];
+        yield ['\\'];
+        yield ['\''];
+        yield [';'];
+        yield [':'];
+        yield ['.'];
+        yield [','];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getInvalidCharactersForIsbn(): Generator
+    {
+        yield ['12345678901234567890123412345678901234-33'];
+        yield ['what'];
+        yield ['!'];
+        yield ['@'];
+        yield ['$'];
+        yield ['%s'];
+        yield ['^'];
+        yield ['&'];
+        yield ['*'];
+        yield ['('];
+        yield [')'];
+        yield ['+'];
+        yield ['='];
+        yield ['{'];
+        yield ['}'];
+        yield ['['];
+        yield ['['];
+        yield ['<'];
+        yield ['>'];
+        yield ['?'];
+        yield ['/'];
+        yield ['\\'];
+        yield ['\''];
+        yield [';'];
+        yield [':'];
+        yield ['.'];
+        yield [','];
+    }
+
+    /**
+     * @return TypedRegexValidator
+     */
+    protected function createValidator(): TypedRegexValidator
     {
         return new TypedRegexValidator($this->createCharacterCleanersMock());
     }
@@ -357,5 +500,18 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
             ->will($this->returnArgument(0));
 
         return $toolsMock;
+    }
+
+    /**
+     * @param Constraint $constraint
+     * @param string $invalidChar
+     */
+    private function assertViolationIsRaised(Constraint $constraint, string $invalidChar): void
+    {
+        $this->validator->validate($invalidChar, $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->setParameter('%s', '"' . $invalidChar . '"')
+            ->assertRaised();
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductOptionsCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductOptionsCommandBuilderTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\OptionsCommandBuilder;
+
+class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
+{
+    /**
+     * @dataProvider getExpectedCommands
+     *
+     * @param array $formData
+     * @param UpdateProductOptionsCommand|null $expectedCommand
+     */
+    public function testBuildCommand(array $formData, ?UpdateProductOptionsCommand $expectedCommand)
+    {
+        $builder = new OptionsCommandBuilder();
+        $builtCommand = $builder->buildCommand($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommand, $builtCommand);
+    }
+
+    public function getExpectedCommands()
+    {
+        yield [
+            [
+                'no data' => ['useless value'],
+            ],
+            null,
+        ];
+
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                ],
+            ],
+            $command = new UpdateProductOptionsCommand($this->getProductId()->getValue()),
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setActive(true);
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                    'active' => 1,
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setManufacturerId(1);
+        yield [
+            [
+                'options' => [
+                    'manufacturer_id' => '1',
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setCondition(ProductCondition::NEW);
+        yield [
+            [
+                'options' => [
+                    'condition' => 'new',
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setShowCondition(false);
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                    'show_condition' => 0,
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setOnlineOnly(true);
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                    'online_only' => true,
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setShowPrice(false);
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                    'show_price' => false,
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setAvailableForOrder(true);
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                    'available_for_order' => '1',
+                ],
+            ],
+            $command,
+        ];
+
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
+        $command->setVisibility(ProductVisibility::INVISIBLE);
+        yield [
+            [
+                'options' => [
+                    'not_handled' => 0,
+                    'visibility' => 'none',
+                ],
+            ],
+            $command,
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | part of product page migration. Integrates form type for product options tab. No styling or moving javascript parts yet, that will be done in another PR. :warning: Options tab contains some information that is handled by UpdateProductDetailsCommand, so this PR doesn't yet handle them. We will need to update ProductCommandBuilderInterface so we could input $formData and get array of related commands from it. @jolelievre is on it. Once its done, we can continue with ProductDetails.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of #14777
| How to test?      | No need for QA yet,  CI :heavy_check_mark: 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22703)
<!-- Reviewable:end -->
