### PR TITLE
Annually reset returns invoices

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -883,5 +883,8 @@ Country</value>
     <configuration id="ADDONS_API_MODULE_CHANNEL" name="ADDONS_API_MODULE_CHANNEL">
       <value>stable</value>
     </configuration>
+    <configuration id="PS_CREDIT_SLIP_RESET" name="PS_CREDIT_SLIP_RESET">
+      <value>0</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
+++ b/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
@@ -54,6 +54,7 @@ final class CreditSlipOptionsConfiguration implements DataConfigurationInterface
     {
         return [
             'slip_prefix' => $this->configuration->get('PS_CREDIT_SLIP_PREFIX'),
+            'slip_reset' => $this->configuration->get('PS_CREDIT_SLIP_RESET'),
         ];
     }
 
@@ -64,6 +65,7 @@ final class CreditSlipOptionsConfiguration implements DataConfigurationInterface
     {
         if ($this->validateConfiguration($configuration)) {
             $this->configuration->set('PS_CREDIT_SLIP_PREFIX', $configuration['slip_prefix']);
+            $this->configuration->set('PS_CREDIT_SLIP_RESET', $configuration['slip_reset']);
         }
 
         return [];

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip;
 
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -43,12 +44,17 @@ final class CreditSlipOptionsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('slip_prefix', TranslatableType::class, [
-            'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),
-            'help' => $this->trans('Prefix used for credit slips.', 'Admin.Orderscustomers.Help'),
-            'required' => false,
-            'error_bubbling' => true,
-            'type' => TextType::class,
-        ]);
+        $builder
+            ->add('slip_prefix', TranslatableType::class, [
+                'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),
+                'help' => $this->trans('Prefix used for credit slips.', 'Admin.Orderscustomers.Help'),
+                'required' => false,
+                'error_bubbling' => true,
+                'type' => TextType::class,
+            ])
+            ->add('slip_reset', SwitchType::class, [
+                'label' => $this->trans('Reset sequential credit slip number at the beginning of the year', 'Admin.Orderscustomers.Feature'),
+                'required' => false,
+            ]);
     }
 }


### PR DESCRIPTION
Update, to reset the subscription number every year.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change, to restart the return invoices annually. Since it currently takes the invoice number by the id of the autoincremental database. In addition to being able to give errors if any record is deleted or exchanged. The proposed change posts the invoices created within the same year, in this way the autoincremental id is not taken into account. It takes into account the order of the invoice in the year of the same.  
| Type?             | improvement
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23080
| How to test?      | It can be verified by downloading the invoice pdf by subscription
| Possible impacts? | PDF invoices by subscription


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23075)
<!-- Reviewable:end -->
