### PR TITLE
Init switches when adding new customization on product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1003,6 +1003,7 @@ var customFieldCollection = (function() {
     var newForm = collectionHolder.attr('data-prototype').replace(/__name__/g, maxCollectionChildren);
     maxCollectionChildren += 1;
     collectionHolder.append('<li>' + newForm + '</li>');
+    window.prestaShopUiKit.init();
   }
 
   return {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customization switch was not init when adding new customization on product page
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21633.
| How to test?      | Go on product page => options, add a customization, switch should be init when adding new customizations


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23177)
<!-- Reviewable:end -->
