### PR TITLE
Improve ProductCommandBuilderInterface for multi return

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandBuilder.php
@@ -40,10 +40,10 @@ class BasicInformationCommandBuilder implements ProductCommandBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function buildCommand(ProductId $productId, array $formData)
+    public function buildCommand(ProductId $productId, array $formData): array
     {
         if (!isset($formData['basic'])) {
-            return null;
+            return [];
         }
 
         $basicData = $formData['basic'];
@@ -62,6 +62,6 @@ class BasicInformationCommandBuilder implements ProductCommandBuilderInterface
             $command->setLocalizedShortDescriptions($basicData['description_short']);
         }
 
-        return $command;
+        return [$command];
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandBuilder.php
@@ -34,15 +34,12 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 final class OptionsCommandBuilder implements ProductCommandBuilderInterface
 {
     /**
-     * @param ProductId $productId
-     * @param array $formData
-     *
-     * @return UpdateProductOptionsCommand|null
+     * {@inheritdoc}
      */
-    public function buildCommand(ProductId $productId, array $formData)
+    public function buildCommand(ProductId $productId, array $formData): array
     {
         if (!isset($formData['options'])) {
-            return null;
+            return [];
         }
 
         $options = $formData['options'];
@@ -73,6 +70,6 @@ final class OptionsCommandBuilder implements ProductCommandBuilderInterface
             $command->setManufacturerId((int) $options['manufacturer_id']);
         }
 
-        return $command;
+        return [$command];
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandBuilder.php
@@ -39,10 +39,10 @@ class PricesCommandBuilder implements ProductCommandBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function buildCommand(ProductId $productId, array $formData)
+    public function buildCommand(ProductId $productId, array $formData): array
     {
         if (!isset($formData['price'])) {
-            return null;
+            return [];
         }
 
         $priceData = $formData['price'];
@@ -70,6 +70,6 @@ class PricesCommandBuilder implements ProductCommandBuilderInterface
             $command->setUnity((string) $priceData['unity']);
         }
 
-        return $command;
+        return [$command];
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCommandBuilderInterface.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCommandBuilderInterface.php
@@ -38,7 +38,7 @@ interface ProductCommandBuilderInterface
      * @param ProductId $productId
      * @param array $formData
      *
-     * @return mixed|null Returns null if the required data for the command is absent
+     * @return array Returns empty array if the required data for the command is absent
      */
-    public function buildCommand(ProductId $productId, array $formData);
+    public function buildCommand(ProductId $productId, array $formData): array;
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCommandCollection.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCommandCollection.php
@@ -35,4 +35,15 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class ProductCommandCollection extends ArrayCollection
 {
+    /**
+     * Merge array of commands into the collection
+     *
+     * @param array $commands
+     */
+    public function merge(array $commands): void
+    {
+        foreach ($commands as $command) {
+            $this->add($command);
+        }
+    }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCommandsBuilder.php
@@ -56,14 +56,14 @@ class ProductCommandsBuilder
      */
     public function buildCommands(ProductId $productId, array $formData): ProductCommandCollection
     {
-        $commands = new ProductCommandCollection();
+        $commandCollection = new ProductCommandCollection();
         foreach ($this->commandBuilders as $commandBuilder) {
-            $command = $commandBuilder->buildCommand($productId, $formData);
-            if (null !== $command) {
-                $commands->add($command);
+            $commands = $commandBuilder->buildCommand($productId, $formData);
+            if (!empty($commands)) {
+                $commandCollection->merge($commands);
             }
         }
 
-        return $commands;
+        return $commandCollection;
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandBuilder.php
@@ -34,15 +34,12 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 final class ShippingCommandBuilder implements ProductCommandBuilderInterface
 {
     /**
-     * @param ProductId $productId
-     * @param array $formData
-     *
-     * @return UpdateProductShippingCommand|null
+     * {@inheritdoc}
      */
-    public function buildCommand(ProductId $productId, array $formData)
+    public function buildCommand(ProductId $productId, array $formData): array
     {
         if (!isset($formData['shipping'])) {
-            return null;
+            return [];
         }
 
         $shippingData = $formData['shipping'];
@@ -84,6 +81,6 @@ final class ShippingCommandBuilder implements ProductCommandBuilderInterface
             $command->setCarrierReferences($shippingData['carriers']);
         }
 
-        return $command;
+        return [$command];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandBuilderTest.php
@@ -38,13 +38,13 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
      * @dataProvider getExpectedCommands
      *
      * @param array $formData
-     * @param UpdateProductBasicInformationCommand|null $expectedCommand
+     * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, ?UpdateProductBasicInformationCommand $expectedCommand)
+    public function testBuildCommand(array $formData, array $expectedCommands)
     {
         $builder = new BasicInformationCommandBuilder();
-        $builtCommand = $builder->buildCommand($this->getProductId(), $formData);
-        $this->assertEquals($expectedCommand, $builtCommand);
+        $builtCommands = $builder->buildCommand($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
     }
 
     public function getExpectedCommands()
@@ -53,7 +53,7 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
             [
                 'no_price_data' => ['useless value'],
             ],
-            null,
+            [],
         ];
 
         $command = new UpdateProductBasicInformationCommand($this->getProductId()->getValue());
@@ -63,7 +63,7 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
                     'not_handled' => 0,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductBasicInformationCommand($this->getProductId()->getValue());
@@ -74,7 +74,7 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
                     'type' => ProductType::TYPE_VIRTUAL,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductBasicInformationCommand($this->getProductId()->getValue());
@@ -91,7 +91,7 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
                     'name' => $localizedNames,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductBasicInformationCommand($this->getProductId()->getValue());
@@ -106,7 +106,7 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
                     'description' => $localizedDescriptions,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductBasicInformationCommand($this->getProductId()->getValue());
@@ -121,7 +121,7 @@ class BasicInformationCommandBuilderTest extends AbstractProductCommandBuilderTe
                     'description_short' => $localizedShortDescriptions,
                 ],
             ],
-            $command,
+            [$command],
         ];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandBuilderTest.php
@@ -37,13 +37,13 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
      * @dataProvider getExpectedCommands
      *
      * @param array $formData
-     * @param UpdateProductPricesCommand|null $expectedCommand
+     * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, ?UpdateProductPricesCommand $expectedCommand)
+    public function testBuildCommand(array $formData, array $expectedCommands)
     {
         $builder = new PricesCommandBuilder();
-        $builtCommand = $builder->buildCommand($this->getProductId(), $formData);
-        $this->assertEquals($expectedCommand, $builtCommand);
+        $builtCommands = $builder->buildCommand($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
     }
 
     public function getExpectedCommands()
@@ -52,7 +52,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
             [
                 'no_price_data' => ['useless value'],
             ],
-            null,
+            [],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -62,7 +62,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'not_handled' => 0,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -74,7 +74,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'price_tax_excluded' => 45.56,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -87,7 +87,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'price_tax_included' => '65.56', // Price tax included is ignored
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -99,7 +99,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'ecotax' => '45.56',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -111,7 +111,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'tax_rules_group_id' => '42',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -123,7 +123,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'on_sale' => '42',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -135,7 +135,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'on_sale' => '0',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -147,7 +147,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'wholesale_price' => '45.56',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -159,7 +159,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'unit_price' => '45.56',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductPricesCommand($this->getProductId()->getValue());
@@ -171,7 +171,7 @@ class PricesCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'unity' => 'kg',
                 ],
             ],
-            $command,
+            [$command],
         ];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductOptionsCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductOptionsCommandBuilderTest.php
@@ -39,13 +39,13 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
      * @dataProvider getExpectedCommands
      *
      * @param array $formData
-     * @param UpdateProductOptionsCommand|null $expectedCommand
+     * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, ?UpdateProductOptionsCommand $expectedCommand)
+    public function testBuildCommand(array $formData, array $expectedCommands)
     {
         $builder = new OptionsCommandBuilder();
-        $builtCommand = $builder->buildCommand($this->getProductId(), $formData);
-        $this->assertEquals($expectedCommand, $builtCommand);
+        $builtCommands = $builder->buildCommand($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
     }
 
     public function getExpectedCommands()
@@ -54,16 +54,17 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
             [
                 'no data' => ['useless value'],
             ],
-            null,
+            [],
         ];
 
+        $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
         yield [
             [
                 'options' => [
                     'not_handled' => 0,
                 ],
             ],
-            $command = new UpdateProductOptionsCommand($this->getProductId()->getValue()),
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -75,7 +76,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'active' => 1,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -86,7 +87,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'manufacturer_id' => '1',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -97,7 +98,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'condition' => 'new',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -109,7 +110,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'show_condition' => 0,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -121,7 +122,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'online_only' => true,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -133,7 +134,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'show_price' => false,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -145,7 +146,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'available_for_order' => '1',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
@@ -157,7 +158,7 @@ class ProductOptionsCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'visibility' => 'none',
                 ],
             ],
-            $command,
+            [$command],
         ];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandBuilderTest.php
@@ -39,13 +39,13 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
      * @dataProvider getExpectedCommands
      *
      * @param array $formData
-     * @param UpdateProductShippingCommand|null $expectedCommand
+     * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, ?UpdateProductShippingCommand $expectedCommand): void
+    public function testBuildCommand(array $formData, array $expectedCommands): void
     {
         $builder = new ShippingCommandBuilder();
-        $builtCommand = $builder->buildCommand($this->getProductId(), $formData);
-        $this->assertEquals($expectedCommand, $builtCommand);
+        $builtCommands = $builder->buildCommand($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
     }
 
     /**
@@ -57,16 +57,17 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
             [
                 'no data' => ['useless value'],
             ],
-            null,
+            [],
         ];
 
+        $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
         yield [
             [
                 'shipping' => [
                     'not_handled' => 0,
                 ],
             ],
-            new UpdateProductShippingCommand($this->getProductId()->getValue()),
+            [$command],
         ];
 
         $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
@@ -83,7 +84,7 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'depth' => 0,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
@@ -94,7 +95,7 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'additional_shipping_cost' => '-0.55',
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
@@ -105,7 +106,7 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'carriers' => ['1', '2', '3'],
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
@@ -116,7 +117,7 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'delivery_time_note_type' => 1,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
@@ -131,7 +132,7 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'delivery_time_in_stock_note' => $localizedNotes,
                 ],
             ],
-            $command,
+            [$command],
         ];
 
         $command = new UpdateProductShippingCommand($this->getProductId()->getValue());
@@ -146,7 +147,7 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
                     'delivery_time_out_stock_note' => $localizedNotes,
                 ],
             ],
-            $command,
+            [$command],
         ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Modify ProductCommandBuilderInterface to return array of commands instead of only one
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | GA green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22766)
<!-- Reviewable:end -->
