### PR TITLE
Fix fields width when view is disabled on product page

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -16,6 +16,10 @@
 .product-page {
   padding-bottom: 80px;
 
+  > #field-disabled {
+    width: 100%;
+  }
+
   .widget-radio-inline {
     margin-bottom: 10px;
 

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -17,6 +17,9 @@
   padding-bottom: 80px;
 
   > #field-disabled {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     width: 100%;
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product fields tabs had different sizes depending of your rights on the backoffice
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #18173.
| How to test?      | See issue, basically : create an employee with view only rights on product page, and see on different tabs if size is fine
| Possible impacts? | Product page with limited rights


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23092)
<!-- Reviewable:end -->
