### PR TITLE
Add test 'Set required fields for address page'

### DIFF
--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
@@ -18,7 +18,7 @@ const foAddAddressesPage = require('@pages/FO/myAccount/addAddress');
 // Import test context
 const testContext = require('@utils/testContext');
 
-const baseContext = 'functional_BO_customers_customers_setRequiredFields';
+const baseContext = 'functional_BO_customers_addresses_setRequiredFields';
 
 // Import data
 const {DefaultAccount} = require('@data/demo/customer');

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
@@ -1,0 +1,127 @@
+require('module-alias/register');
+
+const {expect} = require('chai');
+
+// Import utils
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+
+// Import pages
+const dashboardPage = require('@pages/BO/dashboard');
+const addressesPage = require('@pages/BO/customers/addresses');
+const foLoginPage = require('@pages/FO/login');
+const foHomePage = require('@pages/FO/home');
+const foMyAccountPage = require('@pages/FO/myAccount');
+const foAddressesPage = require('@pages/FO/myAccount/addresses');
+const foAddAddressesPage = require('@pages/FO/myAccount/addAddress');
+
+// Import test context
+const testContext = require('@utils/testContext');
+
+const baseContext = 'functional_BO_customers_customers_setRequiredFields';
+
+// Import data
+const {DefaultAccount} = require('@data/demo/customer');
+const FakerAddress = require('@data/faker/address');
+
+let browserContext;
+let page;
+const addressDataWithVatNumber = new FakerAddress({country: 'France', vatNumber: '0102030405'});
+const addressDataWithoutVatNumber = new FakerAddress({country: 'France'});
+
+describe('Set required fields for customers', async () => {
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await loginCommon.loginBO(this, page);
+  });
+
+  it('should go to \'Customers > Addresses\' page', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
+
+    await dashboardPage.goToSubMenu(
+      page,
+      dashboardPage.customersParentLink,
+      dashboardPage.addressesLink,
+    );
+
+    await addressesPage.closeSfToolBar(page);
+
+    const pageTitle = await addressesPage.getPageTitle(page);
+    await expect(pageTitle).to.contains(addressesPage.pageTitle);
+  });
+
+  [
+    {args: {action: 'select', exist: true, addressData: addressDataWithVatNumber}},
+    {args: {action: 'unselect', exist: false, addressData: addressDataWithoutVatNumber}},
+  ].forEach((test, index) => {
+    it(`should ${test.args.action} 'Vat number' as required fields`, async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}PartnersOffers`, baseContext);
+
+      const textResult = await addressesPage.setRequiredFields(page, 6, test.args.exist);
+      await expect(textResult).to.equal(addressesPage.successfulUpdateMessage);
+    });
+
+    it('should view my shop and login', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `viewMyShop${index}`, baseContext);
+
+      // View shop
+      page = await addressesPage.viewMyShop(page);
+
+      // Change language in FO
+      await foHomePage.changeLanguage(page, 'en');
+
+      // Go to create account page
+      await foHomePage.goToLoginPage(page);
+      await foLoginPage.customerLogin(page, DefaultAccount);
+
+      const connected = await foHomePage.isCustomerConnected(page);
+      await expect(connected, 'Customer is not connected in FO').to.be.true;
+    });
+
+
+    it('should go to addresses page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `goToFOAddressesPage${index}`, baseContext);
+
+      await foMyAccountPage.goToAddressesPage(page);
+      const pageHeaderTitle = await foAddressesPage.getPageTitle(page);
+      await expect(pageHeaderTitle).to.equal(foAddressesPage.pageTitle);
+    });
+
+    it('should go to create address page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAddressPage', baseContext);
+
+      await foAddressesPage.openNewAddressForm(page);
+
+      const pageHeaderTitle = await foAddAddressesPage.getHeaderTitle(page);
+      await expect(pageHeaderTitle).to.equal(foAddAddressesPage.creationFormTitle);
+    });
+
+    it('should check if \'Vat number\' is required', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkOptionalLabel', baseContext);
+
+      const result = await foAddAddressesPage.isVatNumberRequired(page);
+      await expect(result).to.equal(test.args.exist);
+    });
+
+    it('should sign out from FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'sighOutFO', baseContext);
+
+      await foAddAddressesPage.logout(page);
+
+      const isCustomerConnected = await foAddAddressesPage.isCustomerConnected(page);
+      await expect(isCustomerConnected, 'Customer is connected').to.be.false;
+
+      // Go back to BO
+      page = await foAddAddressesPage.closePage(browserContext, page, 0);
+    });
+  });
+});

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
@@ -64,7 +64,7 @@ describe('Set required fields for customers', async () => {
     {args: {action: 'unselect', exist: false, addressData: addressDataWithoutVatNumber}},
   ].forEach((test, index) => {
     it(`should ${test.args.action} 'Vat number' as required fields`, async function () {
-      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}PartnersOffers`, baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}VatNumber`, baseContext);
 
       const textResult = await addressesPage.setRequiredFields(page, 6, test.args.exist);
       await expect(textResult).to.equal(addressesPage.successfulUpdateMessage);
@@ -97,7 +97,7 @@ describe('Set required fields for customers', async () => {
     });
 
     it('should go to create address page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToNewAddressPage', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `goToNewAddressPage${index}`, baseContext);
 
       await foAddressesPage.openNewAddressForm(page);
 
@@ -106,14 +106,14 @@ describe('Set required fields for customers', async () => {
     });
 
     it('should check if \'Vat number\' is required', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkOptionalLabel', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `checkOptionalLabel${index}`, baseContext);
 
       const result = await foAddAddressesPage.isVatNumberRequired(page);
       await expect(result).to.equal(test.args.exist);
     });
 
     it('should sign out from FO', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'sighOutFO', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `signOutFO${index}`, baseContext);
 
       await foAddAddressesPage.logout(page);
 

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
@@ -29,7 +29,13 @@ let page;
 const addressDataWithVatNumber = new FakerAddress({country: 'France', vatNumber: '0102030405'});
 const addressDataWithoutVatNumber = new FakerAddress({country: 'France'});
 
-describe('Set required fields for customers', async () => {
+/*
+Check 'Vat number' to be a required fields
+Go to FO, new address page and verify that 'Vat number' is required
+Uncheck 'Vat number'
+Go to FO, new address page and verify that 'Vat number' is not required
+ */
+describe('Set required fields for addresses', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);

--- a/tests/UI/pages/BO/customers/addresses/index.js
+++ b/tests/UI/pages/BO/customers/addresses/index.js
@@ -42,6 +42,12 @@ class Addresses extends BOBasePage {
     this.paginationLabel = `${this.addressGridPanel} .col-form-label`;
     this.paginationNextLink = `${this.addressGridPanel} #pagination_next_url`;
     this.paginationPreviousLink = `${this.addressGridPanel} [aria-label='Previous']`;
+
+    // Required field section
+    this.setRequiredFieldsButton = 'button[data-target=\'#addressRequiredFieldsContainer\']';
+    this.requiredFieldCheckBox = id => `#required_fields_address_required_fields_${id}`;
+    this.requiredFieldsForm = '#addressRequiredFieldsContainer';
+    this.saveButton = `${this.requiredFieldsForm} button`;
   }
 
   /*
@@ -252,6 +258,34 @@ class Addresses extends BOBasePage {
   async paginationPrevious(page) {
     await this.clickAndWaitForNavigation(page, this.paginationPreviousLink);
     return this.getPaginationLabel(page);
+  }
+
+  // Set required field
+  /**
+   * Set required fields
+   * @param page
+   * @param id
+   * @param valueWanted
+   * @returns {Promise<string>}
+   */
+  async setRequiredFields(page, id, valueWanted = true) {
+    // Check if form is open
+    if (await this.elementNotVisible(page, `${this.requiredFieldsForm}.show`, 1000)) {
+      await Promise.all([
+        this.waitForSelectorAndClick(page, this.setRequiredFieldsButton),
+        this.waitForVisibleSelector(page, `${this.requiredFieldsForm}.show`),
+      ]);
+    }
+
+    // Click on checkbox if not selected
+    const isCheckboxSelected = await this.isCheckboxSelected(page, this.requiredFieldCheckBox(id));
+    if (valueWanted !== isCheckboxSelected) {
+      await page.$eval(`${this.requiredFieldCheckBox(id)} + i`, el => el.click());
+    }
+
+    // Save setting
+    await this.clickAndWaitForNavigation(page, this.saveButton);
+    return this.getAlertSuccessBlockParagraphContent(page);
   }
 }
 

--- a/tests/UI/pages/FO/myAccount/addAddress.js
+++ b/tests/UI/pages/FO/myAccount/addAddress.js
@@ -85,6 +85,15 @@ class AddAddress extends FOBasePage {
     await this.clickAndWaitForNavigation(page, this.saveButton);
     return this.getTextContent(page, this.alertSuccessBlock);
   }
+
+  /**
+   * Is vat number input is required
+   * @param page
+   * @returns {Promise<boolean>}
+   */
+  async isVatNumberRequired(page) {
+    return this.elementVisible(page, `${this.vatNumberInput}:required`, 1000);
+  }
 }
 
 module.exports = new AddAddress();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Add test 'Set required fields for address page'
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | TEST_PATH="functional/BO/04_customers/02_addresses/06_setRequiredFields.js" URL_FO=yourShopURL npm run specific-test
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22985)
<!-- Reviewable:end -->
