### PR TITLE
Make module cache customer dependant for a list of modules

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -221,6 +221,8 @@ abstract class ModuleCore implements ModuleInterface
 
     public static $hosted_modules_blacklist = ['autoupgrade'];
 
+    public static $customer_dependent_module_list = ['ps_featuredproducts', 'ps_bestsellers', 'ps_specials', 'ps_crossselling', 'ps_newproducts'];
+
     /**
      * Set the flag to indicate we are doing an import.
      *
@@ -2455,6 +2457,10 @@ abstract class ModuleCore implements ModuleInterface
             $cache_array[] = (int) $this->context->currency->id;
         }
         $cache_array[] = (int) $this->context->country->id;
+
+        if (in_array($name, self::$customer_dependent_module_list) && !empty($this->context->customer->id)) {
+            $cache_array[] = (int) $this->context->customer->id;
+        }
 
         return implode('|', $cache_array);
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  There are several issues in native modules because module cache is not customer dependant.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #17111 and https://github.com/PrestaShop/ps_featuredproducts/pull/33
| How to test?      |  Add a customer dependent product price, load home page. Authenticate to another user of the same group : the price should be different.
| Possible impacts? | The cache will grow up.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22859)
<!-- Reviewable:end -->
