### PR TITLE
Customization fields and its saved value shows HTML content in order confirmation mail.

### DIFF
--- a/mails/_partials/order_conf_product_list.tpl
+++ b/mails/_partials/order_conf_product_list.tpl
@@ -47,7 +47,7 @@
 						{if count($product['customization']) == 1}
 							<br>
 							{foreach $product['customization'] as $customization}
-								{$customization['customization_text']}
+								{$customization['customization_text'] nofilter}
 							{/foreach}
 						{/if}
 

--- a/mails/_partials/order_conf_product_list.tpl
+++ b/mails/_partials/order_conf_product_list.tpl
@@ -107,7 +107,7 @@
   					<td width="5">&nbsp;</td>
   					<td>
   						<font size="2" face="Open-sans, sans-serif" color="#555454">
-  							{$customization['customization_text']}
+  							{$customization['customization_text'] nofilter}
   						</font>
   					</td>
   					<td width="5">&nbsp;</td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customization fields and their saved value shows HTML content in order confirmation mail.<br>It must show formatted HTML content.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #22330 .
| How to test?      | 1- Go to customizable product: https://prnt.sc/zl9oi5 <br>2- save your customization and place an order.<br>3- We received an order confirmation mail https://prnt.sc/zl9y6q<br>You will see that customization content shows in HTML.
| Possible impacts? | check the mail content of order confirmation mail.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23263)
<!-- Reviewable:end -->
