### PR TITLE
Disable GitHub Actions fail fast

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -7,6 +7,7 @@ jobs:
         strategy:
             matrix:
                 php: ['7.1', '7.2', '7.3', '7.4']
+            fail-fast: false
         steps:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -71,6 +71,7 @@ jobs:
     strategy:
         matrix:
             php: ['7.1', '7.2', '7.3', '7.4']
+        fail-fast: false
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
@@ -111,6 +112,7 @@ jobs:
       strategy:
           matrix:
               php: ['7.1', '7.2', '7.3', '7.4']
+          fail-fast: false
       steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         php: [ '7.1', '7.2', '7.3', '7.4' ]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Default GitHub Action strategy is "fail fast": if a job that must run for php7.1, php7.2 and php7.4 fails for php7.1 it cancels the builds for php7.2 and php7.4. This optimizes the use of CPU.<br/><br/>However this means that if there is an issue for one php version, we have no idea about whether it's only for one php version or for all of them. So in this PR I disable this fail-fast strategy. See [GitHub Action documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22727)
<!-- Reviewable:end -->
