### PR TITLE
Fixed missing APE/SIRET Code in BackOffice Order View

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -28,7 +28,6 @@ namespace PrestaShop\PrestaShop\Adapter\Order\QueryHandler;
 
 use Address;
 use Carrier;
-use Configuration;
 use ConnectionsSource;
 use Context;
 use Country;
@@ -43,6 +42,7 @@ use OrderPayment;
 use OrderSlip;
 use OrderState;
 use PrestaShop\Decimal\Number;
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Customer\CustomerDataProvider;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
 use PrestaShop\PrestaShop\Core\Domain\Exception\InvalidSortingException;
@@ -78,6 +78,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderSourceForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderSourcesForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderStatusForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Image\Parser\ImageTagSourceParserInterface;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
@@ -114,6 +115,11 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
     private $customerDataProvider;
 
     /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
      * @var Context
      */
     private $context;
@@ -138,7 +144,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         Locale $locale,
         Context $context,
         CustomerDataProvider $customerDataProvider,
-        GetOrderProductsForViewingHandlerInterface $getOrderProductsForViewingHandler
+        GetOrderProductsForViewingHandlerInterface $getOrderProductsForViewingHandler,
+        Configuration $configuration
     ) {
         $this->translator = $translator;
         $this->contextLanguageId = $contextLanguageId;
@@ -147,6 +154,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $this->context = $context;
         $this->customerDataProvider = $customerDataProvider;
         $this->getOrderProductsForViewingHandler = $getOrderProductsForViewingHandler;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -164,7 +172,11 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->translator->trans('Tax included', [], 'Admin.Global') :
             $this->translator->trans('Tax excluded', [], 'Admin.Global');
 
-        $invoiceManagementIsEnabled = (bool) Configuration::get('PS_INVOICE', null, null, $order->id_shop);
+        $invoiceManagementIsEnabled = (bool) $this->configuration->get(
+            'PS_INVOICE',
+            null,
+            new ShopConstraint((int) $order->id_shop, (int) $order->id_shop_group)
+        );
 
         return new OrderForViewing(
             (int) $order->id,
@@ -224,6 +236,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $customerStats = $customer->getStats();
         $totalSpentSinceRegistration = Tools::convertPrice($customerStats['total_orders'], $order->id_currency);
 
+        $isB2BEnabled = $this->configuration->getBoolean('PS_B2B_ENABLE');
+
         return new OrderCustomerForViewing(
             $customer->id,
             $customer->firstname,
@@ -234,7 +248,9 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $totalSpentSinceRegistration !== null ? $this->locale->formatPrice($totalSpentSinceRegistration, $currency->iso_code) : '',
             $customerStats['nb_orders'],
             $customer->note,
-            (bool) $customer->is_guest
+            (bool) $customer->is_guest,
+            $isB2BEnabled ? ($customer->ape ?: '') : '',
+            $isB2BEnabled ? ($customer->siret ?: '') : ''
         );
     }
 
@@ -394,9 +410,14 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                     }
                 }
             } elseif (OrderDocumentType::DELIVERY_SLIP === $type) {
+                $conf = $this->configuration->get(
+                    'PS_DELIVERY_PREFIX',
+                    null,
+                    new ShopConstraint($order->id_shop, $order->id_shop_group)
+                );
                 $number = sprintf(
                     '%s%06d',
-                    Configuration::get('PS_DELIVERY_PREFIX', $this->contextLanguageId, null, $order->id_shop),
+                    $conf[$this->contextLanguageId] ?? '',
                     $document->delivery_number
                 );
                 $amount = $this->locale->formatPrice(
@@ -405,9 +426,10 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                 );
                 $numericAmount = $document->total_shipping_tax_incl;
             } elseif (OrderDocumentType::CREDIT_SLIP) {
+                $conf = $this->configuration->get('PS_CREDIT_SLIP_PREFIX');
                 $number = sprintf(
                     '%s%06d',
-                    Configuration::get('PS_CREDIT_SLIP_PREFIX', $this->contextLanguageId),
+                    $conf[$this->contextLanguageId] ?? '',
                     $document->id
                 );
                 $amount = $this->locale->formatPrice(
@@ -430,7 +452,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             );
         }
 
-        $canGenerateInvoice = Configuration::get('PS_INVOICE') &&
+        $canGenerateInvoice = $this->configuration->get('PS_INVOICE') &&
             count($order->getInvoicesCollection()) &&
             $order->invoice_number;
 
@@ -484,7 +506,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                     $trackingUrl = str_replace('@', $item['tracking_number'], $item['url']);
                 }
 
-                $weight = sprintf('%.3f %s', $item['weight'], Configuration::get('PS_WEIGHT_UNIT'));
+                $weight = sprintf('%.3f %s', $item['weight'], $this->configuration->get('PS_WEIGHT_UNIT'));
 
                 $carriers[] = new OrderCarrierForViewing(
                     (int) $item['id_order_carrier'],

--- a/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
@@ -71,7 +71,7 @@ class OrderCustomerForViewing
     private $validOrdersPlaced;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $privateNote;
 
@@ -79,6 +79,16 @@ class OrderCustomerForViewing
      * @var bool
      */
     private $isGuest;
+
+    /**
+     * @var string
+     */
+    private $ape;
+
+    /**
+     * @var string
+     */
+    private $siret;
 
     /**
      * @param int $id
@@ -91,6 +101,8 @@ class OrderCustomerForViewing
      * @param int $validOrdersPlaced
      * @param string|null $privateNote
      * @param bool $isGuest
+     * @param string $ape
+     * @param string $siret
      */
     public function __construct(
         int $id,
@@ -102,7 +114,9 @@ class OrderCustomerForViewing
         string $totalSpentSinceRegistration,
         int $validOrdersPlaced,
         ?string $privateNote,
-        bool $isGuest
+        bool $isGuest,
+        string $ape = '',
+        string $siret = ''
     ) {
         $this->id = $id;
         $this->firstName = $firstName;
@@ -114,6 +128,8 @@ class OrderCustomerForViewing
         $this->validOrdersPlaced = $validOrdersPlaced;
         $this->privateNote = $privateNote;
         $this->isGuest = $isGuest;
+        $this->ape = $ape;
+        $this->siret = $siret;
     }
 
     /**
@@ -194,5 +210,21 @@ class OrderCustomerForViewing
     public function isGuest(): bool
     {
         return $this->isGuest;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApe(): string
+    {
+        return $this->ape;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSiret(): string
+    {
+        return $this->siret;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -202,6 +202,7 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext()'
       - '@prestashop.adapter.data_provider.customer'
       - '@prestashop.adapter.order.query_handler.get_order_products_for_viewing_handler'
+      - '@prestashop.adapter.legacy.configuration'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -79,11 +79,18 @@
           <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
         {% endif %}
 
-        {%  if orderForViewing.customer.ape is not empty %}
+        {%  if orderForViewing.customer.siret is not empty %}
           <p class="mb-1">
+            <strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          </p>
+          <p>{{ orderForViewing.customer.siret }}</p>
+        {% endif %}
+
+        {%  if orderForViewing.customer.ape is not empty %}
+          <p class="mb-1 d-block d-md-none">
             <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
           </p>
-          <p>{{ orderForViewing.customer.ape }}</p>
+          <p class="d-block d-md-none">{{ orderForViewing.customer.ape }}</p>
         {% endif %}
       </div>
       <div id="validatedOrders" class="col-md-6">
@@ -103,11 +110,11 @@
           </p>
         {% endif %}
 
-        {%  if orderForViewing.customer.siret is not empty %}
-          <p class="mb-1">
-            <strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+        {%  if orderForViewing.customer.ape is not empty %}
+          <p class="mb-1 d-none d-md-block">
+            <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
           </p>
-          <p>{{ orderForViewing.customer.siret }}</p>
+          <p class="d-none d-md-block">{{ orderForViewing.customer.ape }}</p>
         {% endif %}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -78,6 +78,13 @@
           </p>
           <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
         {% endif %}
+
+        {%  if orderForViewing.customer.ape is not empty %}
+          <p class="mb-1">
+            <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          </p>
+          <p>{{ orderForViewing.customer.ape }}</p>
+        {% endif %}
       </div>
       <div id="validatedOrders" class="col-md-6">
         <p class="mb-1">
@@ -94,6 +101,13 @@
           <p>
             <span class="badge rounded badge-dark">{{ orderForViewing.customer.totalSpentSinceRegistration }}</span>
           </p>
+        {% endif %}
+
+        {%  if orderForViewing.customer.siret is not empty %}
+          <p class="mb-1">
+            <strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          </p>
+          <p>{{ orderForViewing.customer.siret }}</p>
         {% endif %}
       </div>
     </div>

--- a/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerFeatureContext.php
@@ -93,6 +93,26 @@ class CustomerFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^the customer "(.+)" has SIRET "(.+)"$/
+     */
+    public function customerHasSIRET(string $reference, string $siret): void
+    {
+        $customer = $this->getCustomerByReference($reference);
+        $customer->siret = $siret;
+        $customer->save();
+    }
+
+    /**
+     * @Given /^the customer "(.+)" has APE "(.+)"$/
+     */
+    public function customerHasAPE(string $reference, string $ape): void
+    {
+        $customer = $this->getCustomerByReference($reference);
+        $customer->ape = $ape;
+        $customer->save();
+    }
+
+    /**
      * @When /^I am logged in as "(.+)"$/
      */
     public function setCurrentCustomer($customerName)

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderCustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderCustomerFeatureContext.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use PHPUnit\Framework\Assert as Assert;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderCustomerForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderForViewing;
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+
+class OrderCustomerFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @Then /^the customer of the order "(.+)" has the APE Code "(.*)"$/
+     *
+     * @param string $orderReference
+     * @param string $ape
+     */
+    public function orderCustomerHasAPECode(string $orderReference, string $ape): void
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        /** @var OrderCustomerForViewing $orderCustomerForViewing */
+        $orderCustomerForViewing = $orderForViewing->getCustomer();
+        Assert::assertSame(
+            $ape,
+            $orderCustomerForViewing->getApe(),
+            sprintf(
+                'Expected customer with id "%d" has APE code "%s" but received "%s"',
+                $orderCustomerForViewing->getId(),
+                $orderCustomerForViewing->getApe(),
+                $ape
+            )
+        );
+    }
+
+    /**
+     * @Then /^the customer of the order "(.+)" has the SIRET Code "(.*)"$/
+     *
+     * @param string $orderReference
+     * @param string $siret
+     */
+    public function orderCustomerHasSIRETCode(string $orderReference, string $siret): void
+    {
+        $orderId = SharedStorage::getStorage()->get($orderReference);
+        /** @var OrderForViewing $orderForViewing */
+        $orderForViewing = $this->getQueryBus()->handle(new GetOrderForViewing($orderId));
+        /** @var OrderCustomerForViewing $orderCustomerForViewing */
+        $orderCustomerForViewing = $orderForViewing->getCustomer();
+
+        Assert::assertSame(
+            $siret,
+            $orderCustomerForViewing->getSiret(),
+            sprintf(
+                'Expected customer with id "%d" has SIRET code "%s" but received "%s"',
+                $orderCustomerForViewing->getId(),
+                $orderCustomerForViewing->getSiret(),
+                $siret
+            )
+        );
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_customer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_customer.feature
@@ -1,0 +1,38 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-customer
+@reset-database-before-feature
+@reboot-kernel-before-feature
+@clear-cache-before-feature
+@order-customer
+Feature: Order from Back Office (BO)
+  In order to manage orders for FO customers
+  As a BO user
+  I need to be able to customize orders from the BO
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And the customer "testCustomer" has SIRET "49791663500061"
+    And the customer "testCustomer" has APE "5829C"
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+
+  Scenario: Check B2B when the B2B mode is disabled
+    Given shop configuration for "PS_B2B_ENABLE" is set to 0
+    Then the customer of the order "bo_order1" has the APE Code ""
+    And the customer of the order "bo_order1" has the SIRET Code ""
+
+  Scenario: Check B2B when the B2B mode is enable
+    Given shop configuration for "PS_B2B_ENABLE" is set to 1
+    Then the customer of the order "bo_order1" has the APE Code "5829C"
+    And the customer of the order "bo_order1" has the SIRET Code "49791663500061"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -78,6 +78,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderPaymentFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderShippingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderCartFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\OrderCustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AddressFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderMessageContext
@@ -88,7 +89,6 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Configuration\RoundingTypeConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\PriceDisplayMethodConfigurationFeatureContext
         currency:
             paths:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Fixed missing APE/SIRET Code in BackOffice Order View
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #22983
| How to test?      | Cf. #22983

**:notebook: BC Break :**
* The constructor of the file `src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php` has a new parameter (the 7th) : `\PrestaShop\PrestaShop\Adapter\Configuration $configuration`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23078)
<!-- Reviewable:end -->
