### PR TITLE
Use default currency when supplier currency setting is incorrect

### DIFF
--- a/src/Adapter/Supplier/QueryHandler/GetSupplierForViewingHandler.php
+++ b/src/Adapter/Supplier/QueryHandler/GetSupplierForViewingHandler.php
@@ -134,13 +134,13 @@ final class GetSupplierForViewingHandler implements GetSupplierForViewingHandler
                         );
                         $isoCode = Currency::getIsoCodeById((int) $productInfo['id_currency'])
                             ?: $this->defaultCurrencyIsoCode;
+                        $formattedWholesalePrice = null !== $productInfo['product_supplier_price_te']
+                            ? $this->locale->formatPrice($productInfo['product_supplier_price_te'], $isoCode)
+                            : null;
                         $combinations[$attributeId] = [
                             'reference' => $combination['reference'],
                             'supplier_reference' => $combination['supplier_reference'],
-                            'wholesale_price' => $this->locale->formatPrice(
-                                $productInfo['product_supplier_price_te'],
-                                $isoCode
-                            ),
+                            'wholesale_price' => $formattedWholesalePrice,
                             'ean13' => $combination['ean13'],
                             'upc' => $combination['upc'],
                             'quantity' => $combination['quantity'],
@@ -165,15 +165,18 @@ final class GetSupplierForViewingHandler implements GetSupplierForViewingHandler
                     $product->id,
                     0
                 );
-                $isoCode = Currency::getIsoCodeById((int) $productInfo['id_currency']) ?: $this->defaultCurrencyIsoCode;
                 $product->wholesale_price = $productInfo['product_supplier_price_te'];
                 $product->supplier_reference = $productInfo['product_supplier_reference'];
+                $isoCode = Currency::getIsoCodeById((int) $productInfo['id_currency']) ?: $this->defaultCurrencyIsoCode;
+                $formattedWholesalePrice = null !== $product->wholesale_price
+                    ? $this->locale->formatPrice($product->wholesale_price, $isoCode)
+                    : null;
                 $products[] = [
                     'id' => $product->id,
                     'name' => $product->name,
                     'reference' => $product->reference,
                     'supplier_reference' => $product->supplier_reference,
-                    'wholesale_price' => $this->locale->formatPrice($product->wholesale_price, $isoCode),
+                    'wholesale_price' => $formattedWholesalePrice,
                     'ean13' => $product->ean13,
                     'upc' => $product->upc,
                     'quantity' => $product->quantity,

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -63,6 +63,7 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Supplier\QueryHandler\GetSupplierForViewingHandler'
     arguments:
       - '@prestashop.core.localization.locale.context_locale'
+      - '@=service("prestashop.adapter.legacy.context").getContext().currency.iso_code'
     tags:
       - name: 'tactician.handler'
         command: 'PrestaShop\PrestaShop\Core\Domain\Supplier\Query\GetSupplierForViewing'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | before the Symfony migration of the page Product we could have `id_currency = 0` in the table `ps_product_supplier` and that case was not handled in the new migrated Supplier page. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23278
| How to test?      | Please see #23278
| Possible impacts? | Currency displayed in the supplier section in the product detail page on the BO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23289)
<!-- Reviewable:end -->
