### PR TITLE
Change create order buttons position and wording

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2855,9 +2855,9 @@
       <title>Add variables in JavaScript object and Smarty templates</title>
       <description>Add variables to javascript object that is available in Front Office. These are also available in smarty templates in modules.your_module_name.</description>
     </hook>
-    <hook id="actionFrontControllerSetVariables">
+    <hook id="displayAdminOrderCreateExtraButtons">
       <name>displayAdminOrderCreateExtraButtons</name>
-      <title>Add buttons to create order page inside the dropdown</title>
+      <title>Add buttons on the create order page dropdown</title>
       <description>Add buttons on the create order page dropdown</description>
     </hook>
   </entities>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2855,5 +2855,10 @@
       <title>Add variables in JavaScript object and Smarty templates</title>
       <description>Add variables to javascript object that is available in Front Office. These are also available in smarty templates in modules.your_module_name.</description>
     </hook>
+    <hook id="actionFrontControllerSetVariables">
+      <name>displayAdminOrderCreateExtraButtons</name>
+      <title>Add buttons to create order page inside the dropdown</title>
+      <description>Add buttons on the create order page dropdown</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -21,6 +21,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionFrontControllerSetVariables', 'Add variables in JavaScript object and Smarty templates', 'Add variables to javascript object that is available in Front Office. These are also available in smarty templates in modules.your_module_name.', '1'),
   (NULL, 'displayAdminGridTableBefore', 'Display before Grid table', 'This hook adds new blocks before Grid component table.', '1'),
   (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1')
+  (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons to create order page inside the dropdown', 'Add buttons on the create order page dropdown', '1')
 ;
 
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -21,7 +21,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionFrontControllerSetVariables', 'Add variables in JavaScript object and Smarty templates', 'Add variables to javascript object that is available in Front Office. These are also available in smarty templates in modules.your_module_name.', '1'),
   (NULL, 'displayAdminGridTableBefore', 'Display before Grid table', 'This hook adds new blocks before Grid component table.', '1'),
   (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1')
-  (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons to create order page inside the dropdown', 'Add buttons on the create order page dropdown', '1')
+  (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons on the create order page dropdown', 'Add buttons on the create order page dropdown', '1')
 ;
 
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -83,23 +83,12 @@
 
     {{ form_start(summaryForm, {'action': path('admin_orders_place')}) }}
       <div class="row mt-3">
-        <div class="col col-10">
+        <div class="col col-11">
 
           <div id="js-order-message-wrap">
             {{ ps.form_group_row(summaryForm.order_message, {}, {
               'label': 'Order message'|trans({}, 'Admin.Orderscustomers.Feature'),
             }) }}
-          </div>
-
-          <div class="form-group row mb-2">
-            <div class="col-sm offset-sm-4">
-              <button type="button" class="btn btn-outline-primary" id="js-send-process-order-email-btn">
-                {{ 'Send an email to the customer with the link to process the payment.'|trans({}, 'Admin.Orderscustomers.Help') }}
-              </button>
-              <a id="js-process-order-link" href="#" target="_blank">
-                {{ 'Go on payment page to process the payment.'|trans({}, 'Admin.Orderscustomers.Help') }}
-              </a>
-            </div>
           </div>
 
           {{ ps.form_group_row(summaryForm.payment_module, {}, {
@@ -115,6 +104,13 @@
               <button class="btn btn-primary" type="submit" id="create-order-button">
                 {{ 'Create the order'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
+              <button type="button" class="btn btn-outline-primary" id="js-send-process-order-email-btn">
+                {{ 'Send prepared order to customer'|trans({}, 'Admin.Orderscustomers.Help') }}
+              </button>
+              <a id="js-process-order-link" href="#" target="_blank" class="btn btn-outline-primary">
+                {{ 'Finish the order in front-office'|trans({}, 'Admin.Orderscustomers.Help') }}
+              </a>
+            
               {{ form_row(summaryForm.cart_id, {'attr': {'class': 'js-place-order-cart-id'}}) }}
             </div>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -118,10 +118,10 @@
                 </button>
 
                 <div class="dropdown-menu" aria-labelledby="dropdown-menu-actions">
-                  <button class="dropdown-item" id="js-send-process-order-email-btn">
+                  <button type="button" class="dropdown-item" id="js-send-process-order-email-btn">
                     {{ 'Send pre-filled order to the customer by email'|trans({}, 'Admin.Orderscustomers.Feature') }}
                   </button>
-                  <a class="dropdown-item" id="js-process-order-link">
+                  <a class="dropdown-item" id="js-process-order-link" target="_blank">
                     {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Feature') }}
                   </a>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -124,6 +124,8 @@
                   <a class="dropdown-item" id="js-process-order-link">
                     {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Feature') }}
                   </a>
+
+                  {{ renderhook('displayAdminOrderCreateExtraButtons') }}
                 </div>
               </div>
             

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -104,12 +104,28 @@
               <button class="btn btn-primary" type="submit" id="create-order-button">
                 {{ 'Create the order'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
-              <button type="button" class="btn btn-outline-primary" id="js-send-process-order-email-btn">
-                {{ 'Send pre-filled order to the customer by email'|trans({}, 'Admin.Orderscustomers.Feature') }}
-              </button>
-              <a id="js-process-order-link" href="#" target="_blank" class="btn btn-outline-primary">
-                {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Help') }}
-              </a>
+
+              <div class="btn-group">
+                <button
+                  class="btn btn-outline-primary dropdown-toggle"
+                  type="button"
+                  id="dropdown-menu-actions"
+                  data-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  {{ 'More actions'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                </button>
+
+                <div class="dropdown-menu" aria-labelledby="dropdown-menu-actions">
+                  <button class="dropdown-item" id="js-send-process-order-email-btn">
+                    {{ 'Send pre-filled order to the customer by email'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                  </button>
+                  <a class="dropdown-item" id="js-process-order-link">
+                    {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                  </a>
+                </div>
+              </div>
             
               {{ form_row(summaryForm.cart_id, {'attr': {'class': 'js-place-order-cart-id'}}) }}
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -105,10 +105,10 @@
                 {{ 'Create the order'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
               <button type="button" class="btn btn-outline-primary" id="js-send-process-order-email-btn">
-                {{ 'Send prepared order to customer'|trans({}, 'Admin.Orderscustomers.Help') }}
+                {{ 'Send pre-filled order to the customer by email'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
               <a id="js-process-order-link" href="#" target="_blank" class="btn btn-outline-primary">
-                {{ 'Finish the order in front-office'|trans({}, 'Admin.Orderscustomers.Help') }}
+                {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Help') }}
               </a>
             
               {{ form_row(summaryForm.cart_id, {'attr': {'class': 'js-place-order-cart-id'}}) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Buttons were not clearly UX on create order page
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22644.
| How to test?      | Go on create order page, complete the order and see 3 buttons on the bottom (check issue)
| Possible impacts? | Creation of order in the BO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22888)
<!-- Reviewable:end -->
