### PR TITLE
Exclude gifts from getOrderTotal when selected ONLY_PRODUCTS

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2113,7 +2113,7 @@ class CartCore extends ObjectModel
 
         if ($type == Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING) {
             foreach ($products as $key => $product) {
-                if ($product['is_virtual']) {
+                if (!empty($product['is_virtual'])) {
                     unset($products[$key]);
                 }
             }
@@ -2122,7 +2122,7 @@ class CartCore extends ObjectModel
 
         if ($type == Cart::ONLY_PRODUCTS) {
             foreach ($products as $key => $product) {
-                if ($product['is_gift']) {
+                if (!empty($product['is_gift'])) {
                     unset($products[$key]);
                 }
             }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2120,6 +2120,14 @@ class CartCore extends ObjectModel
             $type = Cart::ONLY_PRODUCTS;
         }
 
+        if ($type == Cart::ONLY_PRODUCTS) {
+            foreach ($products as $key => $product) {
+                if ($product['is_gift']) {
+                    unset($products[$key]);
+                }
+            }
+        }
+
         if (Tax::excludeTaxeOption()) {
             $withTaxes = false;
         }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -254,7 +254,8 @@ class OrderControllerCore extends FrontController
     public function displayAjaxselectDeliveryOption()
     {
         $cart = $this->cart_presenter->present(
-            $this->context->cart
+            $this->context->cart,
+            true
         );
 
         ob_end_clean();
@@ -278,7 +279,7 @@ class OrderControllerCore extends FrontController
             Tools::getAllValues()
         );
 
-        $presentedCart = $this->cart_presenter->present($this->context->cart);
+        $presentedCart = $this->cart_presenter->present($this->context->cart, true);
 
         if (count($presentedCart['products']) <= 0 || $presentedCart['minimalPurchaseRequired']) {
             // if there is no product in current cart, redirect to cart page


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Exclude gift when selecting ONLY_PRODUCTS.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22615
| How to test?      | Follow ticket instruction.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22768)
<!-- Reviewable:end -->
