### PR TITLE
Fix undefined index when iso doesn't exists in language list

### DIFF
--- a/src/PrestaShopBundle/Install/LanguageList.php
+++ b/src/PrestaShopBundle/Install/LanguageList.php
@@ -119,7 +119,7 @@ class LanguageList
      */
     public function getLanguage($iso = null)
     {
-        if (!$iso) {
+        if (!isset($this->languages[$iso])) {
             $iso = $this->language;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The iso code must be tested before trying to use it.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to install with United Kingdom as country.
| Possible impacts? | N/A.


Without the PR:
![image](https://user-images.githubusercontent.com/1462701/105475804-1a422f80-5ca0-11eb-99ec-c30f58739e8a.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22944)
<!-- Reviewable:end -->
