### PR TITLE
Add error message when the payment method is invalid in Back Office's Orders page

### DIFF
--- a/src/Core/Domain/Order/Exception/OrderConstraintException.php
+++ b/src/Core/Domain/Order/Exception/OrderConstraintException.php
@@ -34,5 +34,10 @@ class OrderConstraintException extends OrderException
     /**
      * Used in create order from BO when the customer message is invalid.
      */
-    const INVALID_CUSTOMER_MESSAGE = 1;
+    public const INVALID_CUSTOMER_MESSAGE = 1;
+
+    /**
+     * Used in add payment from BO when the payment method is invalid.
+     */
+    public const INVALID_PAYMENT_METHOD = 2;
 }

--- a/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
+++ b/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
@@ -39,6 +39,16 @@ use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
 class AddPaymentCommand
 {
     /**
+     * @var string
+     */
+    public const INVALID_CHARACTERS_NAME = '<>={}';
+
+    /**
+     * @var string
+     */
+    private const PATTERN_PAYMENT_METHOD_NAME = '/^[^' . self::INVALID_CHARACTERS_NAME . ']*$/u';
+
+    /**
      * @var OrderId
      */
     private $orderId;
@@ -162,7 +172,7 @@ class AddPaymentCommand
      */
     private function assertPaymentMethodIsGenericName($paymentMethod)
     {
-        if (empty($paymentMethod) || !preg_match('/^[^<>={}]*$/u', $paymentMethod)) {
+        if (empty($paymentMethod) || !preg_match(self::PATTERN_PAYMENT_METHOD_NAME, $paymentMethod)) {
             throw new OrderConstraintException(
                 'The selected payment method is invalid.',
                 OrderConstraintException::INVALID_PAYMENT_METHOD

--- a/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
+++ b/src/Core/Domain/Order/Payment/Command/AddPaymentCommand.php
@@ -163,7 +163,10 @@ class AddPaymentCommand
     private function assertPaymentMethodIsGenericName($paymentMethod)
     {
         if (empty($paymentMethod) || !preg_match('/^[^<>={}]*$/u', $paymentMethod)) {
-            throw new OrderConstraintException('The selected payment method is invalid.');
+            throw new OrderConstraintException(
+                'The selected payment method is invalid.',
+                OrderConstraintException::INVALID_PAYMENT_METHOD
+            );
         }
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1928,7 +1928,7 @@ class OrderController extends FrameworkBundleAdminController
             ),
             OrderConstraintException::class => [
                 OrderConstraintException::INVALID_PAYMENT_METHOD => sprintf(
-                    '%s %s ^<>={}',
+                    '%s %s %s',
                     $this->trans(
                         'The selected payment method is invalid.',
                         'Admin.Orderscustomers.Notification'
@@ -1936,7 +1936,8 @@ class OrderController extends FrameworkBundleAdminController
                     $this->trans(
                         'Invalid characters:',
                         'Admin.Notifications.Info'
-                    )
+                    ),
+                    AddPaymentCommand::INVALID_CHARACTERS_NAME
                 ),
             ],
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1926,6 +1926,19 @@ class OrderController extends FrameworkBundleAdminController
                 'Only numbers and decimal points (".") are allowed in the amount fields of the payment block, e.g. 10.50 or 1050.',
                 'Admin.Orderscustomers.Notification'
             ),
+            OrderConstraintException::class => [
+                OrderConstraintException::INVALID_PAYMENT_METHOD => sprintf(
+                    '%s %s ^<>={}',
+                    $this->trans(
+                        'The selected payment method is invalid.',
+                        'Admin.Orderscustomers.Notification'
+                    ),
+                    $this->trans(
+                        'Invalid characters:',
+                        'Admin.Notifications.Info'
+                    )
+                ),
+            ],
         ]);
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderPaymentFeatureContext.php
@@ -30,6 +30,7 @@ use Behat\Gherkin\Node\TableNode;
 use DateTimeImmutable;
 use PHPUnit\Framework\Assert as Assert;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Payment\Command\AddPaymentCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
@@ -156,15 +157,28 @@ class OrderPaymentFeatureContext extends AbstractDomainFeatureContext
             );
         } catch (NegativePaymentAmountException $exception) {
             $this->lastException = $exception;
+        } catch (OrderConstraintException $exception) {
+            $this->lastException = $exception;
         }
     }
 
     /**
      * @Then I should get error that payment amount is negative
      */
-    public function assertLastErrorIsNegativePaymentAmount()
+    public function assertLastErrorIsNegativePaymentAmount(): void
     {
         $this->assertLastErrorIs(NegativePaymentAmountException::class);
+    }
+
+    /**
+     * @Then I should get error that payment method is invalid
+     */
+    public function assertLastErrorIsInvalidPaymentMethod(): void
+    {
+        $this->assertLastErrorIs(
+            OrderConstraintException::class,
+            OrderConstraintException::INVALID_PAYMENT_METHOD
+        );
     }
 
     private function mapToOrderPaymentForViewing(int $paymentId, array $data)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -79,6 +79,17 @@ Feature: Order from Back Office (BO)
     Then I should get error that payment amount is negative
     And order "bo_order1" has 0 payments
 
+  Scenario: pay order with invalid payment method and see it is not valid
+    When order "bo_order1" has 0 payments
+    And I pay order "bo_order1" with the invalid following details:
+      | date           | 2019-11-26 13:56:22 |
+      | payment_method | Paym>>ents by check |
+      | transaction_id | test!@#$%%^^&* OR 1 |
+      | currency       | USD                 |
+      | amount         | 1.548               |
+    Then I should get error that payment method is invalid
+    And order "bo_order1" has 0 payments
+
   Scenario: pay for order
     When I pay order "bo_order1" with the following details:
       | date           | 2019-11-26 13:56:23 |

--- a/tests/Unit/Core/Domain/Order/Payment/Command/AddPaymentCommandTest.php
+++ b/tests/Unit/Core/Domain/Order/Payment/Command/AddPaymentCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit\Core\Domain\Order\Payment\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\NegativePaymentAmountException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Payment\Command\AddPaymentCommand;
+
+class AddPaymentCommandTest extends TestCase
+{
+    public function testAmountIsNegative(): void
+    {
+        $this->expectException(NegativePaymentAmountException::class);
+        $this->expectExceptionMessage('The amount should be greater than 0.');
+        new AddPaymentCommand(1, date('Y-m-d'), 'Check', -1, 2);
+    }
+
+    public function testPaymentMethodIsEmpty(): void
+    {
+        $this->expectException(OrderConstraintException::class);
+        $this->expectExceptionMessage('The selected payment method is invalid.');
+        new AddPaymentCommand(1, date('Y-m-d'), '', 0, 2);
+    }
+
+    /**
+     * @dataProvider getInvalidChars
+     *
+     * @param string $invalidChar
+     */
+    public function testPaymentMethodWithInvalidCharacters(string $invalidChar): void
+    {
+        $this->expectException(OrderConstraintException::class);
+        $this->expectExceptionMessage('The selected payment method is invalid.');
+        new AddPaymentCommand(1, date('Y-m-d'), $invalidChar . 'Check', 0, 2);
+    }
+
+    public function getInvalidChars(): iterable
+    {
+        foreach (str_split(AddPaymentCommand::INVALID_CHARACTERS_NAME) as $invalidChar) {
+            yield [$invalidChar];
+        }
+    }
+
+    public function testConstruct(): void
+    {
+        $instance = new AddPaymentCommand(1, date('Y-m-d'), 'Check', 0, 2);
+
+        $this->assertEquals(1, $instance->getOrderId()->getValue());
+        $this->assertEquals(date('Y-m-d'), $instance->getPaymentDate()->format('Y-m-d'));
+        $this->assertEquals('Check', $instance->getPaymentMethod());
+        $this->assertEquals('0', $instance->getPaymentAmount()->__toString());
+        $this->assertEquals(2, $instance->getPaymentCurrencyId()->getValue());
+        $this->assertNull($instance->getOrderInvoiceId());
+        $this->assertNull($instance->getPaymentTransactionId());
+    }
+
+    public function testConstructWithOrderInvoiceId(): void
+    {
+        $instance = new AddPaymentCommand(1, date('Y-m-d'), 'Check', 0, 2, 3);
+
+        $this->assertEquals(1, $instance->getOrderId()->getValue());
+        $this->assertEquals(date('Y-m-d'), $instance->getPaymentDate()->format('Y-m-d'));
+        $this->assertEquals('Check', $instance->getPaymentMethod());
+        $this->assertEquals('0', $instance->getPaymentAmount()->__toString());
+        $this->assertEquals(2, $instance->getPaymentCurrencyId()->getValue());
+        $this->assertEquals(3, $instance->getOrderInvoiceId());
+        $this->assertNull($instance->getPaymentTransactionId());
+    }
+
+    public function testConstructWithTransactionId(): void
+    {
+        $instance = new AddPaymentCommand(1, date('Y-m-d'), 'Check', 0, 2, 3, 'TransactionId');
+
+        $this->assertEquals(1, $instance->getOrderId()->getValue());
+        $this->assertEquals(date('Y-m-d'), $instance->getPaymentDate()->format('Y-m-d'));
+        $this->assertEquals('Check', $instance->getPaymentMethod());
+        $this->assertEquals('0', $instance->getPaymentAmount()->__toString());
+        $this->assertEquals(2, $instance->getPaymentCurrencyId()->getValue());
+        $this->assertEquals(3, $instance->getOrderInvoiceId());
+        $this->assertEquals('TransactionId', $instance->getPaymentTransactionId());
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | BO - Order Page - Set an error message when the payment method is invalid
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22587
| How to test?      | 1. Go to BO > Orders > Old order page<br>2. Add payment with "Payment method" Paym>>ents by check<br>3.  Click on Add<br>4. **BEFORE** See an error<br>4. **AFTER** An error message is displayed
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22791)
<!-- Reviewable:end -->
