### PR TITLE
Improve the information displayed in the checkout when a product is without stock

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -526,7 +526,7 @@ class CartControllerCore extends FrontController
                     );
                 } elseif (!$update_quantity) {
                     $this->errors[] = $this->trans(
-                        'You already have the maximum quantity available for product %product%.',
+                        'You have reached the maximum order quantity for product %product%.',
                         ['%product%' => $productName],
                         'Shop.Notifications.Error'
                     );

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -647,7 +647,7 @@ class CartControllerCore extends FrontController
 
         if ($product['active']) {
             return $this->trans(
-                'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                'The product %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
                 ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
                 'Shop.Notifications.Error'
             );

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -526,7 +526,7 @@ class CartControllerCore extends FrontController
                     );
                 } elseif (!$update_quantity) {
                     $this->errors[] = $this->trans(
-                        'You have reached the maximum order quantity for product %product%.',
+                        'You have reached the maximum order quantity for the product %product%.',
                         ['%product%' => $productName],
                         'Shop.Notifications.Error'
                     );

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -403,10 +403,12 @@ class CartControllerCore extends FrontController
             $productAttributes = rtrim($productAttributes, $separator . ' ');
         }
 
+        $productName = $product->name . (!empty($productAttributes) ? ' ' . $productAttributes : '');
+
         if (!$product->id || !$product->active || !$product->checkAccess($this->context->cart->id_customer)) {
             $this->{$ErrorKey}[] = $this->trans(
                 'The product %product% is no longer available.',
-                ['%product%' => $product->name . (!empty($productAttributes) ? ' ' . $productAttributes : '')],
+                ['%product%' => $productName],
                 'Shop.Notifications.Error'
             );
 
@@ -447,7 +449,7 @@ class CartControllerCore extends FrontController
         if ('update' !== $mode && $this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
             $this->{$ErrorKey}[] = $this->trans(
                 'The product %product% is no longer available in this quantity.',
-                ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
+                ['%product%' => $productName],
                 'Shop.Notifications.Error'
             );
         }
@@ -457,7 +459,7 @@ class CartControllerCore extends FrontController
             if ($qty_to_check < $product->minimal_quantity) {
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : ''), '%quantity%' => $product->minimal_quantity],
+                    ['%product%' => $productName, '%quantity%' => $product->minimal_quantity],
                     'Shop.Notifications.Error'
                 );
 
@@ -468,7 +470,7 @@ class CartControllerCore extends FrontController
             if ($qty_to_check < $combination->minimal_quantity) {
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : ''), '%quantity%' => $combination->minimal_quantity],
+                    ['%product%' => $productName, '%quantity%' => $combination->minimal_quantity],
                     'Shop.Notifications.Error'
                 );
 
@@ -525,14 +527,14 @@ class CartControllerCore extends FrontController
                 } elseif (!$update_quantity) {
                     $this->errors[] = $this->trans(
                         'You already have the maximum quantity available for product %product%.',
-                        ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
+                        ['%product%' => $productName],
                         'Shop.Notifications.Error'
                     );
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
                         'The product %product% is no longer available in this quantity.',
-                        ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
+                        ['%product%' => $productName],
                         'Shop.Notifications.Error'
                     );
                 }
@@ -645,17 +647,19 @@ class CartControllerCore extends FrontController
             return true;
         }
 
+        $productName = $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '');
+
         if ($product['active']) {
             return $this->trans(
                 'The product %product% in your cart is no longer available in this quantity. Please adjust the quantity to proceed with the order.',
-                ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
+                ['%product%' => $productName],
                 'Shop.Notifications.Error'
             );
         }
 
         return $this->trans(
             'This product (%product%) is no longer available.',
-            ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
+            ['%product%' => $productName],
             'Shop.Notifications.Error'
         );
     }

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -647,7 +647,7 @@ class CartControllerCore extends FrontController
 
         if ($product['active']) {
             return $this->trans(
-                'The product %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
+                'The product %product% in your cart is no longer available in this quantity. Please adjust the quantity to proceed with the order.',
                 ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
                 'Shop.Notifications.Error'
             );

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -393,7 +393,7 @@ class CartControllerCore extends FrontController
 
         $product = new Product($this->id_product, true, $this->context->language->id);
 
-        $productAttributes = null;
+        $productAttributes = '';
         if ($product->hasAttributes()) {
             $separator = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
             $attributes = Product::getAttributesParams($this->id_product, $this->id_product_attribute);

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -406,7 +406,7 @@ class CartControllerCore extends FrontController
         if (!$product->id || !$product->active || !$product->checkAccess($this->context->cart->id_customer)) {
             $this->{$ErrorKey}[] = $this->trans(
                 'The product %product% is no longer available.',
-                ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
+                ['%product%' => $product->name . (!empty($productAttributes) ? ' ' . $productAttributes : '')],
                 'Shop.Notifications.Error'
             );
 

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -392,10 +392,21 @@ class CartControllerCore extends FrontController
         }
 
         $product = new Product($this->id_product, true, $this->context->language->id);
+
+        $productAttributes = null;
+        if ($product->hasAttributes()) {
+            $separator = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
+            $attributes = Product::getAttributesParams($this->id_product, $this->id_product_attribute);
+            foreach ($attributes as $attribute) {
+                $productAttributes .= $attribute['group'] . ' : ' . $attribute['name'] . ' ' . $separator . ' ';
+            }
+            $productAttributes = rtrim($productAttributes, $separator . ' ');
+        }
+
         if (!$product->id || !$product->active || !$product->checkAccess($this->context->cart->id_customer)) {
             $this->{$ErrorKey}[] = $this->trans(
-                'This product (%product%) is no longer available.',
-                ['%product%' => $product->name],
+                'The product %product% is no longer available.',
+                ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
                 'Shop.Notifications.Error'
             );
 
@@ -435,8 +446,8 @@ class CartControllerCore extends FrontController
         // Check product quantity availability
         if ('update' !== $mode && $this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
             $this->{$ErrorKey}[] = $this->trans(
-                'The product is no longer available in this quantity.',
-                [],
+                'The product %product% is no longer available in this quantity.',
+                ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
                 'Shop.Notifications.Error'
             );
         }
@@ -446,7 +457,7 @@ class CartControllerCore extends FrontController
             if ($qty_to_check < $product->minimal_quantity) {
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name, '%quantity%' => $product->minimal_quantity],
+                    ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : ''), '%quantity%' => $product->minimal_quantity],
                     'Shop.Notifications.Error'
                 );
 
@@ -457,7 +468,7 @@ class CartControllerCore extends FrontController
             if ($qty_to_check < $combination->minimal_quantity) {
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
-                    ['%product%' => $product->name, '%quantity%' => $combination->minimal_quantity],
+                    ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : ''), '%quantity%' => $combination->minimal_quantity],
                     'Shop.Notifications.Error'
                 );
 
@@ -513,15 +524,15 @@ class CartControllerCore extends FrontController
                     );
                 } elseif (!$update_quantity) {
                     $this->errors[] = $this->trans(
-                        'You already have the maximum quantity available for this product.',
-                        [],
+                        'You already have the maximum quantity available for product %product%.',
+                        ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
                         'Shop.Notifications.Error'
                     );
                 } elseif ($this->shouldAvailabilityErrorBeRaised($product, $qty_to_check)) {
                     // check quantity after cart quantity update
                     $this->{$ErrorKey}[] = $this->trans(
-                        'The product is no longer available in this quantity.',
-                        [],
+                        'The product %product% is no longer available in this quantity.',
+                        ['%product%' => $product->name . (isset($productAttributes) ? ' ' . $productAttributes : '')],
                         'Shop.Notifications.Error'
                     );
                 }
@@ -637,14 +648,14 @@ class CartControllerCore extends FrontController
         if ($product['active']) {
             return $this->trans(
                 'The item %product% in your cart is no longer available in this quantity. You cannot proceed with your order until the quantity is adjusted.',
-                ['%product%' => $product['name']],
+                ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
                 'Shop.Notifications.Error'
             );
         }
 
         return $this->trans(
             'This product (%product%) is no longer available.',
-            ['%product%' => $product['name']],
+            ['%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : '')],
             'Shop.Notifications.Error'
         );
     }
@@ -662,7 +673,7 @@ class CartControllerCore extends FrontController
                 $this->errors[] = $this->trans(
                     'The minimum purchase order quantity for the product %product% is %quantity%.',
                     [
-                        '%product%' => $product['name'],
+                        '%product%' => $product['name'] . (isset($product['attributes']) ? ' ' . $product['attributes'] : ''),
                         '%quantity%' => $product['minimal_quantity'],
                     ],
                     'Shop.Notifications.Error'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve the information displayed in the checkout when a product is without stock. From https://www.prestashop.com/forums/topic/1041442-nobody-can-figure-it-out-we-need-a-specialist
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23051
| How to test?      | Create a cart with product with attribute. Remove stock and check cart again. Error message is appearing.
| Possible impacts? | Cart display


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23093)
<!-- Reviewable:end -->
