### PR TITLE
Improve naming of the Hook Collector in Symfony debug bar

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
@@ -35,7 +35,9 @@
     {% set text %}
         <div class="sf-toolbar-info-piece">
             <div class="sf-toolbar-info-piece">
-                <b class="sf-toolbar-ajax-info">{{ collector.calledHooks|length }} Hooks called</b>
+                <b class="sf-toolbar-ajax-info">{{ collector.calledHooks|length }}
+                    Hooks called and received by modules
+                </b>
             </div>
             <div class="sf-toolbar-info-piece">
                 <table class="sf-toolbar-ajax-requests">
@@ -79,15 +81,27 @@
     {% else %}
         <div class="sf-tabs">
             <div class="tab">
-                <h3 class="tab-title">Called Hooks <span class="badge">{{ collector.calledHooks|length }}</span></h3>
-
+                <h3 class="tab-title">
+                    Hooks called and received by modules
+                    <span class="badge">{{ collector.calledHooks|length }}</span>
+                </h3>
+                <p>
+                    These hooks have been dispatched by PrestaShop and there are active modules listening and receiving them.
+                </p>
                 <div class="tab-content">
                     {{ helper.render_table(collector.calledHooks, true) }}
                 </div>
             </div>
 
             <div class="tab">
-                <h3 class="tab-title">Not Called Hooks <span class="badge">{{ collector.notCalledHooks|length }}</span></h3>
+                <h3 class="tab-title">
+                    Hooks called but not received by modules
+                    <span class="badge">{{ collector.notCalledHooks|length }}</span>
+                </h3>
+                <p>
+                    These hooks have been dispatched by PrestaShop but no modules
+                    have subscribed to them.
+                </p>
                 <div class="tab-content">
                     {% if collector.notCalledHooks is empty %}
                         <div class="empty">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve naming of the Hook Collector tabs in Symfony debug bar, and add some informations.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23001
| How to test?      | See issue. Names have been improved (screenshots below).
| Possible impacts? | Only the "Hooks" tab of the Symfony debug bar has been modified.

## Screenshots (with changes submitted through the PR)

<img width="1093" alt="Capture d’écran 2021-02-17 à 21 58 24" src="https://user-images.githubusercontent.com/3830050/108267730-dc83da00-716b-11eb-9db2-c13b30939888.png">
<img width="312" alt="Capture d’écran 2021-02-17 à 21 58 35" src="https://user-images.githubusercontent.com/3830050/108267736-dee63400-716b-11eb-9fd1-b6a1539ac296.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23293)
<!-- Reviewable:end -->
