### PR TITLE
Align labels to right and space on red star

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -45,7 +45,12 @@
       @extend .col-sm-4;
       @extend .col-form-label;
 
+      .text-danger {
+        margin-right: 0.5rem;
+      }
+
       @include media-breakpoint-up("sm") {
+        justify-content: flex-end;
         padding-right: 25px;
         text-align: right;
       }

--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -44,6 +44,7 @@
     > .form-control-label:first-of-type:not(.label-on-top) {
       @extend .col-sm-4;
       @extend .col-form-label;
+      display: inline;
 
       .text-danger {
         margin-right: 0.5rem;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Labels were aligned to left, which wasn't the behavior on 177, also red asterisk was too near from the label, it's not spaced by 8 px
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22873.
| How to test?      | Go on Traffic & SEO > SEO & URLs page, see if labels are correctly aligned, like on the screen
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

![image](https://user-images.githubusercontent.com/14963751/105851316-336e1780-5fe3-11eb-890e-73cf73a1fca3.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22996)
<!-- Reviewable:end -->
