### PR TITLE
Set combinations attributes closed by default if combinations > 0

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -130,7 +130,7 @@
           class="attribute-group-name {% if loop.index > 3 or has_combinations %} collapsed {% endif %}"
           data-toggle="collapse"
           href="#attribute-group-{{ attribute_group.id }}"
-          aria-expanded="{% if loop.index <= 3 or has_combinations %}true{% else %}false{% endif %}"
+          aria-expanded="{% if loop.index <= 3 or not has_combinations %}true{% else %}false{% endif %}"
         >
           {{ attribute_group.name }}
         </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -127,14 +127,14 @@
     {% for attribute_group in attribute_groups %}
       <div class="attribute-group">
         <a
-          class="attribute-group-name {% if loop.index > 3 %} collapsed {% endif %}"
+          class="attribute-group-name {% if loop.index > 3 or has_combinations %} collapsed {% endif %}"
           data-toggle="collapse"
           href="#attribute-group-{{ attribute_group.id }}"
-          aria-expanded="{% if loop.index <= 3 %}true{% else %}false{% endif %}"
+          aria-expanded="{% if loop.index <= 3 or has_combinations %}true{% else %}false{% endif %}"
         >
           {{ attribute_group.name }}
         </a>
-        <div class="collapse {% if loop.index <= 3 %} show {% endif %} attributes " id="attribute-group-{{ attribute_group.id }}">
+        <div class="collapse {% if loop.index <= 3 and not has_combinations %} show {% endif %} attributes " id="attribute-group-{{ attribute_group.id }}">
           <div class="attributes-overflow {% if attribute_group.attributes|length > 7 %} two-columns {% endif %}">
             {% for attribute in attribute_group.attributes %}
               <div class="attribute">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Combinations attributes are taking too much places if they have been already generated
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #16100.
| How to test?      | Add new product with combination, go on combinations pan, see that attributes are openned, generate combinations, refresh the page and they should be closed


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23180)
<!-- Reviewable:end -->
