### PR TITLE
Fix Shopping Cart page in BO throwing an exception

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1068,7 +1068,7 @@ class CartCore extends ObjectModel
      * @param Context $shopContext
      * @param array|false|null $specificPriceOutput
      *
-     * @return float
+     * @return float|null
      */
     private function getCartPriceFromCatalog(
         int $productId,
@@ -1081,7 +1081,7 @@ class CartCore extends ObjectModel
         ?int $addressId,
         Context $shopContext,
         &$specificPriceOutput
-    ): float {
+    ): ?float {
         return Product::getPriceStatic(
             $productId,
             $withTaxes,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | The return type of the function `CartCore::getCartPriceFromCatalog()` was to strict compared to the function `ProductCore::Product::getPriceStatic()` that can return null. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22812
| How to test?      | 1. Upgrade from a fresh 1.7.4.1 shop to the last minor (1.7.7.1)<br>2. Go to Orders -> Shopping Carts<br>3. The page should be displayed correctly
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22947)
<!-- Reviewable:end -->
