### PR TITLE
Product page SEO tab

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -33,6 +33,7 @@ import MultipleChoiceTable from '@js/components/multiple-choice-table.js';
 import GeneratableInput from '@js/components/generatable-input.js';
 import CountryStateSelectionToggler from '@components/country-state-selection-toggler';
 import CountryDniRequiredToggler from '@components/country-dni-required-toggler';
+import TextWithLengthCounter from '@components/form/text-with-length-counter';
 import {EventEmitter} from '@components/event-emitter';
 
 const initPrestashopComponents = () => {
@@ -87,6 +88,7 @@ const initPrestashopComponents = () => {
     GeneratableInput,
     CountryStateSelectionToggler,
     CountryDniRequiredToggler,
+    TextWithLengthCounter,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/app/utils/serp/index.js
+++ b/admin-dev/themes/new-theme/js/app/utils/serp/index.js
@@ -107,8 +107,13 @@ class SerpApp {
   }
 
   setUrl(rewrite) {
+    // We replace two placeholders because there was a typo in the initial one
     this.data.url = this.originalUrl.replace(
       '{friendy-url}',
+      rewrite,
+    );
+    this.data.url = this.data.url.replace(
+      '{friendly-url}',
       rewrite,
     );
   }

--- a/admin-dev/themes/new-theme/js/app/utils/serp/index.js
+++ b/admin-dev/themes/new-theme/js/app/utils/serp/index.js
@@ -107,7 +107,7 @@ class SerpApp {
   }
 
   setUrl(rewrite) {
-    // We replace two placeholders because there was a typo in the initial one
+    // We replace two placeholders because there was a typo in the initial one ('friendy' instead of 'friendly')
     this.data.url = this.originalUrl.replace(
       '{friendy-url}',
       rewrite,

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.js
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+import Serp from '@app/utils/serp';
 import ProductMap from '../product-map';
 import ProductPartialUpdater from './product-partial-updater';
 
@@ -35,14 +36,34 @@ $(() => {
       'TinyMCEEditor',
       'TranslatableInput',
       'EventEmitter',
+      'TextWithLengthCounter',
     ],
   );
 
   const $productForm = $(ProductMap.productForm);
 
-  // Form has productId data means that we are in edit mode
-  if ($productForm.data('productId')) {
-    const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);
-    new ProductPartialUpdater(window.prestashop.instance.eventEmitter, $productForm, $productFormSubmitButton).watch();
+  // Init Serp component to preview Search engine display
+  const translatorInput = window.prestashop.instance.translatableInput;
+  new Serp(
+    {
+      container: '#serp-app',
+      defaultTitle: '.serp-default-title:input',
+      watchedTitle: '.serp-watched-title:input',
+      defaultDescription: '.serp-default-description',
+      watchedDescription: '.serp-watched-description',
+      watchedMetaUrl: '.serp-watched-url:input',
+      multiLanguageInput: `${translatorInput.localeInputSelector}:not(.d-none)`,
+      multiLanguageItem: translatorInput.localeItemSelector,
+    },
+    $('#product_preview').data('seo-url'),
+  );
+
+  // Form has no productId data means that we are in creation mode
+  if (!$productForm.data('productId')) {
+    return;
   }
+
+  // From here we init component specific to edition
+  const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);
+  new ProductPartialUpdater(window.prestashop.instance.eventEmitter, $productForm, $productFormSubmitButton).watch();
 });

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.js
@@ -58,7 +58,7 @@ export default class ProductPartialUpdater {
     this.initialData = this.getFormDataAsObject();
     this.$productForm.submit(() => this.updatePartialForm());
     // 'dp.change' event allows tracking datepicker input changes
-    this.$productForm.on('change dp.change', ':input', () => this.updateSubmitButtonState());
+    this.$productForm.on('keyup change dp.change', ':input', () => this.updateSubmitButtonState());
     this.initFormattedTextarea();
   }
 

--- a/src/Adapter/Shop/Url/ProductProvider.php
+++ b/src/Adapter/Shop/Url/ProductProvider.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shop\Url;
+
+use Link;
+use PrestaShop\PrestaShop\Core\Shop\Url\UrlProviderInterface;
+
+/**
+ * Class ProductProvider provides base Front Office URL for context shop.
+ */
+class ProductProvider implements UrlProviderInterface
+{
+    /**
+     * @var Link
+     */
+    private $link;
+
+    /**
+     * @param Link $link
+     */
+    public function __construct(Link $link)
+    {
+        $this->link = $link;
+    }
+
+    /**
+     * Create a link to a product.
+     *
+     * @param int $productId
+     * @param string $rewrite
+     *
+     * @return string
+     */
+    public function getUrl($productId = null, $rewrite = null)
+    {
+        return $this->link->getProductLink((int) $productId, $rewrite);
+    }
+}

--- a/src/Adapter/Shop/Url/ProductProvider.php
+++ b/src/Adapter/Shop/Url/ProductProvider.php
@@ -52,12 +52,12 @@ class ProductProvider implements UrlProviderInterface
     /**
      * Create a link to a product.
      *
-     * @param int $productId
-     * @param string $rewrite
+     * @param int|null $productId
+     * @param string|null $rewrite
      *
      * @return string
      */
-    public function getUrl($productId = null, $rewrite = null)
+    public function getUrl(?int $productId = null, ?string $rewrite = null): string
     {
         return $this->link->getProductLink((int) $productId, $rewrite);
     }

--- a/src/Core/Domain/Product/ProductSettings.php
+++ b/src/Core/Domain/Product/ProductSettings.php
@@ -44,8 +44,8 @@ class ProductSettings
     /**
      * Bellow constants define maximum allowed length of product properties
      */
-    const MAX_NAME_LENGTH = 128;
-    const MAX_MPN_LENGTH = 40;
-    const MAX_META_TITLE_LENGTH = 70;
-    const MAX_META_DESCRIPTION_LENGTH = 160;
+    public const MAX_NAME_LENGTH = 128;
+    public const MAX_MPN_LENGTH = 40;
+    public const MAX_META_TITLE_LENGTH = 70;
+    public const MAX_META_DESCRIPTION_LENGTH = 160;
 }

--- a/src/Core/Domain/Product/ProductSettings.php
+++ b/src/Core/Domain/Product/ProductSettings.php
@@ -46,5 +46,6 @@ class ProductSettings
      */
     const MAX_NAME_LENGTH = 128;
     const MAX_MPN_LENGTH = 40;
-    //@todo: finish up with properties that doesn't have related ValueObjects like description, meta_description etc. (see Product.php)
+    const MAX_META_TITLE_LENGTH = 70;
+    const MAX_META_DESCRIPTION_LENGTH = 160;
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandBuilder.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+/**
+ * Builder used to build UpdateSEO
+ */
+class SEOCommandBuilder implements ProductCommandBuilderInterface
+{
+    public function buildCommand(ProductId $productId, array $formData): array
+    {
+        if (!isset($formData['seo'])) {
+            return [];
+        }
+
+        $seoData = $formData['seo'];
+        $command = new UpdateProductSeoCommand($productId->getValue());
+
+        if (isset($seoData['meta_title'])) {
+            $command->setLocalizedMetaTitles($seoData['meta_title']);
+        }
+        if (isset($seoData['meta_description'])) {
+            $command->setLocalizedMetaDescriptions($seoData['meta_description']);
+        }
+        if (isset($seoData['link_rewrite'])) {
+            $command->setLocalizedLinkRewrites($seoData['link_rewrite']);
+        }
+
+        return [$command];
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -66,6 +66,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
             'basic' => $this->extractBasicData($productForEditing),
             'stock' => $this->extractStockData($productForEditing),
             'price' => $this->extractPriceData($productForEditing),
+            'seo' => $this->extractSEOData($productForEditing),
             'shipping' => $this->extractShippingData($productForEditing),
             'options' => $this->extractOptionsData($productForEditing),
         ];
@@ -151,6 +152,26 @@ final class ProductFormDataProvider implements FormDataProviderInterface
             'wholesale_price' => (float) (string) $productForEditing->getPricesInformation()->getWholesalePrice(),
             'unit_price' => (float) (string) $productForEditing->getPricesInformation()->getUnitPrice(),
             'unity' => $productForEditing->getPricesInformation()->getUnity(),
+        ];
+    }
+
+    /**
+     * @param ProductForEditing $productForEditing
+     *
+     * @return array
+     */
+    private function extractSEOData(ProductForEditing $productForEditing): array
+    {
+        $seoOptions = $productForEditing->getProductSeoOptions();
+
+        return [
+            'meta_title' => $seoOptions->getLocalizedMetaTitles(),
+            'meta_description' => $seoOptions->getLocalizedMetaDescriptions(),
+            'link_rewrite' => $seoOptions->getLocalizedLinkRewrites(),
+            'redirect' => [
+                'type' => $seoOptions->getRedirectType(),
+                'target' => $seoOptions->getRedirectTargetId(),
+            ],
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -193,7 +193,7 @@ class CmsPageController extends FrameworkBundleAdminController
             $formData['page_category_id'] = $categoryParentId;
         }
         $form = $formBuilder->getForm($formData, [
-            'cms_preview_url' => $this->get('prestashop.adapter.shop.url.cms_provider')->getUrl(0, '{friendy-url}'),
+            'cms_preview_url' => $this->get('prestashop.adapter.shop.url.cms_provider')->getUrl(0, '{friendly-url}'),
         ]);
         $form->handleRequest($request);
 
@@ -260,7 +260,7 @@ class CmsPageController extends FrameworkBundleAdminController
                     'cmsPageId' => $cmsPageId,
                 ]),
                 'cms_preview_url' => $this->get('prestashop.adapter.shop.url.cms_provider')
-                    ->getUrl($cmsPageId, '{friendy-url}'),
+                    ->getUrl($cmsPageId, '{friendly-url}'),
             ]);
             $form->handleRequest($request);
         } catch (Exception $e) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -188,7 +188,7 @@ class CategoryController extends FrameworkBundleAdminController
                 'categoryForm' => $categoryForm->createView(),
                 'defaultGroups' => $defaultGroups,
                 'categoryUrl' => $this->get('prestashop.adapter.shop.url.category_provider')
-                    ->getUrl(0, '{friendy-url}'),
+                    ->getUrl(0, '{friendly-url}'),
             ]
         );
     }
@@ -237,7 +237,7 @@ class CategoryController extends FrameworkBundleAdminController
                 'rootCategoryForm' => $rootCategoryForm->createView(),
                 'defaultGroups' => $defaultGroups,
                 'categoryUrl' => $this->get('prestashop.adapter.shop.url.category_provider')
-                    ->getUrl(0, '{friendy-url}'),
+                    ->getUrl(0, '{friendly-url}'),
             ]
         );
     }
@@ -314,7 +314,7 @@ class CategoryController extends FrameworkBundleAdminController
                 'editableCategory' => $editableCategory,
                 'defaultGroups' => $defaultGroups,
                 'categoryUrl' => $this->get('prestashop.adapter.shop.url.category_provider')
-                    ->getUrl($categoryId, '{friendy-url}'),
+                    ->getUrl($categoryId, '{friendly-url}'),
             ]
         );
     }
@@ -386,7 +386,7 @@ class CategoryController extends FrameworkBundleAdminController
                 'editableCategory' => $editableCategory,
                 'defaultGroups' => $defaultGroups,
                 'categoryUrl' => $this->get('prestashop.adapter.shop.url.category_provider')
-                    ->getUrl($categoryId, '{friendy-url}'),
+                    ->getUrl($categoryId, '{friendly-url}'),
             ]
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicInformationType.php
@@ -69,10 +69,20 @@ class BasicInformationType extends TranslatorAwareType
                 'constraints' => [
                     new DefaultLanguage(),
                 ],
+                'options' => [
+                    'attr' => [
+                        'class' => 'serp-default-title',
+                    ],
+                ],
             ])
             ->add('description_short', TranslatableType::class, [
                 'label' => $this->trans('Summary', 'Admin.Global'),
                 'type' => FormattedTextareaType::class,
+                'options' => [
+                    'attr' => [
+                        'class' => 'serp-default-description',
+                    ],
+                ],
             ])
             ->add('description', TranslatableType::class, [
                 'label' => $this->trans('Description', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
+use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -35,12 +36,32 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * This is the parent product form type
  */
 class ProductType extends TranslatorAwareType
 {
+    /**
+     * @var ProductProvider
+     */
+    private $productUrlProvider;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param ProductProvider $productUrlProvider
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        ProductProvider $productUrlProvider
+    ) {
+        parent::__construct($translator, $locales);
+        $this->productUrlProvider = $productUrlProvider;
+    }
+
     /**
      * @param FormBuilderInterface $builder
      * @param array $options
@@ -71,7 +92,7 @@ class ProductType extends TranslatorAwareType
                     'label' => $this->trans('Preview', 'Admin.Actions'),
                     'attr' => [
                         'class' => 'btn-secondary',
-                        'data-seo-url' => 'http://www.google.fr',
+                        'data-seo-url' => $this->productUrlProvider->getUrl((int) $options['product_id'], '{friendly-url}'),
                     ],
                 ])
             ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -68,7 +68,7 @@ class ProductType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $editing = !empty($options['product_id']);
+        $formIsUsedToEditAProduct = !empty($options['product_id']);
         $builder
             ->add('basic', BasicInformationType::class)
             ->add('stock', StockType::class)
@@ -79,14 +79,14 @@ class ProductType extends TranslatorAwareType
             ->add('save', SubmitType::class, [
                 'label' => $this->trans('Save', 'Admin.Actions'),
                 'attr' => [
-                    'disabled' => $editing,
+                    'disabled' => $formIsUsedToEditAProduct,
                     'data-toggle' => 'pstooltip',
                     'title' => $this->trans('Save the product and stay on the current page: ALT+SHIFT+S', 'Admin.Catalog.Help'),
                 ],
             ])
         ;
 
-        if ($editing) {
+        if ($formIsUsedToEditAProduct) {
             $builder
                 ->add('preview', ButtonType::class, [
                     'label' => $this->trans('Preview', 'Admin.Actions'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -53,6 +54,7 @@ class ProductType extends TranslatorAwareType
             ->add('price', PriceType::class)
             ->add('shipping', ShippingType::class)
             ->add('options', OptionsType::class)
+            ->add('seo', SEOType::class)
             ->add('save', SubmitType::class, [
                 'label' => $this->trans('Save', 'Admin.Actions'),
                 'attr' => [
@@ -62,6 +64,18 @@ class ProductType extends TranslatorAwareType
                 ],
             ])
         ;
+
+        if ($editing) {
+            $builder
+                ->add('preview', ButtonType::class, [
+                    'label' => $this->trans('Preview', 'Admin.Actions'),
+                    'attr' => [
+                        'class' => 'btn-secondary',
+                        'data-seo-url' => 'http://www.google.fr',
+                    ],
+                ])
+            ;
+        }
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEOType.php
@@ -45,7 +45,7 @@ class SEOType extends TranslatorAwareType
     {
         $builder
             ->add('meta_title', TranslatableType::class, [
-                'label' => $this->trans('Meta title', 'Admin.Global'),
+                'label' => $this->trans('Meta title', 'Admin.Catalog.Feature'),
                 'required' => false,
                 'type' => TextWithLengthCounterType::class,
                 'help' => $this->trans(
@@ -63,7 +63,7 @@ class SEOType extends TranslatorAwareType
                         new Length([
                             'max' => ProductSettings::MAX_META_TITLE_LENGTH,
                             'maxMessage' => $this->trans(
-                                'This field cannot be longer than %limit% characters',
+                                'This field cannot be longer than %limit% characters.',
                                 'Admin.Notifications.Error',
                                 ['%limit%' => ProductSettings::MAX_META_TITLE_LENGTH]
                             ),
@@ -72,11 +72,11 @@ class SEOType extends TranslatorAwareType
                 ],
             ])
             ->add('meta_description', TranslatableType::class, [
-                'label' => $this->trans('Meta description', 'Admin.Global'),
+                'label' => $this->trans('Meta description', 'Admin.Catalog.Feature'),
                 'required' => false,
                 'type' => TextWithLengthCounterType::class,
                 'help' => $this->trans(
-                    'This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)',
+                    'This description will appear in search engines. It should be a single sentence, shorter than 160 characters (including spaces).',
                     'Admin.Catalog.Help'
                 ),
                 'options' => [
@@ -90,7 +90,7 @@ class SEOType extends TranslatorAwareType
                         new Length([
                             'max' => ProductSettings::MAX_META_DESCRIPTION_LENGTH,
                             'maxMessage' => $this->trans(
-                                'This field cannot be longer than %limit% characters',
+                                'This field cannot be longer than %limit% characters.',
                                 'Admin.Notifications.Error',
                                 ['%limit%' => ProductSettings::MAX_META_DESCRIPTION_LENGTH]
                             ),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEOType.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
+use PrestaShopBundle\Form\Admin\Type\TextWithLengthCounterType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+
+class SEOType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('meta_title', TranslatableType::class, [
+                'label' => $this->trans('Meta title', 'Admin.Global'),
+                'required' => false,
+                'type' => TextWithLengthCounterType::class,
+                'help' => $this->trans(
+                    'Public title for the product\'s page, and for search engines. Leave blank to use the product name. The number of remaining characters is displayed to the left of the field.',
+                    'Admin.Catalog.Help'
+                ),
+                'options' => [
+                    'input' => 'text',
+                    'input_attr' => [
+                        'class' => 'serp-watched-title',
+                    ],
+                    'max_length' => ProductSettings::MAX_META_TITLE_LENGTH,
+                    'position' => 'after',
+                    'constraints' => [
+                        new Length([
+                            'max' => ProductSettings::MAX_META_TITLE_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => ProductSettings::MAX_META_TITLE_LENGTH]
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('meta_description', TranslatableType::class, [
+                'label' => $this->trans('Meta description', 'Admin.Global'),
+                'required' => false,
+                'type' => TextWithLengthCounterType::class,
+                'help' => $this->trans(
+                    'This description will appear in search engines. You need a single sentence, shorter than 160 characters (including spaces)',
+                    'Admin.Catalog.Help'
+                ),
+                'options' => [
+                    'input' => 'textarea',
+                    'input_attr' => [
+                        'class' => 'serp-watched-description',
+                    ],
+                    'max_length' => ProductSettings::MAX_META_DESCRIPTION_LENGTH,
+                    'position' => 'after',
+                    'constraints' => [
+                        new Length([
+                            'max' => ProductSettings::MAX_META_DESCRIPTION_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => ProductSettings::MAX_META_DESCRIPTION_LENGTH]
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('link_rewrite', TranslatableType::class, [
+                'label' => $this->trans('Friendly URL', 'Admin.Catalog.Feature'),
+                'required' => false,
+                'type' => TextType::class,
+                'help' => $this->trans(
+                    'This is the human-readable URL, as generated from the product\'s name. You can change it if you want.',
+                    'Admin.Catalog.Help'
+                ),
+                'options' => [
+                    'attr' => [
+                        'class' => 'serp-watched-url',
+                    ],
+                ],
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextWithLengthCounterType.php
@@ -44,6 +44,7 @@ class TextWithLengthCounterType extends AbstractType
         $view->vars['max_length'] = $options['max_length'];
         $view->vars['position'] = $options['position'];
         $view->vars['input'] = $options['input'];
+        $view->vars['input_attr'] = $options['input_attr'];
     }
 
     /**
@@ -58,11 +59,14 @@ class TextWithLengthCounterType extends AbstractType
             ->setDefaults([
                 'position' => 'before',
                 'input' => 'text',
+                'input_attr' => [],
                 'compound' => false,
             ])
             ->setAllowedTypes('max_length', 'int')
+            ->setAllowedTypes('input_attr', ['array'])
             ->setAllowedValues('position', ['before', 'after'])
-            ->setAllowedValues('input', ['text', 'textarea']);
+            ->setAllowedValues('input', ['text', 'textarea'])
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
@@ -26,6 +26,11 @@ services:
     arguments:
       - "@=service('prestashop.adapter.legacy.context').getContext().link"
 
+  prestashop.adapter.shop.url.product_provider:
+      class: 'PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider'
+      arguments:
+          - "@=service('prestashop.adapter.legacy.context').getContext().link"
+
   prestashop.adapter.shop.query_handler.get_logos_paths_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Shop\QueryHandler\GetLogosPathsHandler'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1264,6 +1264,13 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.sell.product.seo_type:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\SEOType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.sell.product.options_type:
         class: 'PrestaShopBundle\Form\Admin\Sell\Product\OptionsType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1232,6 +1232,8 @@ services:
         class: 'PrestaShopBundle\Form\Admin\Sell\Product\ProductType'
         parent: 'form.type.translatable.aware'
         public: true
+        arguments:
+            - '@prestashop.adapter.shop.url.product_provider'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -8,6 +8,7 @@ services:
             -
                 - '@prestashop.core.form.command_builder.product.basic_information'
                 - '@prestashop.core.form.command_builder.product.prices'
+                - '@prestashop.core.form.command_builder.product.seo'
                 - '@prestashop.core.form.command_builder.product.shipping'
                 - '@prestashop.core.form.command_builder.product.options_command_builder'
                 - '@prestashop.core.form.command_builder.product.stock_command_builder'
@@ -17,6 +18,9 @@ services:
 
     prestashop.core.form.command_builder.product.prices:
         class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PricesCommandBuilder
+
+    prestashop.core.form.command_builder.product.seo:
+        class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SEOCommandBuilder
 
     prestashop.core.form.command_builder.product.shipping:
         class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ShippingCommandBuilder

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -37,6 +37,7 @@
       >
         <i class="material-icons">delete</i>
       </a>
+      {{ form_widget(productForm.preview) }}
       {% endif %}
     </div>
     <div class="col-sm-5 col-lg-8 text-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -25,6 +25,7 @@
 {% set isBasicTabValid = productForm.basic.description.vars.valid and productForm.basic.description_short.vars.valid %}
 {% set isPriceTabValid = productForm.price.vars.valid %}
 {% set isShippingTabValid = productForm.shipping.vars.valid %}
+{% set isSEOTabValid = productForm.seo.vars.valid %}
 {% set isOptionsTabValid = productForm.options.vars.valid %}
 {% set isStockTabValid = productForm.stock.vars.valid %}
 
@@ -53,6 +54,12 @@
     <li id="shipping-tab-nav" class="nav-item{% if not isShippingTabValid %} has-error{% endif %}">
       <a href="#shipping-tab" role="tab" data-toggle="tab" class="nav-link">
         {{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </li>
+
+    <li id="options-tab-nav" class="nav-item{% if not isSEOTabValid %} has-error{% endif %}">
+      <a href="#seo-tab" role="tab" data-toggle="tab" class="nav-link">
+        {{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}
       </a>
     </li>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
@@ -29,7 +29,7 @@
 
   {% block product_catalog_tool_serp %}
     <p>{{ 'Here is a preview of your search engine result, play with it!'|trans({}, 'Admin.Catalog.Feature') }}</p>
-    {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
+    {# Div targeted by the SERP component in VueJs. It displays a Google search result preview. #}
     <div id="serp-app"></div>
   {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
@@ -28,7 +28,7 @@
   <p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
 
   {% block product_catalog_tool_serp %}
-    <p>{{ "Here is a preview of your search engine result, play with it!"|trans({}, 'Admin.Catalog.Feature') }}</p>
+    <p>{{ 'Here is a preview of your search engine result, play with it!'|trans({}, 'Admin.Catalog.Feature') }}</p>
     {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
     <div id="serp-app"></div>
   {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
@@ -1,0 +1,60 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div role="tabpanel" class="form-contenttab tab-pane" id="seo-tab">
+  <h2>{{ 'Search Engine Optimization'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+  <p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
+
+  {% block product_catalog_tool_serp %}
+    <p>{{ "Here is a preview of your search engine result, play with it!"|trans({}, 'Admin.Catalog.Feature') }}</p>
+    {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
+    <div id="serp-app"></div>
+  {% endblock %}
+
+  {{ form_widget(productForm.seo) }}
+
+  <div class="row">
+    <div class="col-md-9">
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {% if configuration('PS_REWRITING_SETTINGS') == 0 %}
+            <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+            {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+          {% else %}
+            <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+            {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+          {% endif %}
+        </p>
+        <p class="alert-text">
+          {% if configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 %}
+            <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+            {# "It" refers to the option "Force update of friendly URL" #}
+            {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/seo.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div role="tabpanel" class="form-contenttab tab-pane" id="seo-tab">
+<div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="seo-tab">
   <h2>{{ 'Search Engine Optimization'|trans({}, 'Admin.Catalog.Feature') }}</h2>
   <p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -53,7 +53,7 @@
 
     <div id="form_content" class="tab-content">
       {% block product_tab_basic %}
-        <div role="tabpanel" class="form-contenttab tab-pane active" id="basic-tab">
+        <div role="tabpanel" class="form-contenttab tab-pane container-fluid active" id="basic-tab">
           {{ form_widget(productForm.basic) }}
         </div>
       {% endblock %}
@@ -65,13 +65,13 @@
       {% endblock %}
 
       {% block product_tab_pricing %}
-        <div role="tabpanel" class="form-contenttab tab-pane" id="pricing-tab">
+        <div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="pricing-tab">
           {{ form_widget(productForm.price) }}
         </div>
       {% endblock %}
 
       {% block product_tab_shipping %}
-        <div role="tabpanel" class="form-contenttab tab-pane" id="shipping-tab">
+        <div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="shipping-tab">
           {{ form_widget(productForm.shipping) }}
         </div>
       {% endblock %}
@@ -83,7 +83,7 @@
       {% endblock %}
 
       {% block product_tab_options %}
-        <div role="tabpanel" class="form-contenttab tab-pane" id="options-tab">
+        <div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="options-tab">
           {{ form_widget(productForm.options) }}
         </div>
       {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -76,6 +76,12 @@
         </div>
       {% endblock %}
 
+      {% block product_tab_seo %}
+        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/seo.html.twig', {
+          'productForm': productForm,
+        }) }}
+      {% endblock %}
+
       {% block product_tab_options %}
         <div role="tabpanel" class="form-contenttab tab-pane" id="options-tab">
           {{ form_widget(productForm.options) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -136,6 +136,7 @@
     {% endif %}
 
     {% set attr = attr|merge({'data-max-length': form.vars.max_length, 'maxlength': form.vars.max_length, 'class': 'js-countable-input'}) -%}
+    {% set attr = attr|merge(input_attr) -%}
 
     {% if form.vars.input == 'textarea' %}
       {{- block('textarea_widget') -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -113,6 +113,7 @@
     {% endif %}
 
     {% set attr = attr|merge({'data-max-length': form.vars.max_length, 'maxlength': form.vars.max_length, 'class': 'js-countable-input'}) -%}
+    {% set attr = attr|merge(input_attr) -%}
 
     {% if form.vars.input == 'textarea' %}
       {{- block('textarea_widget') -}}

--- a/tests/Unit/Adapter/Shop/Url/ProductProviderTest.php
+++ b/tests/Unit/Adapter/Shop/Url/ProductProviderTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Shop\Url;
+
+use Link;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider;
+
+class ProductProviderTest extends TestCase
+{
+    public function testGetUrl()
+    {
+        $productId = 42;
+        $alias = 'super-product';
+        $expectedUrl = 'http://superurl';
+        $linkMock = $this->createMock(Link::class);
+        $linkMock->method('getProductLink')
+            ->with($productId, $alias)
+            ->willReturn($expectedUrl)
+        ;
+        $provider = new ProductProvider($linkMock);
+        $generatedUrl = $provider->getUrl($productId, $alias);
+        $this->assertEquals($expectedUrl, $generatedUrl);
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandBuilderTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SEOCommandBuilder;
+
+class SEOCommandBuilderTest extends AbstractProductCommandBuilderTest
+{
+    /**
+     * @dataProvider getExpectedCommands
+     *
+     * @param array $formData
+     * @param array $expectedCommands
+     */
+    public function testBuildCommand(array $formData, array $expectedCommands)
+    {
+        $builder = new SEOCommandBuilder();
+        $builtCommands = $builder->buildCommand($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
+    }
+
+    public function getExpectedCommands()
+    {
+        yield [
+            [
+                'no_price_data' => ['useless value'],
+            ],
+            [],
+        ];
+
+        $command = new UpdateProductSeoCommand($this->getProductId()->getValue());
+        yield [
+            [
+                'seo' => [
+                    'not_handled' => 0,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateProductSeoCommand($this->getProductId()->getValue());
+        $localizedMetaTitles = [
+            1 => 'Titre français recherche',
+            2 => 'English title seo',
+        ];
+        $command->setLocalizedMetaTitles($localizedMetaTitles);
+        yield [
+            [
+                'seo' => [
+                    'meta_title' => $localizedMetaTitles,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateProductSeoCommand($this->getProductId()->getValue());
+        $localizedMetaDescriptions = [
+            1 => 'Description française recherche',
+            2 => 'English description seo',
+        ];
+        $command->setLocalizedMetaDescriptions($localizedMetaDescriptions);
+        yield [
+            [
+                'seo' => [
+                    'meta_description' => $localizedMetaDescriptions,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateProductSeoCommand($this->getProductId()->getValue());
+        $localizedLinkRewrites = [
+            1 => 'produit-francais',
+            2 => 'english-product',
+        ];
+        $command->setLocalizedLinkRewrites($localizedLinkRewrites);
+        yield [
+            [
+                'seo' => [
+                    'link_rewrite' => $localizedLinkRewrites,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateProductSeoCommand($this->getProductId()->getValue());
+        $command->setLocalizedLinkRewrites($localizedLinkRewrites);
+        $command->setLocalizedMetaTitles($localizedMetaTitles);
+        $command->setLocalizedMetaDescriptions($localizedMetaDescriptions);
+        yield [
+            [
+                'seo' => [
+                    'link_rewrite' => $localizedLinkRewrites,
+                    'meta_description' => $localizedMetaDescriptions,
+                    'meta_title' => $localizedMetaTitles,
+                ],
+            ],
+            [$command],
+        ];
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductBasicInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCategoriesInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCustomizationOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductDetails;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductSeoOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductStockInformation;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\QueryResult\VirtualProductFileForEditing;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ProductFormDataProvider;
+
+class ProductFormDataProviderTest extends TestCase
+{
+    private const PRODUCT_ID = 42;
+    private const DEFAULT_CATEGORY_ID = 51;
+    private const DEFAULT_VIRTUAL_PRODUCT_FILE_ID = 69;
+    private const DEFAULT_QUANTITY = 12;
+
+    public function testGetDefaultData()
+    {
+        $queryBusMock = $this->createMock(CommandBusInterface::class);
+        $provider = new ProductFormDataProvider($queryBusMock);
+
+        $expectedDefaultData = [
+            'basic' => [
+                'type' => ProductType::TYPE_STANDARD,
+            ],
+            'price' => [
+                'price_tax_excluded' => 0,
+                'price_tax_included' => 0,
+                'wholesale_price' => 0,
+                'unit_price' => 0,
+            ],
+            'shipping' => [
+                'width' => 0,
+                'height' => 0,
+                'depth' => 0,
+                'weight' => 0,
+            ],
+        ];
+
+        $defaultData = $provider->getDefaultData();
+        $this->assertEquals($expectedDefaultData, $defaultData);
+    }
+
+    /**
+     * @dataProvider getExpectedData
+     *
+     * @param array $productData
+     * @param array $expectedData
+     */
+    public function testGetData(array $productData, array $expectedData)
+    {
+        $queryBusMock = $this->createQueryBusMock($productData);
+        $provider = new ProductFormDataProvider($queryBusMock);
+
+        $formData = $provider->getData(static::PRODUCT_ID);
+        $this->assertEquals($expectedData, $formData);
+    }
+
+    public function getExpectedData()
+    {
+        $expectedOutputData = $this->getDefaultOutputData();
+        $productData = [];
+        yield [
+            $productData,
+            $expectedOutputData,
+        ];
+
+        $expectedOutputData = $this->getDefaultOutputData();
+        $localizedValues = [
+            1 => 'english',
+            2 => 'french',
+        ];
+        $productData = [
+            'name' => $localizedValues,
+            'type' => ProductType::TYPE_COMBINATION,
+            'description' => $localizedValues,
+            'description_short' => $localizedValues,
+        ];
+        $expectedOutputData['basic']['name'] = $localizedValues;
+        $expectedOutputData['basic']['type'] = ProductType::TYPE_COMBINATION;
+        $expectedOutputData['basic']['description'] = $localizedValues;
+        $expectedOutputData['basic']['description_short'] = $localizedValues;
+        yield [
+            $productData,
+            $expectedOutputData,
+        ];
+
+        $expectedOutputData = $this->getDefaultOutputData();
+        $productData = [
+            'meta_title' => $localizedValues,
+            'meta_description' => $localizedValues,
+            'link_rewrite' => $localizedValues,
+        ];
+        $expectedOutputData['seo']['meta_title'] = $localizedValues;
+        $expectedOutputData['seo']['meta_description'] = $localizedValues;
+        $expectedOutputData['seo']['link_rewrite'] = $localizedValues;
+        yield [
+            $productData,
+            $expectedOutputData,
+        ];
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductForEditing
+     */
+    private function createProductForEditing(array $product): ProductForEditing
+    {
+        return new ProductForEditing(
+            static::PRODUCT_ID,
+            ProductCustomizationOptions::createNotCustomizable(),
+            $this->createBasic($product),
+            $this->createCategories($product),
+            $this->createPricesInformation($product),
+            $this->createOptions($product),
+            $this->createDetails($product),
+            $this->createShippingInformation($product),
+            $this->createSeoOptions($product),
+            $product['attachments'] ?? [],
+            $this->createProductStockInformation($product),
+            $this->createVirtualProductFile($product)
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return VirtualProductFileForEditing|null
+     */
+    private function createVirtualProductFile(array $product): ?VirtualProductFileForEditing
+    {
+        if (!isset($product['virtual_product_file'])) {
+            return null;
+        }
+
+        return new VirtualProductFileForEditing(
+            self::DEFAULT_VIRTUAL_PRODUCT_FILE_ID,
+            $product['virtual_product_file']['filename'] ?? 'filename',
+            $product['virtual_product_file']['display_filename'] ?? 'display_filename',
+            $product['virtual_product_file']['nb_days_accessible'] ?? 0,
+            $product['virtual_product_file']['nb_downloadable'] ?? 0,
+            $product['virtual_product_file']['date_expiration'] ?? null,
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductStockInformation
+     */
+    private function createProductStockInformation(array $product): ProductStockInformation
+    {
+        return new ProductStockInformation(
+            $product['advanced_stock_management'] ?? false,
+            $product['depends_on_stock'] ?? false,
+            $product['pack_stock_type'] ?? PackStockType::STOCK_TYPE_DEFAULT,
+            $product['out_of_stock'] ?? OutOfStockType::OUT_OF_STOCK_DEFAULT,
+            $product['quantity'] ?? static::DEFAULT_QUANTITY,
+            $product['minimal_quantity'] ?? 0,
+            $product['low_stock_threshold'] ?? 0,
+            $product['low_stock_alert'] ?? false,
+            $product['available_now'] ?? [],
+            $product['available_later'] ?? [],
+            $product['location'] ?? 'location',
+            $product['available_date'] ?? null
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductSeoOptions
+     */
+    private function createSeoOptions(array $product): ProductSeoOptions
+    {
+        return new ProductSeoOptions(
+            $product['meta_title'] ?? [],
+            $product['meta_description'] ?? [],
+            $product['link_rewrite'] ?? [],
+            $product['redirect_type'] ?? RedirectType::TYPE_NOT_FOUND,
+            $product['id_type_redirected'] ?? 0
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductShippingInformation
+     */
+    private function createShippingInformation(array $product): ProductShippingInformation
+    {
+        return new ProductShippingInformation(
+            $product['width'] ?? new DecimalNumber('19.86'),
+            $product['height'] ?? new DecimalNumber('19.86'),
+            $product['depth'] ?? new DecimalNumber('19.86'),
+            $product['weight'] ?? new DecimalNumber('19.86'),
+            $product['additional_shipping_cost'] ?? new DecimalNumber('19.86'),
+            $product['carrier_references'] ?? [],
+            $product['delivery_time_note_type'] ?? DeliveryTimeNoteType::TYPE_DEFAULT,
+            $product['delivery_time_in_stock_note'] ?? [],
+            $product['delivery_time_out_stock_note'] ?? []
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductDetails
+     */
+    private function createDetails(array $product): ProductDetails
+    {
+        return new ProductDetails(
+            $product['isbn'] ?? 'isbn',
+            $product['upc'] ?? 'upc',
+            $product['ean13'] ?? 'ean13',
+            $product['mpn'] ?? 'mpn',
+            $product['reference'] ?? 'reference'
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductOptions
+     */
+    private function createOptions(array $product): ProductOptions
+    {
+        return new ProductOptions(
+            $product['active'] ?? true,
+            $product['visibility'] ?? ProductVisibility::VISIBLE_EVERYWHERE,
+            $product['available_for_order'] ?? true,
+            $product['online_only'] ?? false,
+            $product['show_price'] ?? true,
+            $product['condition'] ?? ProductCondition::NEW,
+            $product['show_condition'] ?? false,
+            $product['show_condition'] ?? 0
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductPricesInformation
+     */
+    private function createPricesInformation(array $product): ProductPricesInformation
+    {
+        return new ProductPricesInformation(
+            $product['price'] ?? new DecimalNumber('19.86'),
+            $product['ecotax'] ?? new DecimalNumber('19.86'),
+            $product['id_tax_rules_group'] ?? 1,
+            $product['on_sale'] ?? false,
+            $product['wholesale_price'] ?? new DecimalNumber('19.86'),
+            $product['unit_price'] ?? new DecimalNumber('19.86'),
+            $product['unity'] ?? '',
+            $product['unit_price_ratio'] ?? new DecimalNumber('1'),
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductCategoriesInformation
+     */
+    private function createCategories(array $product): ProductCategoriesInformation
+    {
+        return new ProductCategoriesInformation(
+            $product['categories'] ?? [self::DEFAULT_CATEGORY_ID],
+            self::DEFAULT_CATEGORY_ID
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return ProductBasicInformation
+     */
+    private function createBasic(array $product): ProductBasicInformation
+    {
+        return new ProductBasicInformation(
+            new ProductType($product['type'] ?? ProductType::TYPE_STANDARD),
+            $product['name'] ?? [],
+            $product['description'] ?? [],
+            $product['description_short'] ?? [],
+            $product['tags'] ?? []
+        );
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject|CommandBusInterface
+     */
+    private function createQueryBusMock(array $product)
+    {
+        $queryBusMock = $this->createMock(CommandBusInterface::class);
+
+        $productForEditing = $this->createProductForEditing($product);
+
+        $queryBusMock
+            ->method('handle')
+            ->with($this->isInstanceOf(GetProductForEditing::class))
+            ->willReturn($productForEditing)
+        ;
+
+        return $queryBusMock;
+    }
+
+    /**
+     * @return array
+     */
+    private function getDefaultOutputData(): array
+    {
+        return [
+            'id' => static::PRODUCT_ID,
+            'basic' => [
+                'name' => [],
+                'type' => ProductType::TYPE_STANDARD,
+                'description' => [],
+                'description_short' => [],
+            ],
+            'stock' => [
+                'quantity' => static::DEFAULT_QUANTITY,
+                'minimal_quantity' => 0,
+                'stock_location' => 'location',
+                'low_stock_threshold' => 0,
+                'low_stock_alert' => false,
+                'pack_stock_type' => PackStockType::STOCK_TYPE_DEFAULT,
+                'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
+                'available_now_label' => [],
+                'available_later_label' => [],
+                'available_date' => '',
+            ],
+            'price' => [
+                'price_tax_excluded' => 19.86,
+                'price_tax_included' => 19.86,
+                'ecotax' => 19.86,
+                'tax_rules_group_id' => 1,
+                'on_sale' => false,
+                'wholesale_price' => 19.86,
+                'unit_price' => 19.86,
+                'unity' => '',
+            ],
+            'seo' => [
+                'meta_title' => [],
+                'meta_description' => [],
+                'link_rewrite' => [],
+                'redirect' => [
+                    'type' => RedirectType::TYPE_NOT_FOUND,
+                    'target' => 0,
+                ],
+            ],
+            'shipping' => [
+                'width' => '19.86',
+                'height' => '19.86',
+                'depth' => '19.86',
+                'weight' => '19.86',
+                'additional_shipping_cost' => '19.86',
+                'delivery_time_note_type' => DeliveryTimeNoteType::TYPE_DEFAULT,
+                'delivery_time_in_stock_note' => [],
+                'delivery_time_out_stock_note' => [],
+                'carriers' => [],
+            ],
+            'options' => [
+                'active' => true,
+                'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
+                'available_for_order' => true,
+                'show_price' => true,
+                'online_only' => false,
+                'show_condition' => false,
+                'condition' => ProductCondition::NEW,
+                'tags' => [],
+                'mpn' => 'mpn',
+                'upc' => 'upc',
+                'ean_13' => 'ean13',
+                'isbn' => 'isbn',
+                'reference' => 'reference',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -185,7 +185,7 @@ class ProductFormDataProviderTest extends TestCase
             $product['virtual_product_file']['display_filename'] ?? 'display_filename',
             $product['virtual_product_file']['nb_days_accessible'] ?? 0,
             $product['virtual_product_file']['nb_downloadable'] ?? 0,
-            $product['virtual_product_file']['date_expiration'] ?? null,
+            $product['virtual_product_file']['date_expiration'] ?? null
         );
     }
 
@@ -298,7 +298,7 @@ class ProductFormDataProviderTest extends TestCase
             $product['wholesale_price'] ?? new DecimalNumber('19.86'),
             $product['unit_price'] ?? new DecimalNumber('19.86'),
             $product['unity'] ?? '',
-            $product['unit_price_ratio'] ?? new DecimalNumber('1'),
+            $product['unit_price_ratio'] ?? new DecimalNumber('1')
         );
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR introduces the SEO tab in the new product page It only handles these fields:<br>- meta title<br>- meta description<br>- friendly url<br><br>The missing part is about handling the redirection option because it is based on an input with autocomplete search feature which is based on old legacy JS so it's worth a refactoring that will be made in a separate PR<br><br>Though this PR already includes a few fixes compared to the old page regarding the Serp component that previews the Search engine display, the multilang display was not handled (only fist language was displayed) and the preview of the url didn't work correctly (the reset button for Friendly url is missing for now though it will be added in another PR as well)
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | GA green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22921)
<!-- Reviewable:end -->
