### PR TITLE
Hide category tree by default on product page

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -680,7 +680,7 @@
         vertical-align: middle;
       }
 
-      #categories-tree-expand {
+      #categories-tree-reduce {
         display: none;
       }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig
@@ -40,7 +40,7 @@
         <span class="form-control-label" id="categories-tree-expand"><i class="material-icons">expand_more</i>{{ "Expand"|trans({}, 'Admin.Actions') }}</span>
         <span class="form-control-label" id="categories-tree-reduce"><i class="material-icons">expand_less</i>{{ "Collapse"|trans({}, 'Admin.Actions') }}</span>
       </div>
-      {{ form_widget(form.categories, {'defaultCategory': true}) }} {# see bootstrap_4_layout.html.twig #}
+      {{ form_widget(form.categories, {'defaultCategory': true, defaultHidden: true}) }} {# see bootstrap_4_layout.html.twig #}
     </div>
   </fieldset>
   {{ form_errors(form.categories) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -181,7 +181,7 @@
 {%- endblock choice_tree_widget %}
 
 {% block choice_tree_item_widget -%}
-    <li>
+  <li{% if defaultHidden %} class="more"{% endif %}>
         {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
         {% if multiple -%}
             <div class="checkbox">
@@ -209,7 +209,7 @@
             </div>
         {%- endif %}
         {% if child.children is defined %}
-            <ul>
+            <ul{% if defaultHidden %} style="display: none;"{% endif %}>
                 {% for item in child.children %}
                     {% set child = item %}
                     {{ block('choice_tree_item_widget') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Category tree was opened by default on product page, when there are too much categories this is pretty annoying
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #14955.
| How to test?      | Go on product page and create product page, see if category tree is hidden by default


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23173)
<!-- Reviewable:end -->
