### PR TITLE
Fix sidebar visibility when hidden by default on default theme

### DIFF
--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -188,6 +188,7 @@ $(document).ready(() => {
 
   $('.nav-bar').on('click', '.menu-collapse', function() {
     $('body').toggleClass('page-sidebar-closed');
+    $('.main-menu').toggleClass('sidebar-closed');
 
     if ($('body').hasClass('page-sidebar-closed')) {
       $('nav.nav-bar ul.main-menu > li')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Sidebar items were hidden if you refresh the page on default theme (dashboard for example) with sidebar hidden
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23026.
| How to test?      | Go on dashboard, hide the sidebar, refresh the page, show the sidebar : items should be visible
| Possible impacts? | BO Default theme


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23069)
<!-- Reviewable:end -->
