### PR TITLE
Fix compare function of dashboard's calendar

### DIFF
--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -380,7 +380,7 @@ $( document ).ready(function() {
 	});
 
 	$('#datepicker-compare').click(function() {
-		if ($(this).attr("checked")) {
+    if ($(this).is(":checked")) {
 			$('#compare-options').trigger('change');
 			$('#form-date-body-compare').show();
 			$('#compare-options').prop('disabled', false);

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -380,7 +380,7 @@ $( document ).ready(function() {
 	});
 
 	$('#datepicker-compare').click(function() {
-    if ($(this).is(":checked")) {
+    if ($(this).prop("checked")) {
 			$('#compare-options').trigger('change');
 			$('#form-date-body-compare').show();
 			$('#compare-options').prop('disabled', false);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | We couldn't compare periods on the dashboard because the checkbox wasn't working
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22973.
| How to test?      | Go on the dashboard and try to compare periods, you should be able to do it
| Possible impacts? | The dashboard's calendar

![image](https://user-images.githubusercontent.com/14963751/105853664-37e7ff80-5fe6-11eb-987c-f6fe5e5bee6f.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/22997)
<!-- Reviewable:end -->
