### PR TITLE
Skip Prestashop Merge Requests ends with [merge]

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   message-check:
-    if: "!contains(github.event.pull_request.title, '[merge]')"
+    if: "!endsWith(github.event.pull_request.title, '[merge]')"
     name: Block Merge Commits
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | <<... about the title the [merge] blocking feature, it's a nice idea but we need to put it a the end because the Changelog generating tool refuses PR titles which starts with [ or any exotic symbol...>>. [See original discussion](https://github.com/PrestaShop/PrestaShop/pull/23108#issuecomment-772350678)  by @jolelievre 
| Type?             | improvement 
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | N/A
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23123)
<!-- Reviewable:end -->
