### PR TITLE
Set different 404 strings for different behaviors on classic theme

### DIFF
--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -70,16 +70,13 @@
         <div id="js-product-list-top"></div>
 
         <div id="js-product-list">
-          {capture assign="errorTitle"}
-            {l s='No products available yet' d='Shop.Theme.Catalog'}
+          {capture assign="errorContent"}
+            <h4>{l s='No products available yet' d='Shop.Theme.Catalog'}</h4>
+            <p>{l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Catalog'}</p>
           {/capture}
 
-          {capture assign="errorSubtitle"}
-            {l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Catalog'}
-          {/capture}
-
-          {include file='errors/not-found.tpl' title=$errorTitle subtitle=$errorSubtitle}
-        </div>
+          {include file='errors/not-found.tpl' errorContent=$errorContent}
+        <rdiv>
 
         <div id="js-product-list-bottom"></div>
       {/if}

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -70,7 +70,15 @@
         <div id="js-product-list-top"></div>
 
         <div id="js-product-list">
-          {include file='errors/not-found.tpl'}
+          {capture assign="errorTitle"}
+            {l s='No products available yet' d='Shop.Theme.Catalog'}
+          {/capture}
+
+          {capture assign="errorSubtitle"}
+            {l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Catalog'}
+          {/capture}
+
+          {include file='errors/not-found.tpl' title=$errorTitle subtitle=$errorSubtitle}
         </div>
 
         <div id="js-product-list-bottom"></div>

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -5,4 +5,4 @@
 {extends file='catalog/listing/product-list.tpl'}
 
 {block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Global'}{/block}
-{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are searching for.' d='Shop.Theme.Global'}{/block}
+{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Global'}{/block}

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -4,7 +4,7 @@
  *}
 {extends file='catalog/listing/product-list.tpl'}
 
-{block name="errorContent"}
+{block name="error_content"}
   <h4>{l s='No matches were found for your search' d='Shop.Theme.Catalog'}</h4>
   <p>{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog'}</p>
 {/block}

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -5,4 +5,4 @@
 {extends file='catalog/listing/product-list.tpl'}
 
 {block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Catalog'}{/block}
-{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Global'}{/block}
+{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog}{/block}

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -4,5 +4,7 @@
  *}
 {extends file='catalog/listing/product-list.tpl'}
 
-{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Catalog'}{/block}
-{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog}{/block}
+{block name="errorContent"}
+  <h4>{l s='No matches were found for your search' d='Shop.Theme.Catalog'}</h4>
+  <p>{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog'}</p>
+{/block}

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -3,3 +3,6 @@
  * You can safely remove it if you want it to appear exactly like all other product listing pages
  *}
 {extends file='catalog/listing/product-list.tpl'}
+
+{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Global'}{/block}
+{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are searching for.' d='Shop.Theme.Global'}{/block}

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -4,5 +4,5 @@
  *}
 {extends file='catalog/listing/product-list.tpl'}
 
-{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Global'}{/block}
+{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Catalog'}{/block}
 {block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Global'}{/block}

--- a/themes/classic/templates/errors/404.tpl
+++ b/themes/classic/templates/errors/404.tpl
@@ -30,6 +30,14 @@
   {$page.title}
 {/block}
 
+{capture assign="errorTitle"}
+  {l s='This page could not be found' d='Shop.Theme.Global'}
+{/capture}
+
+{capture assign="errorSubtitle"}
+  {l s='Try to search our catalog, you may find what you are looking for!' d='Shop.Theme.Global'}
+{/capture}
+
 {block name='page_content_container'}
-  {include file='errors/not-found.tpl'}
+  {include file='errors/not-found.tpl' title=$errorTitle subtitle=$errorSubtitle}
 {/block}

--- a/themes/classic/templates/errors/404.tpl
+++ b/themes/classic/templates/errors/404.tpl
@@ -30,14 +30,11 @@
   {$page.title}
 {/block}
 
-{capture assign="errorTitle"}
-  {l s='This page could not be found' d='Shop.Theme.Global'}
-{/capture}
-
-{capture assign="errorSubtitle"}
-  {l s='Try to search our catalog, you may find what you are looking for!' d='Shop.Theme.Global'}
+{capture assign="errorContent"}
+  <h4>{l s='No products available yet' d='Shop.Theme.Catalog'}</h4>
+  <p>{l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Catalog'}</p>
 {/capture}
 
 {block name='page_content_container'}
-  {include file='errors/not-found.tpl' title=$errorTitle subtitle=$errorSubtitle}
+  {include file='errors/not-found.tpl' errorContent=$errorContent}
 {/block}

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -24,7 +24,7 @@
  *}
 <section id="content" class="page-content page-not-found">
   {block name='page_content'}
-    {block name="errorContent"}
+    {block name="error_content"}
       {if isset($errorContent)}
         {$errorContent nofilter}
       {else}

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -28,8 +28,8 @@
       {if isset($errorContent)}
         {$errorContent nofilter}
       {else}
-        <h4>{l s='This page could not be found' d='Shop.Theme.Catalog'}</h4>
-        <p>{l s='Try to search our catalog, you may find what you are looking for!' d='Shop.Theme.Catalog'}</p>
+        <h4>{l s='This page could not be found' d='Shop.Theme.Global'}</h4>
+        <p>{l s='Try to search our catalog, you may find what you are looking for!' d='Shop.Theme.Global'}</p>
       {/if}
     {/block}
 

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -33,7 +33,7 @@
     {if isset($subtitle)}
       <p>{block name="searchSubtitle"}{$subtitle}{/block}</p>
     {else}
-      <p>{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are searching for.' d='Shop.Theme.Global'}{/block}</p>
+      <p>{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog'}{/block}</p>
     {/if}
 
     {block name='search'}

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -24,9 +24,17 @@
  *}
 <section id="content" class="page-content page-not-found">
   {block name='page_content'}
+    {if isset($title)}
+      <h4>{block name="searchTitle"}{$title}{/block}</h4>
+    {else}
+      <h4>{block name="searchTitle"}{l s='Sorry for the inconvenience.' d='Shop.Theme.Global'}{/block}</h4>
+    {/if}
 
-    <h4>{l s='Sorry for the inconvenience.' d='Shop.Theme.Global'}</h4>
-    <p>{l s='Search again what you are looking for' d='Shop.Theme.Global'}</p>
+    {if isset($subtitle)}
+      <p>{block name="searchSubtitle"}{$subtitle}{/block}</p>
+    {else}
+      <p>{block name="searchSubtitle"}{l s='Search again what you are looking for.' d='Shop.Theme.Global'}{/block}</p>
+    {/if}
 
     {block name='search'}
       {hook h='displaySearch'}

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -24,17 +24,14 @@
  *}
 <section id="content" class="page-content page-not-found">
   {block name='page_content'}
-    {if isset($title)}
-      <h4>{block name="searchTitle"}{$title}{/block}</h4>
-    {else}
-      <h4>{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Catalog'}{/block}</h4>
-    {/if}
-
-    {if isset($subtitle)}
-      <p>{block name="searchSubtitle"}{$subtitle}{/block}</p>
-    {else}
-      <p>{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog'}{/block}</p>
-    {/if}
+    {block name="errorContent"}
+      {if isset($errorContent)}
+        {$errorContent nofilter}
+      {else}
+        <h4>{l s='This page could not be found' d='Shop.Theme.Catalog'}</h4>
+        <p>{l s='Try to search our catalog, you may find what you are looking for!' d='Shop.Theme.Catalog'}</p>
+      {/if}
+    {/block}
 
     {block name='search'}
       {hook h='displaySearch'}
@@ -43,6 +40,5 @@
     {block name='hook_not_found'}
       {hook h='displayNotFound'}
     {/block}
-
   {/block}
 </section>

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -27,7 +27,7 @@
     {if isset($title)}
       <h4>{block name="searchTitle"}{$title}{/block}</h4>
     {else}
-      <h4>{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Global'}{/block}</h4>
+      <h4>{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Catalog'}{/block}</h4>
     {/if}
 
     {if isset($subtitle)}

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -27,13 +27,13 @@
     {if isset($title)}
       <h4>{block name="searchTitle"}{$title}{/block}</h4>
     {else}
-      <h4>{block name="searchTitle"}{l s='Sorry for the inconvenience.' d='Shop.Theme.Global'}{/block}</h4>
+      <h4>{block name="searchTitle"}{l s='No matches were found for your search' d='Shop.Theme.Global'}{/block}</h4>
     {/if}
 
     {if isset($subtitle)}
       <p>{block name="searchSubtitle"}{$subtitle}{/block}</p>
     {else}
-      <p>{block name="searchSubtitle"}{l s='Search again what you are looking for.' d='Shop.Theme.Global'}{/block}</p>
+      <p>{block name="searchSubtitle"}{l s='Please try other keywords to describe what you are searching for.' d='Shop.Theme.Global'}{/block}</p>
     {/if}
 
     {block name='search'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | strings for 404 were the same everywhere and it wasn't optimized
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #15118.
| How to test?      | Try different searches on FO, or see issue :)
| Possible impacts? | Search strings, no product strings


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22908)
<!-- Reviewable:end -->
