### PR TITLE
Change import file test to import attributes instead of customers

### DIFF
--- a/tests/UI/campaigns/data/demo/customer.js
+++ b/tests/UI/campaigns/data/demo/customer.js
@@ -10,9 +10,4 @@ module.exports = {
     newsletter: true,
     partnerOffers: true,
   },
-  ImportedCustomer: {
-    email: 'Tiger.Lily@prestashop.com',
-    firstName: 'Lily',
-    lastName: 'Tiger',
-  },
 };

--- a/tests/UI/campaigns/data/demo/sampleFiles.js
+++ b/tests/UI/campaigns/data/demo/sampleFiles.js
@@ -1,5 +1,4 @@
 module.exports = {
-  // TODO replace customers by combinations
   SampleFiles: {
     combinations: {
       value: 'Combinations',

--- a/tests/UI/campaigns/data/demo/sampleFiles.js
+++ b/tests/UI/campaigns/data/demo/sampleFiles.js
@@ -1,8 +1,9 @@
 module.exports = {
+  // TODO replace customers by combinations
   SampleFiles: {
-    customers: {
-      value: 'Customers',
-      name: 'customers_import',
+    combinations: {
+      value: 'Combinations',
+      name: 'combinations_import',
     },
   },
 };

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/02_importFile.js
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/05_import/02_importFile.js
@@ -10,11 +10,10 @@ const loginCommon = require('@commonTests/loginBO');
 // Import pages
 const dashboardPage = require('@pages/BO/dashboard');
 const importPage = require('@pages/BO/advancedParameters/import');
-const customersPage = require('@pages/BO/customers');
+const attributesPage = require('@pages/BO/catalog/attributes');
 
 // Import Data
 const {SampleFiles} = require('@data/demo/sampleFiles');
-const {ImportedCustomer} = require('@data/demo/customer');
 
 // Import test context
 const testContext = require('@utils/testContext');
@@ -27,17 +26,20 @@ let page;
 
 // Variable Used in the download / rename / upload test
 let sampleFilePath;
+const renamedSampleFilePath = `./${SampleFiles.combinations.name}.csv`;
 
-const renamedSampleFilePath = `./${SampleFiles.customers.name}.csv`;
+// Variable used in the "check import success" test
+const initialNumberOfAttributes = 4;
+let numberOfAttributes = 0;
 
 /*
 Go to the import page
-Download the customers sample file
-Import the customer sample file
-Go to customers page
+Download the combinations sample file
+Import the combinations sample file
+Go to attributes and features page
 Check import success
  */
-describe('Import customers', async () => {
+describe('Import combinations', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -68,17 +70,17 @@ describe('Import customers', async () => {
     await expect(pageTitle).to.contains(importPage.pageTitle);
   });
 
-  it(`should download ${SampleFiles.customers.name} sample file`, async function () {
+  it(`should download ${SampleFiles.combinations.name} sample file`, async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'downloadFile', baseContext);
 
-    sampleFilePath = await importPage.downloadSampleFile(page, SampleFiles.customers.name);
+    sampleFilePath = await importPage.downloadSampleFile(page, SampleFiles.combinations.name);
 
     const doesFileExist = await files.doesFileExist(sampleFilePath);
-    await expect(doesFileExist, `${SampleFiles.customers.name} sample file was not downloaded`).to.be.true;
+    await expect(doesFileExist, `${SampleFiles.combinations.name} sample file was not downloaded`).to.be.true;
   });
 
   describe('Import file', async () => {
-    it(`should upload ${SampleFiles.customers.name} sample text file`, async function () {
+    it(`should upload ${SampleFiles.combinations.name} sample text file`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'importFile', baseContext);
 
       // Rename the file and add file extension to be able to upload it
@@ -86,10 +88,10 @@ describe('Import customers', async () => {
 
       const uploadSuccessText = await importPage.uploadSampleFile(
         page,
-        SampleFiles.customers.value,
+        SampleFiles.combinations.value,
         renamedSampleFilePath,
       );
-      await expect(uploadSuccessText).contain(SampleFiles.customers.name);
+      await expect(uploadSuccessText).contain(SampleFiles.combinations.name);
     });
 
     it('should go to next import file step', async function () {
@@ -115,42 +117,26 @@ describe('Import customers', async () => {
   });
 
   describe('Check import success', async () => {
-    it('should go to customers page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPage', baseContext);
+    it('should go to attributes and features page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToCombinationsPage', baseContext);
 
       await importPage.goToSubMenu(
         page,
-        importPage.customersParentLink,
-        importPage.customersLink,
+        importPage.catalogParentLink,
+        importPage.attributesAndFeaturesLink,
       );
 
-      await customersPage.closeSfToolBar(page);
+      await attributesPage.closeSfToolBar(page);
 
-      const pageTitle = await customersPage.getPageTitle(page);
-      await expect(pageTitle).to.contains(customersPage.pageTitle);
+      const pageTitle = await attributesPage.getPageTitle(page);
+      await expect(pageTitle).to.contains(attributesPage.pageTitle);
     });
 
-    it('should filter list by email', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'filterToCheckImportedCustomer', baseContext);
+    it('should reset all filters and get number of attributes in BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'resetFilterFirst', baseContext);
 
-      await customersPage.resetFilter(page);
-
-      await customersPage.filterCustomers(
-        page,
-        'input',
-        'email',
-        ImportedCustomer.email,
-      );
-
-      const textEmail = await customersPage.getTextColumnFromTableCustomers(page, 1, 'email');
-      await expect(textEmail).to.contains(ImportedCustomer.email);
-    });
-
-    it('should check import success', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkImportSuccess', baseContext);
-
-      const customersEmailList = await customersPage.getAllRowsColumnContent(page, 'email');
-      await expect(customersEmailList).contain(ImportedCustomer.email);
+      numberOfAttributes = await attributesPage.resetAndGetNumberOfLines(page);
+      await expect(numberOfAttributes).to.be.above(initialNumberOfAttributes);
     });
   });
 });


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Change import file test to import attributes instead of customers
| Type?             | refacto 
| Category?         | TE 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | //
| How to test?      | Can be tested with this command TEST_PATH="functional/BO/14_advancedParameters/05_import/02_importFile" URL_FO="your FO url " DB_SERVER="your db-server" DB_PASSWD="your db pass" npm run specific-test
| Possible impacts? | any


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22717)
<!-- Reviewable:end -->
