### PR TITLE
Specify product combinations in cart when there is not enough stock 

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -637,7 +637,7 @@ class CartControllerCore extends FrontController
         if ($product['active']) {
             return $this->trans(
                 'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                ['%product%' => $product['name']],
+                ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
                 'Shop.Notifications.Error'
             );
         }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -636,7 +636,7 @@ class CartControllerCore extends FrontController
 
         if ($product['active']) {
             return $this->trans(
-                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                'The product %product% in your cart is no longer available in this quantity. Please adjust the quantity to proceed with the order.',
                 ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
                 'Shop.Notifications.Error'
             );


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/PrestaShop/issues/23051

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve the information displayed in the checkout when a product is without stock<br>From https://www.prestashop.com/forums/topic/1041442-nobody-can-figure-it-out-we-need-a-specialist
| Type?             | improvement
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23051
| How to test?      | Create a cart with product with attribute. Remove stock and check cart again. Error message is appearing.
| Possible impacts? | Cart dispaly


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23059)
<!-- Reviewable:end -->
