### PR TITLE
Faster checkout - depth of 0 means unlimited

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -25,8 +25,6 @@ jobs:
                 with:
                     node-version: '10'
             -   uses: actions/checkout@v2
-                with:
-                    fetch-depth: 0
 
             -   name: PrestaShop Configuration
                 run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: PrestaShop Configuration
         run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v1
@@ -20,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-            fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v1
@@ -44,8 +40,6 @@ jobs:
               php-version: '7.4'
               extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
       -   uses: actions/checkout@v2
-          with:
-              fetch-depth: 0
 
       -   name: Get Composer Cache Directory
           id: composer-cache
@@ -85,8 +79,6 @@ jobs:
               php-version: '7.4'
               extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
       -   uses: actions/checkout@v2
-          with:
-              fetch-depth: 0
 
       -   name: Get Composer Cache Directory
           id: composer-cache

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,8 +11,6 @@ jobs:
           php-version: '7.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -43,8 +41,6 @@ jobs:
                 php-version: '7.4'
                 extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
         -   uses: actions/checkout@v2
-            with:
-                fetch-depth: 0
 
         -   name: Get Composer Cache Directory
             id: composer-cache
@@ -79,8 +75,6 @@ jobs:
                 php-version: ${{ matrix.php }}
                 extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
         -   uses: actions/checkout@v2
-            with:
-                fetch-depth: 0
 
         -   name: PrestaShop Configuration
             run: cp tests-legacy/parameters.yml.travis app/config/parameters.yml
@@ -127,8 +121,6 @@ jobs:
                 mysql root password: 'password'
 
         -   uses: actions/checkout@v2
-            with:
-                fetch-depth: 0
 
         -   name: PrestaShop Configuration
             run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Setup Apache
         run: sudo bash .github/workflows/sanity/setup-apache.sh ${{ github.workspace }} ${{ matrix.php }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | No need to specify depth, 1 is default. Now checkout takes about 6 seconds vs 44 :)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | CI must pass
| Possible impacts? | no

## I am proposing PR only for this repo. But check other PrestaShop repos like modules and delete zero depth there too. Speedup is massive.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22966)
<!-- Reviewable:end -->
