### PR TITLE
PHP sessions are not correctly configured

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -53,7 +53,7 @@ class ContextCore
     /** @var Cookie */
     public $cookie;
 
-    /** @var SessionInterface */
+    /** @var SessionInterface|null */
     public $session;
 
     /** @var Link */

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -32,6 +32,7 @@ use PrestaShopBundle\Translation\TranslatorLanguageLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Class ContextCore.
@@ -51,6 +52,9 @@ class ContextCore
 
     /** @var Cookie */
     public $cookie;
+
+    /** @var SessionInterface */
+    public $session;
 
     /** @var Link */
     public $link;

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -197,6 +197,7 @@ if (PHP_SAPI !== 'cli') {
         Configuration::get('PS_COOKIE_SAMESITE'),
         Context::getContext()->shop->physical_uri
     );
+    $sessionHandler->init();
 
     $context->session = $sessionHandler->getSession();
 }

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -190,12 +190,15 @@ if (defined('_PS_ADMIN_DIR_')) {
     }
 }
 
-$session = new SessionHandler(
-    $cookie_lifetime,
-    $force_ssl,
-    Configuration::get('PS_COOKIE_SAMESITE'),
-    Context::getContext()->shop->physical_uri
-);
+
+if (PHP_SAPI !== 'cli') {
+    $session = new SessionHandler(
+        $cookie_lifetime,
+        $force_ssl,
+        Configuration::get('PS_COOKIE_SAMESITE'),
+        Context::getContext()->shop->physical_uri
+    );
+}
 
 $context->cookie = $cookie;
 

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -190,14 +190,15 @@ if (defined('_PS_ADMIN_DIR_')) {
     }
 }
 
-
 if (PHP_SAPI !== 'cli') {
-    $session = new SessionHandler(
+    $sessionHandler = new SessionHandler(
         $cookie_lifetime,
         $force_ssl,
         Configuration::get('PS_COOKIE_SAMESITE'),
         Context::getContext()->shop->physical_uri
     );
+
+    $context->session = $sessionHandler->getSession();
 }
 
 $context->cookie = $cookie;

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -23,6 +23,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Core\Session\SessionHandler;
+
 $currentDir = dirname(__FILE__);
 
 /* Custom defines made by users */
@@ -175,10 +178,10 @@ $force_ssl = Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_
 if (defined('_PS_ADMIN_DIR_')) {
     $cookie = new Cookie('psAdmin', '', $cookie_lifetime, null, false, $force_ssl);
 } else {
+    $domains = null;
     if ($context->shop->getGroup()->share_order) {
         $cookie = new Cookie('ps-sg' . $context->shop->getGroup()->id, '', $cookie_lifetime, $context->shop->getUrlsSharedCart(), false, $force_ssl);
     } else {
-        $domains = null;
         if ($context->shop->domain != $context->shop->domain_ssl) {
             $domains = array($context->shop->domain_ssl, $context->shop->domain);
         }
@@ -186,6 +189,13 @@ if (defined('_PS_ADMIN_DIR_')) {
         $cookie = new Cookie('ps-s' . $context->shop->id, '', $cookie_lifetime, $domains, false, $force_ssl);
     }
 }
+
+$session = new SessionHandler(
+    $cookie_lifetime,
+    $force_ssl,
+    Configuration::get('PS_COOKIE_SAMESITE'),
+    Context::getContext()->shop->physical_uri
+);
 
 $context->cookie = $cookie;
 

--- a/src/Core/Session/SessionHandler.php
+++ b/src/Core/Session/SessionHandler.php
@@ -76,14 +76,12 @@ class SessionHandler implements SessionHandlerInterface
 
         $this->path = rawurlencode($this->path);
         $this->path = str_replace(['%2F', '%7E', '%2B', '%26'], ['/', '~', '+', '&'], $this->path);
-
-        $this->initialize();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSession(): SessionInterface
+    public function getSession(): ?SessionInterface
     {
         return $this->session;
     }
@@ -91,7 +89,7 @@ class SessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function initialize(): void
+    public function init(): void
     {
         if ($this->isSessionDisabled() || $this->isSessionStarted()) {
             return;

--- a/src/Core/Session/SessionHandler.php
+++ b/src/Core/Session/SessionHandler.php
@@ -93,7 +93,7 @@ class SessionHandler implements SessionHandlerInterface
      */
     public function initialize(): void
     {
-        if ($this->isSessionDisabled()) {
+        if ($this->isSessionDisabled() || $this->isSessionStarted()) {
             return;
         }
 
@@ -120,10 +120,6 @@ class SessionHandler implements SessionHandlerInterface
         }
 
         $this->session = new Session(new PhpBridgeSessionStorage());
-        if ($this->isSessionStarted()) {
-            return;
-        }
-
         $this->session->start();
     }
 

--- a/src/Core/Session/SessionHandler.php
+++ b/src/Core/Session/SessionHandler.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Session;
+
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
+
+class SessionHandler implements SessionHandlerInterface
+{
+    /**
+     *  @var Session
+     */
+    protected $session;
+
+    /**
+     * @var int
+     */
+    protected $lifetime;
+
+    /**
+     * @var bool
+     */
+    protected $isSecure;
+
+    /**
+     * @var string
+     */
+    protected $sameSite;
+
+    /**
+     * @var string
+     */
+    protected $path;
+
+    public function __construct(
+        int $lifetime,
+        bool $isSecure,
+        string $sameSite,
+        string $shopUri
+    ) {
+        $this->lifetime = $lifetime;
+        $this->isSecure = $isSecure;
+        $this->sameSite = $sameSite;
+
+        // Same behaviour as Cookie class
+        $this->path = trim($shopUri, '/\\') . '/';
+        if ($this->path[0] != '/') {
+            $this->path = '/' . $this->path;
+        }
+
+        $this->path = rawurlencode($this->path);
+        $this->path = str_replace(['%2F', '%7E', '%2B', '%26'], ['/', '~', '+', '&'], $this->path);
+
+        $this->initialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSession(): SessionInterface
+    {
+        return $this->session;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(): void
+    {
+        if ($this->isSessionDisabled()) {
+            return;
+        }
+
+        /*
+         * The alternative signature supporting an options array is only available since
+         * PHP 7.3.0, before there is no support for SameSite attribute.
+         */
+        if (PHP_VERSION_ID < 70300) {
+            session_set_cookie_params(
+                $this->lifetime,
+                $this->path . ';SameSite=' . $this->sameSite,
+                '',
+                $this->isSecure,
+                true
+            );
+        } else {
+            session_set_cookie_params([
+                'lifetime' => $this->lifetime,
+                'path' => $this->path,
+                'secure' => $this->isSecure,
+                'httponly' => true,
+                'samesite' => $this->sameSite,
+            ]);
+        }
+
+        $this->session = new Session(new PhpBridgeSessionStorage());
+        if ($this->isSessionStarted()) {
+            return;
+        }
+
+        $this->session->start();
+    }
+
+    /**
+     * Is session disabled
+     *
+     * @return bool
+     */
+    protected function isSessionDisabled(): bool
+    {
+        return $this->getSessionStatus() === PHP_SESSION_DISABLED;
+    }
+
+    /**
+     * Is session started
+     *
+     * @return bool
+     */
+    protected function isSessionStarted(): bool
+    {
+        return $this->getSessionStatus() === PHP_SESSION_ACTIVE;
+    }
+
+    /**
+     * Get Session status
+     *
+     * @return int
+     */
+    protected function getSessionStatus(): int
+    {
+        return session_status();
+    }
+}

--- a/src/Core/Session/SessionHandlerInterface.php
+++ b/src/Core/Session/SessionHandlerInterface.php
@@ -33,7 +33,17 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 interface SessionHandlerInterface
 {
-    public function initialize(): void;
+    /**
+     * Initialize session
+     *
+     * @return void
+     */
+    public function init(): void;
 
-    public function getSession(): SessionInterface;
+    /**
+     * Return the current session
+     *
+     * @return ?SessionInterface
+     */
+    public function getSession(): ?SessionInterface;
 }

--- a/src/Core/Session/SessionHandlerInterface.php
+++ b/src/Core/Session/SessionHandlerInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Session;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * SessionHandlerInterface is used to set PHP Sessions cookie parameters
+ */
+interface SessionHandlerInterface
+{
+    public function initialize(): void;
+
+    public function getSession(): SessionInterface;
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since we add the SameSite attribute in cookies, we have to correctly settle it on PHP sessions depending on the Database configuration in order to allow modules to use $_SESSION when they want
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22711
| How to test?      | Make sure the PHP Session cookie have the same values for SameSite and secure than the PrestaShop Cookie.
| Possible impacts? | Must be tested with & without SSL


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22746)
<!-- Reviewable:end -->
