### PR TITLE
Fix CI problems related to new ps_linklist version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -26,7 +26,7 @@ jobs:
                   ${{ runner.os }}-composer-
 
       -   name: Composer Install
-          run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+          run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       -   name: Run PHPCSFixer
           run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
@@ -56,7 +56,7 @@ jobs:
                     ${{ runner.os }}-composer-
 
         -   name: Composer Install
-            run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+            run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
         -   name: Run phpstan
             run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist
@@ -93,7 +93,7 @@ jobs:
                     ${{ runner.os }}-composer-
 
         -   name: Composer Install
-            run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+            run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
         -   name: Run phpunit
             run: ./vendor/bin/phpunit -c tests/Unit/phpunit.xml
@@ -139,7 +139,7 @@ jobs:
                     ${{ runner.os }}-composer-
 
         -   name: Composer Install
-            run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+            run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
         -   name: Install PrestaShop
             run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -181,8 +181,9 @@ class AppKernel extends Kernel
      */
     private function enableComposerAutoloaderOnModules($modules)
     {
+        $moduleDirectoryPath = rtrim(_PS_MODULE_DIR_, '/') . '/';
         foreach ($modules as $module) {
-            $autoloader = __DIR__ . '/../modules/' . $module . '/vendor/autoload.php';
+            $autoloader = $moduleDirectoryPath . $module . '/vendor/autoload.php';
 
             if (file_exists($autoloader)) {
                 include_once $autoloader;

--- a/composer.json
+++ b/composer.json
@@ -191,6 +191,7 @@
       "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
     ],
     "phpunit-endpoints": [
+      "@composer create-test-db",
       "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
     ],
     "unit-tests": [

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "prestashop/ps_featuredproducts": "^2",
     "prestashop/ps_imageslider": "^3",
     "prestashop/ps_languageselector": "^2",
-    "prestashop/ps_linklist": "^3",
+    "prestashop/ps_linklist": "^4",
     "prestashop/ps_mainmenu": "^2",
     "prestashop/ps_searchbar": "^2",
     "prestashop/ps_sharebuttons": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99c3fe70ae733dbccff7a6006b493e11",
+    "content-hash": "bfea84585532672c3b185d0b974d46e3",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -5071,16 +5071,16 @@
         },
         {
             "name": "prestashop/ps_linklist",
-            "version": "v3.2.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_linklist.git",
-                "reference": "4abf07d4ee2b007df78849fc9475c2dcab087a69"
+                "reference": "3072601605c569e7aa3565a6d57e7bae56428b00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_linklist/zipball/4abf07d4ee2b007df78849fc9475c2dcab087a69",
-                "reference": "4abf07d4ee2b007df78849fc9475c2dcab087a69",
+                "url": "https://api.github.com/repos/PrestaShop/ps_linklist/zipball/3072601605c569e7aa3565a6d57e7bae56428b00",
+                "reference": "3072601605c569e7aa3565a6d57e7bae56428b00",
                 "shasum": ""
             },
             "require": {
@@ -5112,10 +5112,9 @@
             "description": "PrestaShop - Link list",
             "homepage": "https://github.com/PrestaShop/ps_linklist",
             "support": {
-                "issues": "https://github.com/PrestaShop/ps_linklist/issues",
-                "source": "https://github.com/PrestaShop/ps_linklist/tree/master"
+                "source": "https://github.com/PrestaShop/ps_linklist/tree/v4.0.0"
             },
-            "time": "2020-07-10T07:10:55+00:00"
+            "time": "2021-02-11T15:55:29+00:00"
         },
         {
             "name": "prestashop/ps_mainmenu",
@@ -10842,5 +10841,5 @@
     "platform-overrides": {
         "php": "7.1.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Adapter/Module/Tab/ModuleTabRegister.php
+++ b/src/Adapter/Module/Tab/ModuleTabRegister.php
@@ -251,8 +251,7 @@ class ModuleTabRegister
      */
     protected function getModuleAdminControllers($moduleName)
     {
-        $modulePath = _PS_ROOT_DIR_ . '/' . basename(_PS_MODULE_DIR_) .
-                '/' . $moduleName . '/controllers/admin/';
+        $modulePath = rtrim(_PS_MODULE_DIR_, '/') . '/' . $moduleName . '/controllers/admin/';
 
         if (!$this->filesystem->exists($modulePath)) {
             return [];
@@ -280,9 +279,7 @@ class ModuleTabRegister
      */
     protected function getModuleControllersFromRouting(string $moduleName): array
     {
-        $routingFile = _PS_ROOT_DIR_ . '/' . basename(_PS_MODULE_DIR_) .
-            '/' . $moduleName . '/config/routes.yml';
-
+        $routingFile = rtrim(_PS_MODULE_DIR_, '/') . '/' . $moduleName . '/config/routes.yml';
         if (!$this->filesystem->exists($routingFile)) {
             return [];
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/RedirectOptionType.php
@@ -137,7 +137,7 @@ class RedirectOptionType extends TranslatorAwareType
         // This will transform the target ID from model data into an array adapted for TypeaheadProductCollectionType
         $builder->get('target')->addModelTransformer($this->targetTransformer);
         // In case a transformation occurs it will be displayed as an inline error
-        $builder->addEventSubscriber(new TransformationFailureListener($this->translator));
+        $builder->addEventSubscriber(new TransformationFailureListener($this->getTranslator()));
 
         // Preset the input attributes correctly depending on the data
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($entityAttributes) {

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatorAwareType.php
@@ -38,7 +38,7 @@ abstract class TranslatorAwareType extends CommonAbstractType
     /**
      * @var TranslatorInterface
      */
-    protected $translator;
+    private $translator;
 
     /**
      * All languages available on shop. Used for translations.
@@ -65,6 +65,14 @@ abstract class TranslatorAwareType extends CommonAbstractType
     protected function trans($key, $domain, $parameters = [])
     {
         return $this->translator->trans($key, $parameters, $domain);
+    }
+
+    /**
+     * @return TranslatorInterface
+     */
+    protected function getTranslator(): TranslatorInterface
+    {
+        return $this->translator;
     }
 
     /**

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -280,8 +280,8 @@ namespace PrestaShopBundle\Install {
             if (!defined('_PS_TRANSLATIONS_DIR_')) {
                 define('_PS_TRANSLATIONS_DIR_', _PS_ROOT_DIR_ . '/translations/');
             }
-            if (!defined('_PS_MODULES_DIR_')) {
-                define('_PS_MODULES_DIR_', _PS_ROOT_DIR_ . '/modules/');
+            if (!defined('_PS_MODULE_DIR_')) {
+                define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/modules/');
             }
             if (!defined('_PS_MAILS_DIR_')) {
                 define('_PS_MAILS_DIR_', _PS_ROOT_DIR_ . '/mails/');

--- a/src/PrestaShopBundle/Kernel/ModuleRepository.php
+++ b/src/PrestaShopBundle/Kernel/ModuleRepository.php
@@ -84,7 +84,7 @@ final class ModuleRepository
     {
         if (null === $this->activeModulesPaths) {
             $this->activeModulesPaths = [];
-            $modulesFiles = Finder::create()->directories()->in(__DIR__ . '/../../../modules')->depth(0);
+            $modulesFiles = Finder::create()->directories()->in(_PS_MODULE_DIR_)->depth(0);
             $activeModules = $this->getActiveModules();
 
             foreach ($modulesFiles as $moduleFile) {

--- a/tests-legacy/Endpoints/AbstractEndpointAdminTest.php
+++ b/tests-legacy/Endpoints/AbstractEndpointAdminTest.php
@@ -44,7 +44,9 @@ abstract class AbstractEndpointAdminTest extends AbstractEndpointTest
         $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'];
 
         parent::setUp();
+
         $this->initContainerInstance();
+
         if (!defined('_PS_TAB_MODULE_LIST_URL_')) {
             define('_PS_TAB_MODULE_LIST_URL_', '');
         }

--- a/tests-legacy/Endpoints/AbstractEndpointTest.php
+++ b/tests-legacy/Endpoints/AbstractEndpointTest.php
@@ -40,7 +40,6 @@ abstract class AbstractEndpointTest extends TestCase
     {
         define('_PS_ROOT_DIR_', __DIR__ . '/../..');
         define('_PS_ADMIN_DIR_', _PS_ROOT_DIR_ . '/admin-dev');
-        //define('_DB_PREFIX_', 'ps_');
         require_once _PS_ROOT_DIR_ . '/config/defines.inc.php';
         require_once _PS_CONFIG_DIR_ . 'autoload.php';
         require_once _PS_CONFIG_DIR_ . 'bootstrap.php';

--- a/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
+++ b/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
@@ -44,7 +44,7 @@ class DatabaseCreator
         define('_PS_IN_TEST_', true);
         define('__PS_BASE_URI__', '/');
         define('_PS_ROOT_DIR_', __DIR__ . '/../../..');
-        define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/tests-legacy/resources/modules/');
+        define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/modules/');
         require_once __DIR__ . '/../../../install-dev/init.php';
 
         $install = new Install();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We updated the `ps_linklist` module in composer because it didn't match the one from Addons which was more recent, so there were conflicts between the one from composer and the installed one<br><br>Another problem was that we use the modules test folder in too many places (especially in CreateTestDb) which caused this duplication of modules with different versions<br>The command that create test db now is based on the real modules folder which prevents many issues<br><br>Additionally a work was done in several services that scan the modules and didn't use the const properly so in test environment they kept using the regular folder
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23273
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23264)
<!-- Reviewable:end -->
