### PR TITLE
Fix mobile dropdown of multishop context on default theme of the BO

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -103,7 +103,7 @@ $search-border-color: #bbcdd2
 
 		// hide label if width <= tablet landscape size
 		@media (max-width: breakpoint-max('lg'))
-			span
+			a .material-icons
 				display: none
 
 		@media (max-width: $screen-sm-max)
@@ -174,6 +174,7 @@ $search-border-color: #bbcdd2
 				.dropdown-toggle
 					background: none !important
 					color: $brand-info !important
+
 			.material-icons
 				color: $medium-gray
 				top: -1px
@@ -181,6 +182,16 @@ $search-border-color: #bbcdd2
 				display: inline-block !important
 				color: $header-text-color !important
 				text-decoration: none !important
+				@media (max-width: breakpoint-max('lg'))
+					font-size: 0
+					width: 25px
+					height: 25px
+					margin-left: -25px
+					top: -10px
+					position: relative
+					z-index: 50
+					i
+						display: none
 				&:hover
 					color: $brand-info !important
 				i

--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -101,11 +101,6 @@ $search-border-color: #bbcdd2
 			font-size: 20px
 			margin-top: -4px
 
-		// hide label if width <= tablet landscape size
-		@media (max-width: breakpoint-max('lg'))
-			a .material-icons
-				display: none
-
 		@media (max-width: $screen-sm-max)
 			padding:
 				left: 10px !important

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -383,12 +383,6 @@ $header-text-color: #4e6167 !default;
         }
       }
     }
-
-    @media (max-width: breakpoint-max("lg")) {
-      span {
-        display: none;
-      }
-    }
   }
 
   #header-employee-container {
@@ -408,10 +402,10 @@ $header-text-color: #4e6167 !default;
     color: $header-text-color;
     text-decoration: none;
 
-
     .selected-item {
       font-size: 0.8125rem;
       line-height: 17px;
+
       .material-icons {
         top: -1px;
         font-size: 1.25rem;
@@ -419,6 +413,14 @@ $header-text-color: #4e6167 !default;
         &.visibility {
           color: $medium-gray;
           @include transition(0.25s ease-out);
+        }
+      }
+
+      @media (max-width: breakpoint-max("lg")) {
+        font-size: 0;
+
+        .arrow-down {
+          display: none;
         }
       }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We couldn't change shop context on mobile on default theme
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22739.
| How to test?      | See issue, keep in mind that the icon can't be blue, as the markup is not compatible with this behavior !

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22761)
<!-- Reviewable:end -->
