### PR TITLE
Product price returned in request when a search is done when customer group can't see prices

### DIFF
--- a/src/Core/Filter/FrontEndObject/SearchResultProductFilter.php
+++ b/src/Core/Filter/FrontEndObject/SearchResultProductFilter.php
@@ -63,6 +63,7 @@ class SearchResultProductFilter extends HashMapWhitelistFilter
             'reference',
             'regular_price',
             'regular_price_amount',
+            'show_price',
             'tax_name',
             'unit_price',
             'url',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product price is returned in search results, even if customer group can't see prices.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #13354
| How to test?      | Configure customer group as `Show prices: No`. Do a search and check request. Product price should not be returned in `products` array.
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23226)
<!-- Reviewable:end -->
