### PR TITLE
Up status select padding to avoid text getting under arrow

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -78,6 +78,7 @@
     @include transition(0.2s ease-out);
 
     .select-status-colored {
+      padding: 0.375rem 2.2rem 0.375rem 0.4375rem;
       color: #fff;
       background: none;
       border: none;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Dropdown's text was under the arrow on certain long chains
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23114.
| How to test?      | Go on order page and try with a lot of text on the status select


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23136)
<!-- Reviewable:end -->
