### PR TITLE
BO - Orders page - Cannot delete a product restricted by a cart rule

### DIFF
--- a/src/Adapter/Order/Refund/OrderProductRemover.php
+++ b/src/Adapter/Order/Refund/OrderProductRemover.php
@@ -187,7 +187,10 @@ class OrderProductRemover
         $removedOrderCartRules = [];
         foreach ($orderCartRules as $orderCartRule) {
             $cartRule = new CartRule($orderCartRule['id_cart_rule']);
-            $discountedProducts = $cartRule->checkProductRestrictionsFromCart($cart, true, true, true);
+            $discountedProducts = $cartRule->checkProductRestrictionsFromCart($cart, true, false, true);
+            if (!is_array($discountedProducts)) {
+                continue;
+            }
             foreach ($discountedProducts as $discountedProduct) {
                 // The return value is the concatenation of productId and attributeId, but the attributeId is always replaced by 0
                 if ($discountedProduct === $orderDetail->product_id . '-0') {

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -145,7 +145,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     /**
      * @Given /^cart rule "(.+?)" is restricted to the category "(.+?)" with a quantity of (\d+)$/
      */
-    public function cartRuleWithProductRuleRestriction($cartRuleName, $categoryName)
+    public function cartRuleWithProductRuleRestriction(string $cartRuleName, string $categoryName, int $quantity)
     {
         $this->checkCartRuleWithNameExists($cartRuleName);
         $this->categoryFeatureContext->checkCategoryWithNameExists($categoryName);
@@ -153,7 +153,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
 
         Db::getInstance()->execute(
             'INSERT INTO `' . _DB_PREFIX_ . 'cart_rule_product_rule_group` (`id_cart_rule`, `quantity`) ' .
-            'VALUES (' . (int) $this->cartRules[$cartRuleName]->id . ', 1)'
+            'VALUES (' . (int) $this->cartRules[$cartRuleName]->id . ', ' . $quantity . ')'
         );
         $idProductRuleGroup = Db::getInstance()->Insert_ID();
 
@@ -191,9 +191,13 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
 
     /**
      * @Given /^cart rule "(.+)" is restricted to product "(.+)"$/
+     * @Given /^cart rule "(.+)" is restricted to product "(.+)" with a quantity of (\d+)$/
      */
-    public function cartRuleNamedIsRestrictedToProductNamed($cartRuleName, $productName)
-    {
+    public function cartRuleNamedIsRestrictedToProductNamed(
+        string $cartRuleName,
+        string $productName,
+        int $quantity = 1
+    ): void {
         $this->checkCartRuleWithNameExists($cartRuleName);
         $this->productFeatureContext->checkProductWithNameExists($productName);
 
@@ -203,11 +207,20 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         $this->cartRules[$cartRuleName]->save();
 
         // The reduction_product is not enough, we need to define product rules for condition (this is done by the controller usually)
-        Db::getInstance()->insert('cart_rule_product_rule_group', ['id_cart_rule' => $this->cartRules[$cartRuleName]->id, 'quantity' => 1]);
+        Db::getInstance()->insert(
+            'cart_rule_product_rule_group',
+            ['id_cart_rule' => $this->cartRules[$cartRuleName]->id, 'quantity' => $quantity]
+        );
         $productRuleGroupId = Db::getInstance()->Insert_ID();
-        Db::getInstance()->insert('cart_rule_product_rule', ['id_product_rule_group' => $productRuleGroupId, 'type' => 'products']);
+        Db::getInstance()->insert(
+            'cart_rule_product_rule',
+            ['id_product_rule_group' => $productRuleGroupId, 'type' => 'products']
+        );
         $productRuleId = Db::getInstance()->Insert_ID();
-        Db::getInstance()->insert('cart_rule_product_rule_value', ['id_product_rule' => $productRuleId, 'id_item' => $restrictedProduct->id]);
+        Db::getInstance()->insert(
+            'cart_rule_product_rule_value',
+            ['id_product_rule' => $productRuleId, 'id_item' => $restrictedProduct->id]
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1763,4 +1763,12 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             }
         }
     }
+
+    /**
+     * @Then I should get no order error
+     */
+    public function assertNoOrderError()
+    {
+        $this->assertLastErrorIsNull();
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | BO - Orders page - Cannot delete a product restricted by a cart rule
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22625
| How to test?      | Cf. #22625
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22805)
<!-- Reviewable:end -->
