### PR TITLE
Improve TypedRegexValidator->getPattern()

### DIFF
--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -150,7 +150,7 @@ class TypedRegexValidator extends ConstraintValidator
      */
     private function sanitize($value, $type)
     {
-        if ($type === 'name') {
+        if ($type === TypedRegex::TYPE_NAME) {
             $value = stripslashes($value);
         }
 
@@ -171,7 +171,7 @@ class TypedRegexValidator extends ConstraintValidator
      */
     private function match($pattern, $type, $value)
     {
-        $typesToInverseMatching = ['message'];
+        $typesToInverseMatching = [TypedRegex::TYPE_MESSAGE];
 
         if (in_array($type, $typesToInverseMatching, true)) {
             return !preg_match($pattern, $value);

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -171,12 +171,13 @@ class TypedRegexValidator extends ConstraintValidator
      */
     private function match($pattern, $type, $value)
     {
-        $typesToInverseMatching = [TypedRegex::TYPE_MESSAGE];
+        $match = preg_match($pattern, $value);
 
+        $typesToInverseMatching = [TypedRegex::TYPE_MESSAGE];
         if (in_array($type, $typesToInverseMatching, true)) {
-            return !preg_match($pattern, $value);
+            return !$match;
         }
 
-        return preg_match($pattern, $value);
+        return $match;
     }
 }

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -137,7 +137,7 @@ class TypedRegexValidator extends ConstraintValidator
             default:
                 $definedTypes = implode(', ', array_values((new ReflectionClass(TypedRegex::class))->getConstants()));
                 throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, $definedTypes));
-        };
+        }
     }
 
     /**

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
 use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
+use ReflectionClass;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\InvalidArgumentException;
@@ -100,30 +101,43 @@ class TypedRegexValidator extends ConstraintValidator
      */
     private function getPattern($type)
     {
-        $typePatterns = [
-            TypedRegex::TYPE_NAME => $this->characterCleaner->cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'),
-            TypedRegex::TYPE_CATALOG_NAME => $this->characterCleaner->cleanNonUnicodeSupport('/^[^<>;=#{}]*$/u'),
-            TypedRegex::TYPE_GENERIC_NAME => $this->characterCleaner->cleanNonUnicodeSupport('/^[^<>={}]*$/u'),
-            TypedRegex::TYPE_CITY_NAME => $this->characterCleaner->cleanNonUnicodeSupport('/^[^!<>;?=+@#"°{}_$%]*$/u'),
-            TypedRegex::TYPE_ADDRESS => $this->characterCleaner->cleanNonUnicodeSupport('/^[^!<>?=+@{}_$%]*$/u'),
-            TypedRegex::TYPE_POST_CODE => '/^[a-zA-Z 0-9-]+$/',
-            TypedRegex::TYPE_PHONE_NUMBER => '/^[+0-9. ()\/-]*$/',
-            TypedRegex::TYPE_MESSAGE => '/[<>{}]/i',
-            TypedRegex::TYPE_LANGUAGE_ISO_CODE => IsoCode::PATTERN,
-            TypedRegex::TYPE_LANGUAGE_CODE => '/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/',
-            TypedRegex::TYPE_CURRENCY_ISO_CODE => AlphaIsoCode::PATTERN,
-            TypedRegex::TYPE_FILE_NAME => '/^[a-zA-Z0-9_.-]+$/',
-            TypedRegex::TYPE_DNI_LITE => AddressConstraint::DNI_LITE_PATTERN,
-            TypedRegex::TYPE_UPC => Upc::VALID_PATTERN,
-            TypedRegex::TYPE_EAN_13 => Ean13::VALID_PATTERN,
-            TypedRegex::TYPE_ISBN => Isbn::VALID_PATTERN,
-        ];
-
-        if (isset($typePatterns[$type])) {
-            return $typePatterns[$type];
-        }
-
-        throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, implode(',', array_keys($typePatterns))));
+        switch ($type) {
+            case TypedRegex::TYPE_NAME:
+                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u');
+            case TypedRegex::TYPE_CATALOG_NAME:
+                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^<>;=#{}]*$/u');
+            case TypedRegex::TYPE_GENERIC_NAME:
+                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^<>={}]*$/u');
+            case TypedRegex::TYPE_CITY_NAME:
+                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^!<>;?=+@#"°{}_$%]*$/u');
+            case TypedRegex::TYPE_ADDRESS:
+                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^!<>?=+@{}_$%]*$/u');
+            case TypedRegex::TYPE_POST_CODE:
+                return '/^[a-zA-Z 0-9-]+$/';
+            case TypedRegex::TYPE_PHONE_NUMBER:
+                return '/^[+0-9. ()\/-]*$/';
+            case TypedRegex::TYPE_MESSAGE:
+                return '/[<>{}]/i';
+            case TypedRegex::TYPE_LANGUAGE_ISO_CODE:
+                return IsoCode::PATTERN;
+            case TypedRegex::TYPE_LANGUAGE_CODE:
+                return '/^[a-zA-Z]{2}(-[a-zA-Z]{2})?$/';
+            case TypedRegex::TYPE_CURRENCY_ISO_CODE:
+                return AlphaIsoCode::PATTERN;
+            case TypedRegex::TYPE_FILE_NAME:
+                return '/^[a-zA-Z0-9_.-]+$/';
+            case TypedRegex::TYPE_DNI_LITE:
+                return AddressConstraint::DNI_LITE_PATTERN;
+            case TypedRegex::TYPE_UPC:
+                return Upc::VALID_PATTERN;
+            case TypedRegex::TYPE_EAN_13:
+                return Ean13::VALID_PATTERN;
+            case TypedRegex::TYPE_ISBN:
+                return Isbn::VALID_PATTERN;
+            default:
+                $definedTypes = implode(', ', array_values((new ReflectionClass(TypedRegex::class))->getConstants()));
+                throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, $definedTypes));
+        };
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The problem with the previous getPattern() implementation is that it first creates an array with all the regexes (which involves multiple calls to other functions) and then looks for the required one in the array. The most natural and fast way is to use a switch.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
| Possible impacts? | None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22887)
<!-- Reviewable:end -->
