### PR TITLE
Move attribute group services into proper namespace

### DIFF
--- a/src/Adapter/Product/AttributeGroup/AbstractAttributeGroupHandler.php
+++ b/src/Adapter/Product/AttributeGroup/AbstractAttributeGroupHandler.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Adapter\AttributeGroup;
+namespace PrestaShop\PrestaShop\Adapter\Product\AttributeGroup;
 
 use AttributeGroup;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\AttributeGroupException;

--- a/src/Adapter/Product/AttributeGroup/AttributeGroupViewDataProvider.php
+++ b/src/Adapter/Product/AttributeGroup/AttributeGroupViewDataProvider.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Adapter\AttributeGroup;
+namespace PrestaShop\PrestaShop\Adapter\Product\AttributeGroup;
 
 use AttributeGroup;
 use PrestaShop\PrestaShop\Core\AttributeGroup\AttributeGroupViewDataProviderInterface;

--- a/src/Adapter/Product/AttributeGroup/CommandHandler/BulkDeleteAttributeGroupHandler.php
+++ b/src/Adapter/Product/AttributeGroup/CommandHandler/BulkDeleteAttributeGroupHandler.php
@@ -24,31 +24,29 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Adapter\AttributeGroup\CommandHandler;
+namespace PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\AttributeGroup\AbstractAttributeGroupHandler;
-use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Command\DeleteAttributeGroupCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\CommandHandler\DeleteAttributeGroupHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\AttributeGroupException;
+use PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\AbstractAttributeGroupHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Command\BulkDeleteAttributeGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\CommandHandler\BulkDeleteAttributeGroupHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\DeleteAttributeGroupException;
 
 /**
- * Handles command which deletes attribute group using legacy object model
+ * Handles command which deletes multiple attribute groups using legacy object model
  */
-final class DeleteAttributeGroupHandler extends AbstractAttributeGroupHandler implements DeleteAttributeGroupHandlerInterface
+final class BulkDeleteAttributeGroupHandler extends AbstractAttributeGroupHandler implements BulkDeleteAttributeGroupHandlerInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @throws AttributeGroupException
      */
-    public function handle(DeleteAttributeGroupCommand $command)
+    public function handle(BulkDeleteAttributeGroupCommand $command)
     {
-        $attributeGroupId = $command->getAttributeGroupId();
-        $attributeGroup = $this->getAttributeGroupById($attributeGroupId);
+        foreach ($command->getAttributeGroupIds() as $attributeGroupId) {
+            $attributeGroup = $this->getAttributeGroupById($attributeGroupId);
 
-        if (false === $this->deleteAttributeGroup($attributeGroup)) {
-            throw new DeleteAttributeGroupException(sprintf('Failed deleting attribute group with id "%s"', $attributeGroupId->getValue()), DeleteAttributeGroupException::FAILED_DELETE);
+            if (false === $this->deleteAttributeGroup($attributeGroup)) {
+                throw new DeleteAttributeGroupException(sprintf('Failed to delete attribute group with id "%s"', $attributeGroupId->getValue()), DeleteAttributeGroupException::FAILED_BULK_DELETE);
+            }
         }
     }
 }

--- a/src/Adapter/Product/AttributeGroup/CommandHandler/DeleteAttributeGroupHandler.php
+++ b/src/Adapter/Product/AttributeGroup/CommandHandler/DeleteAttributeGroupHandler.php
@@ -24,29 +24,31 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Adapter\AttributeGroup\CommandHandler;
+namespace PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\AttributeGroup\AbstractAttributeGroupHandler;
-use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Command\BulkDeleteAttributeGroupCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\CommandHandler\BulkDeleteAttributeGroupHandlerInterface;
+use PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\AbstractAttributeGroupHandler;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Command\DeleteAttributeGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\CommandHandler\DeleteAttributeGroupHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\AttributeGroupException;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Exception\DeleteAttributeGroupException;
 
 /**
- * Handles command which deletes multiple attribute groups using legacy object model
+ * Handles command which deletes attribute group using legacy object model
  */
-final class BulkDeleteAttributeGroupHandler extends AbstractAttributeGroupHandler implements BulkDeleteAttributeGroupHandlerInterface
+final class DeleteAttributeGroupHandler extends AbstractAttributeGroupHandler implements DeleteAttributeGroupHandlerInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @throws AttributeGroupException
      */
-    public function handle(BulkDeleteAttributeGroupCommand $command)
+    public function handle(DeleteAttributeGroupCommand $command)
     {
-        foreach ($command->getAttributeGroupIds() as $attributeGroupId) {
-            $attributeGroup = $this->getAttributeGroupById($attributeGroupId);
+        $attributeGroupId = $command->getAttributeGroupId();
+        $attributeGroup = $this->getAttributeGroupById($attributeGroupId);
 
-            if (false === $this->deleteAttributeGroup($attributeGroup)) {
-                throw new DeleteAttributeGroupException(sprintf('Failed to delete attribute group with id "%s"', $attributeGroupId->getValue()), DeleteAttributeGroupException::FAILED_BULK_DELETE);
-            }
+        if (false === $this->deleteAttributeGroup($attributeGroup)) {
+            throw new DeleteAttributeGroupException(sprintf('Failed deleting attribute group with id "%s"', $attributeGroupId->getValue()), DeleteAttributeGroupException::FAILED_DELETE);
         }
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/attribute_group.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/attribute_group.yml
@@ -2,14 +2,20 @@ services:
     _defaults:
         public: true
 
-    prestashop.adapter.attribute_group.command_handler.delete_attribute_group_handler:
-        class: 'PrestaShop\PrestaShop\Adapter\AttributeGroup\CommandHandler\DeleteAttributeGroupHandler'
+    prestashop.adapter.product.attribute_group.attribute_group_view_data_provider:
+        class: 'PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\AttributeGroupViewDataProvider'
+        arguments:
+            - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+            - "@=service('prestashop.adapter.legacy.configuration')"
+
+    prestashop.adapter.product.attribute_group.command_handler.delete_attribute_group_handler:
+        class: 'PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\CommandHandler\DeleteAttributeGroupHandler'
         tags:
             - name: 'tactician.handler'
               command: 'PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Command\DeleteAttributeGroupCommand'
 
-    prestashop.adapter.attribute_group.command_handler.bulk_delete_attribute_group_handler:
-        class: 'PrestaShop\PrestaShop\Adapter\AttributeGroup\CommandHandler\BulkDeleteAttributeGroupHandler'
+    prestashop.adapter.product.attribute_group.command_handler.bulk_delete_attribute_group_handler:
+        class: 'PrestaShop\PrestaShop\Adapter\Product\AttributeGroup\CommandHandler\BulkDeleteAttributeGroupHandler'
         tags:
             - name: 'tactician.handler'
               command: 'PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Command\BulkDeleteAttributeGroupCommand'

--- a/src/PrestaShopBundle/Resources/config/services/core/attribute_group.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/attribute_group.yml
@@ -1,9 +1,0 @@
-services:
-  _defaults:
-    public: true
-
-  prestashop.core.attribute_group.attribute_group_view_data_provider:
-    class: 'PrestaShop\PrestaShop\Adapter\AttributeGroup\AttributeGroupViewDataProvider'
-    arguments:
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
-      - "@=service('prestashop.adapter.legacy.configuration')"

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -241,7 +241,7 @@ services:
         parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
         arguments:
             - '@=service("request_stack").getCurrentRequest().attributes.getInt("attributeGroupId")'
-            - '@prestashop.core.attribute_group.attribute_group_view_data_provider'
+            - '@prestashop.adapter.product.attribute_group.attribute_group_view_data_provider'
         public: true
 
     prestashop.core.grid.definition.factory.attribute_group:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Move attribute group services into proper namespace
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | GA green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22722)
<!-- Reviewable:end -->

## Breaking Change

The services and handlers have been moved to another namespace, and their services IDs have also been renamed which strictly speaking is a BC break since they were introduced in 177. However theses services are used in the AttributeGroup page which has not been released yet The controller exists but it is not accessible yet (unless you know its url) so I think it's acceptable to clean these services before the page is actually released
