### PR TITLE
schema.org error in products out of stock when stock management is disabled

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -372,7 +372,9 @@ class ProductLazyArray extends AbstractLazyArray
         $seoAvailability = 'https://schema.org/';
         if ($this->product['quantity'] > 0) {
             $seoAvailability .= 'InStock';
-        } elseif ($this->product['quantity'] <= 0 && $this->product['allow_oosp']) {
+        } elseif (!Configuration::get('PS_STOCK_MANAGEMENT')) {
+            $seoAvailability .= 'InStock';
+        } elseif ($this->product['quantity'] <= 0 && $this->product['allow_oosp'] && Configuration::get('PS_STOCK_MANAGEMENT')) {
             $seoAvailability .= 'PreOrder';
         } else {
             $seoAvailability .= 'OutOfStock';


### PR DESCRIPTION
https://github.com/PrestaShop/PrestaShop/issues/23199

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  develop
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/23199
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes ~#23199~
| How to test?      | Go to disable stock management, Reduce the stock of a product to 0, See good
| Possible impacts? | I think no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23247)
<!-- Reviewable:end -->
