### PR TITLE
Fixed API inconsistent return format of JSON

### DIFF
--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -413,6 +413,8 @@ class WebserviceOutputBuilderCore
                     } else {
                         $output .= $this->renderEntity($object, $depth);
                     }
+                } elseif ($key == 'empty' && $this->objectRender->getContentType() == 'application/json') {
+                    $output .= $this->renderEntity($object, $depth);
                 }
             }
         } else {

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -503,7 +503,7 @@ class WebserviceOutputBuilderCore
         }
         $output .= $this->setIndent($depth) . $this->objectRender->renderNodeHeader($ws_params['objectNodeName'], $ws_params);
 
-        if ($object->id != 0) {
+        if (!empty($object->id)) {
             // This to add virtual Fields for a particular entity.
             $virtual_fields = $this->addVirtualFields($ws_params['objectsNodeName'], $object);
             if (!empty($virtual_fields)) {

--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -163,6 +163,11 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
 
     public function overrideContent($content)
     {
+        array_walk_recursive($this->content, function (&$item) {
+            if (is_null($item)) {
+                $this->content[key($this->content)] = [];
+            }
+        });
         $content = json_encode($this->content, JSON_UNESCAPED_UNICODE);
 
         return (false !== $content) ? $content : '';

--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -163,10 +163,8 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
 
     public function overrideContent($content)
     {
-        array_walk_recursive($this->content, function (&$item) {
-            if (is_null($item)) {
-                $this->content[key($this->content)] = [];
-            }
+        array_walk($this->content, function (&$item) {
+            $item = array_filter($item);
         });
         $content = json_encode($this->content, JSON_UNESCAPED_UNICODE);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | API returns a different format of JSON when it returns an empty list.
| Type?             | bug fix
| Category?         |  WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22760 
| How to test?      | Call api /orders?output_format=JSON&display=full&limit=100000,20 (or other limit number which will return empty list)

**How it looks ?**
See [#22760 comment](https://github.com/PrestaShop/PrestaShop/issues/22760#issuecomment-766392118)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22969)
<!-- Reviewable:end -->
