### PR TITLE
Fix product image form display in mobile view

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1469,6 +1469,9 @@ var formImagesProduct = (function() {
   var dropZoneElem = $('#product-images-dropzone');
   var formZoneElem = $('#product-images-form-container');
 
+  // default state
+  formZoneElem.hide();
+
   formZoneElem.magnificPopup({
     delegate: 'a.open-image',
     type: 'image'
@@ -1500,6 +1503,7 @@ var formImagesProduct = (function() {
         complete: function() {
           toggleColDropzone(false);
           formZoneElem.show();
+          dropZoneElem.addClass('d-none d-md-block');
         }
       });
     },
@@ -1559,6 +1563,7 @@ var formImagesProduct = (function() {
     },
     'close': function() {
       toggleColDropzone(true);
+      dropZoneElem.removeClass('d-none d-md-block');
       dropZoneElem.css('height','');
       formZoneElem.find('#product-images-form').html('');
       formZoneElem.hide();

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -417,9 +417,6 @@
   }
 
   #product-images-form-container {
-    position: absolute;
-    top: 0;
-    right: 0;
     z-index: 0;
     float: left;
     min-height: 200px;
@@ -438,7 +435,7 @@
 
   #product-images-container {
     position: relative;
-    display: inline-block;
+    display: flex;
     width: 100%;
     border: solid 1px $gray-light;
     .dropzone-expander {


### PR DESCRIPTION
Increase in height of caption textarea in product images form exceeded the parent div height.
Product images form did not show up in mobile view after clicking on the previews to edit.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Edit form for product image did not show up in the mobile view and increasing height of the caption in the image edit form exceeded the height of the parent div. <br> Fixed this issue by making dropzone not display when editing product image only in mobile view and when the edit form closes, dropzone is displayed. for the caption field, fixed with making parent flex and removing absolute position of the image form container.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #22957 
| How to test?      | Go to the product page and click on an image of the product in mobile view, does not display. also increase the height of the caption textarea.
| Possible impacts? | no

**Issues:**
![Screenshot from 2021-01-22 23-21-20](https://user-images.githubusercontent.com/48237049/105546160-472f2a80-5d12-11eb-9e14-6fe09f35b3d3.png)
![Screenshot from 2021-01-22 23-22-08](https://user-images.githubusercontent.com/48237049/105546335-79408c80-5d12-11eb-94f7-d6e56dcb09ec.png)


**Fixed:**
![Screenshot from 2021-01-22 23-30-00](https://user-images.githubusercontent.com/48237049/105546436-a1c88680-5d12-11eb-821e-dacffd9fbf38.png)
![Screenshot from 2021-01-22 23-31-23](https://user-images.githubusercontent.com/48237049/105546456-a856fe00-5d12-11eb-8dfe-4e7468655898.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22955)
<!-- Reviewable:end -->
