### PR TITLE
Add test 'Check number of orders in order history page'

### DIFF
--- a/tests/UI/campaigns/functional/FO/03_userAccount/04_orderList.js
+++ b/tests/UI/campaigns/functional/FO/03_userAccount/04_orderList.js
@@ -1,0 +1,81 @@
+require('module-alias/register');
+
+const {expect} = require('chai');
+
+const helper = require('@utils/helpers');
+
+// Import data
+const {DefaultAccount} = require('@data/demo/customer');
+
+// Importing pages
+const foHomePage = require('@pages/FO/home');
+const foLoginPage = require('@pages/FO/login');
+const foMyAccountPage = require('@pages/FO/myAccount');
+const foOrderHistoryPage = require('@pages/FO/myAccount/orderHistory');
+
+// Import test context
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_FO_userAccount_orderList';
+
+let browserContext;
+let page;
+
+const numberOfDefaultOrders = 5;
+
+/*
+Sign in FO with default account
+Go to orders history page
+Check that number of orders is above 5 (default orders)
+ */
+
+describe('Check number of orders in order history page', async () => {
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+  it('should go to FO home page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToFoToCreateAccount', baseContext);
+
+    await foHomePage.goToFo(page);
+    const isHomePage = await foHomePage.isHomePage(page);
+    await expect(isHomePage).to.be.true;
+  });
+
+  it('should go to login page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToLoginFoPage', baseContext);
+
+    await foHomePage.goToLoginPage(page);
+
+    const pageHeaderTitle = await foLoginPage.getPageTitle(page);
+    await expect(pageHeaderTitle).to.equal(foLoginPage.pageTitle);
+  });
+
+  it('Should sign in FO', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'signInFo', baseContext);
+
+    await foLoginPage.customerLogin(page, DefaultAccount);
+    const isCustomerConnected = await foMyAccountPage.isCustomerConnected(page);
+    await expect(isCustomerConnected, 'Customer is not connected').to.be.true;
+  });
+
+  it('should go to order history page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToOrderHistoryPage', baseContext);
+
+    await foMyAccountPage.goToHistoryAndDetailsPage(page);
+    const pageHeaderTitle = await foOrderHistoryPage.getPageTitle(page);
+    await expect(pageHeaderTitle).to.equal(foOrderHistoryPage.pageTitle);
+  });
+
+  it('should go to order history page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkOrderList', baseContext);
+
+    const numberOfOrders = await foOrderHistoryPage.getNumberOfOrders(page);
+    await expect(numberOfOrders).to.be.at.least(numberOfDefaultOrders);
+  });
+});

--- a/tests/UI/pages/FO/myAccount/orderHistory.js
+++ b/tests/UI/pages/FO/myAccount/orderHistory.js
@@ -9,7 +9,8 @@ class OrderHistory extends FOBasePage {
 
     // Selectors
     this.ordersTable = '#content table';
-    this.ordersTableRow = row => `${this.ordersTable} tbody tr:nth-child(${row})`;
+    this.ordersTableRows = `${this.ordersTable} tbody tr`;
+    this.ordersTableRow = row => `${this.ordersTableRows}:nth-child(${row})`;
     this.orderTableColumn = (row, column) => `${this.ordersTableRow(row)} td:nth-child(${column})`;
     this.reorderLink = id => `${this.ordersTable} td.order-actions a[href*='Reorder=&id_order=${id}']`;
     this.detailsLink = row => `${this.ordersTableRow(row)} a[data-link-action='view-order-details']`;
@@ -18,6 +19,15 @@ class OrderHistory extends FOBasePage {
   /*
   Methods
    */
+
+  /**
+   * Get number of order in order history page
+   * @param page
+   * @returns {Promise<number>}
+   */
+  async getNumberOfOrders(page) {
+    return (await page.$$(this.ordersTableRows)).length;
+  }
 
   /**
    * Is reorder link visible


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Add test 'Check number of orders in order history page'
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | `TEST_PATH="functional/FO/03_userAccount/04_orderList.js" URL_FO=shopUrl/ npm run specific-test`
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22874)
<!-- Reviewable:end -->
