### PR TITLE
Translations - ThemeExporter : Use array of directories when getting catalog

### DIFF
--- a/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php
@@ -215,7 +215,7 @@ class ThemeExporter
 
         Flattenizer::flatten($tmpFolderPath . DIRECTORY_SEPARATOR . $locale, $folderPath . DIRECTORY_SEPARATOR . $locale, $locale);
 
-        return $this->themeProvider->getCatalogueFromPaths($folderPath, $locale, '*');
+        return $this->themeProvider->getCatalogueFromPaths([$folderPath], $locale, '*');
     }
 
     /**

--- a/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
@@ -227,7 +227,7 @@ class ThemeProvider extends AbstractProvider
     {
         $path = $this->resourceDirectory . DIRECTORY_SEPARATOR . $this->themeName . DIRECTORY_SEPARATOR . 'translations';
 
-        return $this->getCatalogueFromPaths($path, $this->locale, current($this->getFilters()));
+        return $this->getCatalogueFromPaths([$path], $this->locale, current($this->getFilters()));
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | ThemeProvider::getCatalogueFromPaths expects an array as `paths` argument. Fix the calls to that method to make it an array if single directory is provided
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23233
| How to test?      | Go to BO > International > Translations and export translations catalogue for a language
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23234)
<!-- Reviewable:end -->
