### PR TITLE
Session cookies params

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -597,13 +597,19 @@ class CookieCore
         return null;
     }
 
+    /**
+     * Set session cookie parameters to behave similarly to cookies
+     */
     public function sessionSetCookieParams()
     {
-        if (static::$isSetSessionCookieParams === true) {
+        if (
+            session_status() === PHP_SESSION_DISABLED ||
+            static::$isSetSessionCookieParams === true
+        ) {
             return null;
         }
 
-        if (session_id() == PHP_SESSION_NONE) {
+        if (session_status() === PHP_SESSION_NONE) {
             session_start();
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As you know, the issue of SameSite in PR #20601 has been resolved. But my concern is that session cookies do not behave in the same way as cookies. PrestaShop uses very few sessions in notifications, admin, and during installation. But many modules may use sessions, especially payment modules. They have set session cookie parameters themselves, otherwise, they will probably have a payment transaction error. My suggestion is to do this next to the cookie params.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22711
| How to test?      | Delete all cookies and try to refresh the page.
| Possible impacts? | N/A


<img width="962" alt="ps-sessions" src="https://user-images.githubusercontent.com/9982451/103901793-da5f4200-510e-11eb-8c96-39c789b0c1f4.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22709)
<!-- Reviewable:end -->
