### PR TITLE
Remove header button on mobile and push these into new floating btn

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -69,8 +69,7 @@
   // toolbar buttons
   .toolbar-icons {
     @include media-breakpoint-down(sm) {
-      float: none;
-      overflow-x: auto;
+      display: none;
     }
 
     > .wrapper {
@@ -99,6 +98,18 @@
   .title-row {
     @include clearfix();
     margin-bottom: $grid-gutter-width / 2;
+  }
+
+  .btn-floating {
+    display: none;
+
+    &-menu {
+      max-width: calc(100vw - 2rem);
+    }
+
+    @include media-breakpoint-down(sm) {
+      display: block;
+    }
   }
 }
 

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -149,7 +149,6 @@
         {/foreach}
 
         {if isset($toolbar_btn['modules-list'])}
-          {* TODO: REFACTOR ALL THIS THINGS *}
           <a
             class="btn btn-floating-item {if isset($toolbar_btn['modules-list'].target) && $toolbar_btn['modules-list'].target} _blank{/if}"
             id="page-header-desc-{$table}-{if isset($toolbar_btn['modules-list'].imgclass)}{$toolbar_btn['modules-list'].imgclass}{else}modules-list{/if}"

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -131,7 +131,6 @@
         {hook h='displayDashboardToolbarTopMenu'}
         {foreach from=$toolbar_btn item=btn key=k}
           {if $k != 'back' && $k != 'modules-list'}
-            {* TODO: REFACTOR ALL THIS THINGS *}
             <a
               class="btn btn-floating-item {if isset($btn.target) && $btn.target} _blank{/if} pointer"{if isset($btn.href)}
               id="page-header-desc-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -82,6 +82,7 @@
             {/if}
           </div>
         </div>
+
       {/block}
     </div>
   </div>
@@ -120,5 +121,66 @@
       </ul>
     </div>
   {/if}
+
+  <div class="btn-floating">
+    <button class="btn btn-primary collapsed" data-toggle="collapse" data-target=".btn-floating-container" aria-expanded="false">
+      <i class="material-icons">add</i>
+    </button>
+    <div class="btn-floating-container collapse">
+      <div class="btn-floating-menu">
+        {hook h='displayDashboardToolbarTopMenu'}
+        {foreach from=$toolbar_btn item=btn key=k}
+          {if $k != 'back' && $k != 'modules-list'}
+            {* TODO: REFACTOR ALL THIS THINGS *}
+            <a
+              class="btn btn-floating-item {if isset($btn.target) && $btn.target} _blank{/if} pointer"{if isset($btn.href)}
+              id="page-header-desc-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"
+              href="{$btn.href|escape}"{/if}
+              title="{if isset($btn.help)}{$btn.help}{else}{$btn.desc|escape}{/if}"{if isset($btn.js) && $btn.js}
+              onclick="{$btn.js}"{/if}{if isset($btn.modal_target) && $btn.modal_target}
+              data-target="{$btn.modal_target}"
+              data-toggle="modal"{/if}{if isset($btn.help)}
+              data-toggle="pstooltip"
+              data-placement="bottom"{/if}
+            >
+              {$btn.desc|escape}
+              {if !empty($btn.icon)}<i class="material-icons">{$btn.icon}</i>{/if}
+            </a>
+          {/if}
+        {/foreach}
+
+        {if isset($toolbar_btn['modules-list'])}
+          {* TODO: REFACTOR ALL THIS THINGS *}
+          <a
+            class="btn btn-floating-item {if isset($toolbar_btn['modules-list'].target) && $toolbar_btn['modules-list'].target} _blank{/if}"
+            id="page-header-desc-{$table}-{if isset($toolbar_btn['modules-list'].imgclass)}{$toolbar_btn['modules-list'].imgclass}{else}modules-list{/if}"
+            {if isset($toolbar_btn['modules-list'].href)}href="{$toolbar_btn['modules-list'].href}"{/if}
+            title="{$toolbar_btn['modules-list'].desc}"
+            {if isset($toolbar_btn['modules-list'].js) && $toolbar_btn['modules-list'].js}onclick="{$toolbar_btn['modules-list'].js}"{/if}
+          >
+            {$toolbar_btn['modules-list'].desc}
+          </a>
+        {/if}
+
+        {if isset($help_link) and $help_link != false}
+          {if $enableSidebar}
+            <a class="btn btn-floating-item btn-help btn-sidebar" href="#"
+               title="{l s='Help' d='Admin.Global'}"
+               data-toggle="sidebar"
+               data-target="#right-sidebar"
+               data-url="{$help_link|escape}"
+               id="product_form_open_help"
+            >
+              {l s='Help' d='Admin.Global'}
+            </a>
+          {else}
+            <a class="btn btn-floating-item btn-help" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
+              {l s='Help' d='Admin.Global'}
+            </a>
+          {/if}
+        {/if}
+      </div>
+    </div>
+  </div> 
   {hook h='displayDashboardTop'}
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We wants to get rid of header button as they use too much space on mobile, so we wants to push them to the floating button
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22978.
| How to test?      | Go on Product Lists page for example, see if on desktop view you you see the buttons, and on mobile view you see the floating button. PS: Recommended Modules can't be inside the button for the moment, the module itself needs to be updated as the markup is pushed using JS (which is a bad practice)
| Possible impacts? | Modules using this bar without using the hook


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22984)
<!-- Reviewable:end -->
![image](https://user-images.githubusercontent.com/14963751/105730326-83d76d80-5f2e-11eb-976f-c601943adef9.png)
