### PR TITLE
Ignore refunded state on reserved quantity

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -134,8 +134,8 @@ class StockManager implements StockInterface
     private function updateReservedProductQuantity(int $shopId, int $errorState, int $cancellationState, ?int $idProduct = null, ?int $idOrder = null)
     {
         $statesToIgnore = [
-            (int) $errorState,
-            (int) $cancellationState,
+            $errorState,
+            $cancellationState,
             (int) (new ConfigurationAdapter())->get('PS_OS_REFUND'),
         ];
         $updateReservedQuantityQuery = '

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -148,7 +148,7 @@ class StockManager implements StockInterface
                 WHERE o.id_shop = :shop_id AND
                 os.shipped != 1 AND (
                     o.valid = 1 OR (
-                        os.id_order_state NOT IN (:invalidStates)
+                        os.id_order_state NOT IN (:statesToIgnore)
                     )
                 ) AND sa.id_product = od.product_id AND
                 sa.id_product_attribute = od.product_attribute_id

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -160,7 +160,7 @@ class StockManager implements StockInterface
         $strParams = [
             '{table_prefix}' => _DB_PREFIX_,
             ':shop_id' => (int) $shopId,
-            ':invalidStates' => implode(',', $invalidStates)
+            ':statesToIgnore' => implode(',', $statesToIgnore),
         ];
 
         if ($idProduct) {

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -133,10 +133,10 @@ class StockManager implements StockInterface
      */
     private function updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null)
     {
-        $invalidStates = [
+        $statesToIgnore = [
             (int) $errorState,
             (int) $cancellationState,
-            (int) (new ConfigurationAdapter())->get('PS_OS_REFUND')
+            (int) (new ConfigurationAdapter())->get('PS_OS_REFUND'),
         ];
         $updateReservedQuantityQuery = '
             UPDATE {table_prefix}stock_available sa

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -131,7 +131,7 @@ class StockManager implements StockInterface
      *
      * @return bool
      */
-    private function updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null)
+    private function updateReservedProductQuantity(int $shopId, int $errorState, int $cancellationState, ?int $idProduct = null, ?int $idOrder = null)
     {
         $statesToIgnore = [
             (int) $errorState,

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -133,11 +133,11 @@ class StockManager implements StockInterface
      */
     private function updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null)
     {
-        $invalidStates = array(
+        $invalidStates = [
             (int) $errorState,
             (int) $cancellationState,
             (int) (new ConfigurationAdapter())->get('PS_OS_REFUND')
-        );
+        ];
         $updateReservedQuantityQuery = '
             UPDATE {table_prefix}stock_available sa
             SET sa.reserved_quantity = (


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When order has been in native refunded state, Prestashop must don't include this in the reservation calculation.<br>And must not considerate all line present in Order.<br>And finaly don't reserve stock for order who are in this state. Exactly same behavior for cancelation state.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #23013
| How to test?      | Assure you have quantity available for the product. Go to 'backoffice > catalog > stock'<br>Check reserved stock of your product example 1<br>Create order with the product<br>Change the status of order to payment accepted<br>Go to 'backoffice > catalog > stock' check reserved stock 2<br>Go to 'backoffice > orders ' change order state to "refunded"<br>Go to 'backoffice > catalog > stock' check reserved stock you must see 1<br>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23022)
<!-- Reviewable:end -->
