### PR TITLE
Fix some width and spacing of kpis pan

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -16,6 +16,7 @@
     }
 
     &.box-stats {
+      width: max-content;
       min-width: 13rem;
       padding: 1rem;
       background-color: #fff;
@@ -43,14 +44,20 @@
       align-items: center;
       // stylelint-disable
       justify-content: flex-start !important;
-      padding: 1.1rem 0;
+      padding: 1.1rem 0.6rem;
       padding-top: 0.5rem;
-      margin: 0 -0.5rem !important;
+      margin: 0 -1rem !important;
       overflow: scroll;
       // stylelint-enable
 
       > div {
         margin: 0 0.5rem;
+
+        &:last-child {
+          .box-stats {
+            margin-right: 1rem;
+          }
+        }
 
         i {
           font-size: 1.5rem;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Sometime, kpis pan has a long height, it should adapt width to its content! Also, I still changed the full row width in order to have a better display
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22422.
| How to test?      | Go on KPis pan like Orders list page, and see if all elements got the same height, having his width adapted to his content, look screenshot :)

![image](https://user-images.githubusercontent.com/14963751/104028897-911ff880-51c9-11eb-92a4-61e4becd1dca.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22742)
<!-- Reviewable:end -->
