### PR TITLE
Make separate error templates for empty product lists and search

### DIFF
--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -70,7 +70,9 @@
         <div id="js-product-list-top"></div>
 
         <div id="js-product-list">
-          {include file='errors/not-found.tpl'}
+          {block name='product_list_empty'}
+            {include file='errors/not-found.tpl'}
+          {/block}
         </div>
 
         <div id="js-product-list-bottom"></div>

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -71,7 +71,7 @@
 
         <div id="js-product-list">
           {block name='product_list_empty'}
-            {include file='errors/not-found.tpl'}
+            {include file='errors/no-products.tpl'}
           {/block}
         </div>
 

--- a/themes/classic/templates/catalog/listing/search.tpl
+++ b/themes/classic/templates/catalog/listing/search.tpl
@@ -3,3 +3,7 @@
  * You can safely remove it if you want it to appear exactly like all other product listing pages
  *}
 {extends file='catalog/listing/product-list.tpl'}
+
+{block name='product_list_empty'}
+	{include file='errors/no-products-search.tpl'}
+{/block}

--- a/themes/classic/templates/errors/no-products-search.tpl
+++ b/themes/classic/templates/errors/no-products-search.tpl
@@ -1,0 +1,40 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+<section id="content" class="page-content page-not-found">
+  {block name='page_content'}
+
+    <h4>{l s='No matches were found for your search' d='Shop.Theme.Global'}</h4>
+    <p>{l s='Please try other keywords to describe what you are searching for.' d='Shop.Theme.Global'}</p>
+
+    {block name='search'}
+      {hook h='displaySearch'}
+    {/block}
+
+    {block name='hook_not_found'}
+      {hook h='displayNotFound'}
+    {/block}
+
+  {/block}
+</section>

--- a/themes/classic/templates/errors/no-products.tpl
+++ b/themes/classic/templates/errors/no-products.tpl
@@ -26,7 +26,7 @@
   {block name='page_content'}
 
     <h4>{l s='No products available yet' d='Shop.Theme.Global'}</h4>
-    <p>{l s='Stay tuned! More products will be shown here as they are added. Try to search our catalog.' d='Shop.Theme.Global'}</p>
+    <p>{l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Global'}</p>
 
     {block name='search'}
       {hook h='displaySearch'}

--- a/themes/classic/templates/errors/no-products.tpl
+++ b/themes/classic/templates/errors/no-products.tpl
@@ -1,0 +1,40 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+<section id="content" class="page-content page-not-found">
+  {block name='page_content'}
+
+    <h4>{l s='No products available yet' d='Shop.Theme.Global'}</h4>
+    <p>{l s='Stay tuned! More products will be shown here as they are added. Try to search our catalog.' d='Shop.Theme.Global'}</p>
+
+    {block name='search'}
+      {hook h='displaySearch'}
+    {/block}
+
+    {block name='hook_not_found'}
+      {hook h='displayNotFound'}
+    {/block}
+
+  {/block}
+</section>

--- a/themes/classic/templates/errors/not-found.tpl
+++ b/themes/classic/templates/errors/not-found.tpl
@@ -25,8 +25,8 @@
 <section id="content" class="page-content page-not-found">
   {block name='page_content'}
 
-    <h4>{l s='Sorry for the inconvenience.' d='Shop.Theme.Global'}</h4>
-    <p>{l s='Search again what you are looking for' d='Shop.Theme.Global'}</p>
+    <h4>{l s='This page could not be found' d='Shop.Theme.Global'}</h4>
+    <p>{l s='Try to search our catalog, you may find what you are looking for!' d='Shop.Theme.Global'}</p>
 
     {block name='search'}
       {hook h='displaySearch'}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR improves error messages for empty products lists and search page.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #15118
| How to test?      | Go to empty category and see new errors. Go to prices-drop page and see new error. Go to search page and see different error. 
| Possible impacts? | Theme developers need to adopt if they want to use a new feature.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22913)
<!-- Reviewable:end -->
