### PR TITLE
Fix partial update with double controller and double providers

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -4,6 +4,7 @@ parameters:
 
 imports:
     - { resource: config_dev.yml }
+    - { resource: ../../tests/Integration/PrestaShopBundle/Resources/config/services.yml }
 
 framework:
     test: ~

--- a/src/Core/Form/IdentifiableObject/DataProvider/FullProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/FullProductFormDataProvider.php
@@ -35,9 +35,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 
 /**
- * Provides the data that is used to prefill the Product form
+ * Provides the data that is used to fully prefill the Product form
  */
-final class ProductFormDataProvider implements FormDataProviderInterface
+final class FullProductFormDataProvider implements FormDataProviderInterface
 {
     /**
      * @var CommandBusInterface
@@ -62,6 +62,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
 
         return [
             'id' => $id,
+            'product_id' => $id,
             'basic' => $this->extractBasicData($productForEditing),
             'price' => $this->extractPriceData($productForEditing),
             'shipping' => $this->extractShippingData($productForEditing),

--- a/src/Core/Form/IdentifiableObject/DataProvider/PartialProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/PartialProductFormDataProvider.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
+
+/**
+ * Provides the data that is used to fill the form during partial update
+ * so only limited data is sent. This allows to only rely on the data from request
+ */
+final class PartialProductFormDataProvider implements FormDataProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getData($id)
+    {
+        return [
+            'id' => $id,
+            'product_id' => $id,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultData()
+    {
+        return [];
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -89,6 +89,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
                 'height' => 0,
                 'depth' => 0,
                 'weight' => 0,
+                'additional_shipping_cost' => 0,
             ],
         ];
     }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
@@ -10,7 +10,7 @@ admin_products_v2_create:
 
 admin_products_v2_edit:
   path: /{productId}/edit
-  methods: [GET, POST, PATCH]
+  methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/Catalog/Product/Product:edit
     _legacy_controller: AdminProducts
@@ -21,3 +21,17 @@ admin_products_v2_edit:
       id_product: productId
   requirements:
     productId: \d+
+
+admin_products_v2_update:
+    path: /{productId}/update
+    methods: [POST, PATCH]
+    defaults:
+        _controller: PrestaShopBundle:Admin/Sell/Catalog/Product/Product:update
+        _legacy_controller: AdminProducts
+        _legacy_link:
+            - AdminProducts:updateproduct
+            - AdminProducts:update
+        _legacy_parameters:
+            id_product: productId
+    requirements:
+        productId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -183,9 +183,16 @@ services:
       - 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderReturnStates\OrderReturnStateType'
       - '@prestashop.core.form.identifiable_object.data_provider.order_return_state_form_data_provider'
 
-  prestashop.core.form.identifiable_object.builder.product_form_builder:
+  prestashop.core.form.identifiable_object.builder.full_product_form_builder:
       class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
       factory: 'prestashop.core.form.builder.form_builder_factory:create'
       arguments:
           - 'PrestaShopBundle\Form\Admin\Sell\Product\ProductType'
-          - '@prestashop.core.form.identifiable_object.data_provider.product_form_data_provider'
+          - '@prestashop.core.form.identifiable_object.data_provider.full_product_form_data_provider'
+
+  prestashop.core.form.identifiable_object.builder.partial_product_form_builder:
+      class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+      factory: 'prestashop.core.form.builder.form_builder_factory:create'
+      arguments:
+          - 'PrestaShopBundle\Form\Admin\Sell\Product\ProductType'
+          - '@prestashop.core.form.identifiable_object.data_provider.partial_product_form_data_provider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -149,7 +149,10 @@ services:
     arguments:
       - '@prestashop.core.query_bus'
 
-  prestashop.core.form.identifiable_object.data_provider.product_form_data_provider:
-      class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ProductFormDataProvider'
+  prestashop.core.form.identifiable_object.data_provider.full_product_form_data_provider:
+      class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\FullProductFormDataProvider'
       arguments:
           - '@prestashop.core.query_bus'
+
+  prestashop.core.form.identifiable_object.data_provider.partial_product_form_data_provider:
+      class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\PartialProductFormDataProvider'

--- a/tests/Integration/Core/Form/IdentifiableObject/DataHandler/ProductFormDataHandlerChecker.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/DataHandler/ProductFormDataHandlerChecker.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Integration\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandlerInterface;
+
+class ProductFormDataHandlerChecker implements FormDataHandlerInterface
+{
+    /**
+     * @var FormDataHandlerInterface
+     */
+    private $productFormDataHandler;
+
+    /**
+     * @var ?array
+     */
+    private $lastCreateData;
+
+    /**
+     * @var ?int
+     */
+    private $lastUpdateId;
+
+    /**
+     * @var ?array
+     */
+    private $lastUpdateData;
+
+    /**
+     * ProductFormDataHandlerChecker constructor.
+     *
+     * @param FormDataHandlerInterface $productFormDataHandler
+     */
+    public function __construct(FormDataHandlerInterface $productFormDataHandler)
+    {
+        $this->productFormDataHandler = $productFormDataHandler;
+    }
+
+    public function create(array $data)
+    {
+        $this->lastCreateData = $data;
+
+        return $this->productFormDataHandler->create($data);
+    }
+
+    public function update($id, array $data)
+    {
+        $this->lastUpdateId = $id;
+        $this->lastUpdateData = $data;
+        $this->productFormDataHandler->update($id, $data);
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getLastCreateData(): ?array
+    {
+        return $this->lastCreateData;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLastUpdateId(): ?int
+    {
+        return $this->lastUpdateId;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getLastUpdateData(): ?array
+    {
+        return $this->lastUpdateData;
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductControllerTest.php
@@ -2,9 +2,28 @@
 
 namespace Tests\Integration\PrestaShopBundle\Controller\Admin\Sell\Catalog\Product;
 
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCommandsBuilder;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ProductFormDataHandler;
+use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\DomCrawler\Field\FormField;
+use Symfony\Component\DomCrawler\Form;
 
 /**
+ * This integration test is mostly used to ensure the partial update mechanism is correctly handled, the purpose is to check
+ * that with a set number of differences only partial data is provided to the ProductFormDataHandler so that it can then create
+ * only required CQRS commands.
+ *
+ * We don't check which commands are created it is the responsibility of the ProductFormDataHandler, we only check that the controller
+ * handles the request correctly so that only partial data is provided to the handler.
+ *
+ * For more details about CQRS commands partial generation:
+ *
+ * @see ProductFormDataHandler
+ * @see ProductCommandsBuilder
+ *
  * To run this test run this command from project root:
  * php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit.xml tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductControllerTest.php
  */
@@ -26,35 +45,26 @@ class ProductControllerTest extends WebTestCase
         $this->handleStrictPartialUpdate = false;
     }
 
-    public function testCreateProduct()
+    public function testCreateProduct(): int
     {
         $client = static::createClient();
         $router = $client->getKernel()->getContainer()->get('router');
         $createUrl = $router->generate('admin_products_v2_create');
         $crawler = $client->request('GET', $createUrl);
 
-        // Get button by id #product_save
-        $submitButton = $crawler->selectButton('product_save');
-        $productForm = $submitButton->form();
-
         // Only product name in default language should be required on creation
-        $productForm['product[basic][name][1]'] = 'Test Product';
-
+        $productForm = $this->fillProductForm($crawler, ['product[basic][name][1]' => 'Test Product']);
         $client->submit($productForm);
-        $response = $client->getResponse();
 
         // If creation happens correctly then we are redirect to the edition page
-        $this->assertTrue($response->isRedirection());
-        $redirectUrl = $response->headers->get('Location');
+        $createdProductId = $this->assertSuccessfulRedirection($client);
 
-        $parsedUrl = parse_url($redirectUrl);
-        $routerMatching = $router->match($parsedUrl['path']);
-        $this->assertArrayHasKey('_route', $routerMatching);
-        $this->assertEquals('admin_products_v2_edit', $routerMatching['_route']);
-        $this->assertArrayHasKey('productId', $routerMatching);
-        $this->assertGreaterThan(0, $routerMatching['productId']);
+        // Now we check that the correct data were use by the form handler
+        $dataChecker = $client->getContainer()->get('test.integration.core.form.identifiable_object.data_handler.product_form_data_handler_checker');
+        $createData = $dataChecker->getLastCreateData();
+        $this->assertHandlerData(['basic' => ['name' => [1 => 'Test Product']]], $createData);
 
-        return (int) $routerMatching['productId'];
+        return $createdProductId;
     }
 
     /**
@@ -72,36 +82,17 @@ class ProductControllerTest extends WebTestCase
         $createUrl = $router->generate('admin_products_v2_edit', ['productId' => $productId]);
         $crawler = $client->request('GET', $createUrl);
 
-        // Get button by id #product_save
-        $submitButton = $crawler->selectButton('product_save');
-        $productForm = $submitButton->form();
-        foreach ($formModifications as $formField => $formValue) {
-            $productForm[$formField] = 'Test Update Product';
-        }
-
+        $productForm = $this->fillProductForm($crawler, $formModifications);
         $client->submit($productForm);
-        $response = $client->getResponse();
 
         // If update happens correctly then we are redirect to the same edition page
-        $this->assertTrue($response->isRedirection());
-        $redirectUrl = $response->headers->get('Location');
-        $parsedUrl = parse_url($redirectUrl);
-        $routerMatching = $router->match($parsedUrl['path']);
-        $this->assertArrayHasKey('_route', $routerMatching);
-        $this->assertEquals('admin_products_v2_edit', $routerMatching['_route']);
-        $this->assertArrayHasKey('productId', $routerMatching);
-        $this->assertEquals($productId, $routerMatching['productId']);
+        $redirectionProductId = $this->assertSuccessfulRedirection($client);
+        $this->assertEquals($productId, $redirectionProductId);
 
         // Now we check that the correct data were use by the form handler
         $dataChecker = $client->getContainer()->get('test.integration.core.form.identifiable_object.data_handler.product_form_data_handler_checker');
         $updateData = $dataChecker->getLastUpdateData();
-        if ($this->handlePartialUpdate && !$this->handleStrictPartialUpdate) {
-            // This method is deprecated in PHPUnit for PHP 8.0 but we can't use more recent libraries that replace this
-            // because they require more recent version of PHP than ours, so for now we keep using this one
-            $this->assertArraySubset($expectedUpdateData, $updateData);
-        } else {
-            $this->assertEquals($expectedUpdateData, $updateData);
-        }
+        $this->assertHandlerData($expectedUpdateData, $updateData);
     }
 
     public function getProductEditionModifications()
@@ -120,5 +111,109 @@ class ProductControllerTest extends WebTestCase
                 ],
             ],
         ];
+
+        yield [
+            [
+                'product[shipping][carriers]' => [1, 2],
+            ],
+            [
+                'shipping' => [
+                    'carriers' => [1, 2],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'product[shipping][carriers]' => [1, 3],
+            ],
+            [
+                'shipping' => [
+                    'carriers' => [1, 3],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $expectedData
+     * @param array $handlerData
+     */
+    private function assertHandlerData(array $expectedData, array $handlerData): void
+    {
+        if ($this->handlePartialUpdate && !$this->handleStrictPartialUpdate) {
+            // This method is deprecated in PHPUnit for PHP 8.0 but we can't use more recent libraries that replace this
+            // because they require more recent version of PHP than ours, so for now we keep using this one
+            $this->assertArraySubset($expectedData, $handlerData);
+        } else {
+            $this->assertEquals($expectedData, $handlerData);
+        }
+    }
+
+    /**
+     * Check that request succeeded and therefore redirects to edition page
+     *
+     * @param Client $client
+     *
+     * @return int Returns the product ID from the redirection URL
+     */
+    private function assertSuccessfulRedirection(Client $client): int
+    {
+        $response = $client->getResponse();
+        $this->assertTrue($response->isRedirection());
+        $redirectUrl = $response->headers->get('Location');
+        $parsedUrl = parse_url($redirectUrl);
+
+        $router = $client->getContainer()->get('router');
+        $routerMatching = $router->match($parsedUrl['path']);
+        $this->assertArrayHasKey('_route', $routerMatching);
+        $this->assertEquals('admin_products_v2_edit', $routerMatching['_route']);
+        $this->assertArrayHasKey('productId', $routerMatching);
+        $this->assertGreaterThan(0, $routerMatching['productId']);
+
+        return (int) $routerMatching['productId'];
+    }
+
+    /**
+     * @param Crawler $crawler
+     * @param array $formModifications
+     *
+     * @return Form
+     */
+    private function fillProductForm(Crawler $crawler, array $formModifications): Form
+    {
+        // Get button by id #product_save
+        $submitButton = $crawler->selectButton('product_save');
+        $productForm = $submitButton->form();
+        foreach ($formModifications as $fieldName => $formValue) {
+            if (is_array($formValue)) {
+                // For multi select checkboxes or select inputs
+                /** @var ChoiceFormField[]|ChoiceFormField $formFields */
+                $formFields = $productForm->get($fieldName);
+                // Multiple checkboxes are returned as array
+                if (is_array($formFields)) {
+                    foreach ($formFields as $formField) {
+                        if ('checkbox' === $formField->getType()) {
+                            $optionValue = $formField->availableOptionValues()[0];
+                            if (in_array($optionValue, $formValue)) {
+                                $formField->tick();
+                            } else {
+                                $formField->untick();
+                            }
+                        } else {
+                            $formField->select($formValue);
+                        }
+                    }
+                } else {
+                    $formFields->select($formValue);
+                }
+            } else {
+                /** @var FormField $formField */
+                $formField = $productForm->get($fieldName);
+                $formField->setValue($formValue);
+            }
+        }
+
+        return $productForm;
     }
 }

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Admin\Sell\Catalog\Product;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ProductControllerTest extends WebTestCase
+{
+    public function testCreateProduct()
+    {
+        $client = static::createClient();
+        $router = $client->getKernel()->getContainer()->get('router');
+        $createUrl = $router->generate('admin_products_v2_create');
+        $crawler = $client->request('GET', $createUrl);
+
+        // Get button by id #product_save
+        $submitButton = $crawler->selectButton('product_save');
+        $productForm = $submitButton->form();
+
+        // Only product name in default language should be required on creation
+        $productForm['product[basic][name][1]'] = 'Test Product';
+
+        $client->submit($productForm);
+        $response = $client->getResponse();
+
+        // If creation happens correctly then we are redirect to the edition page
+        $this->assertTrue($response->isRedirection());
+        $redirectUrl = $response->headers->get('Location');
+
+        $parsedUrl = parse_url($redirectUrl);
+        $routerMatching = $router->match($parsedUrl['path']);
+        $this->assertArrayHasKey('_route', $routerMatching);
+        $this->assertEquals('admin_products_v2_edit', $routerMatching['_route']);
+        $this->assertArrayHasKey('productId', $routerMatching);
+        $this->assertGreaterThan(0, $routerMatching['productId']);
+
+        return (int) $routerMatching['productId'];
+    }
+
+    /**
+     * @depends testCreateProduct
+     */
+    public function testEditProduct(int $productId)
+    {
+        $client = static::createClient();
+        $router = $client->getKernel()->getContainer()->get('router');
+        var_dump($productId);
+        $createUrl = $router->generate('admin_products_v2_edit', ['productId' => $productId]);
+        $crawler = $client->request('GET', $createUrl);
+
+        // Get button by id #product_save
+        $submitButton = $crawler->selectButton('product_save');
+        $productForm = $submitButton->form();
+        $productForm['product[basic][name][1]'] = 'Test Update Product';
+
+        $client->submit($productForm);
+        $response = $client->getResponse();
+
+        // If update happens correctly then we are redirect to the same edition page
+        $this->assertTrue($response->isRedirection());
+        $redirectUrl = $response->headers->get('Location');
+        $parsedUrl = parse_url($redirectUrl);
+        $routerMatching = $router->match($parsedUrl['path']);
+        $this->assertArrayHasKey('_route', $routerMatching);
+        $this->assertEquals('admin_products_v2_edit', $routerMatching['_route']);
+        $this->assertArrayHasKey('productId', $routerMatching);
+        $this->assertEquals($productId, $routerMatching['productId']);
+
+        // Now we check that the correct data were use by the form handler
+        $dataChecker = $client->getContainer()->get('test.integration.core.form.identifiable_object.data_handler.product_form_data_handler_checker');
+        $updateData = $dataChecker->getLastUpdateData();
+        $this->assertTrue(isset($updateData['basic']['name'][1]));
+        $this->assertEquals('Test Update Product', $updateData['basic']['name'][1]);
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Resources/config/services.yml
+++ b/tests/Integration/PrestaShopBundle/Resources/config/services.yml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        public: true
+
+    test.integration.core.form.identifiable_object.data_handler.product_form_data_handler_checker:
+        decorates: prestashop.core.form.identifiable_object.data_handler.product_form_data_handler
+        class: 'Tests\Integration\Core\Form\IdentifiableObject\DataHandler\ProductFormDataHandlerChecker'
+        arguments:
+            - '@test.integration.core.form.identifiable_object.data_handler.product_form_data_handler_checker.inner'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Partial update is not handled correctly, so this PR aims to add automatic integration tests to ensure the Product controller behaves as expected and only updates the required data<br /><br />In this PR the solution adopted is to split the form into two controllers (one GET to show the form, one PATCH to handle the form submit) this allows to provide two data providers For GET request the whole form is prefilled with product data so that it shows appropriately in the page, in PATCH request no data is prefilled so that only the data posted in the request is used
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | GA tests green Test form partial update with XDebug (should be done by a developer - optional)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22798)
<!-- Reviewable:end -->
