### PR TITLE
Fix test DB prefixing, run SF2 update in the same php process

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -26,10 +26,6 @@ swiftmailer:
 
 # Doctrine Configuration
 doctrine:
-    dbal:
-        connections:
-            default:
-                dbname: "test_%database_name%"
     orm:
         metadata_cache_driver: "array"
         query_cache_driver: "array"

--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -41,13 +41,16 @@ if (!array_key_exists('parameters', $parameters)) {
     throw new \Exception('Missing "parameters" key in "parameters.php" configuration file');
 }
 
-if (!defined('_PS_IN_TEST_') && isset($_SERVER['argv'])) {
+if (!defined('_PS_IN_TEST_') && php_sapi_name() === 'cli') {
     $input = new \Symfony\Component\Console\Input\ArgvInput();
     $env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
-
     if ($env === 'test') {
         define('_PS_IN_TEST_', 1);
     }
+}
+
+if (defined('_PS_IN_TEST_')) {
+    $parameters['parameters']['database_name'] = 'test_' . $parameters['parameters']['database_name'];
 }
 
 if ($container instanceof \Symfony\Component\DependencyInjection\Container) {

--- a/app/config/set_parameters.php
+++ b/app/config/set_parameters.php
@@ -41,7 +41,7 @@ if (!array_key_exists('parameters', $parameters)) {
     throw new \Exception('Missing "parameters" key in "parameters.php" configuration file');
 }
 
-if (!defined('_PS_IN_TEST_') && php_sapi_name() === 'cli') {
+if (!defined('_PS_IN_TEST_') && \Tools::isPHPCLI()) {
     $input = new \Symfony\Component\Console\Input\ArgvInput();
     $env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
     if ($env === 'test') {
@@ -49,11 +49,11 @@ if (!defined('_PS_IN_TEST_') && php_sapi_name() === 'cli') {
     }
 }
 
-if (defined('_PS_IN_TEST_')) {
+if (defined('_PS_IN_TEST_') && _PS_IN_TEST_) {
     $parameters['parameters']['database_name'] = 'test_' . $parameters['parameters']['database_name'];
 }
 
-if ($container instanceof \Symfony\Component\DependencyInjection\Container) {
+if (isset($container) && $container instanceof \Symfony\Component\DependencyInjection\Container) {
     foreach ($parameters['parameters'] as $key => $value) {
         $container->setParameter($key, $value);
     }
@@ -87,4 +87,6 @@ if ($container instanceof \Symfony\Component\DependencyInjection\Container) {
     if (!isset($parameters['parameters']['use_debug_toolbar']) || false !== $envParameter) {
         $container->setParameter('use_debug_toolbar', !$envParameter);
     }
+} else {
+    return $parameters;
 }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3637,7 +3637,7 @@ exit;
      */
     public static function isPHPCLI()
     {
-        return defined('STDIN') || (Tools::strtolower(PHP_SAPI) == 'cli' && (!isset($_SERVER['REMOTE_ADDR']) || empty($_SERVER['REMOTE_ADDR'])));
+        return php_sapi_name() === 'cli';
     }
 
     public static function argvToGET($argc, $argv)

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3637,7 +3637,7 @@ exit;
      */
     public static function isPHPCLI()
     {
-        return php_sapi_name() === 'cli';
+        return \PHP_SAPI === 'cli';
     }
 
     public static function argvToGET($argc, $argv)

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -104,7 +104,7 @@ if ($lastParametersModificationTime) {
 
     define('_DB_USER_', $config['parameters']['database_user']);
     define('_DB_PASSWD_', $config['parameters']['database_password']);
-    define('_DB_PREFIX_',  $config['parameters']['database_prefix']);
+    define('_DB_PREFIX_', $config['parameters']['database_prefix']);
     define('_MYSQL_ENGINE_',  $config['parameters']['database_engine']);
     define('_PS_CACHING_SYSTEM_',  $config['parameters']['ps_caching']);
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -324,9 +324,6 @@ class Install extends AbstractInstall
      */
     public function generateSf2ProductionEnv()
     {
-        if (defined('_PS_IN_TEST_')) {
-            return true;
-        }
         $schemaUpgrade = new UpgradeDatabase();
         $schemaUpgrade->addDoctrineSchemaUpdate();
         $output = $schemaUpgrade->execute();
@@ -350,8 +347,8 @@ class Install extends AbstractInstall
         $instance = Db::getInstance();
         $instance->execute('SET FOREIGN_KEY_CHECKS=0');
         foreach ($instance->executeS('SHOW TABLES') as $row) {
-            $table = current($row);
-            if (empty(_DB_PREFIX_) || preg_match('#^' . _DB_PREFIX_ . '#i', $table)) {
+            $table = reset($row);
+            if (preg_match('#^' . _DB_PREFIX_ . '#i', $table)) {
                 $instance->execute(($truncate ? 'TRUNCATE TABLE ' : 'DROP TABLE ') . '`' . $table . '`');
             }
         }

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -159,7 +159,7 @@ class ControllerTest extends TestCase
             define('_PS_TAB_MODULE_LIST_URL_', '');
         }
         if (!defined('_DB_SERVER_')) {
-            define('_DB_SERVER_', 'localhost');
+            define('_DB_SERVER_', $configuration['parameters']['database_host']);
         }
         if (!defined('_DB_USER_')) {
             define('_DB_USER_', $configuration['parameters']['database_user']);

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -148,7 +148,7 @@ class ControllerTest extends TestCase
 
     protected function declareRequiredConstants()
     {
-        $configuration = require_once _PS_CACHE_DIR_ . 'appParameters.php';
+        $parameters = (require _PS_ROOT_DIR_ . '/app/config/set_parameters.php')['parameters'];
 
         if (defined('_PS_BO_ALL_THEMES_DIR_')) {
             return;
@@ -159,19 +159,19 @@ class ControllerTest extends TestCase
             define('_PS_TAB_MODULE_LIST_URL_', '');
         }
         if (!defined('_DB_SERVER_')) {
-            define('_DB_SERVER_', $configuration['parameters']['database_host']);
+            define('_DB_SERVER_', $parameters['database_host']);
         }
         if (!defined('_DB_USER_')) {
-            define('_DB_USER_', $configuration['parameters']['database_user']);
+            define('_DB_USER_', $parameters['database_user']);
         }
         if (!defined('_DB_PASSWD_')) {
-            define('_DB_PASSWD_', $configuration['parameters']['database_password']);
+            define('_DB_PASSWD_', $parameters['database_password']);
         }
         if (!defined('_DB_NAME_')) {
-            define('_DB_NAME_', 'test_' . $configuration['parameters']['database_name']);
+            define('_DB_NAME_', $parameters['database_name']);
         }
         if (!defined('_DB_PREFIX_')) {
-            define('_DB_PREFIX_', $configuration['parameters']['database_prefix']);
+            define('_DB_PREFIX_', $parameters['database_prefix']);
         }
         if (!defined('_COOKIE_KEY_')) {
             define('_COOKIE_KEY_', Tools::passwdGen(64));

--- a/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
+++ b/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
@@ -56,8 +56,6 @@ class DatabaseCreator
             exit(1);
         }
 
-        $process = new Process(PHP_BINARY . ' bin/console prestashop:schema:update-without-foreign --env=test');
-        $process->run();
         $install->initializeTestContext();
         $install->installDefaultData('test_shop', false, false, false);
         $install->populateDatabase();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix test DB prefixing, run SF2 update in the same php process,
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #22840 - test DB prefix is kept, but `tests-legacy/create-test-db.php` now does not require unprefixed DB presence (and if needed, test DB prefix can be removed from code with `sed` in CI)
| How to test?      | GH CI must pass.
| Possible impacts? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22823)
<!-- Reviewable:end -->
