### PR TITLE
Fixes issue with cms category ordering in sitemap

### DIFF
--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -396,7 +396,7 @@ class CMSCategoryCore extends ObjectModel
 		WHERE `id_parent` = ' . (int) $this->id . '
 		' . ($active ? 'AND `active` = 1' : '') . '
 		GROUP BY c.`id_cms_category`
-		ORDER BY `name` ASC');
+		ORDER BY `position` ASC');
 
         // Modify SQL result
         foreach ($result as &$row) {

--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -185,7 +185,9 @@ class CMSCategoryCore extends ObjectModel
 				FROM `' . _DB_PREFIX_ . 'cms_category` c
 				' . Shop::addSqlAssociation('cms_category', 'c') . '
 				WHERE c.`id_parent` = ' . (int) $current .
-                    ($active ? ' AND c.`active` = 1' : '');
+                    ($active ? ' AND c.`active` = 1' : '') .
+        ' ORDER BY c.`position`';
+
         $result = Db::getInstance()->executeS($sql);
         foreach ($result as $row) {
             $category['children'][] = CMSCategory::getRecurseCategory($id_lang, $row['id_cms_category'], $active, $links);

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -153,11 +153,11 @@ class CmsPageType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 512,
-                            'maxMessage' => $this->translator->trans(
+                            'max' => 255,
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
-                                ['%limit%' => 512],
-                                'Admin.Notifications.Error'
+                                'Admin.Notifications.Error',
+                                ['%limit%' => 255]
                             ),
                         ]),
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -153,11 +153,11 @@ class CmsPageType extends TranslatorAwareType
                             'type' => 'generic_name',
                         ]),
                         new Length([
-                            'max' => 255,
-                            'maxMessage' => $this->trans(
+                            'max' => 512,
+                            'maxMessage' => $this->translator->trans(
                                 'This field cannot be longer than %limit% characters',
-                                'Admin.Notifications.Error',
-                                ['%limit%' => 255]
+                                ['%limit%' => 512],
+                                'Admin.Notifications.Error'
                             ),
                         ]),
                     ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes issue with cms ordering
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23168 
| How to test?      | Create couple of cms categories, change their position and test that in sitemap their positions reflect the positions in BO.



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23169)
<!-- Reviewable:end -->
