### PR TITLE
Allow extra fields in product combinations

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -710,7 +710,8 @@ class ProductController extends FrameworkBundleAdminController
             foreach ($combinations as $combination) {
                 $formBuilder->add(
                     'combination_' . $combination['id_product_attribute'],
-                    ProductCombination::class
+                    ProductCombination::class,
+                    ['allow_extra_fields' => true]
                 );
             }
         }


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/PrestaShop/issues/22788

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Because we can't use the "displayAdminProductsCombinationBottom" hook properly otherwise.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22788.
| How to test?      | Use displayAdminProductsCombinationBottom with custom form items, details in #22788
| Possible impacts? | Validation may be impaired

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22777)
<!-- Reviewable:end -->
