### PR TITLE
Add deprecation notice on $location of Product and Combination

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -39,7 +39,12 @@ class CombinationCore extends ObjectModel
     /** @var string */
     public $supplier_reference;
 
-    /** @var string */
+    /**
+     * @deprecated since 1.7.8
+     * @see StockAvailable::$location instead
+     *
+     * @var string
+     */
     public $location = '';
 
     public $ean13;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -139,7 +139,12 @@ class ProductCore extends ObjectModel
      */
     public $supplier_reference;
 
-    /** @var string Location */
+    /**
+     * @deprecated since 1.7.8
+     * @see StockAvailable::$location instead
+     *
+     * @var string Location
+     */
     public $location = '';
 
     /** @var string|float Width in default width unit */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | $location property in Product and Combination was deprecated and its planned to be removed in next major version. StockAvailable is the source of truth that stores the location (stock_available database table). It was also related with this PR: https://github.com/PrestaShop/PrestaShop/pull/22185 which homogenized location constraints and made it readOnly in Combination and Product object models.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | #23008
| How to test?      | No manual testing needed, only comment in code was added
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23076)
<!-- Reviewable:end -->
