### PR TITLE
Fix textbox not clickable of tinymce because of z-index

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -1355,6 +1355,7 @@ i.mce-i-resize {
 }
 
 .mce-textbox {
+  z-index: 1;
   display: inline-block;
   height: 28px;
   padding: 0 4px;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Textboxes are sometimes not clickable because an element is over it (see image dimensions for example)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23255.
| How to test?      | Go on product page, add an image to the product description and try to change his dimension, you should be able to click inside the textbox


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23283)
<!-- Reviewable:end -->
