### PR TITLE
Fix nightly autoupgrade - issue with Cookie destruction

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -54,6 +54,9 @@ class CookieCore
     /** @var array Website domain for setcookie() */
     protected $_domain;
 
+    /** @var string|bool SameSite for setcookie() */
+    protected $_sameSite;
+
     /** @var array Path for setcookie() */
     protected $_path;
 
@@ -89,6 +92,7 @@ class CookieCore
         $this->_path = rawurlencode($this->_path);
         $this->_path = str_replace(['%2F', '%7E', '%2B', '%26'], ['/', '~', '+', '&'], $this->_path);
         $this->_domain = $this->getDomain($shared_urls);
+        $this->_sameSite = Configuration::get('PS_COOKIE_SAMESITE');
         $this->_name = 'PrestaShop-' . md5(($this->_standalone ? '' : _PS_VERSION_) . $name . $this->_domain);
         $this->_allow_writing = true;
         $this->_salt = $this->_standalone ? str_pad('', 32, md5('ps' . __FILE__)) : _COOKIE_IV_;
@@ -386,8 +390,6 @@ class CookieCore
             $time = 1;
         }
 
-        $sameSite = Configuration::get('PS_COOKIE_SAMESITE');
-
         /*
          * The alternative signature supporting an options array is only available since
          * PHP 7.3.0, before there is no support for SameSite attribute.
@@ -398,7 +400,7 @@ class CookieCore
                 $content,
                 $time,
                 $this->_path,
-                $this->_domain . '; SameSite=' . $sameSite,
+                $this->_domain . '; SameSite=' . $this->_sameSite,
                 $this->_secure,
                 true
             );
@@ -413,7 +415,7 @@ class CookieCore
                 'domain' => $this->_domain,
                 'secure' => $this->_secure,
                 'httponly' => true,
-                'samesite' => $sameSite,
+                'samesite' => $this->_sameSite,
             ]
         );
     }

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -20,7 +20,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionOverrideEmployeeImage', 'Override Employee Image', 'This hook is used to override the employee image', '1'),
   (NULL, 'actionFrontControllerSetVariables', 'Add variables in JavaScript object and Smarty templates', 'Add variables to javascript object that is available in Front Office. These are also available in smarty templates in modules.your_module_name.', '1'),
   (NULL, 'displayAdminGridTableBefore', 'Display before Grid table', 'This hook adds new blocks before Grid component table.', '1'),
-  (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1')
+  (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1'),
   (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons on the create order page dropdown', 'Add buttons on the create order page dropdown', '1')
 ;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Because `Configuration::get` was called in the `__destruct()` function of `Cookie`, it could lead to an exception if `Db` has already been destructed.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  Fixes https://github.com/PrestaShop/PrestaShop/issues/23281
| How to test?      | It probably must be done by a dev.<br>Do an upgrade **in CLI** with the autoupgrade module from any version to a build of develop PrestaShop with this PR. No exception should be thrown.
| Possible impacts? | /


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23269)
<!-- Reviewable:end -->
