### PR TITLE
Swap count() && is_array() pattern to avoid PHP7.2+ warning

### DIFF
--- a/install-dev/upgrade/php/add_attribute_position.php
+++ b/install-dev/upgrade/php/add_attribute_position.php
@@ -29,14 +29,14 @@ function add_attribute_position()
     $groups = Db::getInstance()->executeS('
 	SELECT DISTINCT `id_attribute_group`
 	FROM `'._DB_PREFIX_.'attribute`');
-    if (count($groups) && is_array($groups)) {
+    if (is_array($groups) && count($groups)) {
         foreach ($groups as $group) {
             $attributes = Db::getInstance()->executeS('
 			SELECT *
 			FROM `'._DB_PREFIX_.'attribute`
 			WHERE `id_attribute_group` = '. (int)($group['id_attribute_group']));
             $i = 0;
-            if (count($attributes) && is_array($attributes)) {
+            if (is_array($attributes) && count($attributes)) {
                 foreach ($attributes as $attribute) {
                     Db::getInstance()->execute('
 					UPDATE `'._DB_PREFIX_.'attribute`

--- a/install-dev/upgrade/php/add_carrier_position.php
+++ b/install-dev/upgrade/php/add_carrier_position.php
@@ -30,7 +30,7 @@ function add_carrier_position()
 	SELECT `id_carrier`
 	FROM `'._DB_PREFIX_.'carrier`
 	WHERE `deleted` = 0');
-    if (count($carriers) && is_array($carriers)) {
+    if (is_array($carriers) && count($carriers)) {
         $i = 0;
         foreach ($carriers as $carrier) {
             Db::getInstance()->execute('

--- a/install-dev/upgrade/php/add_feature_position.php
+++ b/install-dev/upgrade/php/add_feature_position.php
@@ -30,7 +30,7 @@ function add_feature_position()
 	SELECT `id_feature`
 	FROM `'._DB_PREFIX_.'feature`');
     $i = 0;
-    if (count($features) && is_array($features)) {
+    if (is_array($features) && count($features)) {
         foreach ($features as $feature) {
             Db::getInstance()->execute('
 			UPDATE `'._DB_PREFIX_.'feature`

--- a/install-dev/upgrade/php/add_group_attribute_position.php
+++ b/install-dev/upgrade/php/add_group_attribute_position.php
@@ -30,7 +30,7 @@ function add_group_attribute_position()
 	SELECT *
 	FROM `'._DB_PREFIX_.'attribute_group`');
     $i = 0;
-    if (count($groups) && is_array($groups)) {
+    if (is_array($groups) && count($groups)) {
         foreach ($groups as $group) {
             Db::getInstance()->execute('
 				UPDATE `'._DB_PREFIX_.'attribute_group`

--- a/install-dev/upgrade/php/add_missing_rewrite_value.php
+++ b/install-dev/upgrade/php/add_missing_rewrite_value.php
@@ -33,7 +33,7 @@ function add_missing_rewrite_value()
 	WHERE ml.`url_rewrite` = \'\'
 	AND m.`page` != "index"
 	');
-    if (count($pages) && is_array($pages)) {
+    if (is_array($pages) && count($pages)) {
         foreach ($pages as $page) {
             Db::getInstance()->execute('
 			UPDATE `'._DB_PREFIX_.'meta_lang`

--- a/install-dev/upgrade/php/update_customer_default_group.php
+++ b/install-dev/upgrade/php/update_customer_default_group.php
@@ -53,7 +53,7 @@ function update_customer_default_group()
 	FROM `'._DB_PREFIX_.'configuration`
 	WHERE `name` IN (\'PS_UNIDENTIFIED_GROUP\', \'PS_GUEST_GROUP\')');
 
-    if (count($carriers) && is_array($carriers) && count($groups) && is_array($groups)) {
+    if (is_array($carriers) && count($carriers) && is_array($groups) && count($groups)) {
         foreach ($carriers as $carrier) {
             foreach ($groups as $group) {
                 Db::getInstance()->execute('


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Avoid PHP7.2+ warning in count()&&is_array() See: https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | No need QA. Enable E_WARNING messages and visit affected places
| Possible impacts? | Cosmetic, but closing warning popups in debug mode can be quite irritating.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23153)
<!-- Reviewable:end -->
