### PR TITLE
Fixed generation of Robots.txt file when the variable $_SERVER['SERVER_NAME'] is not defined

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2920,7 +2920,7 @@ FileETag none
         }
 
         // Sitemap
-        if (file_exists($sitemap_file) && filesize($sitemap_file)) {
+        if (file_exists($sitemap_file) && filesize($sitemap_file) && isset($_SERVER['SERVER_NAME'])) {
             fwrite($write_fd, "# Sitemap\n");
             $sitemap_filename = basename($sitemap_file);
             fwrite($write_fd, 'Sitemap: ' . static::getProtocol((bool) Configuration::get('PS_SSL_ENABLED')) . $_SERVER['SERVER_NAME']


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed generation of Robots.txt file when the variable `$_SERVER['SERVER_NAME']` is not defined
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Execute behat tests without having the variable `$_SERVER['SERVER_NAME']` defined<br >**Before / After**<br>![image](https://user-images.githubusercontent.com/1533248/104928366-d818a580-59a2-11eb-99c2-e2f7704a9e63.png)
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22821)
<!-- Reviewable:end -->
