### PR TITLE
Add duplicate products in Hook product duplicate after

### DIFF
--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -125,9 +125,10 @@ class AdminProductDataUpdater implements ProductInterface
         }
 
         $failedIdList = [];
+        $duplicateProducts = [];
         foreach ($productIdList as $productId) {
             try {
-                $this->duplicateProduct($productId);
+                $duplicateProducts[] = $this->duplicateProduct($productId);
             } catch (\Exception $e) {
                 $failedIdList[] = $productId;
 
@@ -139,7 +140,11 @@ class AdminProductDataUpdater implements ProductInterface
             throw new UpdateProductException('Cannot duplicate many requested products', 5004);
         }
 
-        return true;
+        if (count($productIdList) > 1 && $duplicateProducts < 1) {
+            return false;
+        }
+
+        return $duplicateProducts;
     }
 
     /**

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -140,7 +140,7 @@ class AdminProductDataUpdater implements ProductInterface
             throw new UpdateProductException('Cannot duplicate many requested products', 5004);
         }
 
-        if (count($productIdList) > 1 && $duplicateProducts < 1) {
+        if (count($productIdList) > 1 && count($duplicateProducts) < 1) {
             return false;
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -853,7 +853,8 @@ class ProductController extends FrameworkBundleAdminController
                         $hookEventParameters
                     );
                     // Hooks: managed in ProductUpdater
-                    $productUpdater->duplicateProductIdList($productIdList);
+                    $duplicateProducstId = $productUpdater->duplicateProductIdList($productIdList);
+                    $hookEventParameters['duplicate_products_id'] = $duplicateProducstId;
                     if (empty($hasMessages)) {
                         $this->addFlash(
                             'success',
@@ -1073,6 +1074,7 @@ class ProductController extends FrameworkBundleAdminController
                     );
                     // Hooks: managed in ProductUpdater
                     $duplicateProductId = $productUpdater->duplicateProduct($id);
+                    $hookEventParameters['duplicate_product_id'] = $duplicateProductId;
                     $this->addFlash(
                         'success',
                         $this->trans('Product successfully duplicated.', 'Admin.Catalog.Notification')

--- a/src/PrestaShopBundle/Service/DataUpdater/Admin/ProductInterface.php
+++ b/src/PrestaShopBundle/Service/DataUpdater/Admin/ProductInterface.php
@@ -63,7 +63,7 @@ interface ProductInterface
      *
      * @throws \PrestaShopBundle\Exception\UpdateProductException if duplication failed
      *
-     * @return mixed|array|bool duplicates products list or false when all failed
+     * @return array|bool duplicates products list or false when all failed
      */
     public function duplicateProductIdList(array $productIdList);
 

--- a/src/PrestaShopBundle/Service/DataUpdater/Admin/ProductInterface.php
+++ b/src/PrestaShopBundle/Service/DataUpdater/Admin/ProductInterface.php
@@ -63,7 +63,7 @@ interface ProductInterface
      *
      * @throws \PrestaShopBundle\Exception\UpdateProductException if duplication failed
      *
-     * @return bool true when succeed
+     * @return mixed|array|bool duplicates products list or false when all failed
      */
     public function duplicateProductIdList(array $productIdList);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we duplicate a product we should have the IDs of the new products created ... This will allow custom fields modules to duplicate their data too.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23508
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/23508
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22923)
<!-- Reviewable:end -->
