### PR TITLE
Prevent adding out of stock products in Create order page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.js
@@ -165,6 +165,7 @@ export default {
   listedProductReferenceField: '.js-product-ref',
   listedProductUnitPriceInput: '.js-product-unit-input',
   listedProductQtyInput: '.js-product-qty-input',
+  listedProductQtyStock: '.js-product-qty-stock',
   listedProductGiftQty: '.js-product-gift-qty',
   productTotalPriceField: '.js-product-total-price',
   listedProductCustomizedTextTemplate: '#js-table-product-customized-text-template',
@@ -179,4 +180,5 @@ export default {
   productAddForm: '#js-add-product-form',
   cartErrorAlertBlock: '#js-cart-error-block',
   cartErrorAlertText: '#js-cart-error-block .alert-text',
+  createOrderButton: '#create-order-button',
 };

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
@@ -287,6 +287,8 @@ export default class ProductManager {
 
     this.selectedCombinationId = combinationId;
     this.productRenderer.renderStock(
+      $(createOrderMap.inStockCounter),
+      $(createOrderMap.quantityInput),
       combination.stock,
       this.selectedProduct.availableOutOfStock || combination.stock <= 0
     );

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
@@ -149,6 +149,7 @@ export default class ProductManager {
     // on success
     EventEmitter.on(eventMap.productQtyChanged, cartInfo => {
       this.productRenderer.cleanCartBlockAlerts();
+      $(createOrderMap.createOrderButton).prop('disabled', false);
       EventEmitter.emit(eventMap.cartLoaded, cartInfo);
 
       enableQtyInputs();
@@ -157,6 +158,7 @@ export default class ProductManager {
     // on failure
     EventEmitter.on(eventMap.productQtyChangeFailed, e => {
       this.productRenderer.renderCartBlockErrorAlert(e.responseJSON.message);
+      $(createOrderMap.createOrderButton).prop('disabled', true);
       enableQtyInputs();
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
@@ -76,8 +76,8 @@ export default class ProductRenderer {
         this.renderStock(
           $template.find(createOrderMap.listedProductQtyStock),
           $template.find(createOrderMap.listedProductQtyInput),
-          product.stock,
-          product.availableOutOfStock || (product.stock <= 0)
+          product.availableStock,
+          product.availableOutOfStock || (product.availableStock <= 0)
         );
         $template.find(createOrderMap.productTotalPriceField).text(product.price);
         $template.find(createOrderMap.productRemoveBtn).data('product-id', product.productId);

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
@@ -179,15 +179,15 @@ export default class ProductRenderer {
   /**
    * Updates stock text helper value
    *
-   * @param {object} inputStockCounter
-   * @param {object} inputQuantity
-   * @param {number} stock
-   * @param {boolean} infinitMax
+   * @param {object} inputStockCounter Text Help with the stock counter
+   * @param {object} inputQuantity Input for the stock
+   * @param {number} stock Available stock for the product
+   * @param {boolean} infiniteMax If the product order has no limits
    */
-  renderStock(inputStockCounter, inputQuantity, stock, infinitMax) {
+  renderStock(inputStockCounter, inputQuantity, stock, infiniteMax) {
     inputStockCounter.text(stock);
 
-    if (!infinitMax) {
+    if (!infiniteMax) {
       inputQuantity.attr('max', stock);
     } else {
       inputQuantity.removeAttr('max');

--- a/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-renderer.js
@@ -73,6 +73,12 @@ export default class ProductRenderer {
         $template.find(createOrderMap.listedProductQtyInput).data('attribute-id', product.attributeId);
         $template.find(createOrderMap.listedProductQtyInput).data('customization-id', customizationId);
         $template.find(createOrderMap.listedProductQtyInput).data('prev-qty', product.quantity);
+        this.renderStock(
+          $template.find(createOrderMap.listedProductQtyStock),
+          $template.find(createOrderMap.listedProductQtyInput),
+          product.stock,
+          product.availableOutOfStock || (product.stock <= 0)
+        );
         $template.find(createOrderMap.productTotalPriceField).text(product.price);
         $template.find(createOrderMap.productRemoveBtn).data('product-id', product.productId);
         $template.find(createOrderMap.productRemoveBtn).data('attribute-id', product.attributeId);
@@ -160,7 +166,12 @@ export default class ProductRenderer {
    * @param {object} product
    */
   renderProductMetadata(product) {
-    this.renderStock(product.stock, product.availableOutOfStock || (product.stock <= 0));
+    this.renderStock(
+      $(createOrderMap.inStockCounter),
+      $(createOrderMap.quantityInput),
+      product.stock,
+      product.availableOutOfStock || (product.stock <= 0)
+    );
     this._renderCombinations(product.combinations);
     this._renderCustomizations(product.customizationFields);
   }
@@ -168,16 +179,18 @@ export default class ProductRenderer {
   /**
    * Updates stock text helper value
    *
+   * @param {object} inputStockCounter
+   * @param {object} inputQuantity
    * @param {number} stock
    * @param {boolean} infinitMax
    */
-  renderStock(stock, infinitMax) {
-    $(createOrderMap.inStockCounter).text(stock);
+  renderStock(inputStockCounter, inputQuantity, stock, infinitMax) {
+    inputStockCounter.text(stock);
 
     if (!infinitMax) {
-      $(createOrderMap.quantityInput).attr('max', stock);
+      inputQuantity.attr('max', stock);
     } else {
-      $(createOrderMap.quantityInput).removeAttr('max');
+      inputQuantity.removeAttr('max');
     }
   }
 

--- a/admin-dev/themes/new-theme/scss/pages/_orders_create.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_orders_create.scss
@@ -8,4 +8,9 @@
       overflow: hidden;
     }
   }
+  #products-table {
+    .js-product-qty-input {
+      margin-top: 22px;
+    }
+  }
 }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3784,10 +3784,10 @@ class ProductCore extends ObjectModel
      * Get available product quantities (this method already have decreased products in cart).
      *
      * @param int $idProduct Product id
-     * @param int $idProductAttribute Product attribute id (optional)
+     * @param int|null $idProductAttribute Product attribute id (optional)
      * @param bool|null $cacheIsPack
      * @param Cart|null $cart
-     * @param int $idCustomization Product customization id (optional)
+     * @param int|null $idCustomization Product customization id (optional)
      *
      * @return int Available quantities
      */

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3887,6 +3887,11 @@ class ProductCore extends ObjectModel
         return false;
     }
 
+    /**
+     * @param int $out_of_stock
+     *
+     * @return bool|int Returns false is Stock Management is disabled, or the (int) configuration if it's enabled
+     */
     public static function isAvailableWhenOutOfStock($out_of_stock)
     {
         /** @TODO 1.5.0 Update of STOCK_MANAGEMENT & ORDER_OUT_OF_STOCK */

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -553,7 +553,10 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             \Tools::ps_round($product['total'], $currency->precision),
             $this->contextLink->getImageLink($product['link_rewrite'], $product['id_image'], 'small_default'),
             $this->getProductCustomizedData($cart, $product),
-            Product::getQuantity((int) $product['id_product']),
+            Product::getQuantity(
+                (int) $product['id_product'],
+                isset($product['id_product_attribute']) ? (int) $product['id_product_attribute'] : null
+            ),
             Product::isAvailableWhenOutOfStock((int) $product['out_of_stock']) !== 0,
             !empty($product['is_gift'])
         );

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -553,6 +553,8 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             \Tools::ps_round($product['total'], $currency->precision),
             $this->contextLink->getImageLink($product['link_rewrite'], $product['id_image'], 'small_default'),
             $this->getProductCustomizedData($cart, $product),
+            Product::getQuantity((int) $product['id_product']),
+            (bool) Product::isAvailableWhenOutOfStock($product['out_of_stock']),
             !empty($product['is_gift'])
         );
     }

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -554,7 +554,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             $this->contextLink->getImageLink($product['link_rewrite'], $product['id_image'], 'small_default'),
             $this->getProductCustomizedData($cart, $product),
             Product::getQuantity((int) $product['id_product']),
-            (bool) Product::isAvailableWhenOutOfStock($product['out_of_stock']),
+            Product::isAvailableWhenOutOfStock((int) $product['out_of_stock']) !== 0,
             !empty($product['is_gift'])
         );
     }

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php
@@ -81,6 +81,16 @@ class CartProduct
     private $customization;
 
     /**
+     * @var int
+     */
+    private $stock;
+
+    /**
+     * @var bool
+     */
+    private $availableOutOfStock;
+
+    /**
      * @var bool
      */
     private $isGift;
@@ -98,6 +108,8 @@ class CartProduct
      * @param string $price
      * @param string $imageLink
      * @param Customization|null $customization
+     * @param int $stock
+     * @param bool $availableOutOfStock
      * @param bool $isGift
      */
     public function __construct(
@@ -111,6 +123,8 @@ class CartProduct
         string $price,
         string $imageLink,
         ?Customization $customization,
+        int $stock,
+        bool $availableOutOfStock,
         bool $isGift = false
     ) {
         $this->productId = $productId;
@@ -123,6 +137,8 @@ class CartProduct
         $this->price = $price;
         $this->imageLink = $imageLink;
         $this->customization = $customization;
+        $this->stock = $stock;
+        $this->availableOutOfStock = $availableOutOfStock;
         $this->isGift = $isGift;
     }
 
@@ -204,6 +220,22 @@ class CartProduct
     public function getCustomization(): ?Customization
     {
         return $this->customization;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStock(): int
+    {
+        return $this->stock;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAvailableOutOfStock(): bool
+    {
+        return $this->availableOutOfStock;
     }
 
     /**

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php
@@ -70,6 +70,7 @@ class CartProduct
      * @var string
      */
     private $price;
+
     /**
      * @var string
      */

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php
@@ -83,7 +83,7 @@ class CartProduct
     /**
      * @var int
      */
-    private $stock;
+    private $availableStock;
 
     /**
      * @var bool
@@ -108,7 +108,7 @@ class CartProduct
      * @param string $price
      * @param string $imageLink
      * @param Customization|null $customization
-     * @param int $stock
+     * @param int $availableStock
      * @param bool $availableOutOfStock
      * @param bool $isGift
      */
@@ -123,7 +123,7 @@ class CartProduct
         string $price,
         string $imageLink,
         ?Customization $customization,
-        int $stock,
+        int $availableStock,
         bool $availableOutOfStock,
         bool $isGift = false
     ) {
@@ -137,7 +137,7 @@ class CartProduct
         $this->price = $price;
         $this->imageLink = $imageLink;
         $this->customization = $customization;
-        $this->stock = $stock;
+        $this->availableStock = $availableStock;
         $this->availableOutOfStock = $availableOutOfStock;
         $this->isGift = $isGift;
     }
@@ -225,9 +225,9 @@ class CartProduct
     /**
      * @return int
      */
-    public function getStock(): int
+    public function getAvailableStock(): int
     {
-        return $this->stock;
+        return $this->availableStock;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -99,7 +99,7 @@
                 <input name="product_quantity" id="quantity-input" type="number" min="1" value="1" class="form-control">
                 <small class="form-text">
                   {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
-                  <span  class="js-in-stock-counter"></span>
+                  <span class="js-in-stock-counter"></span>
                 </small>
               </div>
             </div>
@@ -217,7 +217,13 @@
     </td>
     <td class="js-product-ref"></td>
     <td><input class="form-control js-product-unit-input" type="text"></td>
-    <td><input type="number" min="1" class="form-control js-product-qty-input" style="max-width: 100px;"></td>
+    <td>
+      <input type="number" min="1" class="form-control js-product-qty-input" style="max-width: 100px;">
+      <small class="form-text">
+        {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        <span class="js-product-qty-stock"></span>
+      </small>
+    </td>
     <td class="js-product-total-price"></td>
     <td class="text-right">
       <button class="btn btn-outline-danger js-product-remove-btn">{{ 'Remove'|trans({}, 'Admin.Actions') }}</button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Prevent adding out of stock products in Create order page
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #22109
| How to test?      | Cf #22109

**:notebook: BC Breaks :**
* In `src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartProduct.php`, the constructor has two new parameters in 11th `int $stock` and 12th `bool $availableOutOfStock`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22920)
<!-- Reviewable:end -->
