### PR TITLE
Add test 'Carrier options - order by ascending/descending '

### DIFF
--- a/tests/UI/campaigns/functional/BO/09_shipping/02_preferences/02_carrierOptions/02_updateCarriersSortOption.js
+++ b/tests/UI/campaigns/functional/BO/09_shipping/02_preferences/02_carrierOptions/02_updateCarriersSortOption.js
@@ -37,14 +37,14 @@ let numberOfCarriers = 0;
 Go to shipping > Carriers page
 Activate the 2 carriers 'My cheap carrier' and 'My light carrier'
 Go to shipping > preferences page
-Choose sort by 'Price'
+Choose sort by 'Price' and orderBy 'Ascending/Descending'
 Go to FO and check the carriers sort
-Go back to BO and choose sort by 'Position'
+Go back to BO and choose sort by 'Position' and orderBy 'Ascending/Descending'
 Go to FO and check the carriers sort
 Go back to BO > shipping > Carriers
 Disable the 2 carriers 'My cheap carrier' and 'My light carrier'
  */
-describe('Update \'sort carriers by\' and check it in FO', async () => {
+describe('Update \'sort carriers by\' and \'Order carriers by\' then check it in FO', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -144,12 +144,16 @@ describe('Update \'sort carriers by\' and check it in FO', async () => {
       Carriers.cheapCarrier.name,
       Carriers.lightCarrier.name,
     ];
-
-    ['Position', 'Price'].forEach((sortBy, index) => {
-      it(`should set sort by '${sortBy}' in BO`, async function () {
+    [
+      {args: {sortBy: 'Position', orderBy: 'Ascending'}},
+      {args: {sortBy: 'Position', orderBy: 'Descending'}},
+      {args: {sortBy: 'Price', orderBy: 'Descending'}},
+      {args: {sortBy: 'Price', orderBy: 'Ascending'}},
+    ].forEach((test, index) => {
+      it(`should set sort by '${test.args.sortBy}' and order by '${test.args.orderBy}' in BO`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `setDefaultCarrier${index}`, baseContext);
 
-        const textResult = await preferencesPage.setCarrierSortBy(page, sortBy);
+        const textResult = await preferencesPage.setCarrierSortOrderBy(page, test.args.sortBy, test.args.orderBy);
         await expect(textResult).to.contain(preferencesPage.successfulUpdateMessage);
       });
 
@@ -190,16 +194,24 @@ describe('Update \'sort carriers by\' and check it in FO', async () => {
         await expect(isStepAddressComplete, 'Step Address is not complete').to.be.true;
       });
 
-      it(`should verify the sort of carriers by '${sortBy}'`, async function () {
-        await testContext.addContextItem(this, 'testIdentifier', `checkDefaultCarrier${index}`, baseContext);
+      it('should verify the sort of carriers', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `checkSort${index}`, baseContext);
 
-        if (sortBy === 'Price') {
+        if (test.args.sortBy === 'Price') {
           const sortedCarriers = await foCheckoutPage.getAllCarriersPrices(page);
           const expectedResult = await foCheckoutPage.sortArray(sortedCarriers, true);
-          await expect(sortedCarriers).to.deep.equal(expectedResult);
-        } else {
+          if (test.args.orderBy === 'Ascending') {
+            await expect(sortedCarriers).to.deep.equal(expectedResult);
+          } else {
+            await expect(sortedCarriers).to.deep.equal(expectedResult.reverse());
+          }
+        } else if (test.args.sortBy === 'Position') {
           const sortedCarriers = await foCheckoutPage.getAllCarriersNames(page);
-          await expect(sortedCarriers).to.deep.equal(sortByPosition);
+          if (test.args.orderBy === 'Ascending') {
+            await expect(sortedCarriers).to.deep.equal(sortByPosition);
+          } else {
+            await expect(sortedCarriers).to.deep.equal(sortByPosition.reverse());
+          }
         }
       });
 

--- a/tests/UI/pages/BO/shipping/preferences/index.js
+++ b/tests/UI/pages/BO/shipping/preferences/index.js
@@ -17,6 +17,7 @@ class Preferences extends BOBasePage {
     this.carrierOptionForm = '#carrier-options';
     this.defaultCarrierSelect = '#form_carrier_options_default_carrier';
     this.sortBySelect = '#form_carrier_options_carrier_default_order_by';
+    this.orderBySelect = '#form_carrier_options_carrier_default_order_way';
     this.saveCarrierOptionsButton = `${this.carrierOptionForm} button`;
   }
 
@@ -56,10 +57,12 @@ class Preferences extends BOBasePage {
    * Set carriers sort By 'Price' or 'Position' in carrier option form
    * @param page
    * @param sortBy
+   * @param orderBy
    * @returns {Promise<string>}
    */
-  async setCarrierSortBy(page, sortBy) {
+  async setCarrierSortOrderBy(page, sortBy, orderBy = 'Ascending') {
     await this.selectByVisibleText(page, this.sortBySelect, sortBy);
+    await this.selectByVisibleText(page, this.orderBySelect, orderBy);
 
     // Save configuration and return successful message
     await this.clickAndWaitForNavigation(page, this.saveCarrierOptionsButton);

--- a/tests/UI/pages/BO/shipping/preferences/index.js
+++ b/tests/UI/pages/BO/shipping/preferences/index.js
@@ -54,7 +54,7 @@ class Preferences extends BOBasePage {
   }
 
   /**
-   * Set carriers sort By 'Price' or 'Position' in carrier option form
+   * Set carriers sort By 'Price' or 'Position' / order by 'Ascending' or 'descending' in carrier options form
    * @param page
    * @param sortBy
    * @param orderBy


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Add test 'Carrier options - order by ascending/descending '
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | TEST_PATH="functional/BO/09_shipping/02_preferences/02_carrierOptions/02_updateCarriersSortOption" URL_FO=yourShopURL npm run specific-test


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23023)
<!-- Reviewable:end -->
