### PR TITLE
Prevent setting duplicate order status names

### DIFF
--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -162,4 +162,21 @@ class OrderStateCore extends ObjectModel
     {
         return !($this->unremovable);
     }
+
+    /**
+     * @param string $name
+     * @param int $idLang
+     * @param int|null $excludeIdOrderState ID of the order state excluded for the search
+     *
+     * @return int
+     */
+    public static function countByLocalizedName(string $name, int $idLang, ?int $excludeIdOrderState): int
+    {
+        return (int) DB::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+            'SELECT COUNT(*) AS count FROM ' . _DB_PREFIX_ . 'order_state_lang' .
+            ' WHERE id_lang = ' . $idLang .
+            ' AND name =  \'' . pSQL($name) . '\'' .
+            ($excludeIdOrderState ? ' AND id_order_state != ' . $excludeIdOrderState : '')
+        );
+    }
 }

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -173,10 +173,13 @@ class OrderStateCore extends ObjectModel
     public static function countByLocalizedName(string $name, int $idLang, ?int $excludeIdOrderState): int
     {
         return (int) DB::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
-            'SELECT COUNT(*) AS count FROM ' . _DB_PREFIX_ . 'order_state_lang' .
-            ' WHERE id_lang = ' . $idLang .
-            ' AND name =  \'' . pSQL($name) . '\'' .
-            ($excludeIdOrderState ? ' AND id_order_state != ' . $excludeIdOrderState : '')
+            'SELECT COUNT(*) AS count' .
+            ' FROM ' . _DB_PREFIX_ . 'order_state_lang osl' .
+            ' INNER JOIN ' . _DB_PREFIX_ . 'order_state os ON (os.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = ' . $idLang . ')' .
+            ' WHERE osl.id_lang = ' . $idLang .
+            ' AND osl.name =  \'' . pSQL($name) . '\'' .
+            ' AND os.deleted = 0' .
+            ($excludeIdOrderState ? ' AND osl.id_order_state != ' . $excludeIdOrderState : '')
         );
     }
 }

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -164,15 +164,17 @@ class OrderStateCore extends ObjectModel
     }
 
     /**
+     * Check if a localized name in database for a specific lang (and excluding some IDs)
+     *
      * @param string $name
      * @param int $idLang
      * @param int|null $excludeIdOrderState ID of the order state excluded for the search
      *
-     * @return int
+     * @return bool
      */
-    public static function countByLocalizedName(string $name, int $idLang, ?int $excludeIdOrderState): int
+    public static function existsLocalizedNameInDatabase(string $name, int $idLang, ?int $excludeIdOrderState): bool
     {
-        return (int) DB::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+        return (bool) DB::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             'SELECT COUNT(*) AS count' .
             ' FROM ' . _DB_PREFIX_ . 'order_state_lang osl' .
             ' INNER JOIN ' . _DB_PREFIX_ . 'order_state os ON (os.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = ' . $idLang . ')' .

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -602,11 +602,17 @@ class AdminStatusesControllerCore extends AdminController
             if (!$this->access('add')) {
                 return;
             }
-            $langIds = Language::getIDs(false);
 
+            $langIds = Language::getIDs(false);
+            $langDefault = (int) Configuration::get('PS_LANG_DEFAULT');
             foreach ($langIds as $id_lang) {
+                $name = (string) Tools::getValue('name_' . $id_lang);
+                if (empty($name)) {
+                    $name = (string) Tools::getValue('name_' . $langDefault);
+                }
+
                 $exists = OrderState::existsLocalizedNameInDatabase(
-                    (string) Tools::getValue('name_' . $id_lang),
+                    $name,
                     (int) $id_lang,
                     Tools::getIsset('id_order_state') ? (int) Tools::getValue('id_order_state') : null
                 );

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -605,12 +605,12 @@ class AdminStatusesControllerCore extends AdminController
             $langIds = Language::getIDs(false);
 
             foreach ($langIds as $id_lang) {
-                $count = OrderState::countByLocalizedName(
+                $exists = OrderState::existsLocalizedNameInDatabase(
                     (string) Tools::getValue('name_' . $id_lang),
                     (int) $id_lang,
                     Tools::getIsset('id_order_state') ? (int) Tools::getValue('id_order_state') : null
                 );
-                if ($count) {
+                if ($exists) {
                     $this->errors[] = $this->trans('This name already exists.', [], 'Admin.Design.Notification');
                     break;
                 }

--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -602,6 +602,19 @@ class AdminStatusesControllerCore extends AdminController
             if (!$this->access('add')) {
                 return;
             }
+            $langIds = Language::getIDs(false);
+
+            foreach ($langIds as $id_lang) {
+                $count = OrderState::countByLocalizedName(
+                    (string) Tools::getValue('name_' . $id_lang),
+                    (int) $id_lang,
+                    Tools::getIsset('id_order_state') ? (int) Tools::getValue('id_order_state') : null
+                );
+                if ($count) {
+                    $this->errors[] = $this->trans('This name already exists.', [], 'Admin.Design.Notification');
+                    break;
+                }
+            }
 
             $this->deleted = false; // Disabling saving historisation
             $_POST['invoice'] = (int) Tools::getValue('invoice_on');
@@ -614,7 +627,7 @@ class AdminStatusesControllerCore extends AdminController
             $_POST['pdf_delivery'] = (int) Tools::getValue('pdf_delivery_on');
             $_POST['pdf_invoice'] = (int) Tools::getValue('pdf_invoice_on');
             if (!$_POST['send_email']) {
-                foreach (Language::getIDs(false) as $id_lang) {
+                foreach ($langIds as $id_lang) {
                     $_POST['template_' . $id_lang] = '';
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Check if an order status has the same name in Add/Edit
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22870
| How to test?      | Add or Edit an order status and try to set the label identical to an existing one (like @hibatallahAouadni did in https://github.com/PrestaShop/PrestaShop/issues/22870#issuecomment-769142051)<br>Specs from @MatShir : https://github.com/PrestaShop/PrestaShop/issues/22870#issuecomment-772563200


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23142)
<!-- Reviewable:end -->
