### PR TITLE
Fix structured in last element of breadcrumbs

### DIFF
--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <nav data-depth="{$breadcrumb.count}" class="breadcrumb hidden-sm-down">
-  <ol itemscope itemtype="http://schema.org/BreadcrumbList">
+  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
     {block name='breadcrumb'}
       {foreach from=$breadcrumb.links item=path name=breadcrumb}
         {block name='breadcrumb_item'}

--- a/themes/classic/templates/_partials/breadcrumb.tpl
+++ b/themes/classic/templates/_partials/breadcrumb.tpl
@@ -23,20 +23,18 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <nav data-depth="{$breadcrumb.count}" class="breadcrumb hidden-sm-down">
-  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+  <ol itemscope itemtype="http://schema.org/BreadcrumbList">
     {block name='breadcrumb'}
       {foreach from=$breadcrumb.links item=path name=breadcrumb}
         {block name='breadcrumb_item'}
-          {if not $smarty.foreach.breadcrumb.last}
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-              <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
-              <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
-            </li>
-          {elseif isset($path.title)}
-            <li>
-              <span>{$path.title}</span>
-            </li>
-          {/if}
+          <li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            {if not $smarty.foreach.breadcrumb.last}
+                <a itemprop="item" href="{$path.url}"><span itemprop="name">{$path.title}</span></a>
+            {else}
+                <span itemprop="name">{$path.title}</span>
+            {/if}
+            <meta itemprop="position" content="{$smarty.foreach.breadcrumb.iteration}">
+          </li>
         {/block}
       {/foreach}
     {/block}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds structured data even to the last element of breadcrumbs and simplifies the data a bit. It fixes google complaining on homepage. Structured data should be set on all keys of the breadcrumbs - https://schema.org/BreadcrumbList
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/22416
| How to test?      | Apply PR and test your product page and homepage here - https://search.google.com/structured-data/testing-tool
| Possible impacts? | Not likely.

There are two PRs on this topic already, but they are not a proper fix.
#22607 - Fixes homepage, but still does not fix, that there is no structured data for the last element.
#22417 - This is wrong. It changes the last element back to link and it messes up the position of breadcrumbs, because there is position=1 hardcoded.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22704)
<!-- Reviewable:end -->
