### PR TITLE
Remove useless redirection on shop logo in multilingual context

### DIFF
--- a/themes/classic/templates/_partials/header.tpl
+++ b/themes/classic/templates/_partials/header.tpl
@@ -61,12 +61,12 @@
         <div class="col-md-2 hidden-sm-down" id="_desktop_logo">
             {if $page.page_name == 'index'}
               <h1>
-                <a href="{$urls.base_url}">
+                <a href="{$urls.pages.index}">
                   <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name}" loading="lazy">
                 </a>
               </h1>
             {else}
-                <a href="{$urls.base_url}">
+                <a href="{$urls.pages.index}">
                   <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name}" loading="lazy">
                 </a>
             {/if}

--- a/themes/classic/templates/checkout/_partials/header.tpl
+++ b/themes/classic/templates/checkout/_partials/header.tpl
@@ -27,7 +27,7 @@
     <div class="container">
       <div class="row">
         <div class="col-md-6 hidden-sm-down" id="_desktop_logo">
-          <a href="{$urls.base_url}">
+          <a href="{$urls.pages.index}">
             <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name} {l s='logo' d='Shop.Theme.Global'}" loading="lazy">
           </a>
         </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In multilingual context, the shop logo link to the home page doesn't have the lang prefix (/en). So, a redirection takes places on every click. Google doesn't like redirection so much.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22748.
| How to test?      | see #22748.
| Possible impacts? | No

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22749)
<!-- Reviewable:end -->
