### PR TITLE
Cast productSupplier reference to string

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandBuilder.php
@@ -82,7 +82,7 @@ final class ProductSuppliersCommandBuilder implements ProductCommandBuilderInter
             'product_id' => $productId,
             'supplier_id' => $supplierId,
             'currency_id' => (int) $productSupplierData['currency_id'],
-            'reference' => $productSupplierData['reference'],
+            'reference' => (string) $productSupplierData['reference'],
             'price_tax_excluded' => (string) $productSupplierData['price_tax_excluded'],
             'combination_id' => (int) $productSupplierData['combination_id'],
             'product_supplier_id' => (int) $productSupplierData['product_supplier_id'],

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductSuppliersCommandBuilderTest.php
@@ -85,7 +85,7 @@ class ProductSuppliersCommandBuilderTest extends AbstractProductCommandBuilderTe
                 [
                     'supplier_id' => 3,
                     'currency_id' => 5,
-                    'reference' => 'lel',
+                    'reference' => '',
                     'price_tax_excluded' => '50.65',
                     'combination_id' => 0,
                     'product_supplier_id' => 1,
@@ -110,7 +110,7 @@ class ProductSuppliersCommandBuilderTest extends AbstractProductCommandBuilderTe
                         [
                             'supplier_id' => 3,
                             'currency_id' => 5,
-                            'reference' => 'lel',
+                            'reference' => null,
                             'price_tax_excluded' => '50.65',
                             'combination_id' => null,
                             'product_supplier_id' => 1,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Little bugfix in recently merged PR (https://github.com/PrestaShop/PrestaShop/pull/22743). Cast reference to string to avoid type error and allow saving product supplier without providing reference (because it is optional)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of #19683
| How to test?      | Check that in new product page Product supplier can be saved without providing reference. (It is still integration process, so **We do not need QA for this until we finish Product form**). CI :heavy_check_mark: 
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23205)
<!-- Reviewable:end -->
