### PR TITLE
Replaced hooks displayAdminList<Before|After> with displayAdminGridTable<Before|After>

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2784,5 +2784,15 @@
       <title>Category footer</title>
       <description>This hook adds new blocks under the products listing in a category/search</description>
     </hook>
+    <hook id="displayAdminGridTableBefore">
+      <name>displayAdminGridTableBefore</name>
+      <title>Display before Grid table</title>
+      <description>This hook adds new blocks before Grid component table</description>
+    </hook>
+    <hook id="displayAdminGridTableAfter">
+      <name>displayAdminGridTableAfter</name>
+      <title>Display after Grid table</title>
+      <description>This hook adds new blocks after Grid component table</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook_alias.xml
+++ b/install-dev/data/xml/hook_alias.xml
@@ -349,5 +349,13 @@
       <alias>actionFrontControllerAfterInit</alias>
       <name>actionFrontControllerInitAfter</name>
     </hook_alias>
+    <hook_alias id="displayAdminListBefore">
+      <alias>displayAdminListBefore</alias>
+      <name>displayAdminGridTableBefore</name>
+    </hook_alias>
+    <hook_alias id="displayAdminListAfter">
+      <alias>displayAdminListAfter</alias>
+      <name>displayAdminGridTableAfter</name>
+    </hook_alias>
   </entities>
 </entity_hook_alias>

--- a/install-dev/upgrade/sql/1.7.7.2.sql
+++ b/install-dev/upgrade/sql/1.7.7.2.sql
@@ -1,0 +1,25 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8';
+
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+    (NULL, 'displayAdminGridTableBefore', 'Display before Grid table', 'This hook adds new blocks before Grid component table.', '1'),
+    (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1')
+;
+
+UPDATE `PREFIX_hook_module` AS hm
+    INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name = 'displayAdminListBefore'
+    INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'displayAdminGridTableBefore'
+    SET hm.id_hook = hto.id_hook;
+DELETE FROM `PREFIX_hook` WHERE name = 'displayAdminListBefore';
+
+UPDATE `PREFIX_hook_module` AS hm
+    INNER JOIN `PREFIX_hook` AS hfrom ON hm.id_hook = hfrom.id_hook AND hfrom.name = 'displayAdminListAfter'
+    INNER JOIN `PREFIX_hook` AS hto ON hto.name = 'displayAdminGridTableAfter'
+    SET hm.id_hook = hto.id_hook;
+DELETE FROM `PREFIX_hook` WHERE name = 'displayAdminListAfter';
+
+
+INSERT INTO `PREFIX_hook_alias` (`name`, `alias`) VALUES
+     ('displayAdminGridTableBefore', 'displayAdminListBefore'),
+     ('displayAdminGridTableAfter', 'displayAdminListAfter')
+;

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/table.html.twig
@@ -23,7 +23,19 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{{
+  renderhook(
+    'displayAdminGridTableBefore',
+    {
+      'grid': grid,
+      'legacy_controller': app.request.attributes.get('_legacy_controller'),
+      'controller': app.request.attributes.get('_controller')
+    }
+  )
+}}
+
 {{ form_start(grid.filter_form, {'attr': {'id': grid.id ~ '_filter_form', 'class': 'table-responsive'}}) }}
+
 <table class="grid-table js-grid-table table {% if is_ordering_column(grid) %}grid-ordering-column{% endif %} {% if grid.attributes.is_empty_state %}border-0{% endif %}"
        id="{{ grid.id }}_grid_table"
        data-query="{{ grid.data.query }}"
@@ -54,3 +66,14 @@
   {% block grid_table_footer %}{% endblock %}
 </table>
 {{ form_end(grid.filter_form) }}
+
+{{
+  renderhook(
+    'displayAdminGridTableAfter',
+    {
+      'grid': grid,
+      'legacy_controller': app.request.attributes.get('_legacy_controller'),
+      'controller': app.request.attributes.get('_controller')
+    }
+  )
+}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Replaced hooks `displayAdminListBefore` with `displayAdminGridTableBefore` and `displayAdminListAfter` with `displayAdminGridTableAfter`<br> :heart_eyes_cat:@kpodemski for #22922
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22910
| How to test?      | Use the ps_qualityassurance module and register for each hook:<br>* Hook name: `displayAdminListBefore` / `displayAdminListAfter` / `displayAdminGridTableBefore` / `displayAdminGridTableAfter`<br>* Content: `return '<h3>Order Hook</h3>';`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22980)
<!-- Reviewable:end -->
