### PR TITLE
Fix the combination's disappearance from Cart when it's updated by WS

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -284,7 +284,7 @@ class CombinationCore extends ObjectModel
      *
      * @return bool
      */
-    public function deleteCartProductCombination(): bool
+    protected function deleteCartProductCombination(): bool
     {
         return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id);
     }

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -282,7 +282,7 @@ class CombinationCore extends ObjectModel
     /**
      * Delete product combination from cart.
      *
-     * @return array Deletion result
+     * @return bool
      */
     public function deleteCartProductCombination()
     {

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -286,6 +286,10 @@ class CombinationCore extends ObjectModel
      */
     protected function deleteCartProductCombination(): bool
     {
+        if ((int) $this->id === 0) {
+            return false;
+        }
+
         return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id);
     }
 

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -284,7 +284,7 @@ class CombinationCore extends ObjectModel
      *
      * @return bool
      */
-    public function deleteCartProductCombination()
+    public function deleteCartProductCombination(): bool
     {
         return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id);
     }

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -174,6 +174,10 @@ class CombinationCore extends ObjectModel
             return false;
         }
 
+        if (!$this->deleteCartProductCombination()) {
+            return false;
+        }
+
         $this->deleteFromSupplier($this->id_product);
         Product::updateDefaultAttribute($this->id_product);
         Tools::clearColorListCache((int) $this->id_product);
@@ -266,7 +270,6 @@ class CombinationCore extends ObjectModel
             return false;
         }
         $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = ' . (int) $this->id);
-        $result &= Db::getInstance()->delete('cart_product', '`id_product_attribute` = ' . (int) $this->id);
         $result &= Db::getInstance()->delete('product_attribute_image', '`id_product_attribute` = ' . (int) $this->id);
 
         if ($result) {
@@ -274,6 +277,16 @@ class CombinationCore extends ObjectModel
         }
 
         return $result;
+    }
+
+    /**
+     * Delete product combination from cart.
+     *
+     * @return array Deletion result
+     */
+    public function deleteCartProductCombination()
+    {
+        return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove combination from cart ONLY on delete. Before ,when web service update the combination, deleteAssociations method was called and that combination left the customer cart.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23061
| How to test?      | Cf. #23061
| Possible impacts? | Check that this does not break the expected relational integrity and business rules.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23081)
<!-- Reviewable:end -->
