### PR TITLE
Rename addAnchor parameter in getProductLink method

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -135,7 +135,7 @@ class LinkCore
         $ipa = null,
         $force_routes = false,
         $relativeProtocol = false,
-        $addAnchor = false,
+        $anchor_with_ids = false,
         $extraParams = []
     ) {
         $dispatcher = Dispatcher::getInstance();
@@ -230,7 +230,7 @@ class LinkCore
         if ($ipa) {
             $product = $this->getProductObject($product, $idLang, $idShop);
         }
-        $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $addAnchor) : '';
+        $anchor = $ipa ? $product->getAnchor((int) $ipa, (bool) $anchor_with_ids) : '';
 
         return $url . $dispatcher->createUrl('product_rule', $idLang, array_merge($params, $extraParams), $force_routes, $anchor, $idShop);
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | @jonatanrs Rename addAnchor parameter in getProductLink method
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | It is a simple renaming of a parameter to make it easier to understand what it does, since the current name is completely incorrect.
| Possible impacts? | No impact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23017)
<!-- Reviewable:end -->
