### PR TITLE
Fix product description lists color on FO

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -35,6 +35,10 @@
       padding-left: 0.75rem;
       list-style: inherit;
       list-style-position: inside;
+
+      li {
+        color: $gray;
+      }
     }
   }
 }

--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -38,6 +38,7 @@
       list-style-position: inside;
 
       li {
+        font-size: 0.9375rem;
         color: $gray;
       }
     }

--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -34,13 +34,16 @@
     ul,
     ol {
       padding-left: 0.75rem;
-      list-style: inherit;
       list-style-position: inside;
 
       li {
         font-size: 0.9375rem;
         color: $gray;
       }
+    }
+
+    ul {
+      list-style-type: disc;
     }
   }
 }

--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -31,7 +31,8 @@
       height: auto;
     }
 
-    ul {
+    ul,
+    ol {
       padding-left: 0.75rem;
       list-style: inherit;
       list-style-position: inside;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Image descriptions lists are black instead of grey (like the whole product page)
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23064.
| How to test?      | Add a list in a product description, go to the product page and see if the color is grey instead of black (see issue for reference)
| Possible impacts? | Product page color of description


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23073)
<!-- Reviewable:end -->
