### PR TITLE
Update composer version of ps_categorytree

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4330,16 +4330,16 @@
         },
         {
             "name": "prestashop/ps_categorytree",
-            "version": "v2.0.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_categorytree.git",
-                "reference": "37b36138c083c8c724b5a6dd6c32f25aabbb08a5"
+                "reference": "70a8504d2fd1396359efa0184497c4082afe2ebd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_categorytree/zipball/37b36138c083c8c724b5a6dd6c32f25aabbb08a5",
-                "reference": "37b36138c083c8c724b5a6dd6c32f25aabbb08a5",
+                "url": "https://api.github.com/repos/PrestaShop/ps_categorytree/zipball/70a8504d2fd1396359efa0184497c4082afe2ebd",
+                "reference": "70a8504d2fd1396359efa0184497c4082afe2ebd",
                 "shasum": ""
             },
             "require": {
@@ -4367,9 +4367,9 @@
             "description": "PrestaShop category tree links",
             "homepage": "https://github.com/PrestaShop/ps_categorytree",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_categorytree/tree/v2.0.1"
+                "source": "https://github.com/PrestaShop/ps_categorytree/tree/v2.0.2"
             },
-            "time": "2021-01-12T13:41:05+00:00"
+            "time": "2021-02-16T14:53:25+00:00"
         },
         {
             "name": "prestashop/ps_checkpayment",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Because the module blockcategories wasn't uninstalled when upgrading PrestaShop to 1.7.7.x, the FO wasn't working properly as the module is not 1.7.7.x compatible. This PR aims to fix the issue by uninstalling blockcategories when its 1.7.7.x equivalent (ps_categorytree) is installed.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23275
| How to test?      | Please see #23275
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23276)
<!-- Reviewable:end -->
