### PR TITLE
Add html validation to radio buttons on category tree

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -56,6 +56,10 @@
       {% if categoryForm.id_parent is defined %}
       <div class="form-group row">
         <label class="form-control-label">
+          {% if categoryForm.vars.required %}
+            <span class="text-danger">*</span>
+          {% endif %}
+
           {{ 'Parent category'|trans({}, 'Admin.Catalog.Feature') }}
         </label>
         <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -181,7 +181,7 @@
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
-  <li{% if defaultHidden is same as(true) %} class="more"{% endif %}>
+  <li{% if defaultHidden is defined and defaultHidden is same as(true) %} class="more"{% endif %}>
         {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
         {% if multiple -%}
             <div class="checkbox">
@@ -210,7 +210,7 @@
             </div>
         {%- endif %}
         {% if child.children is defined %}
-            <ul{% if defaultHidden is same as(true) %} style="display: none;"{% endif %}>
+            <ul{% if defaultHidden is defined and defaultHidden is same as(true) %} style="display: none;"{% endif %}>
                 {% for item in child.children %}
                     {% set child = item %}
                     {{ block('choice_tree_item_widget') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -187,7 +187,6 @@
             <div class="checkbox">
                 <label>
                   <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
-      
                     {% if child.active is defined and child.active == 0 %}
                         <i>{{ child.name }}</i>
                     {%- else -%}
@@ -201,7 +200,7 @@
         {%- else -%}
             <div class="radio">
                 <label>
-                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category" {% if required %}required{% endif %}>
+                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category"{% if required %} required{% endif %}>
                     {{ child.name }}
                     {% if defaultCategory is defined %}
                         <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -201,7 +201,7 @@
         {%- else -%}
             <div class="radio">
                 <label>
-                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category" {% if required %}required {% endif %}>
+                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category" {% if required %}required{% endif %}>
                     {{ child.name }}
                     {% if defaultCategory is defined %}
                         <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -186,7 +186,7 @@
         {% if multiple -%}
             <div class="checkbox">
                 <label>
-                  <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
+                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
                     {% if child.active is defined and child.active == 0 %}
                         <i>{{ child.name }}</i>
                     {%- else -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -181,7 +181,7 @@
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
-  <li{% if defaultHidden %} class="more"{% endif %}>
+  <li{% if defaultHidden is equal(true) %} class="more"{% endif %}>
         {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
         {% if multiple -%}
             <div class="checkbox">
@@ -210,7 +210,7 @@
             </div>
         {%- endif %}
         {% if child.children is defined %}
-            <ul{% if defaultHidden %} style="display: none;"{% endif %}>
+            <ul{% if defaultHidden is equal(true) %} style="display: none;"{% endif %}>
                 {% for item in child.children %}
                     {% set child = item %}
                     {{ block('choice_tree_item_widget') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -186,7 +186,8 @@
         {% if multiple -%}
             <div class="checkbox">
                 <label>
-                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
+                  <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {% if required %}required {% endif %}{{ checked }}>
+      
                     {% if child.active is defined and child.active == 0 %}
                         <i>{{ child.name }}</i>
                     {%- else -%}
@@ -200,7 +201,7 @@
         {%- else -%}
             <div class="radio">
                 <label>
-                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category">
+                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category" {% if required %}required {% endif %}>
                     {{ child.name }}
                     {% if defaultCategory is defined %}
                         <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -181,7 +181,7 @@
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
-  <li{% if defaultHidden is equal(true) %} class="more"{% endif %}>
+  <li{% if defaultHidden is same as(true) %} class="more"{% endif %}>
         {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
         {% if multiple -%}
             <div class="checkbox">
@@ -210,7 +210,7 @@
             </div>
         {%- endif %}
         {% if child.children is defined %}
-            <ul{% if defaultHidden is equal(true) %} style="display: none;"{% endif %}>
+            <ul{% if defaultHidden is same as(true) %} style="display: none;"{% endif %}>
                 {% for item in child.children %}
                     {% set child = item %}
                     {{ block('choice_tree_item_widget') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -186,7 +186,7 @@
         {% if multiple -%}
             <div class="checkbox">
                 <label>
-                  <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {% if required %}required {% endif %}{{ checked }}>
+                  <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
       
                     {% if child.active is defined and child.active == 0 %}
                         <i>{{ child.name }}</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% block material_choice_tree_widget %}
-  <div class="material-choice-tree-container js-choice-tree-container {% if required %}required{% endif %}" id="{{ form.vars.id }}">
+  <div class="material-choice-tree-container js-choice-tree-container{% if required %} required{% endif %}" id="{{ form.vars.id }}">
   <div class="choice-tree-actions">
     <span class="form-control-label js-toggle-choice-tree-action"
           data-expanded-text="{{ 'Expand'|trans({}, 'Admin.Actions') }}"

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -94,7 +94,7 @@
        value="{{ choice[choice_value] }}"
        {% if choice[choice_value] in selected_values %}checked{% endif %}
        {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
-       {% if required %}required {% endif %}
+       {% if required %}required{% endif %}
       >
       <i class="form-check-round"></i>
       {{ choice[choice_label] }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -72,12 +72,12 @@
     <div class="md-checkbox md-checkbox-inline">
       <label>
         <input type="checkbox"
-               {% if choice[choice_value] is not null %}
-                 name="{{ form.vars.full_name }}[]"
-                 value="{{ choice[choice_value] }}"
-                 {% if choice[choice_value] in selected_values %}checked{% endif %}
-               {% endif %}
-               {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
+         {% if choice[choice_value] is not null %}
+           name="{{ form.vars.full_name }}[]"
+           value="{{ choice[choice_value] }}"
+           {% if choice[choice_value] in selected_values %}checked{% endif %}
+         {% endif %}
+         {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
         >
         <i class="md-checkbox-control"></i>
         {{ choice[choice_label] }}
@@ -90,10 +90,11 @@
   <div class="radio js-input-wrapper form-check form-check-radio">
     <label class="form-check-label">
       <input type="radio"
-             name="{{ form.vars.full_name }}"
-             value="{{ choice[choice_value] }}"
-             {% if choice[choice_value] in selected_values %}checked{% endif %}
-             {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
+       name="{{ form.vars.full_name }}"
+       value="{{ choice[choice_value] }}"
+       {% if choice[choice_value] in selected_values %}checked{% endif %}
+       {% if disabled or choice[choice_value] in disabled_values %}disabled{% endif %}
+       {% if required %}required {% endif %}
       >
       <i class="form-check-round"></i>
       {{ choice[choice_label] }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% block material_choice_tree_widget %}
-<div class="material-choice-tree-container js-choice-tree-container" id="{{ form.vars.id }}">
+  <div class="material-choice-tree-container js-choice-tree-container {% if required %}required{% endif %}" id="{{ form.vars.id }}">
   <div class="choice-tree-actions">
     <span class="form-control-label js-toggle-choice-tree-action"
           data-expanded-text="{{ 'Expand'|trans({}, 'Admin.Actions') }}"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Category trees are not blocking the submit form if required
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19612.
| How to test?      | See issue, btw, it doesn't fix the material checkbox one, that should be done using JavaScript inside the UIKit, with an helper class in order to create the control : 1. Install PS and [sample module (https://github.com/202ecommerce/checkboform) 2. See error by validating the form without checking checkboxes (won't work on material checkboxes)
| Possible impacts? | Every radio trees


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22942)
<!-- Reviewable:end -->

⚠️ Mergeable when https://github.com/PrestaShop/prestashop-ui-kit/pull/137 is merged and UIKit 1.2.2 is released ⚠️ 