### PR TITLE
Hide shop name on mobile

### DIFF
--- a/admin-dev/themes/default/sass/partials/_header.sass
+++ b/admin-dev/themes/default/sass/partials/_header.sass
@@ -159,6 +159,8 @@ $search-border-color: #bbcdd2
 		overflow-x: hidden
 		i
 			color: $medium-gray
+		@media (max-width: 768px)
+			font-size: 0!important
 		@media (max-width: 320px)
 			max-width: 140px
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -346,6 +346,10 @@ $header-text-color: #4e6167 !default;
     color: $header-text-color;
     white-space: nowrap;
 
+    @media (max-width: breakpoint-max("sm")) {
+      font-size: 0;
+    }
+
     &:hover {
       color: $primary;
       text-decoration: none;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | shop name was breaking the header bar on mobile inside BO
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22987.
| How to test?      | Go on the bo on both default and new-theme pages and see on mobile if the header button shop is now normal
| Possible impacts? | every responsive pages

![image](https://user-images.githubusercontent.com/14963751/105733968-660c0780-5f32-11eb-82b7-1cf59ea3890f.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22988)
<!-- Reviewable:end -->
