### PR TITLE
Add option to specify if the customer choose to receive available products

### DIFF
--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -34,6 +34,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
     private $giftCost = 0;
     private $includeTaxes = false;
     private $displayTaxesLabel = false;
+    private $separatePackagesAllowed = false;
 
     public function setRecyclablePackAllowed($recyclablePackAllowed)
     {
@@ -120,6 +121,18 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
         return '';
     }
 
+    public function setSeparatePackagesAllowed($separatePackagesAllowed)
+    {
+        $this->separatePackagesAllowed = $separatePackagesAllowed;
+
+        return $this;
+    }
+
+    public function isSeparatePackagesAllowed()
+    {
+        return $this->separatePackagesAllowed;
+    }
+
     public function handleRequest(array $requestParams = [])
     {
         if (isset($requestParams['delivery_option'])) {
@@ -135,6 +148,9 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
             $this->getCheckoutSession()->setGift(
                 $useGift,
                 ($useGift && isset($requestParams['gift_message'])) ? $requestParams['gift_message'] : ''
+            );
+            $this->getCheckoutSession()->setSeparatePackagesAllowed(
+                isset($requestParams['allow_seperated_package']) ? $requestParams['allow_seperated_package'] : false
             );
         }
 
@@ -186,6 +202,10 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                         'Shop.Theme.Checkout'
                     ),
                     'message' => $this->getCheckoutSession()->getGift()['message'],
+                ],
+                'separatePackages' => [
+                    'allowed' => $this->isSeparatePackagesAllowed(),
+                    'isSeparatePackage' =>  $this->getCheckoutSession()->isSeparatePackagesAllowed()
                 ],
             ]
         );

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -150,7 +150,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                 ($useGift && isset($requestParams['gift_message'])) ? $requestParams['gift_message'] : ''
             );
             $this->getCheckoutSession()->setSeparatePackagesAllowed(
-                isset($requestParams['allow_seperated_package']) ? $requestParams['allow_seperated_package'] : false
+                isset($requestParams['allow_separated_package']) ? $requestParams['allow_separated_package'] : false
             );
         }
 

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -153,7 +153,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                 ($useGift && isset($requestParams['gift_message'])) ? $requestParams['gift_message'] : ''
             );
             $this->getCheckoutSession()->setSeparatePackagesAllowed(
-                isset($requestParams['allow_separated_package']) ? $requestParams['allow_separated_package'] : false
+                $requestParams['allow_separated_package'] ??  false
             );
         }
 

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -124,7 +124,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
         return '';
     }
 
-    public function setSeparatePackagesAllowed($separatePackagesAllowed)
+    public function setSeparatePackagesAllowed(bool $separatePackagesAllowed): self
     {
         $this->separatePackagesAllowed = $separatePackagesAllowed;
 

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -34,6 +34,9 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
     private $giftCost = 0;
     private $includeTaxes = false;
     private $displayTaxesLabel = false;
+    /**
+     * @var bool
+     */
     private $separatePackagesAllowed = false;
 
     public function setRecyclablePackAllowed($recyclablePackAllowed)

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -131,7 +131,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
         return $this;
     }
 
-    public function isSeparatePackagesAllowed()
+    public function isSeparatePackagesAllowed(): bool
     {
         return $this->separatePackagesAllowed;
     }

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -208,7 +208,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                 ],
                 'separatePackages' => [
                     'allowed' => $this->isSeparatePackagesAllowed(),
-                    'isSeparatePackage' => $this->getCheckoutSession()->isSeparatePackagesAllowed()
+                    'isSeparatePackage' => $this->getCheckoutSession()->isSeparatePackagesAllowed(),
                 ],
             ]
         );

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -153,7 +153,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                 ($useGift && isset($requestParams['gift_message'])) ? $requestParams['gift_message'] : ''
             );
             $this->getCheckoutSession()->setSeparatePackagesAllowed(
-                $requestParams['allow_separated_package'] ??  false
+                $requestParams['allow_separated_package'] ?? false
             );
         }
 

--- a/classes/checkout/CheckoutDeliveryStep.php
+++ b/classes/checkout/CheckoutDeliveryStep.php
@@ -208,7 +208,7 @@ class CheckoutDeliveryStepCore extends AbstractCheckoutStep
                 ],
                 'separatePackages' => [
                     'allowed' => $this->isSeparatePackagesAllowed(),
-                    'isSeparatePackage' =>  $this->getCheckoutSession()->isSeparatePackagesAllowed()
+                    'isSeparatePackage' => $this->getCheckoutSession()->isSeparatePackagesAllowed()
                 ],
             ]
         );

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -196,4 +196,15 @@ class CheckoutSessionCore
     {
         return $this->context->link->getPageLink('order');
     }
+
+    public function setSeparatePackagesAllowed($separatePackagesAllowed)
+    {
+        $this->context->cart->allow_seperated_package = $separatePackagesAllowed;
+        return $this->context->cart->update();
+    }
+
+    public function isSeparatePackagesAllowed()
+    {
+        return $this->context->cart->allow_seperated_package;
+    }
 }

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -197,7 +197,7 @@ class CheckoutSessionCore
         return $this->context->link->getPageLink('order');
     }
 
-    public function setSeparatePackagesAllowed($separatePackagesAllowed)
+    public function setSeparatePackagesAllowed(bool $separatePackagesAllowed): bool
     {
         $this->context->cart->allow_separated_package = (bool) $separatePackagesAllowed;
 

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -199,7 +199,7 @@ class CheckoutSessionCore
 
     public function setSeparatePackagesAllowed(bool $separatePackagesAllowed): bool
     {
-        $this->context->cart->allow_separated_package = (bool) $separatePackagesAllowed;
+        $this->context->cart->allow_separated_package = $separatePackagesAllowed;
 
         return $this->context->cart->update();
     }

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -199,7 +199,7 @@ class CheckoutSessionCore
 
     public function setSeparatePackagesAllowed(bool $separatePackagesAllowed): bool
     {
-        $this->context->cart->allow_separated_package = $separatePackagesAllowed;
+        $this->context->cart->allow_seperated_package = $separatePackagesAllowed;
 
         return $this->context->cart->update();
     }

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -203,7 +203,7 @@ class CheckoutSessionCore
         return $this->context->cart->update();
     }
 
-    public function isSeparatePackagesAllowed()
+    public function isSeparatePackagesAllowed(): bool
     {
         return $this->context->cart->allow_seperated_package;
     }

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -199,7 +199,7 @@ class CheckoutSessionCore
 
     public function setSeparatePackagesAllowed($separatePackagesAllowed)
     {
-        $this->context->cart->allow_separated_package = $separatePackagesAllowed;
+        $this->context->cart->allow_separated_package = (bool) $separatePackagesAllowed;
         return $this->context->cart->update();
     }
 

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -200,6 +200,7 @@ class CheckoutSessionCore
     public function setSeparatePackagesAllowed($separatePackagesAllowed)
     {
         $this->context->cart->allow_separated_package = (bool) $separatePackagesAllowed;
+
         return $this->context->cart->update();
     }
 

--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -199,7 +199,7 @@ class CheckoutSessionCore
 
     public function setSeparatePackagesAllowed($separatePackagesAllowed)
     {
-        $this->context->cart->allow_seperated_package = $separatePackagesAllowed;
+        $this->context->cart->allow_separated_package = $separatePackagesAllowed;
         return $this->context->cart->update();
     }
 

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -397,7 +397,8 @@ class OrderControllerCore extends FrontController
                     $this->context->cart->getGiftWrappingPrice(
                         $checkoutDeliveryStep->getIncludeTaxes()
                     )
-                );
+                )
+                ->setSeparatePackagesAllowed((bool)Configuration::get('PS_SHIP_WHEN_AVAILABLE'));
 
             $checkoutProcess->addStep($checkoutDeliveryStep);
         }

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -398,7 +398,7 @@ class OrderControllerCore extends FrontController
                         $checkoutDeliveryStep->getIncludeTaxes()
                     )
                 )
-                ->setSeparatePackagesAllowed((bool)Configuration::get('PS_SHIP_WHEN_AVAILABLE'));
+                ->setSeparatePackagesAllowed((bool) Configuration::get('PS_SHIP_WHEN_AVAILABLE'));
 
             $checkoutProcess->addStep($checkoutDeliveryStep);
         }

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -105,6 +105,15 @@
               </div>
             {/if}
 
+            {if $separatePackages.allowed}
+              <span class="custom-checkbox">
+                <input class="js-gift-checkbox" id="allow_seperated_package" name="allow_seperated_package"
+                       type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
+                <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
+                <label for="allow_seperated_package">{l s='Send available products first' d='Shop.Theme.Checkout'}</label>
+              </span>
+            {/if}
+
           </div>
         </div>
         <button type="submit" class="continue btn btn-primary float-xs-right" name="confirmDeliveryOption" value="1">

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -81,11 +81,11 @@
           <div class="order-options">
             {if $separatePackages.allowed}
               <span class="custom-checkbox">
-              <input id="allow_separated_package" name="allow_separated_package"
-                     type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
-              <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
-              <label for="allow_separated_package">{l s='Receive available products first' d='Shop.Theme.Checkout'}</label>
-            </span>
+                <input id="allow_separated_package" name="allow_separated_package"
+                  type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
+                <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
+                <label for="allow_separated_package">{l s='Receive available products first' d='Shop.Theme.Checkout'}</label>
+              </span>
             {/if}
 
             <div id="delivery">

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -81,7 +81,7 @@
           <div class="order-options">
             {if $separatePackages.allowed}
               <span class="custom-checkbox">
-              <input class="js-gift-checkbox" id="allow_separated_package" name="allow_separated_package"
+              <input id="allow_separated_package" name="allow_separated_package"
                      type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
               <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
               <label for="allow_separated_package">{l s='Receive available products first' d='Shop.Theme.Checkout'}</label>

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -79,6 +79,15 @@
             </div>
           {/block}
           <div class="order-options">
+            {if $separatePackages.allowed}
+              <span class="custom-checkbox">
+              <input class="js-gift-checkbox" id="allow_separated_package" name="allow_separated_package"
+                     type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
+              <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
+              <label for="allow_separated_package">{l s='Receive available products first' d='Shop.Theme.Checkout'}</label>
+            </span>
+            {/if}
+
             <div id="delivery">
               <label for="delivery_message">{l s='If you would like to add a comment about your order, please write it in the field below.' d='Shop.Theme.Checkout'}</label>
               <textarea rows="2" cols="120" id="delivery_message" name="delivery_message">{$delivery_message}</textarea>
@@ -103,15 +112,6 @@
                 <label for="gift_message">{l s='If you\'d like, you can add a note to the gift:' d='Shop.Theme.Checkout'}</label>
                 <textarea rows="2" cols="120" id="gift_message" name="gift_message">{$gift.message}</textarea>
               </div>
-            {/if}
-
-            {if $separatePackages.allowed}
-              <span class="custom-checkbox">
-                <input class="js-gift-checkbox" id="allow_separated_package" name="allow_separated_package"
-                       type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
-                <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
-                <label for="allow_separated_package">{l s='Receive available products first' d='Shop.Theme.Checkout'}</label>
-              </span>
             {/if}
 
           </div>

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -110,7 +110,7 @@
                 <input class="js-gift-checkbox" id="allow_separated_package" name="allow_separated_package"
                        type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
                 <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
-                <label for="allow_separated_package">{l s='Send available products first' d='Shop.Theme.Checkout'}</label>
+                <label for="allow_separated_package">{l s='Receive available products first' d='Shop.Theme.Checkout'}</label>
               </span>
             {/if}
 

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -107,7 +107,7 @@
 
             {if $separatePackages.allowed}
               <span class="custom-checkbox">
-                <input class="js-gift-checkbox" id="allow_seperated_package" name="allow_seperated_package"
+                <input class="js-gift-checkbox" id="allow_separated_package" name="allow_separated_package"
                        type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
                 <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
                 <label for="allow_seperated_package">{l s='Send available products first' d='Shop.Theme.Checkout'}</label>

--- a/themes/classic/templates/checkout/_partials/steps/shipping.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/shipping.tpl
@@ -110,7 +110,7 @@
                 <input class="js-gift-checkbox" id="allow_separated_package" name="allow_separated_package"
                        type="checkbox" value="1" {if $separatePackages.isSeparatePackage}checked="checked"{/if}>
                 <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
-                <label for="allow_seperated_package">{l s='Send available products first' d='Shop.Theme.Checkout'}</label>
+                <label for="allow_separated_package">{l s='Send available products first' d='Shop.Theme.Checkout'}</label>
               </span>
             {/if}
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | In PrestaShop 1.6 the customer was able to choose to recieve available products first. The option is still available in cart but the controller do not use it anymore.
| Type?             | bug fix
| Category?         |  CO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #9781
| How to test?      | Add an available product and an unavailable product (but orderable) in the cart. Enter in the checkout tunnel. In the shipping step, check the checkbox "Send available products first". The order should be split in two.
| Possible impacts? | The option is inactive by default, impacts are very limited.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22941)
<!-- Reviewable:end -->
