### PR TITLE
Fix button spaces on catalog page of the BO

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/products_catalog.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/products_catalog.scss
@@ -32,6 +32,12 @@
   #catalog-actions {
     align-items: start;
 
+    @include media-breakpoint-down(sm) {
+      #product_catalog_category_tree_filter {
+        margin-bottom: 0.5rem;
+      }
+    }
+
     .row + .row {
       padding-top: $grid-gutter-width / 2;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Buttons needs spaces on mobile so it's not collapsed to each others
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23097.
| How to test?      | Go on catalog page, open mobile responsive mode, see space between buttons actions
| Possible impacts? | Nothing really important


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23098)
<!-- Reviewable:end -->
