### PR TITLE
Add ProviderDefinition and complete Factory

### DIFF
--- a/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
+++ b/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
@@ -29,10 +29,10 @@ namespace PrestaShop\PrestaShop\Core\Translation\Builder;
 
 use Exception;
 use InvalidArgumentException;
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\DTO\DomainTranslation;
 use PrestaShop\PrestaShop\Core\Translation\DTO\MessageTranslation;
 use PrestaShop\PrestaShop\Core\Translation\DTO\Translations;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Exception\UnexpectedTranslationTypeException;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory;
 use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\BackofficeProviderDefinition;
@@ -167,7 +167,7 @@ class TranslationCatalogueBuilder
      * @return Translations
      *
      * @throws UnexpectedTranslationTypeException
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function getRawCatalogue(
         string $type,

--- a/src/Core/Translation/Exception/InvalidThemeException.php
+++ b/src/Core/Translation/Exception/InvalidThemeException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+class InvalidThemeException extends CoreException
+{
+}

--- a/src/Core/Translation/Exception/TranslationFilesNotFoundException.php
+++ b/src/Core/Translation/Exception/TranslationFilesNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+class TranslationFilesNotFoundException extends CoreException
+{
+}

--- a/src/Core/Translation/Finder/TranslationFinder.php
+++ b/src/Core/Translation/Finder/TranslationFinder.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Finder;
 
+use InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -100,7 +101,7 @@ class TranslationFinder
 
         try {
             $translationFiles = $finder->files()->notName('index.php')->in($paths);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             throw new TranslationFilesNotFoundException(sprintf('Could not crawl for translation files: %s', $e->getMessage()), self::ERR_DIRECTORY_NOT_FOUND, $e);
         }
 

--- a/src/Core/Translation/Finder/TranslationFinder.php
+++ b/src/Core/Translation/Finder/TranslationFinder.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Finder;
 
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
@@ -50,7 +50,7 @@ class TranslationFinder
      *
      * @return MessageCatalogue
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function getCatalogueFromPaths(array $paths, string $locale, string $pattern = null): MessageCatalogue
     {
@@ -88,7 +88,7 @@ class TranslationFinder
      *
      * @return Finder
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     private function getTranslationFilesFromPath(array $paths, string $pattern): Finder
     {
@@ -101,11 +101,11 @@ class TranslationFinder
         try {
             $translationFiles = $finder->files()->notName('index.php')->in($paths);
         } catch (\InvalidArgumentException $e) {
-            throw new FileNotFoundException(sprintf('Could not crawl for translation files: %s', $e->getMessage()), self::ERR_DIRECTORY_NOT_FOUND, $e);
+            throw new TranslationFilesNotFoundException(sprintf('Could not crawl for translation files: %s', $e->getMessage()), self::ERR_DIRECTORY_NOT_FOUND, $e);
         }
 
         if (count($translationFiles) === 0) {
-            throw new FileNotFoundException('There are no translation file available.', self::ERR_NO_FILES_IN_DIRECTORY);
+            throw new TranslationFilesNotFoundException('There are no translation file available.', self::ERR_NO_FILES_IN_DIRECTORY);
         }
 
         return $translationFiles;

--- a/src/Core/Translation/Provider/CatalogueLayersProviderInterface.php
+++ b/src/Core/Translation/Provider/CatalogueLayersProviderInterface.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -64,7 +64,7 @@ interface CatalogueLayersProviderInterface
      *
      * @param string $locale
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      *
      * @return MessageCatalogue
      */
@@ -75,8 +75,6 @@ interface CatalogueLayersProviderInterface
      * It's done from the Admin and stored in DB.
      *
      * @param string $locale
-     *
-     * @throws FileNotFoundException
      *
      * @return MessageCatalogue
      */

--- a/src/Core/Translation/Provider/CatalogueLayersProviderInterface.php
+++ b/src/Core/Translation/Provider/CatalogueLayersProviderInterface.php
@@ -54,8 +54,6 @@ interface CatalogueLayersProviderInterface
      *
      * @param string $locale the language for which you need translations
      *
-     * @throws FileNotFoundException
-     *
      * @return MessageCatalogue
      */
     public function getDefaultCatalogue(string $locale): MessageCatalogue;

--- a/src/Core/Translation/Provider/CatalogueProviderFactory.php
+++ b/src/Core/Translation/Provider/CatalogueProviderFactory.php
@@ -100,6 +100,16 @@ class CatalogueProviderFactory
      * @TODO We keep for now the dependency to PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader
      *   We will create, in the core, a TranslationRepositoryInterface and inject to DatabaseTransloader the LangRepositoryInterface and TranslationRepositoryInterface as dependencies
      *   to be fully independent from PrestaShopBundle
+     *
+     * @param DatabaseTranslationLoader $databaseTranslationLoader
+     * @param LegacyModuleExtractorInterface $legacyModuleExtractor
+     * @param LoaderInterface $legacyFileLoader
+     * @param ThemeExtractor $themeExtractor
+     * @param ThemeRepository $themeRepository
+     * @param Filesystem $filesystem
+     * @param string $themesDirectory
+     * @param string $modulesDirectory
+     * @param string $translationsDirectory
      */
     public function __construct(
         DatabaseTranslationLoader $databaseTranslationLoader,

--- a/src/Core/Translation/Provider/CatalogueProviderFactory.php
+++ b/src/Core/Translation/Provider/CatalogueProviderFactory.php
@@ -146,7 +146,7 @@ class CatalogueProviderFactory
         }
 
         // This should never be thrown if every Type has his Provider defined in constructor
-        throw new UnexpectedTranslationTypeException(sprintf('Unexpected type %s', $type));
+        throw new UnexpectedTranslationTypeException(sprintf('Could not fetch provider for given definition type "%s"', $type));
     }
 
     /**
@@ -156,7 +156,7 @@ class CatalogueProviderFactory
      */
     private function getCoreCatalogueProvider(ProviderDefinitionInterface $providerDefinition): CatalogueLayersProviderInterface
     {
-        if (!array_key_exists($providerDefinition->getType(), $this->providers)) {
+        if (!isset($this->providers[$providerDefinition->getType()])) {
             $this->providers[$providerDefinition->getType()] = new CoreCatalogueLayersProvider(
                 $this->databaseTranslationLoader,
                 $this->translationsDirectory,
@@ -175,7 +175,7 @@ class CatalogueProviderFactory
      */
     private function getModuleCatalogueProvider(ModuleProviderDefinition $providerDefinition): CatalogueLayersProviderInterface
     {
-        if (!array_key_exists($providerDefinition->getType(), $this->providers)) {
+        if (!isset($this->providers[$providerDefinition->getType()])) {
             $this->providers[$providerDefinition->getType()] = new ModuleCatalogueLayersProvider(
                 $this->databaseTranslationLoader,
                 $this->legacyModuleExtractor,
@@ -198,7 +198,7 @@ class CatalogueProviderFactory
      */
     private function getThemeCatalogueProvider(ThemeProviderDefinition $providerDefinition): CatalogueLayersProviderInterface
     {
-        if (!array_key_exists($providerDefinition->getType(), $this->providers)) {
+        if (!isset($this->providers[$providerDefinition->getType()])) {
             $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
             $coreFrontProvider = new CoreCatalogueLayersProvider(
                 $this->databaseTranslationLoader,

--- a/src/Core/Translation/Provider/CatalogueProviderFactory.php
+++ b/src/Core/Translation/Provider/CatalogueProviderFactory.php
@@ -55,10 +55,6 @@ class CatalogueProviderFactory
      */
     private $databaseTranslationLoader;
     /**
-     * @var string
-     */
-    private $resourceDirectory;
-    /**
      * @var LegacyModuleExtractorInterface
      */
     private $legacyModuleExtractor;
@@ -105,11 +101,9 @@ class CatalogueProviderFactory
         Filesystem $filesystem,
         string $themesDirectory,
         string $modulesDirectory,
-        string $translationsDirectory,
-        string $resourceDirectory
+        string $translationsDirectory
     ) {
         $this->databaseTranslationLoader = $databaseTranslationLoader;
-        $this->resourceDirectory = $resourceDirectory;
         $this->legacyModuleExtractor = $legacyModuleExtractor;
         $this->legacyFileLoader = $legacyFileLoader;
         $this->modulesDirectory = $modulesDirectory;
@@ -151,7 +145,7 @@ class CatalogueProviderFactory
         if (!array_key_exists($providerDefinition->getType(), $this->providers)) {
             $this->providers[$providerDefinition->getType()] = new CoreCatalogueLayersProvider(
                 $this->databaseTranslationLoader,
-                $this->resourceDirectory,
+                $this->translationsDirectory,
                 $providerDefinition->getFilenameFilters(),
                 $providerDefinition->getTranslationDomains()
             );
@@ -169,7 +163,6 @@ class CatalogueProviderFactory
                 $this->legacyFileLoader,
                 $this->modulesDirectory,
                 $this->translationsDirectory,
-                $this->resourceDirectory,
                 $providerDefinition->getModuleName(),
                 $providerDefinition->getFilenameFilters(),
                 $providerDefinition->getTranslationDomains()
@@ -185,7 +178,7 @@ class CatalogueProviderFactory
             $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
             $coreFrontProvider = new CoreCatalogueLayersProvider(
                 $this->databaseTranslationLoader,
-                $this->resourceDirectory,
+                $this->translationsDirectory,
                 $coreFrontProviderDefinition->getFilenameFilters(),
                 $coreFrontProviderDefinition->getTranslationDomains()
             );

--- a/src/Core/Translation/Provider/CatalogueProviderFactory.php
+++ b/src/Core/Translation/Provider/CatalogueProviderFactory.php
@@ -50,38 +50,47 @@ class CatalogueProviderFactory
      * @var CatalogueLayersProviderInterface[]
      */
     private $providers = [];
+
     /**
      * @var DatabaseTranslationLoader
      */
     private $databaseTranslationLoader;
+
     /**
      * @var LegacyModuleExtractorInterface
      */
     private $legacyModuleExtractor;
+
     /**
      * @var LoaderInterface
      */
     private $legacyFileLoader;
+
     /**
      * @var string
      */
     private $modulesDirectory;
+
     /**
      * @var string
      */
     private $translationsDirectory;
+
     /**
      * @var ThemeExtractor
      */
     private $themeExtractor;
+
     /**
      * @var ThemeRepository
      */
     private $themeRepository;
+
     /**
      * @var Filesystem
      */
     private $filesystem;
+
     /**
      * @var string
      */
@@ -140,6 +149,11 @@ class CatalogueProviderFactory
         throw new UnexpectedTranslationTypeException(sprintf('Unexpected type %s', $type));
     }
 
+    /**
+     * @param ProviderDefinitionInterface $providerDefinition
+     *
+     * @return CatalogueLayersProviderInterface
+     */
     private function getCoreCatalogueProvider(ProviderDefinitionInterface $providerDefinition): CatalogueLayersProviderInterface
     {
         if (!array_key_exists($providerDefinition->getType(), $this->providers)) {
@@ -154,6 +168,11 @@ class CatalogueProviderFactory
         return $this->providers[$providerDefinition->getType()];
     }
 
+    /**
+     * @param ModuleProviderDefinition $providerDefinition
+     *
+     * @return CatalogueLayersProviderInterface
+     */
     private function getModuleCatalogueProvider(ModuleProviderDefinition $providerDefinition): CatalogueLayersProviderInterface
     {
         if (!array_key_exists($providerDefinition->getType(), $this->providers)) {
@@ -172,6 +191,11 @@ class CatalogueProviderFactory
         return $this->providers[$providerDefinition->getType()];
     }
 
+    /**
+     * @param ThemeProviderDefinition $providerDefinition
+     *
+     * @return CatalogueLayersProviderInterface
+     */
     private function getThemeCatalogueProvider(ThemeProviderDefinition $providerDefinition): CatalogueLayersProviderInterface
     {
         if (!array_key_exists($providerDefinition->getType(), $this->providers)) {

--- a/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
@@ -38,7 +38,7 @@ use Symfony\Component\Translation\MessageCatalogue;
  *
  * @see CatalogueLayersProviderInterface to understand the 3 layers.
  */
-class BackofficeCatalogueLayersProvider implements CatalogueLayersProviderInterface
+class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
 {
     /**
      * We need a connection to DB to load user translated catalogue.
@@ -71,17 +71,31 @@ class BackofficeCatalogueLayersProvider implements CatalogueLayersProviderInterf
      * @var UserTranslatedCatalogueProvider
      */
     private $userTranslatedCatalogueProvider;
+    /**
+     * @var array
+     */
+    private $filenameFilters;
+    /**
+     * @var array
+     */
+    private $translationDomains;
 
     /**
      * @param DatabaseTranslationLoader $databaseTranslationLoader
      * @param string $resourceDirectory
+     * @param string[] $filenameFilters
+     * @param string[] $translationDomains
      */
     public function __construct(
         DatabaseTranslationLoader $databaseTranslationLoader,
-        string $resourceDirectory
+        string $resourceDirectory,
+        array $filenameFilters,
+        array $translationDomains
     ) {
         $this->databaseTranslationLoader = $databaseTranslationLoader;
         $this->resourceDirectory = $resourceDirectory;
+        $this->filenameFilters = $filenameFilters;
+        $this->translationDomains = $translationDomains;
     }
 
     /**
@@ -108,38 +122,12 @@ class BackofficeCatalogueLayersProvider implements CatalogueLayersProviderInterf
         return $this->getUserTranslatedCatalogueProvider()->getCatalogue($locale);
     }
 
-    /**
-     * This is for Default and FileTranslated catalogue.
-     * In the translations directory, we will take any file starting with 'Admin' and followed by alphabetical characters.
-     *
-     * @return string[]
-     */
-    protected function getFilenameFilters(): array
-    {
-        return [
-            '#^Admin[A-Z]#',
-        ];
-    }
-
-    /**
-     * This is for UserTranslated catalogue.
-     * In the translations table, we will take any translation having domain starting with 'Admin' and followed by alphabetical characters.
-     *
-     * @return string[]
-     */
-    protected function getTranslationDomains(): array
-    {
-        return [
-            '^Admin[A-Z]',
-        ];
-    }
-
     private function getDefaultCatalogueProvider(): DefaultCatalogueProvider
     {
         if (null === $this->defaultCatalogueProvider) {
             $this->defaultCatalogueProvider = new DefaultCatalogueProvider(
                 $this->resourceDirectory . DIRECTORY_SEPARATOR . 'default',
-                $this->getFilenameFilters()
+                $this->filenameFilters
             );
         }
 
@@ -151,7 +139,7 @@ class BackofficeCatalogueLayersProvider implements CatalogueLayersProviderInterf
         if (null === $this->fileTranslatedCatalogueProvider) {
             $this->fileTranslatedCatalogueProvider = new FileTranslatedCatalogueProvider(
                 $this->resourceDirectory,
-                $this->getFilenameFilters()
+                $this->filenameFilters
             );
         }
 
@@ -163,7 +151,7 @@ class BackofficeCatalogueLayersProvider implements CatalogueLayersProviderInterf
         if (null === $this->userTranslatedCatalogueProvider) {
             $this->userTranslatedCatalogueProvider = new UserTranslatedCatalogueProvider(
                 $this->databaseTranslationLoader,
-                $this->getTranslationDomains()
+                $this->translationDomains
             );
         }
 

--- a/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -71,10 +72,12 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
      * @var UserTranslatedCatalogueProvider
      */
     private $userTranslatedCatalogueProvider;
+
     /**
      * @var array
      */
     private $filenameFilters;
+
     /**
      * @var array
      */
@@ -83,8 +86,8 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
     /**
      * @param DatabaseTranslationLoader $databaseTranslationLoader
      * @param string $resourceDirectory
-     * @param string[] $filenameFilters
-     * @param string[] $translationDomains
+     * @param array<int, string> $filenameFilters
+     * @param array<int, string> $translationDomains
      */
     public function __construct(
         DatabaseTranslationLoader $databaseTranslationLoader,
@@ -122,6 +125,11 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
         return $this->getUserTranslatedCatalogueProvider()->getCatalogue($locale);
     }
 
+    /**
+     * @return DefaultCatalogueProvider
+     *
+     * @throws FileNotFoundException
+     */
     private function getDefaultCatalogueProvider(): DefaultCatalogueProvider
     {
         if (null === $this->defaultCatalogueProvider) {
@@ -134,6 +142,11 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
         return $this->defaultCatalogueProvider;
     }
 
+    /**
+     * @return FileTranslatedCatalogueProvider
+     *
+     * @throws FileNotFoundException
+     */
     private function getFileTranslatedCatalogueProvider(): FileTranslatedCatalogueProvider
     {
         if (null === $this->fileTranslatedCatalogueProvider) {
@@ -146,6 +159,9 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
         return $this->fileTranslatedCatalogueProvider;
     }
 
+    /**
+     * @return UserTranslatedCatalogueProvider
+     */
     private function getUserTranslatedCatalogueProvider(): UserTranslatedCatalogueProvider
     {
         if (null === $this->userTranslatedCatalogueProvider) {

--- a/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -104,7 +104,7 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
     /**
      * {@inheritdoc}
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function getDefaultCatalogue(string $locale): MessageCatalogue
     {
@@ -130,7 +130,7 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
     /**
      * @return DefaultCatalogueProvider
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     private function getDefaultCatalogueProvider(): DefaultCatalogueProvider
     {
@@ -147,7 +147,7 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
     /**
      * @return FileTranslatedCatalogueProvider
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     private function getFileTranslatedCatalogueProvider(): FileTranslatedCatalogueProvider
     {

--- a/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/CoreCatalogueLayersProvider.php
@@ -32,10 +32,11 @@ use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
- * Returns the 3 layers of translation catalogues related to the Backoffice interface translations.
- * The default catalogue is in app/Resources/translations/default, in any file starting with "Admin"
- * The file catalogue is in app/Resources/translations/LOCALE, in any file starting with "Admin"
- * The user catalogue is stored in DB, domain starting with Admin and theme is NULL.
+ * Returns the 3 layers of translation catalogues related to the Core interface translations.
+ * The files pattern depends on the desired Type
+ * The default catalogue is in app/Resources/translations/default, in any file starting with "files pattern"
+ * The file catalogue is in app/Resources/translations/LOCALE, in any file starting with "files pattern"
+ * The user catalogue is stored in DB, domain starting with "files pattern" and theme is NULL.
  *
  * @see CatalogueLayersProviderInterface to understand the 3 layers.
  */
@@ -50,7 +51,6 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
 
     /**
      * This is the directory where Default and FileTranslated translations are stored.
-     * For the Backoffice catalogue,
      *   - Default catalogue is within resourceDirectory/default
      *   - FileTranslated catalogue is in resourceDirectory/locale
      *
@@ -103,6 +103,8 @@ class CoreCatalogueLayersProvider implements CatalogueLayersProviderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws FileNotFoundException
      */
     public function getDefaultCatalogue(string $locale): MessageCatalogue
     {

--- a/src/Core/Translation/Provider/DefaultCatalogueProvider.php
+++ b/src/Core/Translation/Provider/DefaultCatalogueProvider.php
@@ -43,7 +43,7 @@ class DefaultCatalogueProvider extends AbstractCatalogueProvider
     private $defaultCatalogueDirectory;
 
     /**
-     * @var array
+     * @var array<int, string>
      */
     private $filenameFilters;
 

--- a/src/Core/Translation/Provider/DefaultCatalogueProvider.php
+++ b/src/Core/Translation/Provider/DefaultCatalogueProvider.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Finder\TranslationFinder;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -51,12 +51,12 @@ class DefaultCatalogueProvider extends AbstractCatalogueProvider
      * @param string $defaultCatalogueDirectory Directory where to look files
      * @param string[] $filenameFilters Array of globs to use to match files
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function __construct(string $defaultCatalogueDirectory, array $filenameFilters)
     {
         if (!is_dir($defaultCatalogueDirectory) || !is_readable($defaultCatalogueDirectory)) {
-            throw new FileNotFoundException(sprintf('Directory %s does not exist', $defaultCatalogueDirectory));
+            throw new TranslationFilesNotFoundException(sprintf('Directory %s does not exist', $defaultCatalogueDirectory));
         }
 
         if (!$this->assertIsArrayOfString($filenameFilters)) {
@@ -74,7 +74,7 @@ class DefaultCatalogueProvider extends AbstractCatalogueProvider
      *
      * @return MessageCatalogue
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function getCatalogue(string $locale): MessageCatalogue
     {

--- a/src/Core/Translation/Provider/Definition/AbstractCoreProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/AbstractCoreProviderDefinition.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for core translation providers.
+ */
+abstract class AbstractCoreProviderDefinition implements ProviderDefinitionInterface
+{
+    /**
+     * @return string
+     */
+    abstract public function getType(): string;
+
+    /**
+     * Returns a list of patterns to filter catalogue files.
+     * Depends on the translation type.
+     *
+     * @return string[]
+     */
+    abstract public function getFilenameFilters(): array;
+
+    /**
+     * Returns a list of patterns to filter translation domains.
+     * Depends on the translation type.
+     *
+     * @return string[]
+     */
+    abstract public function getTranslationDomains(): array;
+}

--- a/src/Core/Translation/Provider/Definition/AbstractCoreProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/AbstractCoreProviderDefinition.php
@@ -41,7 +41,7 @@ abstract class AbstractCoreProviderDefinition implements ProviderDefinitionInter
      * Returns a list of patterns to filter catalogue files.
      * Depends on the translation type.
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     abstract public function getFilenameFilters(): array;
 
@@ -49,7 +49,7 @@ abstract class AbstractCoreProviderDefinition implements ProviderDefinitionInter
      * Returns a list of patterns to filter translation domains.
      * Depends on the translation type.
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     abstract public function getTranslationDomains(): array;
 }

--- a/src/Core/Translation/Provider/Definition/AbstractCoreProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/AbstractCoreProviderDefinition.php
@@ -41,7 +41,7 @@ abstract class AbstractCoreProviderDefinition implements ProviderDefinitionInter
      * Returns a list of patterns to filter catalogue files.
      * Depends on the translation type.
      *
-     * @return string[]
+     * @return array<string>
      */
     abstract public function getFilenameFilters(): array;
 
@@ -49,7 +49,7 @@ abstract class AbstractCoreProviderDefinition implements ProviderDefinitionInter
      * Returns a list of patterns to filter translation domains.
      * Depends on the translation type.
      *
-     * @return string[]
+     * @return array<string>
      */
     abstract public function getTranslationDomains(): array;
 }

--- a/src/Core/Translation/Provider/Definition/BackofficeProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/BackofficeProviderDefinition.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for Backoffice translation provider.
+ */
+class BackofficeProviderDefinition extends AbstractCoreProviderDefinition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_BACK;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return [
+            '#^Admin[A-Z]#',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return [
+            '^Admin[A-Z]',
+        ];
+    }
+}

--- a/src/Core/Translation/Provider/Definition/FrontofficeProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/FrontofficeProviderDefinition.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for Backoffice translation provider.
+ */
+class FrontofficeProviderDefinition extends AbstractCoreProviderDefinition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_FRONT;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return [
+            '#^Shop*#',
+            '#^Modules(.*)Shop#',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return [
+            '^Shop*',
+            '^Modules(.*)Shop',
+        ];
+    }
+}

--- a/src/Core/Translation/Provider/Definition/MailsBodyProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/MailsBodyProviderDefinition.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for Backoffice translation provider.
+ */
+class MailsBodyProviderDefinition extends AbstractCoreProviderDefinition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_MAILS_BODY;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return ['#EmailsBody*#'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return ['EmailsBody*'];
+    }
+}

--- a/src/Core/Translation/Provider/Definition/MailsProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/MailsProviderDefinition.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for Backoffice translation provider.
+ */
+class MailsProviderDefinition extends AbstractCoreProviderDefinition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_MAILS;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return ['#EmailsSubject*#'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return ['EmailsSubject*'];
+    }
+}

--- a/src/Core/Translation/Provider/Definition/ModuleProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/ModuleProviderDefinition.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
+
+/**
+ * Properties container for single Module translation provider.
+ */
+class ModuleProviderDefinition extends AbstractCoreProviderDefinition
+{
+    /**
+     * @var string
+     */
+    private $moduleName;
+
+    public function __construct(string $moduleName)
+    {
+        $this->moduleName = $moduleName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_MODULES;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModuleName(): string
+    {
+        return $this->moduleName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return ['#^' . preg_quote(DomainHelper::buildModuleBaseDomain($this->moduleName)) . '([A-Z]|\.|$)#'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return ['^' . preg_quote(DomainHelper::buildModuleBaseDomain($this->moduleName)) . '([A-Z]|$)'];
+    }
+}

--- a/src/Core/Translation/Provider/Definition/OthersProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/OthersProviderDefinition.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for Backoffice translation provider.
+ */
+class OthersProviderDefinition extends AbstractCoreProviderDefinition
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_OTHERS;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return ['#^messages*#'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return ['^messages*'];
+    }
+}

--- a/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
+++ b/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
 

--- a/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
+++ b/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
@@ -56,7 +56,7 @@ interface ProviderDefinitionInterface
      * Returns a list of patterns to filter catalogue files.
      * Depends on the translation type.
      *
-     * @return string[]
+     * @return array<string>
      */
     public function getFilenameFilters(): array;
 
@@ -64,7 +64,7 @@ interface ProviderDefinitionInterface
      * Returns a list of patterns to filter translation domains.
      * Depends on the translation type.
      *
-     * @return string[]
+     * @return array<string>
      */
     public function getTranslationDomains(): array;
 }

--- a/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
+++ b/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+interface ProviderDefinitionInterface
+{
+    public const TYPE_BACK = 'back';
+    public const TYPE_FRONT = 'front';
+    public const TYPE_MAILS = 'mails';
+    public const TYPE_MAILS_BODY = 'mails_body';
+    public const TYPE_OTHERS = 'others';
+    public const TYPE_MODULES = 'modules';
+    public const TYPE_THEMES = 'themes';
+
+    public const ALLOWED_TYPES = [
+        self::TYPE_BACK,
+        self::TYPE_FRONT,
+        self::TYPE_MAILS,
+        self::TYPE_MAILS_BODY,
+        self::TYPE_OTHERS,
+        self::TYPE_MODULES,
+        self::TYPE_THEMES,
+    ];
+
+    /**
+     * @return string
+     */
+    public function getType(): string;
+
+    /**
+     * Returns a list of patterns to filter catalogue files.
+     * Depends on the translation type.
+     *
+     * @return string[]
+     */
+    public function getFilenameFilters(): array;
+
+    /**
+     * Returns a list of patterns to filter translation domains.
+     * Depends on the translation type.
+     *
+     * @return string[]
+     */
+    public function getTranslationDomains(): array;
+}

--- a/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
+++ b/src/Core/Translation/Provider/Definition/ProviderDefinitionInterface.php
@@ -56,7 +56,7 @@ interface ProviderDefinitionInterface
      * Returns a list of patterns to filter catalogue files.
      * Depends on the translation type.
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     public function getFilenameFilters(): array;
 
@@ -64,7 +64,7 @@ interface ProviderDefinitionInterface
      * Returns a list of patterns to filter translation domains.
      * Depends on the translation type.
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     public function getTranslationDomains(): array;
 }

--- a/src/Core/Translation/Provider/Definition/ThemeProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/ThemeProviderDefinition.php
@@ -39,10 +39,13 @@ class ThemeProviderDefinition implements ProviderDefinitionInterface
      */
     private $themeName;
 
+    /**
+     * @param string|null $themeName
+     */
     public function __construct(?string $themeName = null)
     {
         if (null === $themeName) {
-            $themeName = self::DEFAULT_THEME_NAME;
+            $themeName = static::DEFAULT_THEME_NAME;
         }
 
         $this->themeName = $themeName;

--- a/src/Core/Translation/Provider/Definition/ThemeProviderDefinition.php
+++ b/src/Core/Translation/Provider/Definition/ThemeProviderDefinition.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider\Definition;
+
+/**
+ * Properties container for single Module translation provider.
+ */
+class ThemeProviderDefinition implements ProviderDefinitionInterface
+{
+    public const DEFAULT_THEME_NAME = 'classic';
+
+    /**
+     * @var string
+     */
+    private $themeName;
+
+    public function __construct(?string $themeName = null)
+    {
+        if (null === $themeName) {
+            $themeName = self::DEFAULT_THEME_NAME;
+        }
+
+        $this->themeName = $themeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_THEMES;
+    }
+
+    /**
+     * @return string
+     */
+    public function getThemeName(): string
+    {
+        return $this->themeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return [];
+    }
+}

--- a/src/Core/Translation/Provider/FileTranslatedCatalogueProvider.php
+++ b/src/Core/Translation/Provider/FileTranslatedCatalogueProvider.php
@@ -45,7 +45,7 @@ class FileTranslatedCatalogueProvider extends AbstractCatalogueProvider
     private $translatedCatalogueDirectory;
 
     /**
-     * @var array
+     * @var array<int, string>
      */
     private $filenameFilters;
 

--- a/src/Core/Translation/Provider/FileTranslatedCatalogueProvider.php
+++ b/src/Core/Translation/Provider/FileTranslatedCatalogueProvider.php
@@ -50,22 +50,22 @@ class FileTranslatedCatalogueProvider extends AbstractCatalogueProvider
     private $filenameFilters;
 
     /**
-     * @param string $directory
+     * @param string $translatedCatalogueDirectory
      * @param array $filenameFilters
      *
      * @throws FileNotFoundException
      */
-    public function __construct(string $directory, array $filenameFilters)
+    public function __construct(string $translatedCatalogueDirectory, array $filenameFilters)
     {
-        if (!is_dir($directory) || !is_readable($directory)) {
-            throw new FileNotFoundException(sprintf('Directory %s does not exist', $directory));
+        if (!is_dir($translatedCatalogueDirectory) || !is_readable($translatedCatalogueDirectory)) {
+            throw new FileNotFoundException(sprintf('Directory %s does not exist', $translatedCatalogueDirectory));
         }
 
         if (!$this->assertIsArrayOfString($filenameFilters)) {
             throw new \InvalidArgumentException('Given filename filters are invalid. An array of strings was expected.');
         }
 
-        $this->translatedCatalogueDirectory = $directory;
+        $this->translatedCatalogueDirectory = $translatedCatalogueDirectory;
         $this->filenameFilters = $filenameFilters;
     }
 

--- a/src/Core/Translation/Provider/FileTranslatedCatalogueProvider.php
+++ b/src/Core/Translation/Provider/FileTranslatedCatalogueProvider.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Finder\TranslationFinder;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -53,12 +53,12 @@ class FileTranslatedCatalogueProvider extends AbstractCatalogueProvider
      * @param string $translatedCatalogueDirectory
      * @param array $filenameFilters
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function __construct(string $translatedCatalogueDirectory, array $filenameFilters)
     {
         if (!is_dir($translatedCatalogueDirectory) || !is_readable($translatedCatalogueDirectory)) {
-            throw new FileNotFoundException(sprintf('Directory %s does not exist', $translatedCatalogueDirectory));
+            throw new TranslationFilesNotFoundException(sprintf('Directory %s does not exist', $translatedCatalogueDirectory));
         }
 
         if (!$this->assertIsArrayOfString($filenameFilters)) {
@@ -76,7 +76,7 @@ class FileTranslatedCatalogueProvider extends AbstractCatalogueProvider
      *
      * @return MessageCatalogue
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function getCatalogue(string $locale): MessageCatalogue
     {

--- a/src/Core/Translation/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ModuleCatalogueLayersProvider.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider;
+
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShopBundle\Translation\DomainNormalizer;
+use PrestaShopBundle\Translation\Exception\UnsupportedLocaleException;
+use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
+use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Returns the 3 layers of translation catalogues related to the Backoffice interface translations.
+ * The default catalogue is in app/Resources/translations/default, in any file starting with "Admin"
+ * The file catalogue is in app/Resources/translations/LOCALE, in any file starting with "Admin"
+ * The user catalogue is stored in DB, domain starting with Admin and theme is NULL.
+ *
+ * @see CatalogueLayersProviderInterface to understand the 3 layers.
+ */
+class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
+{
+    /**
+     * We need a connection to DB to load user translated catalogue.
+     *
+     * @var DatabaseTranslationLoader
+     */
+    private $databaseTranslationLoader;
+
+    /**
+     * This is the directory where Default and FileTranslated translations are stored.
+     * For the Backoffice catalogue,
+     *   - Default catalogue is within resourceDirectory/default
+     *   - FileTranslated catalogue is in resourceDirectory/locale
+     *
+     * @var string
+     */
+    private $resourceDirectory;
+
+    /**
+     * @var DefaultCatalogueProvider
+     */
+    private $defaultCatalogueProvider;
+
+    /**
+     * @var FileTranslatedCatalogueProvider
+     */
+    private $fileTranslatedCatalogueProvider;
+
+    /**
+     * @var UserTranslatedCatalogueProvider
+     */
+    private $userTranslatedCatalogueProvider;
+    /**
+     * @var string
+     */
+    private $moduleName;
+    /**
+     * @var string
+     */
+    private $modulesDirectory;
+    /**
+     * @var string
+     */
+    private $translationsDirectory;
+
+    /**
+     * @var MessageCatalogue[]
+     */
+    private $defaultCatalogueCache;
+    /**
+     * @var LegacyModuleExtractorInterface
+     */
+    private $legacyModuleExtractor;
+    /**
+     * @var LoaderInterface
+     */
+    private $legacyFileLoader;
+    /**
+     * @var array
+     */
+    private $filenameFilters;
+    /**
+     * @var array
+     */
+    private $translationDomains;
+
+    /**
+     * @param DatabaseTranslationLoader $databaseTranslationLoader
+     * @param LegacyModuleExtractorInterface $legacyModuleExtractor
+     * @param LoaderInterface $legacyFileLoader
+     * @param string $modulesDirectory
+     * @param string $translationsDirectory
+     * @param string $resourceDirectory
+     * @param string $moduleName
+     * @param array $filenameFilters
+     * @param array $translationDomains
+     */
+    public function __construct(
+        DatabaseTranslationLoader $databaseTranslationLoader,
+        LegacyModuleExtractorInterface $legacyModuleExtractor,
+        LoaderInterface $legacyFileLoader,
+        string $modulesDirectory,
+        string $translationsDirectory,
+        string $resourceDirectory,
+        string $moduleName,
+        array $filenameFilters,
+        array $translationDomains
+    ) {
+        $this->databaseTranslationLoader = $databaseTranslationLoader;
+        $this->resourceDirectory = $resourceDirectory;
+        $this->moduleName = $moduleName;
+        $this->modulesDirectory = $modulesDirectory;
+        $this->translationsDirectory = $translationsDirectory;
+        $this->legacyModuleExtractor = $legacyModuleExtractor;
+        $this->legacyFileLoader = $legacyFileLoader;
+        $this->filenameFilters = $filenameFilters;
+        $this->translationDomains = $translationDomains;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultCatalogue(string $locale): MessageCatalogue
+    {
+        try {
+            $defaultCatalogue = $this->getDefaultCatalogueProvider($locale)->getCatalogue($locale);
+        } catch (FileNotFoundException $e) {
+            var_dump($e->getMessage());
+            $defaultCatalogue = $this->getCachedDefaultCatalogue($locale);
+        }
+
+        return $defaultCatalogue;
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     */
+    public function getFileTranslatedCatalogue(string $locale): MessageCatalogue
+    {
+        try {
+            return $this->getFileTranslatedCatalogueProvider()->getCatalogue($locale);
+        } catch (FileNotFoundException $exception) {
+            return $this->buildTranslationCatalogueFromLegacyFiles($locale);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserTranslatedCatalogue(string $locale): MessageCatalogue
+    {
+        return $this->getUserTranslatedCatalogueProvider()->getCatalogue($locale);
+    }
+
+    private function getDefaultCatalogueProvider(string $locale): DefaultCatalogueProvider
+    {
+        if (null === $this->defaultCatalogueProvider) {
+            $this->defaultCatalogueProvider = new DefaultCatalogueProvider(
+                $this->translationsDirectory . DIRECTORY_SEPARATOR . $locale,
+                $this->filenameFilters
+            );
+        }
+
+        return $this->defaultCatalogueProvider;
+    }
+
+    private function getFileTranslatedCatalogueProvider(): FileTranslatedCatalogueProvider
+    {
+        if (null === $this->fileTranslatedCatalogueProvider) {
+            $this->fileTranslatedCatalogueProvider = new FileTranslatedCatalogueProvider(
+                $this->translationsDirectory,
+                $this->filenameFilters
+            );
+        }
+
+        return $this->fileTranslatedCatalogueProvider;
+    }
+
+    private function getUserTranslatedCatalogueProvider(): UserTranslatedCatalogueProvider
+    {
+        if (null === $this->userTranslatedCatalogueProvider) {
+            $this->userTranslatedCatalogueProvider = new UserTranslatedCatalogueProvider(
+                $this->databaseTranslationLoader,
+                $this->translationDomains
+            );
+        }
+
+        return $this->userTranslatedCatalogueProvider;
+    }
+
+    /**
+     * Builds the catalogue including the translated wordings ONLY
+     *
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     */
+    private function buildTranslationCatalogueFromLegacyFiles(string $locale): MessageCatalogue
+    {
+        // the message catalogue needs to be indexed by original wording, but legacy files are indexed by hash
+        // therefore, we need to build the default catalogue (by analyzing source code)
+        // then cross reference the wordings found in the default catalogue
+        // with the hashes found in the module's legacy translation file.
+
+        $legacyFilesCatalogue = new MessageCatalogue($locale);
+        $catalogueFromPhpAndSmartyFiles = $this->getDefaultCatalogue($locale);
+
+        try {
+            $catalogueFromLegacyTranslationFiles = $this->legacyFileLoader->load(
+                $this->getBuiltInModuleDirectory(),
+                $locale
+            );
+        } catch (UnsupportedLocaleException $exception) {
+            // this happens when there is no translation file found for the desired locale
+            return $catalogueFromPhpAndSmartyFiles;
+        }
+
+        foreach ($catalogueFromPhpAndSmartyFiles->all() as $currentDomain => $items) {
+            foreach (array_keys($items) as $translationKey) {
+                $legacyKey = md5($translationKey);
+
+                if ($catalogueFromLegacyTranslationFiles->has($legacyKey, $currentDomain)) {
+                    $legacyFilesCatalogue->set(
+                        $translationKey,
+                        $catalogueFromLegacyTranslationFiles->get($legacyKey, $currentDomain),
+                        // use current domain and not module domain, otherwise we'd lose the third part from the domain
+                        $currentDomain
+                    );
+                }
+            }
+        }
+
+        return $legacyFilesCatalogue;
+    }
+
+    /**
+     * @return string
+     */
+    private function getBuiltInModuleDirectory(): string
+    {
+        return implode(DIRECTORY_SEPARATOR, [
+            $this->modulesDirectory,
+            $this->moduleName,
+            'translations',
+        ]) . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * Returns the cached default catalogue
+     *
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     */
+    private function getCachedDefaultCatalogue(string $locale): MessageCatalogue
+    {
+        $catalogueCacheKey = $this->moduleName . '|' . $locale;
+
+        if (!isset($this->defaultCatalogueCache[$catalogueCacheKey])) {
+            $this->defaultCatalogueCache[$catalogueCacheKey] = $this->buildFreshDefaultCatalogue($locale);
+        }
+
+        return $this->defaultCatalogueCache[$catalogueCacheKey];
+    }
+
+    /**
+     * Builds the default catalogue
+     *
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     */
+    private function buildFreshDefaultCatalogue(string $locale): MessageCatalogue
+    {
+        $defaultCatalogue = new MessageCatalogue($locale);
+
+        try {
+            // look up files in the core translations
+            $defaultCatalogue = (new DefaultCatalogueProvider(
+                $this->translationsDirectory . DIRECTORY_SEPARATOR . 'default',
+                $this->filenameFilters
+            ))
+                ->getCatalogue($locale);
+        } catch (FileNotFoundException $exception) {
+            // there are no xliff files for this module in the core
+        }
+
+        try {
+            // analyze files and extract wordings
+            /** @var MessageCatalogue $additionalDefaultCatalogue */
+            $additionalDefaultCatalogue = $this->legacyModuleExtractor->extract($this->moduleName, $locale);
+            $defaultCatalogue = $this->filterDomains($additionalDefaultCatalogue);
+        } catch (UnsupportedLocaleException $exception) {
+            // Do nothing as support of legacy files is deprecated
+        }
+
+        return $defaultCatalogue;
+    }
+
+    /**
+     * Replaces dots in the catalogue's domain names
+     * and filters out domains not corresponding to the one from this module
+     *
+     * @param MessageCatalogue $catalogue
+     *
+     * @return MessageCatalogue
+     */
+    private function filterDomains(MessageCatalogue $catalogue): MessageCatalogue
+    {
+        $normalizer = new DomainNormalizer();
+        $newCatalogue = new MessageCatalogue($catalogue->getLocale());
+
+        foreach ($catalogue->getDomains() as $domain) {
+            // remove dots
+            $newDomain = $normalizer->normalize($domain);
+
+            // add delimiters
+            // only add if the domain is relevant to this module
+            foreach ($this->filenameFilters as $pattern) {
+                if (preg_match($pattern, $newDomain)) {
+                    $newCatalogue->add(
+                        $catalogue->all($domain),
+                        $newDomain
+                    );
+                    break;
+                }
+            }
+        }
+
+        return $newCatalogue;
+    }
+}

--- a/src/Core/Translation/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ModuleCatalogueLayersProvider.php
@@ -53,16 +53,6 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
     private $databaseTranslationLoader;
 
     /**
-     * This is the directory where Default and FileTranslated translations are stored.
-     * For the Backoffice catalogue,
-     *   - Default catalogue is within resourceDirectory/default
-     *   - FileTranslated catalogue is in resourceDirectory/locale
-     *
-     * @var string
-     */
-    private $resourceDirectory;
-
-    /**
      * @var DefaultCatalogueProvider
      */
     private $defaultCatalogueProvider;
@@ -116,7 +106,6 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
      * @param LoaderInterface $legacyFileLoader
      * @param string $modulesDirectory
      * @param string $translationsDirectory
-     * @param string $resourceDirectory
      * @param string $moduleName
      * @param array $filenameFilters
      * @param array $translationDomains
@@ -127,13 +116,11 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
         LoaderInterface $legacyFileLoader,
         string $modulesDirectory,
         string $translationsDirectory,
-        string $resourceDirectory,
         string $moduleName,
         array $filenameFilters,
         array $translationDomains
     ) {
         $this->databaseTranslationLoader = $databaseTranslationLoader;
-        $this->resourceDirectory = $resourceDirectory;
         $this->moduleName = $moduleName;
         $this->modulesDirectory = $modulesDirectory;
         $this->translationsDirectory = $translationsDirectory;
@@ -151,7 +138,6 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
         try {
             $defaultCatalogue = $this->getDefaultCatalogueProvider($locale)->getCatalogue($locale);
         } catch (FileNotFoundException $e) {
-            var_dump($e->getMessage());
             $defaultCatalogue = $this->getCachedDefaultCatalogue($locale);
         }
 

--- a/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
@@ -27,12 +27,13 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\PrestaShop\Core\Translation\Exception\InvalidThemeException;
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
 use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
-use PrestaShopException;
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -183,10 +184,10 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         try {
             $theme = $this->themeRepository->getInstanceByName($this->themeName);
             if (!$theme instanceof Theme) {
-                throw new PrestaShopException();
+                throw new InvalidThemeException();
             }
             $this->theme = $theme;
-        } catch (PrestaShopException $e) {
+        } catch (Exception $e) {
             throw new RuntimeException(sprintf('The theme "%s" doesn\'t exist', $this->themeName), 0, $e);
         }
     }

--- a/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
@@ -38,10 +38,10 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
- * Returns the 3 layers of translation catalogues related to the Backoffice interface translations.
- * The default catalogue is in app/Resources/translations/default, in any file starting with "Admin"
- * The file catalogue is in app/Resources/translations/LOCALE, in any file starting with "Admin"
- * The user catalogue is stored in DB, domain starting with Admin and theme is NULL.
+ * Returns the 3 layers of translation catalogues related to the Theme translations.
+ * The default catalogue is extracted from Theme's templates
+ * The file catalogue is extracted from Core's file (in any file starting with "Shop") and from theme directory themes/THEMENAME/translations
+ * The user catalogue is stored in DB, domain starting with Shop and theme is equal to the desired theme.
  *
  * @see CatalogueLayersProviderInterface to understand the 3 layers.
  */
@@ -85,7 +85,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
     private $themeResourcesDir;
 
     /**
-     * @var \PrestaShop\PrestaShop\Core\Addon\Theme\Theme
+     * @var Theme
      */
     private $theme;
 

--- a/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Translation\Provider;
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
 use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use PrestaShopException;
@@ -136,7 +136,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
      *
      * @return MessageCatalogue
      *
-     * @throws FileNotFoundException
+     * @throws TranslationFilesNotFoundException
      */
     public function getFileTranslatedCatalogue(string $locale): MessageCatalogue
     {
@@ -152,7 +152,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
 
             // overwrite with the theme's own catalogue
             $catalogue->addCatalogue($fileTranslatedCatalogue);
-        } catch (FileNotFoundException $e) {
+        } catch (TranslationFilesNotFoundException $e) {
             // there are no translation files, ignore them
             return new MessageCatalogue($locale);
         }

--- a/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
 use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use PrestaShopException;
+use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -52,30 +53,37 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
      * @var DatabaseTranslationLoader
      */
     private $databaseTranslationLoader;
+
     /**
      * @var string
      */
     private $themeName;
+
     /**
      * @var CatalogueLayersProviderInterface
      */
     private $coreFrontProvider;
+
     /**
      * @var ThemeExtractor
      */
     private $themeExtractor;
+
     /**
      * @var ThemeRepository
      */
     private $themeRepository;
+
     /**
      * @var Filesystem
      */
     private $filesystem;
+
     /**
      * @var string
      */
     private $themeResourcesDir;
+
     /**
      * @var \PrestaShop\PrestaShop\Core\Addon\Theme\Theme
      */
@@ -179,7 +187,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
             }
             $this->theme = $theme;
         } catch (PrestaShopException $e) {
-            throw new \RuntimeException(sprintf('The theme "%s" doesn\'t exist', $this->themeName), 0, $e);
+            throw new RuntimeException(sprintf('The theme "%s" doesn\'t exist', $this->themeName), 0, $e);
         }
     }
 

--- a/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Provider/ThemeCatalogueLayersProvider.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Provider;
+
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
+use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
+use PrestaShopException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Returns the 3 layers of translation catalogues related to the Backoffice interface translations.
+ * The default catalogue is in app/Resources/translations/default, in any file starting with "Admin"
+ * The file catalogue is in app/Resources/translations/LOCALE, in any file starting with "Admin"
+ * The user catalogue is stored in DB, domain starting with Admin and theme is NULL.
+ *
+ * @see CatalogueLayersProviderInterface to understand the 3 layers.
+ */
+class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
+{
+    /**
+     * We need a connection to DB to load user translated catalogue.
+     *
+     * @var DatabaseTranslationLoader
+     */
+    private $databaseTranslationLoader;
+    /**
+     * @var string
+     */
+    private $themeName;
+    /**
+     * @var CatalogueLayersProviderInterface
+     */
+    private $coreFrontProvider;
+    /**
+     * @var ThemeExtractor
+     */
+    private $themeExtractor;
+    /**
+     * @var ThemeRepository
+     */
+    private $themeRepository;
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+    /**
+     * @var string
+     */
+    private $themeResourcesDir;
+    /**
+     * @var \PrestaShop\PrestaShop\Core\Addon\Theme\Theme
+     */
+    private $theme;
+
+    /**
+     * @param CatalogueLayersProviderInterface $coreFrontProvider
+     * @param DatabaseTranslationLoader $databaseTranslationLoader
+     * @param ThemeExtractor $themeExtractor
+     * @param ThemeRepository $themeRepository
+     * @param Filesystem $filesystem
+     * @param string $themeResourcesDir
+     * @param string $themeName
+     */
+    public function __construct(
+        CatalogueLayersProviderInterface $coreFrontProvider,
+        DatabaseTranslationLoader $databaseTranslationLoader,
+        ThemeExtractor $themeExtractor,
+        ThemeRepository $themeRepository,
+        Filesystem $filesystem,
+        string $themeResourcesDir,
+        string $themeName
+    ) {
+        $this->databaseTranslationLoader = $databaseTranslationLoader;
+        $this->coreFrontProvider = $coreFrontProvider;
+        $this->themeExtractor = $themeExtractor;
+        $this->themeRepository = $themeRepository;
+        $this->filesystem = $filesystem;
+        $this->themeResourcesDir = $themeResourcesDir;
+        $this->themeName = $themeName;
+
+        $this->assertThemeIsValid();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultCatalogue(
+        string $locale,
+        bool $refreshCache = false
+    ): MessageCatalogue {
+        // Extracts wordings from the theme's templates
+        return $this->themeExtractor->extract($this->theme, $locale, $refreshCache);
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     *
+     * @throws FileNotFoundException
+     */
+    public function getFileTranslatedCatalogue(string $locale): MessageCatalogue
+    {
+        // load front office catalogue
+        $catalogue = $this->coreFrontProvider->getFileTranslatedCatalogue($locale);
+
+        try {
+            $fileTranslatedCatalogue = (new FileTranslatedCatalogueProvider(
+                $this->getResourceDirectory(),
+                ['*']
+            ))
+                ->getCatalogue($locale);
+
+            // overwrite with the theme's own catalogue
+            $catalogue->addCatalogue($fileTranslatedCatalogue);
+        } catch (FileNotFoundException $e) {
+            // there are no translation files, ignore them
+            return new MessageCatalogue($locale);
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     */
+    public function getUserTranslatedCatalogue(string $locale): MessageCatalogue
+    {
+        return (new UserTranslatedCatalogueProvider(
+            $this->databaseTranslationLoader,
+            ['*'],
+            $this->themeName
+        ))
+            ->getCatalogue($locale);
+    }
+
+    /**
+     * Check if theme is registered in DB and set class property
+     */
+    private function assertThemeIsValid(): void
+    {
+        try {
+            $theme = $this->themeRepository->getInstanceByName($this->themeName);
+            if (!$theme instanceof Theme) {
+                throw new PrestaShopException();
+            }
+            $this->theme = $theme;
+        } catch (PrestaShopException $e) {
+            throw new \RuntimeException(sprintf('The theme "%s" doesn\'t exist', $this->themeName), 0, $e);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function getResourceDirectory(): string
+    {
+        $resourceDirectory = implode(DIRECTORY_SEPARATOR, [
+            rtrim($this->themeResourcesDir, DIRECTORY_SEPARATOR),
+            $this->themeName,
+            'translations',
+        ]);
+        $this->filesystem->mkdir($resourceDirectory);
+
+        return $resourceDirectory;
+    }
+}

--- a/src/Core/Translation/Provider/UserTranslatedCatalogueProvider.php
+++ b/src/Core/Translation/Provider/UserTranslatedCatalogueProvider.php
@@ -41,7 +41,7 @@ class UserTranslatedCatalogueProvider extends AbstractCatalogueProvider
     private $databaseTranslationReader;
 
     /**
-     * @var array
+     * @var array<int, string>
      */
     private $translationDomains;
 
@@ -55,7 +55,7 @@ class UserTranslatedCatalogueProvider extends AbstractCatalogueProvider
      * If not given, the translations returns will be the ones with 'theme IS NULL'
      *
      * @param DatabaseTranslationLoader $databaseTranslationReader
-     * @param array $translationDomains
+     * @param array<int, string> $translationDomains
      * @param string|null $themeName
      */
     public function __construct(

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -9,7 +9,7 @@ services:
             - '@prestashop.translation.translation_catalogue_builder'
 
     prestashop.translation.translation_catalogue_builder:
-        class: PrestaShopBundle\Translation\TranslationCatalogueBuilder
+        class: PrestaShop\PrestaShop\Core\Translation\Builder\TranslationCatalogueBuilder
         arguments:
             - '@prestashop.translation.provider.catalogue_provider_factory'
 
@@ -31,9 +31,16 @@ services:
 
     #TRANSLATIONS PROVIDERS
     prestashop.translation.provider.catalogue_provider_factory:
-        class: PrestaShopBundle\Translation\Provider\CatalogueProviderFactory
+        class: PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory
         arguments:
             - '@prestashop.translation.database_loader'
+            - '@prestashop.translation.legacy_module.extractor'
+            - '@prestashop.translation.legacy_file_loader'
+            - '@prestashop.translation.theme_extractor'
+            - '@prestashop.core.addon.theme.repository'
+            - '@filesystem'
+            - '%themes_translations_dir%'
+            - '%modules_dir%'
             - "%translations_dir%"
 
     prestashop.translation.backoffice_provider:

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShopBundle\Translation\Extractor;
 
+use Exception;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper;
 use PrestaShop\TranslationToolsBundle\Translation\Extractor\SmartyExtractor;
@@ -100,11 +101,11 @@ class ThemeExtractor
      * @param string $locale
      * @param bool $rootDir
      *
-     * @return mixed
+     * @return MessageCatalogue|null
      *
-     * @throws \Exception
+     * @throws Exception
      */
-    public function extract(Theme $theme, $locale = 'en-US', $rootDir = false)
+    public function extract(Theme $theme, $locale = 'en-US', $rootDir = false): ?MessageCatalogue
     {
         $this->catalog = new MessageCatalogue($locale);
         // remove the last "/"
@@ -129,7 +130,9 @@ class ThemeExtractor
                     $options['path'] = $this->outputPath;
                 }
 
-                return $dumper->dump($this->catalog, $options);
+                $dumper->dump($this->catalog, $options);
+
+                return $this->catalog;
             }
         }
 
@@ -184,12 +187,12 @@ class ThemeExtractor
      * @param string $locale
      * @param MessageCatalogue $catalogue
      *
-     * @throws \Exception
+     * @throws Exception
      */
     private function overrideFromDatabase($themeName, $locale, &$catalogue)
     {
         if (null === $this->themeProvider) {
-            throw new \Exception('Theme provider is required.');
+            throw new Exception('Theme provider is required.');
         }
 
         $databaseCatalogue = $this->themeProvider

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractor.php
@@ -189,7 +189,7 @@ class ThemeExtractor
      *
      * @throws Exception
      */
-    private function overrideFromDatabase($themeName, $locale, &$catalogue)
+    private function overrideFromDatabase($themeName, $locale, &$catalogue): void
     {
         if (null === $this->themeProvider) {
             throw new Exception('Theme provider is required.');

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
@@ -27,13 +27,132 @@
 
 namespace PrestaShopBundle\Translation\Provider;
 
-use PrestaShop\PrestaShop\Core\Translation\Finder\TranslationFinder as CoreTranslationFinder;
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 
 /**
  * Helper used to build a MessageCataloguer from xliff files
  *
  * @deprecated Please use PrestaShop\PrestaShop\Core\Translation\Provider\TranslationFinder instead
  */
-class TranslationFinder extends CoreTranslationFinder
+class TranslationFinder
 {
+    private const ERR_NO_FILES_IN_DIRECTORY = 1;
+    private const ERR_DIRECTORY_NOT_FOUND = 2;
+
+    /**
+     * @param array $paths a list of paths when we can look for translations
+     * @param string $locale the Symfony (not the PrestaShop one) locale
+     * @param string|null $pattern a regular expression
+     *
+     * @return MessageCatalogue
+     *
+     * @throws FileNotFoundException
+     */
+    public function getCatalogueFromPaths(array $paths, string $locale, string $pattern = null): MessageCatalogue
+    {
+        $translationFiles = $this->getTranslationFilesFromPath($paths, $pattern);
+
+        return $this->buildCatalogueFromFiles($translationFiles, $locale);
+    }
+
+    /**
+     * @param MessageCatalogueInterface $catalogue
+     *
+     * @return MessageCatalogue
+     */
+    private function removeTrailingLocaleFromDomains(MessageCatalogueInterface $catalogue): MessageCatalogue
+    {
+        $messages = $catalogue->all();
+        $locale = $catalogue->getLocale();
+        $localeSuffix = '.' . $locale;
+        $suffixLength = strlen($localeSuffix);
+
+        foreach ($catalogue->getDomains() as $domain) {
+            if (substr($domain, -$suffixLength) === $localeSuffix) {
+                $cleanDomain = substr($domain, 0, -$suffixLength);
+                $messages[$cleanDomain] = $messages[$domain];
+                unset($messages[$domain]);
+            }
+        }
+
+        return new MessageCatalogue($locale, $messages);
+    }
+
+    /**
+     * @param string[] $paths
+     * @param string $pattern
+     *
+     * @return Finder
+     *
+     * @throws FileNotFoundException
+     */
+    private function getTranslationFilesFromPath(array $paths, string $pattern): Finder
+    {
+        $finder = new Finder();
+
+        if (null !== $pattern) {
+            $finder->name($pattern);
+        }
+
+        try {
+            $translationFiles = $finder->files()->notName('index.php')->in($paths);
+        } catch (\InvalidArgumentException $e) {
+            throw new FileNotFoundException(sprintf('Could not crawl for translation files: %s', $e->getMessage()), self::ERR_DIRECTORY_NOT_FOUND, $e);
+        }
+
+        if (count($translationFiles) === 0) {
+            throw new FileNotFoundException('There are no translation file available.', self::ERR_NO_FILES_IN_DIRECTORY);
+        }
+
+        return $translationFiles;
+    }
+
+    /**
+     * @param Finder $translationFiles
+     * @param string $locale
+     *
+     * @return MessageCatalogue
+     */
+    private function buildCatalogueFromFiles(Finder $translationFiles, string $locale): MessageCatalogue
+    {
+        $messageCatalogue = new MessageCatalogue($locale);
+        $xliffFileLoader = new XliffFileLoader();
+
+        /** @var SplFileInfo $file */
+        foreach ($translationFiles as $file) {
+            if ('xlf' === $file->getExtension()) {
+                $domain = $this->getDomainFromFile($file, $locale);
+
+                $fileCatalogue = $xliffFileLoader->load($file->getPathname(), $locale, $domain);
+                $messageCatalogue->addCatalogue(
+                    $this->removeTrailingLocaleFromDomains($fileCatalogue)
+                );
+            }
+        }
+
+        return $messageCatalogue;
+    }
+
+    /**
+     * @param SplFileInfo $file
+     * @param string $locale
+     *
+     * @return string
+     */
+    private function getDomainFromFile(SplFileInfo $file, string $locale): string
+    {
+        $basename = $file->getBasename('.xlf');
+
+        $domain = $basename;
+        if (strpos($basename, $locale) === false) {
+            $domain .= '.' . $locale;
+        }
+
+        return $domain;
+    }
 }

--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
@@ -27,6 +27,7 @@
 
 namespace PrestaShopBundle\Translation\Provider;
 
+use InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -101,7 +102,7 @@ class TranslationFinder
 
         try {
             $translationFiles = $finder->files()->notName('index.php')->in($paths);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             throw new FileNotFoundException(sprintf('Could not crawl for translation files: %s', $e->getMessage()), self::ERR_DIRECTORY_NOT_FOUND, $e);
         }
 

--- a/tests/Integration/Core/Translation/Provider/AbstractCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/AbstractCatalogueLayersProviderTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Translation\Provider;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Test the provider of backOffice translations
+ */
+abstract class AbstractCatalogueLayersProviderTest extends KernelTestCase
+{
+    /**
+     * @var string
+     */
+    protected $translationsDir;
+
+    public function setUp()
+    {
+        self::bootKernel();
+        $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+    }
+
+    abstract protected function getProvider(array $databaseContent = []);
+
+    protected function getDefaultCatalogue($locale): MessageCatalogue
+    {
+        return $this->getProvider()->getDefaultCatalogue($locale);
+    }
+
+    protected function getFileTranslatedCatalogue($locale): MessageCatalogue
+    {
+        return $this->getProvider()->getFileTranslatedCatalogue($locale);
+    }
+
+    protected function getUserTranslatedCatalogue(string $locale, array $databaseContent = []): MessageCatalogue
+    {
+        return $this->getProvider($databaseContent)->getUserTranslatedCatalogue($locale);
+    }
+
+    /**
+     * @param array $expected
+     * @param MessageCatalogue $catalogue
+     */
+    protected function assertResultIsAsExpected(array $expected, MessageCatalogue $catalogue): void
+    {
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(array_keys($expected), $domains);
+
+        // verify that the catalogues are complete
+        foreach ($expected as $expectedDomain => $expectedValues) {
+            $this->assertCount($expectedValues['count'], $messages[$expectedDomain]);
+
+            foreach ($expectedValues['translations'] as $translationKey => $translationValue) {
+                $this->assertSame($translationValue, $catalogue->get($translationKey, $expectedDomain));
+            }
+        }
+    }
+}

--- a/tests/Integration/Core/Translation/Provider/BackofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/BackofficeCatalogueLayersProviderTest.php
@@ -52,28 +52,11 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a XLIFF catalogue from the locale's `translations` directory
      */
-    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $databaseContent = [
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
-            ],
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
-                'theme' => 'classic',
-            ],
-        ];
-
         $providerDefinition = new BackofficeProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
@@ -104,28 +87,11 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a default catalogue from the `translations` default directory
      */
-    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $databaseContent = [
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
-            ],
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
-                'theme' => 'classic',
-            ],
-        ];
-
         $providerDefinition = new BackofficeProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
@@ -151,7 +117,7 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         $this->assertSame('', $catalogue->get('Uninstall', 'AdminActions'));
     }
 
-    public function testItLoadsCustomizedTranslationsFromDatabase()
+    public function testItLoadsCustomizedTranslationsFromDatabase(): void
     {
         $databaseContent = [
             [

--- a/tests/Integration/Core/Translation/Provider/BackofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/BackofficeCatalogueLayersProviderTest.php
@@ -54,16 +54,8 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $providerDefinition = new BackofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -89,16 +81,8 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $providerDefinition = new BackofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/default
-        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getDefaultCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -136,16 +120,8 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new BackofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -162,5 +138,22 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
 
         $this->assertSame('Save and stay', $catalogue->get('Save and stay', 'AdminActions'));
         $this->assertSame('Traduction customisée', $catalogue->get('Uninstall', 'AdminActions'));
+    }
+
+    /**
+     * @param array $databaseContent
+     *
+     * @return CoreCatalogueLayersProvider
+     */
+    private function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
+    {
+        $providerDefinition = new BackofficeProviderDefinition();
+
+        return new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
     }
 }

--- a/tests/Integration/Core/Translation/Provider/FrontofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/FrontofficeCatalogueLayersProviderTest.php
@@ -64,7 +64,7 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a XLIFF catalogue from the locale's `translations` directory
      */
-    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
         $providerDefinition = new FrontofficeProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -100,7 +100,7 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a default catalogue from the `translations` default directory
      */
-    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
         $providerDefinition = new FrontofficeProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -133,7 +133,7 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
         $this->assertSame('', $catalogue->get('(order processing will be longer)', 'ModulesWirepaymentShop'));
     }
 
-    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase(): void
     {
         $databaseContent = [
             [
@@ -181,7 +181,7 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
         $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ModulesWirepaymentShop'));
     }
 
-    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase(): void
     {
         $databaseContent = [
             [

--- a/tests/Integration/Core/Translation/Provider/FrontofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/FrontofficeCatalogueLayersProviderTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Translation\Provider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Translation\Provider\CoreCatalogueLayersProvider;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\FrontofficeProviderDefinition;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Test the provider of frontOffice translations
+ */
+class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
+{
+    /**
+     * @var string
+     */
+    private $translationsDir;
+
+    public function setUp()
+    {
+        self::bootKernel();
+        /*
+         * The translation directory actually contains these files for locale = fr-FR
+         * - AdminActions.fr-FR.xlf
+         * - EmailsBody.fr-FR.xlf
+         * - EmailsSubject.fr-FR.xlf
+         * - messages.fr-FR.xlf
+         * - ModulesCheckpaymentAdmin.fr-FR.xlf
+         * - ModulesCheckpaymentShop.fr-FR.xlf
+         * - ModulesWirepaymentAdmin.fr-FR.xlf
+         * - ModulesWirepaymentShop.fr-FR.xlf
+         * - ShopNotificationsWarning.fr-FR.xlf
+         */
+        $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+    }
+
+    /**
+     * Test it loads a XLIFF catalogue from the locale's `translations` directory
+     */
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    {
+        $providerDefinition = new FrontofficeProviderDefinition();
+        $provider = new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from translations/fr-FR
+        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // verify all catalogues are loaded
+        $this->assertSame(['ModulesCheckpaymentShop', 'ModulesWirepaymentShop', 'ShopNotificationsWarning'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
+        $this->assertCount(15, $messages['ModulesWirepaymentShop']);
+        $this->assertCount(8, $messages['ShopNotificationsWarning']);
+
+        $this->assertSame('Vous ne possédez pas de bon de réduction.', $catalogue->get('You do not have any vouchers.', 'ShopNotificationsWarning'));
+        $this->assertSame('Vous ne pouvez pas créer de nouvelle commande depuis votre pays (%s).', $catalogue->get('You cannot place a new order from your country (%s).', 'ShopNotificationsWarning'));
+        $this->assertSame('(le traitement de la commande sera plus long)', $catalogue->get('(order processing will be longer)', 'ModulesWirepaymentShop'));
+    }
+
+    /**
+     * Test it loads a default catalogue from the `translations` default directory
+     */
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    {
+        $providerDefinition = new FrontofficeProviderDefinition();
+        $provider = new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from translations/default
+        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // verify all catalogues are loaded
+        $this->assertSame(['ModulesCheckpaymentShop', 'ModulesWirepaymentShop', 'ShopNotificationsWarning'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
+        $this->assertCount(20, $messages['ModulesWirepaymentShop']);
+        $this->assertCount(8, $messages['ShopNotificationsWarning']);
+
+        $this->assertSame('', $catalogue->get('You do not have any vouchers.', 'ShopNotificationsWarning'));
+        $this->assertSame('', $catalogue->get('You cannot place a new order from your country (%s).', 'ShopNotificationsWarning'));
+        $this->assertSame('', $catalogue->get('(order processing will be longer)', 'ModulesWirepaymentShop'));
+    }
+
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'ShopNotificationsWarning',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'ModulesWirepaymentShop',
+                'theme' => null,
+            ],
+        ];
+
+        $providerDefinition = new FrontofficeProviderDefinition();
+        $provider = new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(['ModulesWirepaymentShop', 'ShopNotificationsWarning'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(1, $messages['ModulesWirepaymentShop']);
+        $this->assertCount(1, $messages['ShopNotificationsWarning']);
+
+        $this->assertSame('You do not have any vouchers.', $catalogue->get('You do not have any vouchers.', 'ShopNotificationsWarning'));
+        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'ShopNotificationsWarning'));
+        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ModulesWirepaymentShop'));
+    }
+
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'ShopNotificationsWarning',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'ModulesWirepaymentShop',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 1',
+                'translation' => 'Un texte inventé 1',
+                'domain' => 'AdminActions',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 2',
+                'translation' => 'Un texte inventé 2',
+                'domain' => 'ModuleWirepaymentShop',
+                'theme' => 'otherTheme',
+            ],
+        ];
+
+        $providerDefinition = new FrontofficeProviderDefinition();
+        $provider = new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // If the theme name is null, the translations which have theme = 'classic' are taken
+        $this->assertEmpty($domains);
+        $this->assertEmpty($messages);
+    }
+}

--- a/tests/Integration/Core/Translation/Provider/FrontofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/FrontofficeCatalogueLayersProviderTest.php
@@ -66,16 +66,8 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $providerDefinition = new FrontofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -102,16 +94,8 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $providerDefinition = new FrontofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/default
-        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getDefaultCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -152,16 +136,8 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new FrontofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -214,16 +190,8 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new FrontofficeProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -235,5 +203,20 @@ class FrontofficeCatalogueLayersProviderTest extends KernelTestCase
         // If the theme name is null, the translations which have theme = 'classic' are taken
         $this->assertEmpty($domains);
         $this->assertEmpty($messages);
+    }
+
+    /**
+     * @param array $databaseContent
+     */
+    private function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
+    {
+        $providerDefinition = new FrontofficeProviderDefinition();
+
+        return new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
     }
 }

--- a/tests/Integration/Core/Translation/Provider/MailsBodyCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsBodyCatalogueLayersProviderTest.php
@@ -64,7 +64,7 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a XLIFF catalogue from the locale's `translations` directory
      */
-    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
         $providerDefinition = new MailsBodyProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -96,7 +96,7 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a default catalogue from the `translations` default directory
      */
-    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
         $providerDefinition = new MailsBodyProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -125,7 +125,7 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
         $this->assertSame('Here is your login email address:', $catalogue->get('Here is your login email address:', 'ShopNotificationsWarning'));
     }
 
-    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase(): void
     {
         $databaseContent = [
             [
@@ -167,7 +167,7 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
         $this->assertEmpty($messages);
     }
 
-    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase(): void
     {
         $databaseContent = [
             [

--- a/tests/Integration/Core/Translation/Provider/MailsBodyCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsBodyCatalogueLayersProviderTest.php
@@ -66,16 +66,8 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $providerDefinition = new MailsBodyProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -98,16 +90,8 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $providerDefinition = new MailsBodyProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/default
-        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getDefaultCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -144,16 +128,8 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new MailsBodyProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -200,13 +176,7 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new MailsBodyProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
+        $provider = $this->getProvider($databaseContent);
 
         // load catalogue from database translations
         $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
@@ -225,5 +195,22 @@ class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
 
         $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'EmailsBody'));
         $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'EmailsBody'));
+    }
+
+    /**
+     * @param array $databaseContent
+     *
+     * @return CoreCatalogueLayersProvider
+     */
+    private function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
+    {
+        $providerDefinition = new MailsBodyProviderDefinition();
+
+        return new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
     }
 }

--- a/tests/Integration/Core/Translation/Provider/MailsBodyCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsBodyCatalogueLayersProviderTest.php
@@ -29,14 +29,14 @@ namespace Tests\Integration\Core\Translation\Provider;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CoreCatalogueLayersProvider;
-use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\BackofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\MailsBodyProviderDefinition;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
- * Test the provider of backOffice translations
+ * Test the provider of frontOffice translations
  */
-class BackofficeCatalogueLayersProviderTest extends KernelTestCase
+class MailsBodyCatalogueLayersProviderTest extends KernelTestCase
 {
     /**
      * @var string
@@ -46,6 +46,18 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
     public function setUp()
     {
         self::bootKernel();
+        /*
+         * The translation directory actually contains these files for locale = fr-FR
+         * - AdminActions.fr-FR.xlf
+         * - EmailsBody.fr-FR.xlf
+         * - EmailsSubject.fr-FR.xlf
+         * - messages.fr-FR.xlf
+         * - ModulesCheckpaymentAdmin.fr-FR.xlf
+         * - ModulesCheckpaymentShop.fr-FR.xlf
+         * - ModulesWirepaymentAdmin.fr-FR.xlf
+         * - ModulesWirepaymentShop.fr-FR.xlf
+         * - ShopNotificationsWarning.fr-FR.xlf
+         */
         $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
     }
 
@@ -54,26 +66,9 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
     {
-        $databaseContent = [
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
-            ],
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
-                'theme' => 'classic',
-            ],
-        ];
-
-        $providerDefinition = new BackofficeProviderDefinition();
+        $providerDefinition = new MailsBodyProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
@@ -89,16 +84,13 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         $domains = $catalogue->getDomains();
         sort($domains);
 
-        $this->assertSame('AdminActions', array_keys($messages)[0]);
-
         // verify all catalogues are loaded
-        $this->assertSame(['AdminActions'], $domains);
+        $this->assertSame(['EmailsBody'], $domains);
 
         // verify that the catalogues are complete
-        $this->assertCount(90, $messages['AdminActions']);
+        $this->assertCount(349, $messages['EmailsBody']);
 
-        $this->assertSame('Enregistrer et rester', $catalogue->get('Save and stay', 'AdminActions'));
-        $this->assertSame('Désinstaller', $catalogue->get('Uninstall', 'AdminActions'));
+        $this->assertSame('Voici votre adresse e-mail de connexion :', $catalogue->get('Here is your login email address:', 'EmailsBody'));
     }
 
     /**
@@ -106,26 +98,9 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
     {
-        $databaseContent = [
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
-            ],
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
-                'theme' => 'classic',
-            ],
-        ];
-
-        $providerDefinition = new BackofficeProviderDefinition();
+        $providerDefinition = new MailsBodyProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
@@ -142,35 +117,34 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         sort($domains);
 
         // verify all catalogues are loaded
-        $this->assertSame(['AdminActions'], $domains);
+        $this->assertSame(['EmailsBody'], $domains);
 
         // verify that the catalogues are complete
-        $this->assertCount(91, $messages['AdminActions']);
+        $this->assertCount(353, $messages['EmailsBody']);
 
-        $this->assertSame('', $catalogue->get('Save and stay', 'AdminActions'));
-        $this->assertSame('', $catalogue->get('Uninstall', 'AdminActions'));
+        $this->assertSame('Here is your login email address:', $catalogue->get('Here is your login email address:', 'ShopNotificationsWarning'));
     }
 
-    public function testItLoadsCustomizedTranslationsFromDatabase()
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
     {
         $databaseContent = [
             [
                 'lang' => 'fr-FR',
                 'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'EmailsBody',
+                'theme' => 'classic',
             ],
             [
                 'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'EmailsBody',
                 'theme' => 'classic',
             ],
         ];
 
-        $providerDefinition = new BackofficeProviderDefinition();
+        $providerDefinition = new MailsBodyProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
             new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
@@ -188,13 +162,68 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         $domains = $catalogue->getDomains();
         sort($domains);
 
-        // verify all catalogues are loaded
-        $this->assertSame(['AdminActions'], $domains);
+        // If the theme name is null, the translations which have theme = 'classic' are taken
+        $this->assertEmpty($domains);
+        $this->assertEmpty($messages);
+    }
+
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'EmailsBody',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'EmailsBody',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 1',
+                'translation' => 'Un texte inventé 1',
+                'domain' => 'AdminActions',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 2',
+                'translation' => 'Un texte inventé 2',
+                'domain' => 'ModuleWirepaymentShop',
+                'theme' => 'classic',
+            ],
+        ];
+
+        $providerDefinition = new MailsBodyProviderDefinition();
+        $provider = new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(['EmailsBody'], $domains);
 
         // verify that the catalogues are complete
-        $this->assertCount(1, $messages['AdminActions']);
+        $this->assertCount(2, $messages['EmailsBody']);
 
-        $this->assertSame('Save and stay', $catalogue->get('Save and stay', 'AdminActions'));
-        $this->assertSame('Traduction customisée', $catalogue->get('Uninstall', 'AdminActions'));
+        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'EmailsBody'));
+        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'EmailsBody'));
     }
 }

--- a/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
@@ -66,16 +66,8 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $providerDefinition = new MailsProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -98,16 +90,8 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $providerDefinition = new MailsProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/default
-        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getDefaultCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -144,16 +128,8 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new MailsProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -200,16 +176,8 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new MailsProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -225,5 +193,22 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
 
         $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'EmailsSubject'));
         $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'EmailsSubject'));
+    }
+
+    /**
+     * @param array $databaseContent
+     *
+     * @return CoreCatalogueLayersProvider
+     */
+    private function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
+    {
+        $providerDefinition = new MailsProviderDefinition();
+
+        return new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
     }
 }

--- a/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
@@ -29,14 +29,14 @@ namespace Tests\Integration\Core\Translation\Provider;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CoreCatalogueLayersProvider;
-use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\BackofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\MailsProviderDefinition;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
- * Test the provider of backOffice translations
+ * Test the provider of frontOffice translations
  */
-class BackofficeCatalogueLayersProviderTest extends KernelTestCase
+class MailsCatalogueLayersProviderTest extends KernelTestCase
 {
     /**
      * @var string
@@ -46,6 +46,18 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
     public function setUp()
     {
         self::bootKernel();
+        /*
+         * The translation directory actually contains these files for locale = fr-FR
+         * - AdminActions.fr-FR.xlf
+         * - EmailsBody.fr-FR.xlf
+         * - EmailsSubject.fr-FR.xlf
+         * - messages.fr-FR.xlf
+         * - ModulesCheckpaymentAdmin.fr-FR.xlf
+         * - ModulesCheckpaymentShop.fr-FR.xlf
+         * - ModulesWirepaymentAdmin.fr-FR.xlf
+         * - ModulesWirepaymentShop.fr-FR.xlf
+         * - ShopNotificationsWarning.fr-FR.xlf
+         */
         $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
     }
 
@@ -54,26 +66,9 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
     {
-        $databaseContent = [
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
-            ],
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
-                'theme' => 'classic',
-            ],
-        ];
-
-        $providerDefinition = new BackofficeProviderDefinition();
+        $providerDefinition = new MailsProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
@@ -89,16 +84,13 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         $domains = $catalogue->getDomains();
         sort($domains);
 
-        $this->assertSame('AdminActions', array_keys($messages)[0]);
-
         // verify all catalogues are loaded
-        $this->assertSame(['AdminActions'], $domains);
+        $this->assertSame(['EmailsSubject'], $domains);
 
         // verify that the catalogues are complete
-        $this->assertCount(90, $messages['AdminActions']);
+        $this->assertCount(24, $messages['EmailsSubject']);
 
-        $this->assertSame('Enregistrer et rester', $catalogue->get('Save and stay', 'AdminActions'));
-        $this->assertSame('Désinstaller', $catalogue->get('Uninstall', 'AdminActions'));
+        $this->assertSame('Log : Vous avez un nouveau message d\'alerte dans votre boutique', $catalogue->get('Log: You have a new alert from your shop', 'EmailsSubject'));
     }
 
     /**
@@ -106,26 +98,9 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
     {
-        $databaseContent = [
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
-            ],
-            [
-                'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
-                'theme' => 'classic',
-            ],
-        ];
-
-        $providerDefinition = new BackofficeProviderDefinition();
+        $providerDefinition = new MailsProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
@@ -142,35 +117,34 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         sort($domains);
 
         // verify all catalogues are loaded
-        $this->assertSame(['AdminActions'], $domains);
+        $this->assertSame(['EmailsSubject'], $domains);
 
         // verify that the catalogues are complete
-        $this->assertCount(91, $messages['AdminActions']);
+        $this->assertCount(24, $messages['EmailsSubject']);
 
-        $this->assertSame('', $catalogue->get('Save and stay', 'AdminActions'));
-        $this->assertSame('', $catalogue->get('Uninstall', 'AdminActions'));
+        $this->assertSame('Log: You have a new alert from your shop', $catalogue->get('Log: You have a new alert from your shop', 'ShopNotificationsWarning'));
     }
 
-    public function testItLoadsCustomizedTranslationsFromDatabase()
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
     {
         $databaseContent = [
             [
                 'lang' => 'fr-FR',
                 'key' => 'Uninstall',
-                'translation' => 'Traduction customisée',
-                'domain' => 'AdminActions',
-                'theme' => null,
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'EmailsSubject',
+                'theme' => 'classic',
             ],
             [
                 'lang' => 'fr-FR',
-                'key' => 'Some made up text',
-                'translation' => 'Un texte inventé',
-                'domain' => 'ShopActions',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'EmailsSubject',
                 'theme' => 'classic',
             ],
         ];
 
-        $providerDefinition = new BackofficeProviderDefinition();
+        $providerDefinition = new MailsProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
             new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
             $this->translationsDir,
@@ -188,13 +162,68 @@ class BackofficeCatalogueLayersProviderTest extends KernelTestCase
         $domains = $catalogue->getDomains();
         sort($domains);
 
-        // verify all catalogues are loaded
-        $this->assertSame(['AdminActions'], $domains);
+        // If the theme name is null, the translations which have theme = 'classic' are taken
+        $this->assertEmpty($domains);
+        $this->assertEmpty($messages);
+    }
+
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'EmailsSubject',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'EmailsSubject',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 1',
+                'translation' => 'Un texte inventé 1',
+                'domain' => 'AdminActions',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 2',
+                'translation' => 'Un texte inventé 2',
+                'domain' => 'ModuleWirepaymentShop',
+                'theme' => 'classic',
+            ],
+        ];
+
+        $providerDefinition = new MailsProviderDefinition();
+        $provider = new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(['EmailsSubject'], $domains);
 
         // verify that the catalogues are complete
-        $this->assertCount(1, $messages['AdminActions']);
+        $this->assertCount(2, $messages['EmailsSubject']);
 
-        $this->assertSame('Save and stay', $catalogue->get('Save and stay', 'AdminActions'));
-        $this->assertSame('Traduction customisée', $catalogue->get('Uninstall', 'AdminActions'));
+        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'EmailsSubject'));
+        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'EmailsSubject'));
     }
 }

--- a/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
@@ -64,7 +64,7 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a XLIFF catalogue from the locale's `translations` directory
      */
-    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
         $providerDefinition = new MailsProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -96,7 +96,7 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a default catalogue from the `translations` default directory
      */
-    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
         $providerDefinition = new MailsProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -125,7 +125,7 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
         $this->assertSame('Log: You have a new alert from your shop', $catalogue->get('Log: You have a new alert from your shop', 'ShopNotificationsWarning'));
     }
 
-    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase(): void
     {
         $databaseContent = [
             [
@@ -167,7 +167,7 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
         $this->assertEmpty($messages);
     }
 
-    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase(): void
     {
         $databaseContent = [
             [

--- a/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/MailsCatalogueLayersProviderTest.php
@@ -30,59 +30,32 @@ namespace Tests\Integration\Core\Translation\Provider;
 use Doctrine\ORM\EntityManagerInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\MailsProviderDefinition;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
  * Test the provider of frontOffice translations
  */
-class MailsCatalogueLayersProviderTest extends KernelTestCase
+class MailsCatalogueLayersProviderTest extends AbstractCatalogueLayersProviderTest
 {
-    /**
-     * @var string
-     */
-    private $translationsDir;
-
-    public function setUp()
-    {
-        self::bootKernel();
-        /*
-         * The translation directory actually contains these files for locale = fr-FR
-         * - AdminActions.fr-FR.xlf
-         * - EmailsBody.fr-FR.xlf
-         * - EmailsSubject.fr-FR.xlf
-         * - messages.fr-FR.xlf
-         * - ModulesCheckpaymentAdmin.fr-FR.xlf
-         * - ModulesCheckpaymentShop.fr-FR.xlf
-         * - ModulesWirepaymentAdmin.fr-FR.xlf
-         * - ModulesWirepaymentShop.fr-FR.xlf
-         * - ShopNotificationsWarning.fr-FR.xlf
-         */
-        $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
-    }
-
     /**
      * Test it loads a XLIFF catalogue from the locale's `translations` directory
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
         // load catalogue from translations/fr-FR
-        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getFileTranslatedCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
-
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
+        $expected = [
+            'EmailsSubject' => [
+                'count' => 24,
+                'translations' => [
+                    'Log: You have a new alert from your shop' => 'Log : Vous avez un nouveau message d\'alerte dans votre boutique',
+                ],
+            ],
+        ];
 
         // verify all catalogues are loaded
-        $this->assertSame(['EmailsSubject'], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(24, $messages['EmailsSubject']);
-
-        $this->assertSame('Log : Vous avez un nouveau message d\'alerte dans votre boutique', $catalogue->get('Log: You have a new alert from your shop', 'EmailsSubject'));
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     /**
@@ -91,22 +64,19 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
         // load catalogue from translations/default
-        $catalogue = $this->getProvider()->getDefaultCatalogue('fr-FR');
+        $catalogue = $this->getDefaultCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
-
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
+        $expected = [
+            'EmailsSubject' => [
+                'count' => 24,
+                'translations' => [
+                    'Log: You have a new alert from your shop' => '',
+                ],
+            ],
+        ];
 
         // verify all catalogues are loaded
-        $this->assertSame(['EmailsSubject'], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(24, $messages['EmailsSubject']);
-
-        $this->assertSame('Log: You have a new alert from your shop', $catalogue->get('Log: You have a new alert from your shop', 'ShopNotificationsWarning'));
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase(): void
@@ -129,7 +99,7 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
         ];
 
         // load catalogue from database translations
-        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getUserTranslatedCatalogue('fr-FR', $databaseContent);
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -177,22 +147,20 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
         ];
 
         // load catalogue from database translations
-        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getUserTranslatedCatalogue('fr-FR', $databaseContent);
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+        $expected = [
+            'EmailsSubject' => [
+                'count' => 2,
+                'translations' => [
+                    'Uninstall' => 'Uninstall Traduction customisée',
+                    'Install' => 'Install Traduction customisée',
+                ],
+            ],
+        ];
 
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
-
-        $this->assertSame(['EmailsSubject'], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(2, $messages['EmailsSubject']);
-
-        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'EmailsSubject'));
-        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'EmailsSubject'));
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     /**
@@ -200,7 +168,7 @@ class MailsCatalogueLayersProviderTest extends KernelTestCase
      *
      * @return CoreCatalogueLayersProvider
      */
-    private function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
+    protected function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
     {
         $providerDefinition = new MailsProviderDefinition();
 

--- a/tests/Integration/Core/Translation/Provider/ModuleCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/ModuleCatalogueLayersProviderTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Translation\Provider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\ModuleCatalogueLayersProvider;
+use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Test the provider of frontOffice translations
+ */
+class ModuleCatalogueLayersProviderTest extends KernelTestCase
+{
+    /**
+     * @var string
+     */
+    private $translationsDir;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|LegacyModuleExtractorInterface
+     */
+    private $legacyModuleExtractor;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|LoaderInterface
+     */
+    private $legacyFileLoader;
+    /**
+     * @var mixed
+     */
+    private $modulesDir;
+
+    public function setUp()
+    {
+        self::bootKernel();
+        /*
+         * The translation directory actually contains these files for locale = fr-FR
+         * - AdminActions.fr-FR.xlf
+         * - EmailsBody.fr-FR.xlf
+         * - EmailsSubject.fr-FR.xlf
+         * - messages.fr-FR.xlf
+         * - ModulesCheckpaymentAdmin.fr-FR.xlf
+         * - ModulesCheckpaymentShop.fr-FR.xlf
+         * - ModulesWirepaymentAdmin.fr-FR.xlf
+         * - ModulesWirepaymentShop.fr-FR.xlf
+         * - ShopNotificationsWarning.fr-FR.xlf
+         */
+        $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+        $this->modulesDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+
+        $this->legacyModuleExtractor = $this->createMock(LegacyModuleExtractorInterface::class);
+        $this->legacyFileLoader = $this->createMock(LoaderInterface::class);
+    }
+
+    /**
+     * Test it loads a XLIFF catalogue from the locale's `translations` directory
+     */
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    {
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from translations/fr-FR
+        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // verify all catalogues are loaded
+        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(15, $messages['ModulesCheckpaymentAdmin']);
+        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
+
+        $this->assertSame('Aucune devise disponible pour ce module', $catalogue->get('No currency has been set for this module.', 'ModulesCheckpaymentAdmin'));
+        $this->assertSame('Envoyez votre chèque à cette adresse', $catalogue->get('Send your check to this address', 'ModulesCheckpaymentShop'));
+    }
+
+    /**
+     * Test it loads a default catalogue from the `translations` default directory
+     */
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    {
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from translations/default
+        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // verify all catalogues are loaded
+        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(15, $messages['ModulesCheckpaymentAdmin']);
+        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
+
+        $this->assertSame('', $catalogue->get('No currency has been set for this module.', 'ModulesCheckpaymentAdmin'));
+    }
+
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'ModulesCheckpaymentAdmin',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'ModulesCheckpaymentShop',
+                'theme' => 'classic',
+            ],
+        ];
+
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // If the theme name is null, the translations which have theme = 'classic' are taken
+        $this->assertEmpty($domains);
+        $this->assertEmpty($messages);
+    }
+
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'ModulesCheckpaymentAdmin',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'ModulesCheckpaymentShop',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 1',
+                'translation' => 'Un texte inventé 1',
+                'domain' => 'AdminActions',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 2',
+                'translation' => 'Un texte inventé 2',
+                'domain' => 'ModulesCheckpaymentAdmin',
+                'theme' => 'classic',
+            ],
+        ];
+
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(1, $messages['ModulesCheckpaymentAdmin']);
+        $this->assertCount(1, $messages['ModulesCheckpaymentShop']);
+
+        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'ModulesCheckpaymentAdmin'));
+        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ModulesCheckpaymentShop'));
+    }
+
+    /*
+     * @TODO: Test fallbacks to load legacy translations
+     */
+}

--- a/tests/Integration/Core/Translation/Provider/ModuleCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/ModuleCatalogueLayersProviderTest.php
@@ -87,20 +87,8 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
-        $provider = new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->legacyModuleExtractor,
-            $this->legacyFileLoader,
-            $this->modulesDir,
-            $this->translationsDir,
-            $providerDefinition->getModuleName(),
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider('Checkpayment')->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -183,20 +171,9 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
-        $provider = new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->legacyModuleExtractor,
-            $this->legacyFileLoader,
-            $this->modulesDir,
-            $this->translationsDir,
-            $providerDefinition->getModuleName(),
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/default
-        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+        // even if module exists with translations built in
+        $catalogue = $this->getProvider('Checkpayment')->getDefaultCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -287,20 +264,8 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
-        $provider = new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->legacyModuleExtractor,
-            $this->legacyFileLoader,
-            $this->modulesDir,
-            $this->translationsDir,
-            $providerDefinition->getModuleName(),
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider('Checkpayment', $databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -347,20 +312,8 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
-        $provider = new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->legacyModuleExtractor,
-            $this->legacyFileLoader,
-            $this->modulesDir,
-            $this->translationsDir,
-            $providerDefinition->getModuleName(),
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider('Checkpayment', $databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -377,5 +330,27 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
 
         $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'ModulesCheckpaymentAdmin'));
         $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ModulesCheckpaymentShop'));
+    }
+
+    /**
+     * @param string $moduleName
+     * @param array $databaseContent
+     *
+     * @return ModuleCatalogueLayersProvider
+     */
+    private function getProvider(string $moduleName, array $databaseContent = []): ModuleCatalogueLayersProvider
+    {
+        $providerDefinition = new ModuleProviderDefinition($moduleName);
+
+        return new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
     }
 }

--- a/tests/Integration/Core/Translation/Provider/ModuleCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/ModuleCatalogueLayersProviderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Core\Translation\Provider;
 
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ModuleProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Provider\ModuleCatalogueLayersProvider;
 use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractor;
@@ -47,14 +48,17 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
      * @var string
      */
     private $translationsDir;
+
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|LegacyModuleExtractorInterface
+     * @var MockObject|LegacyModuleExtractorInterface
      */
     private $legacyModuleExtractor;
+
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|LoaderInterface
+     * @var MockObject|LoaderInterface
      */
     private $legacyFileLoader;
+
     /**
      * @var mixed
      */
@@ -90,22 +94,23 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         // load catalogue from translations/fr-FR
         $catalogue = $this->getProvider('Checkpayment')->getFileTranslatedCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
-
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
+        $expected = [
+            'ModulesCheckpaymentAdmin' => [
+                'count' => 15,
+                'translations' => [
+                    'No currency has been set for this module.' => 'Aucune devise disponible pour ce module',
+                ],
+            ],
+            'ModulesCheckpaymentShop' => [
+                'count' => 19,
+                'translations' => [
+                    'Send your check to this address' => 'Envoyez votre chèque à cette adresse',
+                ],
+            ],
+        ];
 
         // verify all catalogues are loaded
-        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(15, $messages['ModulesCheckpaymentAdmin']);
-        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
-
-        $this->assertSame('Aucune devise disponible pour ce module', $catalogue->get('No currency has been set for this module.', 'ModulesCheckpaymentAdmin'));
-        $this->assertSame('Envoyez votre chèque à cette adresse', $catalogue->get('Send your check to this address', 'ModulesCheckpaymentShop'));
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     /**
@@ -142,28 +147,29 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         // load catalogue from translations/fr-FR
         $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
-
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
+        $expected = [
+            'ModulesTranslationtestAdmin' => [
+                'count' => 1,
+                'translations' => [
+                    'Modern controller' => 'Contrôleur moderne',
+                ],
+            ],
+            'ModulesTranslationtestSomefile.with-things' => [
+                'count' => 1,
+                'translations' => [
+                    'Smarty template' => 'Le template Smarty',
+                ],
+            ],
+            'ModulesTranslationtestTranslationtest' => [
+                'count' => 1,
+                'translations' => [
+                    'Hello World' => 'Bonjour le monde',
+                ],
+            ],
+        ];
 
         // verify all catalogues are loaded
-        $this->assertSame([
-            'ModulesTranslationtestAdmin',
-            'ModulesTranslationtestSomefile.with-things',
-            'ModulesTranslationtestTranslationtest',
-        ], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(1, $messages['ModulesTranslationtestAdmin']);
-        $this->assertCount(1, $messages['ModulesTranslationtestSomefile.with-things']);
-        $this->assertCount(1, $messages['ModulesTranslationtestTranslationtest']);
-
-        $this->assertSame('Bonjour le monde', $catalogue->get('Hello World', 'ModulesTranslationtestTranslationtest'));
-        $this->assertSame('Le template Smarty', $catalogue->get('Smarty template', 'ModulesTranslationtestSomefile.with-things'));
-        $this->assertSame('Contrôleur moderne', $catalogue->get('Modern controller', 'ModulesTranslationtestAdmin'));
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     /**
@@ -175,21 +181,23 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         // even if module exists with translations built in
         $catalogue = $this->getProvider('Checkpayment')->getDefaultCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
-
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
+        $expected = [
+            'ModulesCheckpaymentAdmin' => [
+                'count' => 15,
+                'translations' => [
+                    'No currency has been set for this module.' => '',
+                ],
+            ],
+            'ModulesCheckpaymentShop' => [
+                'count' => 19,
+                'translations' => [
+                    '(order processing will be longer)' => '',
+                ],
+            ],
+        ];
 
         // verify all catalogues are loaded
-        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(15, $messages['ModulesCheckpaymentAdmin']);
-        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
-
-        $this->assertSame('', $catalogue->get('No currency has been set for this module.', 'ModulesCheckpaymentAdmin'));
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     /**
@@ -221,28 +229,31 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         // load catalogue from translations/default
         $catalogue = $provider->getDefaultCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
-
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
+        $expected = [
+            'ModulesTranslationtestAdmin' => [
+                'count' => 1,
+                'translations' => [
+                    'Modern controller' => 'Modern controller',
+                ],
+            ],
+            'ModulesTranslationtestSomefile.with-things' => [
+                'count' => 1,
+                'translations' => [
+                    'Smarty template' => 'Smarty template',
+                ],
+            ],
+            'ModulesTranslationtestTranslationtest' => [
+                'count' => 3,
+                'translations' => [
+                    'Hello World' => 'Hello World',
+                    'An error occured, please check your zip file' => 'An error occured, please check your zip file',
+                    'his wording belongs to the module file' => 'his wording belongs to the module file',
+                ],
+            ],
+        ];
 
         // verify all catalogues are loaded
-        $this->assertSame([
-            'ModulesTranslationtestAdmin',
-            'ModulesTranslationtestSomefile.with-things',
-            'ModulesTranslationtestTranslationtest',
-        ], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(1, $messages['ModulesTranslationtestAdmin']);
-        $this->assertCount(1, $messages['ModulesTranslationtestSomefile.with-things']);
-        $this->assertCount(3, $messages['ModulesTranslationtestTranslationtest']);
-
-        $this->assertSame('Hello World', $catalogue->get('Hello World', 'ModulesTranslationtestTranslationtest'));
-        $this->assertSame('Smarty template', $catalogue->get('Smarty template', 'ModulesTranslationtestSomefile.with-things'));
-        $this->assertSame('Modern controller', $catalogue->get('Modern controller', 'ModulesTranslationtestAdmin'));
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase(): void
@@ -315,21 +326,23 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         // load catalogue from database translations
         $catalogue = $this->getProvider('Checkpayment', $databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
-        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+        $expected = [
+            'ModulesCheckpaymentAdmin' => [
+                'count' => 1,
+                'translations' => [
+                    'Uninstall' => 'Uninstall Traduction customisée',
+                ],
+            ],
+            'ModulesCheckpaymentShop' => [
+                'count' => 1,
+                'translations' => [
+                    'Install' => 'Install Traduction customisée',
+                ],
+            ],
+        ];
 
-        // Check integrity of translations
-        $messages = $catalogue->all();
-        $domains = $catalogue->getDomains();
-        sort($domains);
-
-        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
-
-        // verify that the catalogues are complete
-        $this->assertCount(1, $messages['ModulesCheckpaymentAdmin']);
-        $this->assertCount(1, $messages['ModulesCheckpaymentShop']);
-
-        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'ModulesCheckpaymentAdmin'));
-        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ModulesCheckpaymentShop'));
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
     }
 
     /**
@@ -352,5 +365,30 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()
         );
+    }
+
+    /**
+     * @param array $expected
+     * @param MessageCatalogue $catalogue
+     */
+    private function assertResultIsAsExpected(array $expected, MessageCatalogue $catalogue): void
+    {
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(array_keys($expected), $domains);
+
+        // verify that the catalogues are complete
+        foreach ($expected as $expectedDomain => $expectedValues) {
+            $this->assertCount($expectedValues['count'], $messages[$expectedDomain]);
+
+            foreach ($expectedValues['translations'] as $translationKey => $translationValue) {
+                $this->assertSame($translationValue, $catalogue->get($translationKey, $expectedDomain));
+            }
+        }
     }
 }

--- a/tests/Integration/Core/Translation/Provider/OthersCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/OthersCatalogueLayersProviderTest.php
@@ -64,7 +64,7 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a XLIFF catalogue from the locale's `translations` directory
      */
-    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
         $providerDefinition = new OthersProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -96,7 +96,7 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
     /**
      * Test it loads a default catalogue from the `translations` default directory
      */
-    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
         $providerDefinition = new OthersProviderDefinition();
         $provider = new CoreCatalogueLayersProvider(
@@ -125,7 +125,7 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
         $this->assertSame('Attributes generator', $catalogue->get('Attributes generator', 'ShopNotificationsWarning'));
     }
 
-    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase(): void
     {
         $databaseContent = [
             [
@@ -167,7 +167,7 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
         $this->assertEmpty($messages);
     }
 
-    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase(): void
     {
         $databaseContent = [
             [

--- a/tests/Integration/Core/Translation/Provider/OthersCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/OthersCatalogueLayersProviderTest.php
@@ -66,16 +66,8 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $providerDefinition = new OthersProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -98,16 +90,8 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
     {
-        $providerDefinition = new OthersProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from translations/default
-        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getDefaultCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -144,16 +128,8 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new OthersProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -200,16 +176,8 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $providerDefinition = new OthersProviderDefinition();
-        $provider = new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
-            $this->translationsDir,
-            $providerDefinition->getFilenameFilters(),
-            $providerDefinition->getTranslationDomains()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -225,5 +193,22 @@ class OthersCatalogueLayersProviderTest extends KernelTestCase
 
         $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'messages'));
         $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'messages'));
+    }
+
+    /**
+     * @param array $databaseContent
+     *
+     * @return CoreCatalogueLayersProvider
+     */
+    private function getProvider(array $databaseContent = []): CoreCatalogueLayersProvider
+    {
+        $providerDefinition = new OthersProviderDefinition();
+
+        return new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
     }
 }

--- a/tests/Integration/Core/Translation/Provider/ThemeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/ThemeCatalogueLayersProviderTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Translation\Provider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\ModuleCatalogueLayersProvider;
+use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Test the provider of frontOffice translations
+ */
+class ThemeCatalogueLayersProviderTest extends KernelTestCase
+{
+    /**
+     * @var string
+     */
+    private $translationsDir;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|LegacyModuleExtractorInterface
+     */
+    private $legacyModuleExtractor;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|LoaderInterface
+     */
+    private $legacyFileLoader;
+    /**
+     * @var mixed
+     */
+    private $modulesDir;
+
+    public function setUp()
+    {
+        self::bootKernel();
+        /*
+         * The translation directory actually contains these files for locale = fr-FR
+         * - AdminActions.fr-FR.xlf
+         * - EmailsBody.fr-FR.xlf
+         * - EmailsSubject.fr-FR.xlf
+         * - messages.fr-FR.xlf
+         * - ModulesCheckpaymentAdmin.fr-FR.xlf
+         * - ModulesCheckpaymentShop.fr-FR.xlf
+         * - ModulesWirepaymentAdmin.fr-FR.xlf
+         * - ModulesWirepaymentShop.fr-FR.xlf
+         * - ShopNotificationsWarning.fr-FR.xlf
+         */
+        $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+        $this->modulesDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+
+        $this->legacyModuleExtractor = $this->createMock(LegacyModuleExtractorInterface::class);
+        $this->legacyFileLoader = $this->createMock(LoaderInterface::class);
+    }
+
+    /**
+     * Test it loads a XLIFF catalogue from the locale's `translations` directory
+     */
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory()
+    {
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from translations/fr-FR
+        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // verify all catalogues are loaded
+        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(15, $messages['ModulesCheckpaymentAdmin']);
+        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
+
+        $this->assertSame('Aucune devise disponible pour ce module', $catalogue->get('No currency has been set for this module.', 'ModulesCheckpaymentAdmin'));
+        $this->assertSame('Envoyez votre chèque à cette adresse', $catalogue->get('Send your check to this address', 'ModulesCheckpaymentShop'));
+    }
+
+    /**
+     * Test it loads a default catalogue from the `translations` default directory
+     */
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles()
+    {
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from translations/default
+        $catalogue = $provider->getDefaultCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // verify all catalogues are loaded
+        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(15, $messages['ModulesCheckpaymentAdmin']);
+        $this->assertCount(19, $messages['ModulesCheckpaymentShop']);
+
+        $this->assertSame('', $catalogue->get('No currency has been set for this module.', 'ModulesCheckpaymentAdmin'));
+    }
+
+    public function testItDoesntLoadsCustomizedTranslationsWithThemeDefinedFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'ModulesCheckpaymentAdmin',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'ModulesCheckpaymentShop',
+                'theme' => 'classic',
+            ],
+        ];
+
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        // If the theme name is null, the translations which have theme = 'classic' are taken
+        $this->assertEmpty($domains);
+        $this->assertEmpty($messages);
+    }
+
+    public function testItLoadsCustomizedTranslationsWithNoThemeFromDatabase()
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Uninstall Traduction customisée',
+                'domain' => 'ModulesCheckpaymentAdmin',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Install',
+                'translation' => 'Install Traduction customisée',
+                'domain' => 'ModulesCheckpaymentShop',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 1',
+                'translation' => 'Un texte inventé 1',
+                'domain' => 'AdminActions',
+                'theme' => 'classic',
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text 2',
+                'translation' => 'Un texte inventé 2',
+                'domain' => 'ModulesCheckpaymentAdmin',
+                'theme' => 'classic',
+            ],
+        ];
+
+        $providerDefinition = new ModuleProviderDefinition('Checkpayment');
+        $provider = new ModuleCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDir,
+            $this->translationsDir,
+            $this->modulesDir,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+
+        // load catalogue from database translations
+        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(['ModulesCheckpaymentAdmin', 'ModulesCheckpaymentShop'], $domains);
+
+        // verify that the catalogues are complete
+        $this->assertCount(1, $messages['ModulesCheckpaymentAdmin']);
+        $this->assertCount(1, $messages['ModulesCheckpaymentShop']);
+
+        $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'ModulesCheckpaymentAdmin'));
+        $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ModulesCheckpaymentShop'));
+    }
+
+    /*
+     * @TODO: Test fallbacks to load legacy translations
+     */
+}

--- a/tests/Integration/Core/Translation/Provider/ThemeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Provider/ThemeCatalogueLayersProviderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Core\Translation\Provider;
 
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CoreCatalogueLayersProvider;
@@ -51,11 +52,11 @@ class ThemeCatalogueLayersProviderTest extends KernelTestCase
      */
     private $translationsDir;
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|LegacyModuleExtractorInterface
+     * @var MockObject|LegacyModuleExtractorInterface
      */
     private $themeExtractor;
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|LoaderInterface
+     * @var MockObject|LoaderInterface
      */
     private $themeRepository;
     /**
@@ -106,28 +107,8 @@ class ThemeCatalogueLayersProviderTest extends KernelTestCase
      */
     public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
     {
-        $databaseTranslationLoader = new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class));
-        $providerDefinition = new ThemeProviderDefinition('fakeThemeForTranslations');
-        $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
-        $coreFrontProvider = new CoreCatalogueLayersProvider(
-            $databaseTranslationLoader,
-            $this->translationsDir,
-            $coreFrontProviderDefinition->getFilenameFilters(),
-            $coreFrontProviderDefinition->getTranslationDomains()
-        );
-
-        $provider = new ThemeCatalogueLayersProvider(
-            $coreFrontProvider,
-            $databaseTranslationLoader,
-            $this->themeExtractor,
-            $this->themeRepository,
-            $this->filesystem,
-            $this->themesDir,
-            $providerDefinition->getThemeName()
-        );
-
         // load catalogue from translations/fr-FR
-        $catalogue = $provider->getFileTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider()->getFileTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -247,28 +228,8 @@ class ThemeCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $databaseTranslationLoader = new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class));
-        $providerDefinition = new ThemeProviderDefinition('fakeThemeForTranslations');
-        $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
-        $coreFrontProvider = new CoreCatalogueLayersProvider(
-            $databaseTranslationLoader,
-            $this->translationsDir,
-            $coreFrontProviderDefinition->getFilenameFilters(),
-            $coreFrontProviderDefinition->getTranslationDomains()
-        );
-
-        $provider = new ThemeCatalogueLayersProvider(
-            $coreFrontProvider,
-            $databaseTranslationLoader,
-            $this->themeExtractor,
-            $this->themeRepository,
-            $this->filesystem,
-            $this->themesDir,
-            $providerDefinition->getThemeName()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -301,28 +262,8 @@ class ThemeCatalogueLayersProviderTest extends KernelTestCase
             ],
         ];
 
-        $databaseTranslationLoader = new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class));
-        $providerDefinition = new ThemeProviderDefinition('fakeThemeForTranslations');
-        $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
-        $coreFrontProvider = new CoreCatalogueLayersProvider(
-            $databaseTranslationLoader,
-            $this->translationsDir,
-            $coreFrontProviderDefinition->getFilenameFilters(),
-            $coreFrontProviderDefinition->getTranslationDomains()
-        );
-
-        $provider = new ThemeCatalogueLayersProvider(
-            $coreFrontProvider,
-            $databaseTranslationLoader,
-            $this->themeExtractor,
-            $this->themeRepository,
-            $this->filesystem,
-            $this->themesDir,
-            $providerDefinition->getThemeName()
-        );
-
         // load catalogue from database translations
-        $catalogue = $provider->getUserTranslatedCatalogue('fr-FR');
+        $catalogue = $this->getProvider($databaseContent)->getUserTranslatedCatalogue('fr-FR');
 
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
 
@@ -339,5 +280,33 @@ class ThemeCatalogueLayersProviderTest extends KernelTestCase
 
         $this->assertSame('Install Traduction customisée', $catalogue->get('Install', 'ShopThemeActions'));
         $this->assertSame('Uninstall Traduction customisée', $catalogue->get('Uninstall', 'ShopThemeCart'));
+    }
+
+    /**
+     * @param array $databaseContent
+     *
+     * @return ThemeCatalogueLayersProvider
+     */
+    private function getProvider(array $databaseContent = []): ThemeCatalogueLayersProvider
+    {
+        $databaseTranslationLoader = new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class));
+        $providerDefinition = new ThemeProviderDefinition('fakeThemeForTranslations');
+        $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
+        $coreFrontProvider = new CoreCatalogueLayersProvider(
+            $databaseTranslationLoader,
+            $this->translationsDir,
+            $coreFrontProviderDefinition->getFilenameFilters(),
+            $coreFrontProviderDefinition->getTranslationDomains()
+        );
+
+        return new ThemeCatalogueLayersProvider(
+            $coreFrontProvider,
+            $databaseTranslationLoader,
+            $this->themeExtractor,
+            $this->themeRepository,
+            $this->filesystem,
+            $this->themesDir,
+            $providerDefinition->getThemeName()
+        );
     }
 }

--- a/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Foo/Bar.xlf
+++ b/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Foo/Bar.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="/home/isow/workspace/PrestaShop/tests/Resources/themes/fakeThemeForTranslations/templates/checkout/cart.tpl" source-language="fr-FR" target-language="fr-FR" datatype="plaintext">
+    <body>
+      <trans-unit id="d1a2ba84e96d5baba4aff54f471d44d4">
+        <source>Cancel cart</source>
+        <target>Cancel cart</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Theme/Actions.xlf
+++ b/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Theme/Actions.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="/home/isow/workspace/PrestaShop/tests/Resources/themes/fakeThemeForTranslations/templates/page.tpl" source-language="fr-FR" target-language="fr-FR" datatype="plaintext">
+    <body>
+      <trans-unit id="63a6a88c066880c5ac42394a22803ca6">
+        <source>Refresh</source>
+        <target>Refresh</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Theme/Cart.xlf
+++ b/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Theme/Cart.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="/home/isow/workspace/PrestaShop/tests/Resources/themes/fakeThemeForTranslations/templates/checkout/cart.tpl" source-language="fr-FR" target-language="fr-FR" datatype="plaintext">
+    <body>
+      <trans-unit id="1f379957091c42f23ad4e3840f0b0a65">
+        <source>Apply cart</source>
+        <target>Apply cart</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Theme/Product.xlf
+++ b/tests/Resources/themes/fakeThemeForTranslations/fr-FR/Shop/Theme/Product.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="/home/isow/workspace/PrestaShop/tests/Resources/themes/fakeThemeForTranslations/templates/catalog/product.tpl" source-language="fr-FR" target-language="fr-FR" datatype="plaintext">
+    <body>
+      <trans-unit id="a38a66d53a6edc2d8e37bb36b45814ee">
+        <source>Show product</source>
+        <target>Show product</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/themes/fakeThemeForTranslations/translations/fr-FR/ShopTheme.fr-FR.xlf
+++ b/tests/Resources/themes/fakeThemeForTranslations/translations/fr-FR/ShopTheme.fr-FR.xlf
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/controller/FrontController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ec0fc0100c4fc1ce4eea230c3dc10360" approved="yes">
+        <source>Undefined</source>
+        <target state="final">Indéfini</target>
+        <note>Line: 886</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/AddressesController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf" approved="yes">
+        <source>Addresses</source>
+        <target state="final">Adresses</target>
+        <note>Line: 70</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/DiscountController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6adf97f83acf6453d4a6a4b1070f3754" approved="yes">
+        <source>None</source>
+        <target state="final">Aucun</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="bafd7322c6e97d25b6299b5d6fe8920b" approved="yes">
+        <source>No</source>
+        <target state="final">Non</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="93cba07454f06a4a960172bbd6e2a435" approved="yes">
+        <source>Yes</source>
+        <target state="final">Oui</target>
+        <note>Line: 110</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderReturnController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e06d7593c1cd6dabef450be6c3da7091" approved="yes">
+        <source>Merchandise returns</source>
+        <target state="final">Retours produit</target>
+        <note>Line: 176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PageNotFoundController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f2fbecfb4e1f8fd471dcc0881d8518f1" approved="yes">
+        <source>The page you are looking for was not found.</source>
+        <target state="final">La page que vous cherchez n'a pas été trouvée.</target>
+        <note>Line: 59</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/SitemapController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c82004d1ded071651efc9f2138342c50" approved="yes">
+        <source>Our Offers</source>
+        <target state="final">Nos offres</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911" approved="yes">
+        <source>Log in</source>
+        <target state="final">Se connecter</target>
+        <note>Line: 128</note>
+      </trans-unit>
+      <trans-unit id="1aa668d559a3a32a44796aeee6978a59" approved="yes">
+        <source>Create new account</source>
+        <target state="final">Créer un nouveau compte</target>
+        <note>Line: 134</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/StoresController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6" approved="yes">
+        <source>Monday</source>
+        <target state="final">Lundi</target>
+        <note>Line: 206</note>
+      </trans-unit>
+      <trans-unit id="5792315f09a5d54fb7e3d066672b507f" approved="yes">
+        <source>Tuesday</source>
+        <target state="final">Mardi</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="796c163589f295373e171842f37265d5" approved="yes">
+        <source>Wednesday</source>
+        <target state="final">Mercredi</target>
+        <note>Line: 212</note>
+      </trans-unit>
+      <trans-unit id="78ae6f0cd191d25147e252dc54768238" approved="yes">
+        <source>Thursday</source>
+        <target state="final">Jeudi</target>
+        <note>Line: 215</note>
+      </trans-unit>
+      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4" approved="yes">
+        <source>Friday</source>
+        <target state="final">Vendredi</target>
+        <note>Line: 218</note>
+      </trans-unit>
+      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc" approved="yes">
+        <source>Saturday</source>
+        <target state="final">Samedi</target>
+        <note>Line: 221</note>
+      </trans-unit>
+      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177" approved="yes">
+        <source>Sunday</source>
+        <target state="final">Dimanche</target>
+        <note>Line: 224</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/ManufacturerController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097" approved="yes">
+        <source>Brands</source>
+        <target state="final">Marques</target>
+        <note>Line: 204</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Presenter/Cart/CartPresenter.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1f87346a16cf80c372065de3c54c86d9" approved="yes">
+        <source>(tax incl.)</source>
+        <target state="final">TTC</target>
+        <note>Line: 431</note>
+      </trans-unit>
+      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0" approved="yes">
+        <source>(tax excl.)</source>
+        <target state="final">(HT)</target>
+        <note>Line: 432</note>
+      </trans-unit>
+      <trans-unit id="e3ddbe6b144e01554bfa072db9bcca2f" approved="yes">
+        <source>(tax included)</source>
+        <target state="final">(TTC)</target>
+        <note>Line: 434</note>
+      </trans-unit>
+      <trans-unit id="e9e7ca277da652bde67ef5faafb755dc" approved="yes">
+        <source>(tax excluded)</source>
+        <target state="final">(hors taxe)</target>
+        <note>Line: 435</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Presenter/Product/ProductLazyArray.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f4a0d7cb0cd45214c8ca5912c970de13" approved="yes">
+        <source>Tax included</source>
+        <target state="final">TTC</target>
+        <note>Line: 398</note>
+      </trans-unit>
+      <trans-unit id="befcac0f9644a7abee43e69f49252ac4" approved="yes">
+        <source>Tax excluded</source>
+        <target state="final">HT</target>
+        <note>Line: 399</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/cms/category.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="38629047675346c704697fb85268192f" approved="yes">
+        <source>List of subcategories in %category_name%:</source>
+        <target state="final">Liste des sous-catégories dans %category_name% :</target>
+        <note>Context:
+File: themes/StarterTheme/templates/cms/category.tpl:34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/cms/stores.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="673ae02fffb72f0fe68a66f096a01347" approved="yes">
+        <source>Phone:</source>
+        <target state="final">Tél. :</target>
+        <note>Context:
+File: themes/StarterTheme/templates/cms/stores.tpl:47</note>
+      </trans-unit>
+      <trans-unit id="6a1e265f92087bb6dd18194833fe946b" approved="yes">
+        <source>Email:</source>
+        <target state="final">E-mail :</target>
+        <note>Context:
+File: themes/StarterTheme/templates/cms/stores.tpl:53</note>
+      </trans-unit>
+      <trans-unit id="80a0c205cd57b22fca7f174253870300" approved="yes">
+        <source>Opening hours</source>
+        <target state="final">Heures d'ouverture</target>
+        <note>Context:
+File: themes/StarterTheme/templates/cms/stores.tpl:56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/contactform/views/templates/widget/contactform.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="02d4482d332e1aef3437cd61c9bcc624" approved="yes">
+        <source>Contact us</source>
+        <target state="final">Contactez-nous</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0e2fb5b02182fd28b9b96e86ed27838f" approved="yes">
+        <source>Fax:</source>
+        <target state="final">Fax :</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="1300caaefd15b839f37952dc7cc75d82" approved="yes">
+        <source>Call us:</source>
+        <target state="final">Appelez-nous :</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="a0bfe0853cf82bdf5dcb9b0bac76c357" approved="yes">
+        <source>Email us:</source>
+        <target state="final">Envoyez-nous un e-mail :</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="3aea774cdcd8f2c45549f10758a71323" approved="yes">
+        <source>Store information</source>
+        <target state="final">Informations</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_contactinfo/ps_contactinfo.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c6359db4a43cb7267a84b389229fd073" approved="yes">
+        <source>Call us: [1]%phone%[/1]</source>
+        <target state="final">Appelez-nous : [1]%phone%[/1]</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="da6eb684bd77243a780629a180c9d19b" approved="yes">
+        <source>Fax: [1]%fax%[/1]</source>
+        <target state="final">Fax : [1]%fax%[/1]</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="077d21d48dae9586405c0d264f6d32e7" approved="yes">
+        <source>Email us: [1]%email%[/1]</source>
+        <target state="final">Écrivez-nous : [1]%email%[/1]</target>
+        <note>Line: 58</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="77295c7d814e7397c55f64ec06313984" approved="yes">
+        <source>Currency:</source>
+        <target state="final">Devise :</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="72d43a6525ac95e552ca4eaf1dc0ad1a" approved="yes">
+        <source>Currency dropdown</source>
+        <target state="final">Sélecteur de devise</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_emailsubscription/views/templates/hook/ps_emailsubscription-column.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3805f49499fa5010c394e219aa1fe7a0" approved="yes">
+        <source>Get our latest news and special sales</source>
+        <target state="final">Recevez nos offres spéciales</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_imageslider/views/templates/hook/slider.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6dbac206aa2d7e374277ae9ff8ec1987" approved="yes">
+        <source>Carousel buttons</source>
+        <target state="final">Boutons du carrousel</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="dd1f775e443ff3b9a89270713580a51b" approved="yes">
+        <source>Previous</source>
+        <target state="final">Précédent</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="10ac3d04253ef7e1ddc73e6091c0cd55" approved="yes">
+        <source>Next</source>
+        <target state="final">Suivant</target>
+        <note>Line: 56</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_languageselector/ps_languageselector.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0885f0c211f74834f0109c5abaf4cdc4" approved="yes">
+        <source>Language:</source>
+        <target state="final">Langue :</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="217148b9c333b63a3fb1883670f5bff2" approved="yes">
+        <source>Language dropdown</source>
+        <target state="final">Sélecteur de langue</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_shoppingcart/modal.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d0f369aab921195580d8319855bbb69f" approved="yes">
+        <source>%label%:</source>
+        <target state="final">%label% :</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="d3d2e617335f08df83599665eef8a418" approved="yes">
+        <source>Close</source>
+        <target state="final">Fermer</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/footer.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7601c8e861088bd27255e18afaefab6b" approved="yes">
+        <source>%copyright% %year% - Ecommerce software by %prestashop%</source>
+        <target state="final">%copyright% %year% - Logiciel e-commerce par %prestashop%</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2143f8cb66482342b35208bdc3fd949c" approved="yes">
+        <source>Active filters</source>
+        <target state="final">Filtres actifs</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/facets.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7a1c5301da6b1ce9e4345bd501397045" approved="yes">
+        <source>(no filter)</source>
+        <target state="final">(aucun filtre)</target>
+        <note>Line: 139</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/sort-orders.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6f9d01a14011f05fffe48559583fc609" approved="yes">
+        <source>Sort by:</source>
+        <target state="final">Trier par :</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/header.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="96d6f2e7e1f705ab5e59c84a6dc009b2" approved="yes">
+        <source>logo</source>
+        <target state="final">logo</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/cms/category.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1d34e1ee316477a8f64a835307f5b84e" approved="yes">
+        <source>List of pages in %category_name%:</source>
+        <target state="final">Liste des pages dans %category_name% :</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="6c5c05a5b907385c60c3baa4087ea1a1" approved="yes">
+        <source>List of sub categories in %name%:</source>
+        <target state="final">Liste des sous-catégories dans %name% :</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/cms/sitemap.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5813ce0ec7196c492c97596718f71969" approved="yes">
+        <source>Sitemap</source>
+        <target state="final">Plan du site</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/cms/stores.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="34c869c542dee932ef8cd96d2f91cae6" approved="yes">
+        <source>Our stores</source>
+        <target state="final">Nos magasins</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="adc4f9f9cccaa450c10977d50da58d8d" approved="yes">
+        <source>About and Contact</source>
+        <target state="final">À propos et Contact</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/my-account-links.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5" approved="yes">
+        <source>Home</source>
+        <target state="final">Accueil</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="44749712dbec183e983dcd78a7736c41" approved="yes">
+        <source>Date</source>
+        <target state="final">Date</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be" approved="yes">
+        <source>Status</source>
+        <target state="final">État</target>
+        <note>Line: 89</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/maintenance.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="27b4383b976d6be981598d457cc7e62d" approved="yes">
+        <source>We'll be back soon.</source>
+        <target state="final">Nous serons bientôt de retour.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/not-found.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7e74146e0ff2e289abfc8bec1d2b2a18" approved="yes">
+        <source>Sorry for the inconvenience.</source>
+        <target state="final">Veuillez nous excuser pour le désagrément.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="519ee4cd58a2b719f7113965cc949d24" approved="yes">
+        <source>Search again what you are looking for</source>
+        <target state="final">Effectuez une nouvelle recherche</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/restricted-country.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6351030f724f6f42fd11ec9aa6ee8c76" approved="yes">
+        <source>403 Forbidden</source>
+        <target state="final">403 Interdit</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="cf8092a0be7b972d6cee3db90bfaf923" approved="yes">
+        <source>You cannot access this store from your country. We apologize for the inconvenience.</source>
+        <target state="final">Vous ne pouvez pas accéder à notre boutique depuis votre pays. Veuillez nous excuser de la gêne occasionnée.</target>
+        <note>Line: 44</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/themes/fakeThemeForTranslations/translations/fr-FR/ShopThemeCustomeraccount.fr-FR.xlf
+++ b/tests/Resources/themes/fakeThemeForTranslations/translations/fr-FR/ShopThemeCustomeraccount.fr-FR.xlf
@@ -1,0 +1,543 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/form/CustomerFormatter.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a9e3d6296e9b194ee466230d8438935a" approved="yes">
+        <source>Receive offers from our partners</source>
+        <target state="final">Recevoir les offres de nos partenaires</target>
+        <note>Line: 225</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderSlipController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6f6347e99d6511fc895179a42301c001" approved="yes">
+        <source>#%id%</source>
+        <target state="final">#%id%</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_customersignin/ps_customersignin.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4b877ba8588b19f1b278510bf2b57ebb" approved="yes">
+        <source>Log me out</source>
+        <target state="final">Me déconnecter</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/checkout/_partials/cart-summary.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5238bd0d26ee4c221badd6e6c6475412" approved="yes">
+        <source>Your order</source>
+        <target state="final">Votre commande</target>
+        <note>Context:
+File: themes/StarterTheme/templates/checkout/_partials/cart-summary.tpl:32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/checkout/_partials/steps/personal-information.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0fc5b0bad7e8ab38a2cdcadc05cb248f" approved="yes">
+        <source>Connected as %first_name% %last_name%.</source>
+        <target state="final">Connecté en tant que %first_name% %last_name%.</target>
+        <note>Context:
+File: themes/StarterTheme/templates/checkout/_partials/steps/personal-information.tpl:6</note>
+      </trans-unit>
+      <trans-unit id="929c1ec3a80a6e8a557bad8985e63991" approved="yes">
+        <source>No account?</source>
+        <target state="final">Pas de compte ?</target>
+        <note>Context:
+File: themes/StarterTheme/templates/checkout/_partials/steps/personal-information.tpl:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/customer/history.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bcd1b68617759b1dfcff0403a6b5a8d1" approved="yes">
+        <source>PDF</source>
+        <target state="final">PDF</target>
+        <note>Context:
+File: themes/StarterTheme/templates/customer/history.tpl:64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/customer/my-account.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="999fe77c512638fd1b2ff18646d24781" approved="yes">
+        <source>Welcome to your account. Here you can manage all of your personal information and orders.</source>
+        <target state="final">Bienvenue sur votre page d'accueil. Vous pouvez y gérer vos informations personnelles ainsi que vos commandes.</target>
+        <note>Context:
+File: themes/StarterTheme/templates/customer/my-account.tpl:34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f2fc7490cbdb0db5cd6f1a4e7edb0da1" approved="yes">
+        <source>Your account</source>
+        <target state="final">Votre compte</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_customersignin/ps_customersignin.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2cbfb6731610056e1d0aaacde07096c1" approved="yes">
+        <source>View my customer account</source>
+        <target state="final">Voir mon compte client</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="d4151a9a3959bdd43690735737034f27" approved="yes">
+        <source>Log in to your customer account</source>
+        <target state="final">Identifiez-vous</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/checkout/_partials/steps/personal-information.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="8e3ecabff428ab5465ab8feb928436e0" approved="yes">
+        <source>Not you? [1]Log out[/1]</source>
+        <target state="final">Ce n'est pas vous ? [1]Se déconnecter[/1]</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="6280ed214163d6e214763ff970910cdc" approved="yes">
+        <source>Connected as [1]%firstname% %lastname%[/1].</source>
+        <target state="final">Connecté en tant que [1]%firstname% %lastname%[/1].</target>
+        <note>Line: 13</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/my-account-links.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a958dbb46713e59856c35f89e5092a5e" approved="yes">
+        <source>Back to your account</source>
+        <target state="final">Retour à votre compte</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-detail-return.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3956298bcfc047e15b0e0d218492ce09" approved="yes">
+        <source>Merchandise return</source>
+        <target state="final">Retour de marchandise</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="bef8403608dc4cb3ade799f63dd4bf59" approved="yes">
+        <source>If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.</source>
+        <target state="final">Si vous désirez nous retourner un ou plusieurs produits, veuillez cocher chacun d'entre eux et spécifier un motif de retour, puis valider.</target>
+        <note>Line: 237</note>
+      </trans-unit>
+      <trans-unit id="1af342a10e8238b722ba844facf5768b" approved="yes">
+        <source>Request a return</source>
+        <target state="final">Renvoyer un produit</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="fdfac28b5ad628f25649d9c2eb4fc62e" approved="yes">
+        <source>Returned</source>
+        <target state="final">Retourné</target>
+        <note>Line: 205</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-messages.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="41de6d6cfb8953c021bbe4ba0701c8a1" approved="yes">
+        <source>Messages</source>
+        <target state="final">Messages</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="58b3d8603dffe8484e90c0ca371921ac" approved="yes">
+        <source>Add a message</source>
+        <target state="final">Ajouter un message :</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="d93651d012e77dac5581b08db33195b2" approved="yes">
+        <source>If you would like to add a comment about your order, please write it in the field below.</source>
+        <target state="final">Si vous voulez nous laisser un message à propos de votre commande, merci de bien vouloir le renseigner dans le champ ci-contre</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/address.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f469203cd9de85e9583bae25f1cb0557" approved="yes">
+        <source>Update your address</source>
+        <target state="final">Mettre à jour votre adresse</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="393d8c6bc7a04264bd9523dc8c92b818" approved="yes">
+        <source>New address</source>
+        <target state="final">Nouvelle adresse</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/addresses.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3908e1afa0ff22fbf112aff3c5ba55c1" approved="yes">
+        <source>Your addresses</source>
+        <target state="final">Vos adresses</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/authentication.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="11f4b4ba23dc72ee5e86ff5a90bdde60" approved="yes">
+        <source>Log in to your account</source>
+        <target state="final">Connectez-vous à votre compte</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="952998528c20798fbd22b49d505a29d5" approved="yes">
+        <source>No account? Create one here</source>
+        <target state="final">Pas de compte ? Créez-en un</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/discount.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="70b77fea994d1bda0a46cb5f9c9275f3" approved="yes">
+        <source>Your vouchers</source>
+        <target state="final">Vos bons de réduction</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/guest-login.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6b10b52dc4d44e780e6e38073668be56" approved="yes">
+        <source>Guest Order Tracking</source>
+        <target state="final">Suivi de commande invité</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d2948a89e47a4ad7eb8412c1c260ea88" approved="yes">
+        <source>To track your order, please enter the following information:</source>
+        <target state="final">Afin de suivre votre commande, veuillez saisir les informations suivantes :</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="92dbb751eb9457441af82a53f3cfae54" approved="yes">
+        <source>For example: QIIXJXNUI or QIIXJXNUI#1</source>
+        <target state="final">Par exemple : QIIXJXNUI ou QIIXJXNUI#1</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/guest-tracking.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3aedb5d3a3e36f7bb6baf1fbb9497894" approved="yes">
+        <source>Guest Tracking</source>
+        <target state="final">Suivi de commande</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="109636f722b8fccc95d072b2760a6282" approved="yes">
+        <source>Transform your guest account into a customer account and enjoy:</source>
+        <target state="final">Transformez votre compte invité en compte client et bénéficiez des avantages suivants :</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="7a8fe8aaa64e691d82f429d39e0df3a5" approved="yes">
+        <source>Personalized and secure access</source>
+        <target state="final">Accès au site sécurisé et personnalisé</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="93aef17b1541efc1c3f8bd6679972096" approved="yes">
+        <source>Fast and easy checkout</source>
+        <target state="final">Passage de commande rapide et facile</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="1f1015bbef5f42d858e8486397ad8f3e" approved="yes">
+        <source>Easier merchandise return</source>
+        <target state="final">Retours produits plus faciles</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/history.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="782c8b38bce4f2f6975ca7f33ac8189b" approved="yes">
+        <source>Order history</source>
+        <target state="final">Historique de vos commandes</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="28d5817f910ec3a8856126f5860fa490" approved="yes">
+        <source>Here are the orders you've placed since your account was created.</source>
+        <target state="final">Vous trouverez ici vos commandes passées depuis la création de votre compte</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="3ec365dd533ddb7ef3d1c111186ce872" approved="yes">
+        <source>Details</source>
+        <target state="final">Détails</target>
+        <note>Line: 101</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/identity.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6335a00a08fde0fbb8f6d6630cdadd92" approved="yes">
+        <source>Your personal information</source>
+        <target state="final">Vos informations personnelles</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/my-account.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a82868319826fb092b73968e661b5b38" approved="yes">
+        <source>Vouchers</source>
+        <target state="final">Bons de réduction</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="d1a365ea7809ae5831c6d9f86886630c" approved="yes">
+        <source>Credit slips</source>
+        <target state="final">Avoirs</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="284b47b0bb63ae2df3b29f0e691d6fcf" approved="yes">
+        <source>Addresses</source>
+        <target state="final">Adresses</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="da4791bc9700aca963b560fcb7db0605" approved="yes">
+        <source>Add first address</source>
+        <target state="final">Ajouter une première adresse</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="a82be0f551b8708bc08eb33cd9ded0cf" approved="yes">
+        <source>Information</source>
+        <target state="final">Informations</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="cea4dedd9147586b361b90e900944690" approved="yes">
+        <source>Order history and details</source>
+        <target state="final">Historique et détails de mes commandes</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="e06d7593c1cd6dabef450be6c3da7091" approved="yes">
+        <source>Merchandise returns</source>
+        <target state="final">Retours produit</target>
+        <note>Line: 89</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-detail.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3" approved="yes">
+        <source>Order details</source>
+        <target state="final">Détails de la commande</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="674592d247a228106f4f0d9f81c0d92c" approved="yes">
+        <source>Order Reference %reference% - placed on %date%</source>
+        <target state="final">Commande n°%reference% du %date%</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="e682495785e844d491378817aa34aa3f" approved="yes">
+        <source>Download your invoice as a PDF file.</source>
+        <target state="final">Téléchargez votre facture au format PDF</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="755bb0834a77079fd1330b555b69e6bf" approved="yes">
+        <source>You have given permission to receive your order in recycled packaging.</source>
+        <target state="final">Vous avez accepté de recevoir votre commande dans un emballage recyclé.</target>
+        <note>Line: 69</note>
+      </trans-unit>
+      <trans-unit id="e14bc5cef02df7369b604ea3885adb96" approved="yes">
+        <source>You have requested gift wrapping for this order.</source>
+        <target state="final">Vous avez demandé un papier cadeau pour cette commande.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4" approved="yes">
+        <source>Message</source>
+        <target state="final">Message</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="46774573a61204e0aac6c4ab10247d3e" approved="yes">
+        <source>Follow your order's status step-by-step</source>
+        <target state="final">Suivre votre commande pas à pas</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="ced55d097872ab13bf177e8d31db396f" approved="yes">
+        <source>Click the following link to track the delivery of your order</source>
+        <target state="final">Cliquez sur le lien suivant pour suivre la livraison de votre commande</target>
+        <note>Line: 122</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-follow.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a240fa27925a635b08dc28c9e4f9216d" approved="yes">
+        <source>Order</source>
+        <target state="final">Commande</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="446faa7da2d42ba4ffeda73cb119dd91" approved="yes">
+        <source>Date issued</source>
+        <target state="final">Date d'émission</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="9cf9ab35a1b24314913bb739d25a0b36" approved="yes">
+        <source>Here is a list of pending merchandise returns</source>
+        <target state="final">Voici la liste des retours produits en cours</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="988fd738de9c6d177440c5dcf69e73ce" approved="yes">
+        <source>Return</source>
+        <target state="final">Retour</target>
+        <note>Line: 74</note>
+      </trans-unit>
+      <trans-unit id="d442cb92c3b031eceacbfe87605b9356" approved="yes">
+        <source>Package status</source>
+        <target state="final">État du retour</target>
+        <note>Line: 78</note>
+      </trans-unit>
+      <trans-unit id="6d72e074fdface4ae892543d39434175" approved="yes">
+        <source>Returns form</source>
+        <target state="final">Bon de retour</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-return.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f" approved="yes">
+        <source>Return details</source>
+        <target state="final">Détails du retour</target>
+        <note>Line: 4</note>
+      </trans-unit>
+      <trans-unit id="4aa65c7cc01324ce850c2975f548d637" approved="yes">
+        <source>%number% on %date%</source>
+        <target state="final">%number% le %date%</target>
+        <note>Line: 12</note>
+      </trans-unit>
+      <trans-unit id="88be9ea838e21273267409d76af3b284" approved="yes">
+        <source>We have logged your return request.</source>
+        <target state="final">Nous avons enregistré votre demande de retour.</target>
+        <note>Line: 18</note>
+      </trans-unit>
+      <trans-unit id="d45c14e2fb387664ad2a66a2b8f7c0a4" approved="yes">
+        <source>Your package must be returned to us within %number% days of receiving your order.</source>
+        <target state="final">Votre colis doit nous être retourné dans les %number% jours suite à la réception de votre commande.</target>
+        <note>Line: 19</note>
+      </trans-unit>
+      <trans-unit id="77264630b0f035a114135e26f0e56a5c" approved="yes">
+        <source>The current status of your merchandise return is: [1] %status% [/1]</source>
+        <target state="final">L'état actuel de votre retour produit est : [1] %status% [/1]</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="b24be74c768f02b296d4e8f41be486fb" approved="yes">
+        <source>List of items to be returned:</source>
+        <target state="final">Liste des articles à retourner :</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="92a9774c2a5df29ac4bffb46219ea9cd" approved="yes">
+        <source>Reminder</source>
+        <target state="final">Rappel</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="2b79d007c64009edf92d06f7cb280b25" approved="yes">
+        <source>All merchandise must be returned in its original packaging and in its original state.</source>
+        <target state="final">Tous les produits doivent être retournés dans leur emballage et leur état d'origine.</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="3407538083069a115822986f5b34b21f" approved="yes">
+        <source>Please print out the [1]returns form[/1] and include it with your package.</source>
+        <target state="final">Veuillez imprimer le [1]bon de retour[/1] et l'inclure dans votre colis.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="2e2d29136e330ac7ba96f9004901be3a" approved="yes">
+        <source>Please check the [1]returns form[/1] for the correct address.</source>
+        <target state="final">Veuillez vérifier que le [1]bon de retour[/1] contient la bonne adresse.</target>
+        <note>Line: 123</note>
+      </trans-unit>
+      <trans-unit id="16dafae9102750489087d1d087b72aba" approved="yes">
+        <source>When we receive your package, we will notify you by email. We will then begin processing order reimbursement.</source>
+        <target state="final">Dès réception de votre colis, nous procéderons au remboursement du montant de votre commande et vous en informerons par e-mail.</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="f393a2fe17dc0cacff53a136479b845d" approved="yes">
+        <source>Please let us know if you have any questions.</source>
+        <target state="final">Veuillez nous contacter pour toute question.</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="f637120d9f24c366b382ede6c21cddf0" approved="yes">
+        <source>If the conditions of return listed above are not respected, we reserve the right to refuse your package and/or reimbursement.</source>
+        <target state="final">Si les conditions de retour listées ci-dessus ne sont pas respectées, nous nous réservons le droit de refuser votre colis ou votre remboursement.</target>
+        <note>Line: 143</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/order-slip.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5996bd24bf8b740b8205e0d9fe1a0709" approved="yes">
+        <source>Credit slips you have received after canceled orders.</source>
+        <target state="final">Liste des avoirs reçus suite à des annulations de commandes.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45" approved="yes">
+        <source>Credit slip</source>
+        <target state="final">Avoir</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="3cb6ea48a427bf3a1687302e3b764c27" approved="yes">
+        <source>View credit slip</source>
+        <target state="final">Afficher l'avoir</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-email.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f28d8a87d03470521d5a992312bfaed8" approved="yes">
+        <source>Please enter the email address you used to register. You will receive a temporary link to reset your password.</source>
+        <target state="final">Veuillez renseigner l'adresse e-mail que vous avez utilisée à la création de votre compte. Vous recevrez un lien temporaire pour réinitialiser votre mot de passe.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-infos.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="01a569ddc6cf67ddec2a683f0a5f5956" approved="yes">
+        <source>Forgot your password?</source>
+        <target state="final">Mot de passe oublié ?</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/password-new.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="32fe59513f5bbdd353b4527cc6af55ce" approved="yes">
+        <source>Reset your password</source>
+        <target state="final">Réinitialiser votre mot de passe</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="24e372d72a306d924e8f1e53900dd7b6" approved="yes">
+        <source>Email address: %email%</source>
+        <target state="final">Adresse e-mail : %email%</target>
+        <note>Line: 48</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/registration.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2fdfd506efea08144c0794c32ca8250a" approved="yes">
+        <source>Create an account</source>
+        <target state="final">Créez votre compte</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="21bdc5689c12595ae14298354d5550d5" approved="yes">
+        <source>Already have an account?</source>
+        <target state="final">Vous avez déjà un compte ?</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="54fc27e749c6998fb54cebc1a0879692" approved="yes">
+        <source>Log in instead!</source>
+        <target state="final">Connectez-vous !</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/translations/default/EmailsBody.xlf
+++ b/tests/Resources/translations/default/EmailsBody.xlf
@@ -1,0 +1,2276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/PaymentModule.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="44aa13304026bb46ad79f4151f16634a">
+        <source>(waiting for validation)</source>
+        <target>(waiting for validation)</target>
+        <note>Line: 630</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/components/footer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="96dad7f0d711c3408786ba1ee05402b3">
+        <source><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="{prestashop_url}">PrestaShop™</a>]]></source>
+        <target><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="{prestashop_url}">PrestaShop™</a>]]></target>
+        <note>Line: 6</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/account.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2498c963bfc06e8fca88007ec322b769">
+        <source>Your login email address on {shop_name}</source>
+        <target>Your login email address on {shop_name}</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="7cfb9d536fcd7aa70c333e8e73b287e2">
+        <source>Here is your login email address:</source>
+        <target>Here is your login email address:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/backoffice_order.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bffeb374bf71938ffc4faa42afbf1679">
+        <source><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></source>
+        <target><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/bankwire.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b33ea5c9409a67cb6e1f6bc3f0828f0">
+        <source>Awaiting wire payment</source>
+        <target>Awaiting wire payment</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="f4a6af01d092af11dca29cb89578b124">
+        <source>You have selected to pay by wire transfer.</source>
+        <target>You have selected to pay by wire transfer.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="fc1ae3c1dd1d9d9a44da719fa9966f0e">
+        <source>Here are the bank details for your transfer:</source>
+        <target>Here are the bank details for your transfer:</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/cheque.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a51341e25ff7710496cf86468d797169">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></source>
+        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="d698e777b19f6f487ae0490950174fde">
+        <source>Awaiting check payment</source>
+        <target>Awaiting check payment</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="ecf01c46965fdfd36eb98b271276c0d5">
+        <source>You have selected to pay by check.</source>
+        <target>You have selected to pay by check.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="b6592595266708e46d1d420ab7153213">
+        <source>Here are the bank details for your check:</source>
+        <target>Here are the bank details for your check:</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="ed750ed3b775eb7ed37644ceb05c713b">
+        <source>Your order with the reference [1]{order_name}[/1] has been placed successfully and will be [1]shipped as soon as we receive your payment[/1].</source>
+        <target>Your order with the reference [1]{order_name}[/1] has been placed successfully and will be [1]shipped as soon as we receive your payment[/1].</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/contact.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="31e15b28c2f071f74f47eb8bcd612d94">
+        <source>Customer e-mail address:</source>
+        <target>Customer e-mail address:</target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="83fa39a28a4d159061c408fbd6a249e7">
+        <source>Order ID:</source>
+        <target>Order ID:</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/contact_form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1edbec13a38606f19c0bae544a7c6552">
+        <source>Your message to {shop_name} Customer Service</source>
+        <target>Your message to {shop_name} Customer Service</target>
+        <note>Line: 7</note>
+      </trans-unit>
+      <trans-unit id="e92ba0cecb0593f537515b2aa2d1c701">
+        <source>Your message has been sent successfully.</source>
+        <target>Your message has been sent successfully.</target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="76890cf906149b370ea6f7d1bd8eaf9a">
+        <source>We will answer as soon as possible.</source>
+        <target>We will answer as soon as possible.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/credit_slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="72dbe899c04eb3875b29b5b274340dac">
+        <source>Credit slip created</source>
+        <target>Credit slip created</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="99f89e9a116e1c07f62ba17fb0312db6">
+        <source><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
+        <target><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="4c15700279d273ce67d98810a4b87943">
+        <source>We have generated a credit slip in your name for order with the reference [1]{order_name}[/1].</source>
+        <target>We have generated a credit slip in your name for order with the reference [1]{order_name}[/1].</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/download_product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5f55a607fea61a402ceac66cc99f1e9e">
+        <source><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></source>
+        <target><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></target>
+        <note>Line: 8</note>
+      </trans-unit>
+      <trans-unit id="30acb55a5efc4a32a30a0c3db85f37d1">
+        <source>Product(s) now available for download</source>
+        <target>Product(s) now available for download</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/employee_password.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4785f7efb27f2905a05564903db18b23">
+        <source>Your {shop_name} login information</source>
+        <target>Your {shop_name} login information</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="e2fa64dedc8a3422d409cbe4eebd19bb">
+        <source>Here is your personal login information for [1]{shop_name}[/1]:</source>
+        <target>Here is your personal login information for [1]{shop_name}[/1]:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="78e365acb087fd1f8d494dae0001de10">
+        <source>E-mail address:</source>
+        <target>E-mail address:</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/forward_msg.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8595a98bbe6d6b0e3b9b0681b3b4aa71">
+        <source>Customer service - Forwarded discussion</source>
+        <target>Customer service - Forwarded discussion</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="2bf185aaec7301d0862e4d69fce26d60">
+        <source>[1]{employee}[/1] added [1]"{comment}"[/1]</source>
+        <target>[1]{employee}[/1] added [1]"{comment}"[/1]</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/guest_to_customer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9893de883531529d4a66a3851265f02e">
+        <source>Your customer account creation</source>
+        <target>Your customer account creation</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="49bea2c7e271e5cd440a295dd6fadc72">
+        <source>Please be careful when sharing these login details with others.</source>
+        <target>Please be careful when sharing these login details with others.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="f4938f5d59c6c3adc14bf0cc30bc37f5">
+        <source>Your guest account for [1]{shop_name}[/1] has been transformed into a customer account.</source>
+        <target>Your guest account for [1]{shop_name}[/1] has been transformed into a customer account.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/import.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a218495ad30949e8ea1f64a261e37463">
+        <source>Import complete</source>
+        <target>Import complete</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/in_transit.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1b0d1cd23421d9cea08507e950e87094">
+        <source>{followup}</source>
+        <target>{followup}</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="2fe643b2ef0a5fd0e912cd9a784510a7">
+        <source>Your order with the reference [1]{order_name}[/1] is currently in transit.</source>
+        <target>Your order with the reference [1]{order_name}[/1] is currently in transit.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/log_alert.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="07e3b33fd6a9b33d3d9cacea26dc1899">
+        <source>You have received a new log alert</source>
+        <target>You have received a new log alert</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="6c1d03a23b1b8a7eeec963fdfa8e95c5">
+        <source>[1]Warning:[/1] you have received a new log alert in your Back Office.</source>
+        <target>[1]Warning:[/1] you have received a new log alert in your Back Office.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/order_canceled.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d9081e325264b44431f85a40bdca4985">
+        <source>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been canceled.</source>
+        <target>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been canceled.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/order_customer_comment.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="381fc38b470ed543424afbd43f224453">
+        <source>Message from a customer</source>
+        <target>Message from a customer</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/order_return_state.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="34d125dc458bced25eaf5e2e272c0d75">
+        <source>Return #{id_order_return} - update</source>
+        <target>Return #{id_order_return} - update</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/outofstock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e25d137c27dca2618629678d2df71113">
+        <source>Item(s) out of stock</source>
+        <target>Item(s) out of stock</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="5468cd18ba24d269db5ebe9177abca4a">
+        <source>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</source>
+        <target>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/password.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="53423ed6d9f522de8d41539456628786">
+        <source>Your new {shop_name} login details</source>
+        <target>Your new {shop_name} login details</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/password_query.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="280f51a8705636bd7e7ba595529411d4">
+        <source>Password reset request for {shop_name}</source>
+        <target>Password reset request for {shop_name}</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="278b2a400e176e90d476fb69cb881f59">
+        <source>To confirm this action, please use the following link:</source>
+        <target>To confirm this action, please use the following link:</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/payment.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6daabaab43cdbd67346ae71828b1710c">
+        <source>Payment processed</source>
+        <target>Payment processed</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="2762264cddd3133c3486886e31681873">
+        <source><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></source>
+        <target><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/payment_error.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3dd0be333980f0b0f0895cdb6322d117">
+        <source>Payment processing error</source>
+        <target>Payment processing error</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="96c8c962f040049e80bccbea08e2d776">
+        <source><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></source>
+        <target><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="5f2142258e3f214d12efeb927f2a7aef">
+        <source>We cannot ship your order until we receive your payment.</source>
+        <target>We cannot ship your order until we receive your payment.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/preparation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="643562a9ae7099c8aabfdc93478db117">
+        <source>Processing</source>
+        <target>Processing</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="d87f9ab0faa0b39a5240d1ce19529905">
+        <source><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></source>
+        <target><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/refund.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b3e67c974cc0ca43712679a17bedf6db">
+        <source><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></source>
+        <target><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/reply_msg.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="95d1732a1f5200c8e176bea0a5562804">
+        <source><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></source>
+        <target><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/shipped.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0cc952b66ca292a2e4a1bc53453b287">
+        <source>Your order has been shipped</source>
+        <target>Your order has been shipped</target>
+        <note>Line: 8</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/test.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8b1a9953c4611296a827abf8c47804d7">
+        <source>Hello</source>
+        <target>Hello</target>
+        <note>Line: 6</note>
+      </trans-unit>
+      <trans-unit id="632f6256903fd72ff83498831d2999b6">
+        <source>This is a [1]test e-mail[/1] from your shop.</source>
+        <target>This is a [1]test e-mail[/1] from your shop.</target>
+        <note>Line: 15</note>
+      </trans-unit>
+      <trans-unit id="79986d6ab2382663070d8cd7e31f2287">
+        <source>If you can read this, the test was successful!</source>
+        <target>If you can read this, the test was successful!</target>
+        <note>Line: 17</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/voucher.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6edfaaf163aab585fb50f909e6f2cadf">
+        <source>Voucher created</source>
+        <target>Voucher created</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="6e27b373aa04d07be7c5a65bbd9f45ed">
+        <source>A voucher has been created in your name as a result of your order with the reference [1]{order_name}[/1].</source>
+        <target>A voucher has been created in your name as a result of your order with the reference [1]{order_name}[/1].</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="f210a22fd1ec8eddd8236938d009f3a6">
+        <source>[1]Voucher code: {voucher_num}[/1] in the amount of [1]{voucher_amount}[/1]</source>
+        <target>[1]Voucher code: {voucher_num}[/1] in the amount of [1]{voucher_amount}[/1]</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/voucher_new.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5bb0c38774ca650d9548d682e175dc75">
+        <source>This is to inform you about the creation of a voucher.</source>
+        <target>This is to inform you about the creation of a voucher.</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_1.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a037426f7ede13b30759469aaca5ad91">
+        <source>Your {shop_name} login details</source>
+        <target>Your {shop_name} login details</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="ca0c09ad63f8cd2f732058be8d2b3a97">
+        <source>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</source>
+        <target>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="85fa10f1ee5c7941ec596c4247c8102b">
+        <source>As an incentive, we can give you a discount of [1]{amount}%[/1] off your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target>As an incentive, we can give you a discount of [1]{amount}%[/1] off your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_2.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="212dcee7c3ca3ee5fbae444b2f07c62d">
+        <source>Thank you for your order at {shop_name}.</source>
+        <target>Thank you for your order at {shop_name}.</target>
+        <note>Line: 8</note>
+      </trans-unit>
+      <trans-unit id="0930414a3b73fde90cef246f0f70a1c8">
+        <source>As our way of saying thanks, we want to give you a discount of [1]{amount}%[/1] off your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target>As our way of saying thanks, we want to give you a discount of [1]{amount}%[/1] off your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</target>
+        <note>Line: 23</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_3.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5a230b8b0490a33cf1fa3a577e1b4ef3">
+        <source>You are one of our best customers and as such we want to thank you for your continued patronage.</source>
+        <target>You are one of our best customers and as such we want to thank you for your continued patronage.</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="fb143851ff94b8816192dd378774d266">
+        <source>As appreciation for your loyalty, we want to give you a discount of [1]{amount}%[/1] valid on your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target>As appreciation for your loyalty, we want to give you a discount of [1]{amount}%[/1] valid on your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_4.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="42578524d7fb1953f903bcc5160495ea">
+        <source>Here is your coupon:</source>
+        <target>Here is your coupon:</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="24986b852e72fcfba407bd807f790abd">
+        <source>Enter this code in your shopping cart to get your discount.</source>
+        <target>Enter this code in your shopping cart to get your discount.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="7ed5b90c2f87440a6e83fc35dca83242">
+        <source>You are one of our best customers, however you have not placed an order in {days_threshold} days.</source>
+        <target>You are one of our best customers, however you have not placed an order in {days_threshold} days.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="fa0d0ed10aae850868404d1a9e7a66b2">
+        <source>We wish to thank you for the trust you have placed in us and want to give you a discount of [1]{amount}%[/1] valid on your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target>We wish to thank you for the trust you have placed in us and want to give you a discount of [1]{amount}%[/1] valid on your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/customer_qty.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5b736bebe50e10240ff58d486494dc7b">
+        <source>This item is once again in-stock.</source>
+        <target>This item is once again in-stock.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="16ce091d5fafd5b92941221eab85f3af">
+        <source>You can access the product page by clicking on the link:</source>
+        <target>You can access the product page by clicking on the link:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="d5c8de069674d35946f2e88642635485">
+        <source>You can order it right now from our online shop.</source>
+        <target>You can order it right now from our online shop.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/new_order.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bb09440b8cab954c036c4a45558857a5">
+        <source>Total Tax paid</source>
+        <target>Total Tax paid</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="6881c1c321e65a31d35137f960022cf7">
+        <source>A new order was placed on {shop_name} by the following customer: {firstname} {lastname} ({email})</source>
+        <target>A new order was placed on {shop_name} by the following customer: {firstname} {lastname} ({email})</target>
+        <note>Line: 14</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/order_changed.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fce4d5217e51f199cfbd10ae913cc5dd">
+        <source><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
+        <target><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="008400d8db73946ba53b2d7f091eb845">
+        <source>Order {order_name}</source>
+        <target>Order {order_name}</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="992ed3f1f7ce7be683fd4051138b693e">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></source>
+        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="6eaf1dae59f88437851d95f504f9cb3c">
+        <source>Order edited</source>
+        <target>Order edited</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="26b5ca3acdfdbd5fe92a5cb24dcc204e">
+        <source>Your order with the reference [1]{order_name}[/1] has been modified.</source>
+        <target>Your order with the reference [1]{order_name}[/1] has been modified.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/productcoverage.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="22609de33e6e9ee1be5b2bf9ae16514c">
+        <source>The stock cover is now less than the specified minimum of:</source>
+        <target>The stock cover is now less than the specified minimum of:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/productoutofstock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="756a94b60256e8aacdf10706925eb01e">
+        <source>{product} is nearly out of stock.</source>
+        <target>{product} is nearly out of stock.</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="72943b79a01324b1875811ff792bdad0">
+        <source>The remaining stock is now less than the specified minimum of</source>
+        <target>The remaining stock is now less than the specified minimum of</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/return_slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f">
+        <source>Return details</source>
+        <target>Return details</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="f2d476bf166cc31b450908f8606b0fd5">
+        <source>{order_name} Placed on {date}</source>
+        <target>{order_name} Placed on {date}</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailsubscription/newsletter_verif.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3f796454690dc2d7f26db5d45c48b187">
+        <source>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</source>
+        <target>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</target>
+        <note>Line: 22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailsubscription/newsletter_voucher.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7bf7f18afabb5122fa68fbab617e509b">
+        <source>Newsletter subscription</source>
+        <target>Newsletter subscription</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="289f1fb0b0a7ed1c03d1f1f597666f67">
+        <source>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</source>
+        <target>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/referralprogram/referralprogram-congratulations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="43614475dd83d9e6b291a2805ee620fc">
+        <source><![CDATA[Your referred friend [1]{sponsored_firstname} {sponsored_lastname}[/1] has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your referred friend [1]{sponsored_firstname} {sponsored_lastname}[/1] has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="1b9efd76beb745e43205f60167621060">
+        <source>We are pleased to offer you a voucher worth [1]{discount_display} (voucher # {discount_name})[/1] that you can use on your next order.</source>
+        <target>We are pleased to offer you a voucher worth [1]{discount_display} (voucher # {discount_name})[/1] that you can use on your next order.</target>
+        <note>Line: 23</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/referralprogram/referralprogram-invitation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="efd0d72633aeb91f063cfa143f56ca6b">
+        <source>join us!</source>
+        <target>join us!</target>
+        <note>Line: 7</note>
+      </trans-unit>
+      <trans-unit id="c4ae632d712131d48fcb9c6197933fe6">
+        <source><![CDATA[Your friend [1]{firstname} {lastname}[/1] wants to refer you on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your friend [1]{firstname} {lastname}[/1] wants to refer you on <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="dbec0bbd293d01bb529aceafda9d0af0">
+        <source>Get referred and earn a discount voucher of [1]{discount}![/1]</source>
+        <target>Get referred and earn a discount voucher of [1]{discount}![/1]</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="34ef083263a212936be7907709faab44">
+        <source>It's very easy to sign up. Just click here!</source>
+        <target>It's very easy to sign up. Just click here!</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="ba14b0fd8b7764d2fdf225b11b6e3fc3">
+        <source>When signing up, don't forget to provide the e-mail address of your referring friend:</source>
+        <target>When signing up, don't forget to provide the e-mail address of your referring friend:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/referralprogram/referralprogram-voucher.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6540b502e953f4c05abeb8f234cd50bf">
+        <source>Referral Program</source>
+        <target>Referral Program</target>
+        <note>Line: 22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/account.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="22a9d6a64a74d0f58a11fa7013f4b83a">
+        <source>Thank you for creating a customer account at {shop_name}.</source>
+        <target>Thank you for creating a customer account at {shop_name}.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="d5b14d16c4008efddbee79cb56af5455">
+        <source>Here are your login details:</source>
+        <target>Here are your login details:</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="d70650ce5612f05bfe75c1962fa1e519">
+        <source>Important Security Tips:</source>
+        <target>Important Security Tips:</target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="def00214a95442dc7899951abd9a6104">
+        <source>Always keep your account details safe.</source>
+        <target>Always keep your account details safe.</target>
+        <note>Line: 384</note>
+      </trans-unit>
+      <trans-unit id="1559b55f6ea1de9f9b8826e9be306e6f">
+        <source>Never disclose your login details to anyone.</source>
+        <target>Never disclose your login details to anyone.</target>
+        <note>Line: 389</note>
+      </trans-unit>
+      <trans-unit id="7601ee5e7968d91a7b4f099f4b4b84d0">
+        <source>Change your password regularly.</source>
+        <target>Change your password regularly.</target>
+        <note>Line: 394</note>
+      </trans-unit>
+      <trans-unit id="8f9011f4a1219e51c8a0638d2af3f29a">
+        <source>Should you suspect someone is using your account illegally, please notify us immediately.</source>
+        <target>Should you suspect someone is using your account illegally, please notify us immediately.</target>
+        <note>Line: 399</note>
+      </trans-unit>
+      <trans-unit id="de421ce3bebc9b5a2ee30fcf0312cb68">
+        <source>You can now place orders on our shop:</source>
+        <target>You can now place orders on our shop:</target>
+        <note>Line: 460</note>
+      </trans-unit>
+      <trans-unit id="08bd40c7543007ad06e4fce31618f6ec">
+        <source>Account</source>
+        <target>Account</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="edccc47e82abb1a733820982878c5fb0">
+        <source>Your login details on {shop_name}</source>
+        <target>Your login details on {shop_name}</target>
+        <note>Line: 184</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/backoffice_order.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="abc81c0d865925584b1269c996d7b297">
+        <source>A new order has been generated on your behalf.</source>
+        <target>A new order has been generated on your behalf.</target>
+        <note>Line: 167</note>
+      </trans-unit>
+      <trans-unit id="fb08925252dd912f564413fb5109eb06">
+        <source>Back Office Order</source>
+        <target>Back Office Order</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="bfa8b60dbfd44914f8cf61b57c641784">
+        <source><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to complete the payment.]]></source>
+        <target><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to complete the payment.]]></target>
+        <note>Line: 232</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/bankwire.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21e4851289ecc91b65023c2563344aa7">
+        <source>Account owner:</source>
+        <target>Account owner:</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="20a650d87733bd5895c979de29864a73">
+        <source>Account details:</source>
+        <target>Account details:</target>
+        <note>Line: 397</note>
+      </trans-unit>
+      <trans-unit id="312d898d92d8ba90499ef0dac27270be">
+        <source>Bank address:</source>
+        <target>Bank address:</target>
+        <note>Line: 402</note>
+      </trans-unit>
+      <trans-unit id="b8f05e3501f419f9f7ec08026a9342be">
+        <source>Please specify your order reference in the bankwire description.</source>
+        <target>Please specify your order reference in the bankwire description.</target>
+        <note>Line: 407</note>
+      </trans-unit>
+      <trans-unit id="35b4b09d5d0686ec5c2e2cc9f3d9039c">
+        <source>Bankwire</source>
+        <target>Bankwire</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="e59458c2ad3850466357a1cd342adc51">
+        <source>Pending payment</source>
+        <target>Pending payment</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="8f4dccd9e6900a3bbae488901ba81ce5">
+        <source>Payment method: bank wire</source>
+        <target>Payment method: bank wire</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="b59639f1f1bf84129e44b83fe192b10a">
+        <source>You have decided to pay by bank wire.</source>
+        <target>You have decided to pay by bank wire.</target>
+        <note>Line: 379</note>
+      </trans-unit>
+      <trans-unit id="920fcf4696dd1caa2d08eae6ebc8d29a">
+        <source>Here is the information you need for your transfer:</source>
+        <target>Here is the information you need for your transfer:</target>
+        <note>Line: 380</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/cheque.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6702a6e3bc2dce95c3e3b61fe578f29c">
+        <source>Amount:</source>
+        <target>Amount:</target>
+        <note>Line: 385</note>
+      </trans-unit>
+      <trans-unit id="1c3bd8f6bd066270354607c08f930baf">
+        <source>Payable to the order of:</source>
+        <target>Payable to the order of:</target>
+        <note>Line: 391</note>
+      </trans-unit>
+      <trans-unit id="8f1fb2295c4289bae9fc26549b4b45f2">
+        <source>Please mail your check to:</source>
+        <target>Please mail your check to:</target>
+        <note>Line: 397</note>
+      </trans-unit>
+      <trans-unit id="b4556791acee238c77be9ed338a29e80">
+        <source>Thank you for shopping with {shop_name}!</source>
+        <target>Thank you for shopping with {shop_name}!</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="97b07b4e5caa086464d9f38956718d2b">
+        <source>Your order with the reference [1]{order_name}[/1] has been placed successfully. You can expect [1]delivery as soon as your payment is received[/1].</source>
+        <target>Your order with the reference [1]{order_name}[/1] has been placed successfully. You can expect [1]delivery as soon as your payment is received[/1].</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="060bf2d587991d8f090a1309b285291c">
+        <source>Check</source>
+        <target>Check</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="0664188509e5edc8daac0d8c80bc05b3">
+        <source>Awaiting payment by check</source>
+        <target>Awaiting payment by check</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="6a9e91ee7fe91c99fc2b5915a2555a57">
+        <source>Payment method: check</source>
+        <target>Payment method: check</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="0cce70a6fc36b8ed06d4a0241b36eecb">
+        <source>You have decided to pay by bank check.</source>
+        <target>You have decided to pay by bank check.</target>
+        <note>Line: 379</note>
+      </trans-unit>
+      <trans-unit id="10766e013f1b6a5cbc249604bb7fc286">
+        <source>Here is the information you need for your check:</source>
+        <target>Here is the information you need for your check:</target>
+        <note>Line: 380</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/contact.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a1cee0a898793ad5101154ac97984d8a">
+        <source>Message from a {shop_name} customer</source>
+        <target>Message from a {shop_name} customer</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="53659d236625358b98797389fd2504fa">
+        <source>Attached file:</source>
+        <target>Attached file:</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="c1ebb17bfd89ea960194a6162b299cda">
+        <source>Order ID #:</source>
+        <target>Order ID #:</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="bbaff12800505b22a853e8b7f4eb6a22">
+        <source>Contact</source>
+        <target>Contact</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="482757e4afa747b69445ed1bfa8ea542">
+        <source>Customer Email Address:</source>
+        <target>Customer Email Address:</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/contact_form.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="465d60b936c982d7b57674f30ba022d0">
+        <source>Product:</source>
+        <target>Product:</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="3f65d6e17a11466983fd177702cf6a71">
+        <source>Contact Form</source>
+        <target>Contact Form</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="608a2464e2d26ee3b336400c920f87d0">
+        <source>Your message has been sent successfully, thank you for taking the time to write!</source>
+        <target>Your message has been sent successfully, thank you for taking the time to write!</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="7897b8cbc40618fdd3c1ad502ba47faa">
+        <source>We will reply as soon as possible.</source>
+        <target>We will reply as soon as possible.</target>
+        <note>Line: 255</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/credit_slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f53e8d0e97c47ce70ca9c5eaa08a00d0">
+        <source>Credit Slip</source>
+        <target>Credit Slip</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45">
+        <source>Credit slip</source>
+        <target>Credit slip</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="c44669ebfaeb42d8895e332f6199688e">
+        <source>A credit slip has been generated in your name for order with the reference [1]{order_name}[/1].</source>
+        <target>A credit slip has been generated in your name for order with the reference [1]{order_name}[/1].</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="933bd01e99683693ad9ddf8405040681">
+        <source><![CDATA[Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Credit slips</a> section of your customer account.]]></source>
+        <target><![CDATA[Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Credit slips</a> section of your customer account.]]></target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="313c18a58c9b461fbb29be3e39837d95">
+        <source><![CDATA[Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%credit_slips_label%</a> section of your customer account.]]></source>
+        <target><![CDATA[Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%credit_slips_label%</a> section of your customer account.]]></target>
+        <note>Line: 303</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/download_product.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c4e48432bc1c131388456f9fca605baf">
+        <source>Download products</source>
+        <target>Download products</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="a6c40a67df49207ba0519d1bee14a484">
+        <source>Thank you for your order with the reference {order_name} from [1]{shop_name}[/1]</source>
+        <target>Thank you for your order with the reference {order_name} from [1]{shop_name}[/1]</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="9e81969b0d999f5daa0d37ce13fb7001">
+        <source>Product(s) to download</source>
+        <target>Product(s) to download</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="8bbeb216836330d437043e36617d5325">
+        <source>You have [1]{nbProducts}[/1] product(s) now available for download using the following link(s):</source>
+        <target>You have [1]{nbProducts}[/1] product(s) now available for download using the following link(s):</target>
+        <note>Line: 249</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/employee_password.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="668a8d8d7ffe5da112b266e46b79b685">
+        <source>First name:</source>
+        <target>First name:</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="be5e0b5d50d48b049bd0f7b57cd163f9">
+        <source>Last name:</source>
+        <target>Last name:</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="a3b24a2a75c846bdf0bc8449746a8637">
+        <source>Employee password</source>
+        <target>Employee password</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="02fef144b687c453c4a1ae7c4e3e150b">
+        <source>Here is your personal login information for {shop_name}</source>
+        <target>Here is your personal login information for {shop_name}</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="0b937cfeb30c586cd659a58173bd37c7">
+        <source>Here is your identification information on [1]{shop_name}[/1]</source>
+        <target>Here is your identification information on [1]{shop_name}[/1]</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/forward_msg.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a9854b516855755f7a9246d781d4f57b">
+        <source>Discussion history:</source>
+        <target>Discussion history:</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="5a02acdd25040de97181665e4e84caa4">
+        <source>[1]{employee}[/1] wanted to forward this discussion to you.</source>
+        <target>[1]{employee}[/1] wanted to forward this discussion to you.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="459ea98b5f18960e8c26da4754208f75">
+        <source>Forward message</source>
+        <target>Forward message</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="c413b39ac8eea02ebfbee487d1d9ea16">
+        <source>Customer Service - Discussion Forwarded</source>
+        <target>Customer Service - Discussion Forwarded</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="638dae1199098a2faffc18b14086ecc5">
+        <source>[1]{employee}[/1] added [1]{comment}[/1]</source>
+        <target>[1]{employee}[/1] added [1]{comment}[/1]</target>
+        <note>Line: 252</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/guest_to_customer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b75184fa489c948c6debc4d635fefa5a">
+        <source>You can access your customer account on our shop:</source>
+        <target>You can access your customer account on our shop:</target>
+        <note>Line: 309</note>
+      </trans-unit>
+      <trans-unit id="2df994fe4798f819768c87824ec15ced">
+        <source>Email address:</source>
+        <target>Email address:</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="016878df57341f82e0702d9259bfb7d8">
+        <source>Guest to customer</source>
+        <target>Guest to customer</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="387c721c8acb98382f1d18feccf3dd55">
+        <source>Your guest account has been turned into a customer account</source>
+        <target>Your guest account has been turned into a customer account</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="3008c9316cf28c5f439bbcc2e43b2e3e">
+        <source>Congratulations, your guest account for [1]{shop_name}[/1] has been turned into a customer account!</source>
+        <target>Congratulations, your guest account for [1]{shop_name}[/1] has been turned into a customer account!</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="9964a987c88f49c4be016b1af2801403">
+        <source>Click on the following link to set up your password:</source>
+        <target>Click on the following link to set up your password:</target>
+        <note>Line: 248</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/import.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="293a2b3dd4b7fb2d950c8128be6d14f7">
+        <source>The file {filename} has been successfully imported to your shop.</source>
+        <target>The file {filename} has been successfully imported to your shop.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="72d6d7a1885885bb55a565fd1070581a">
+        <source>Import</source>
+        <target>Import</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="23e7f4b70281e1293a4985626589aeee">
+        <source>Import finished</source>
+        <target>Import finished</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/in_transit.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7ec4f8b296984ffe6ea829b7e1743577">
+        <source>In transit</source>
+        <target>In transit</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="34f49f671cedfb2d5f8080ec14120281">
+        <source>You can track your package using the following link:</source>
+        <target>You can track your package using the following link:</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="b395812bfd92c9b2c5cce4335dbdf404">
+        <source>Your order with the reference [1]{order_name}[/1] is on its way.</source>
+        <target>Your order with the reference [1]{order_name}[/1] is on its way.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/log_alert.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad69fd3d0352d7e45ccca96a1048a747">
+        <source><![CDATA[You can check for it in the [1]Advanced Parameters > Logs[/1] section of your back office.]]></source>
+        <target><![CDATA[You can check for it in the [1]Advanced Parameters > Logs[/1] section of your back office.]]></target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="0f170325fe7cbbbd2be4d705b277650e">
+        <source>Log Alert</source>
+        <target>Log Alert</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="223e2a86894ef6ae6d9a96b2d4f53acf">
+        <source>New alert message saved</source>
+        <target>New alert message saved</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="3cfb2805cc4075e0a98e932afb94d132">
+        <source>[1]WARNING:[/1] you have received a new log alert in your back office.</source>
+        <target>[1]WARNING:[/1] you have received a new log alert in your back office.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/newsletter.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ffb7e666a70151215b4c55c6268d7d72">
+        <source>Newsletter</source>
+        <target>Newsletter</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_canceled.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3baf03ed2980c9f339731f052c12b37d">
+        <source>Order canceled</source>
+        <target>Order canceled</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="059b64746023360b7ab478fd850ffeb3">
+        <source>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been canceled by the merchant.</source>
+        <target>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been canceled by the merchant.</target>
+        <note>Line: 241</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_conf.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fb077ecba55e5552916bde26d8b9e794">
+        <source>Order confirmation</source>
+        <target>Order confirmation</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="ca102bf009d3e0d62a4fc6918b20110e">
+        <source>Thank you for shopping on [1]{shop_name}[/1]!</source>
+        <target>Thank you for shopping on [1]{shop_name}[/1]!</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="ff2fa78f07ffe4ac52c0d0b5ff7f0baa">
+        <source>Thank you for your order on [1]{shop_name}[/1]!</source>
+        <target>Thank you for your order on [1]{shop_name}[/1]!</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="96b0141273eabab320119c467cdcaf17">
+        <source>Total</source>
+        <target>Total</target>
+        <note>Line: 382</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_customer_comment.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1607c3534ee9bdb8638858fa4bb9261b">
+        <source>You have received a new message regarding order with the reference</source>
+        <target>You have received a new message regarding order with the reference</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="fa44c7d88039cc2a3caf05195e1e45bb">
+        <source>Order customer comment</source>
+        <target>Order customer comment</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="c744bfa52ba85ff901bab4ed9319978e">
+        <source>Message from customer</source>
+        <target>Message from customer</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_merchant_comment.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2769d37f4eb00f2c9b940ee928f1b426">
+        <source>Message from {shop_name}</source>
+        <target>Message from {shop_name}</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="940663fd4428d2c86f9a4780b6574028">
+        <source>Message:</source>
+        <target>Message:</target>
+        <note>Line: 307</note>
+      </trans-unit>
+      <trans-unit id="15c197c97ee33f7da7df21d315fb7f71">
+        <source>You have received a new message from [1]{shop_name}[/1] regarding order with the reference [1]{order_name}[/1].</source>
+        <target>You have received a new message from [1]{shop_name}[/1] regarding order with the reference [1]{order_name}[/1].</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="371e76fdc916e1fc3818f6b96dee5219">
+        <source>Order merchant comment</source>
+        <target>Order merchant comment</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_return_state.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="96aac675caae8b0ca0a5227ce8a6a7c6">
+        <source>We have updated the progress on your return #{id_order_return}, the new status is:</source>
+        <target>We have updated the progress on your return #{id_order_return}, the new status is:</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="3bc517b4a402645da419438914f481c6">
+        <source>Order return #{id_order_return} - Update</source>
+        <target>Order return #{id_order_return} - Update</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="d28c38eafee0f9e02256b284275603f9">
+        <source>Order return state</source>
+        <target>Order return state</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/outofstock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="be07158cdaa6c7244af799f3cdd6dad5">
+        <source>Thanks for your order with the reference {order_name} from {shop_name}.</source>
+        <target>Thanks for your order with the reference {order_name} from {shop_name}.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="e57e950cfde3e24c3674f9266753edec">
+        <source><![CDATA[Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.]]></source>
+        <target><![CDATA[Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.]]></target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="b55197a49e8c4cd8c314bc2aa39d6feb">
+        <source>Out of stock</source>
+        <target>Out of stock</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="cfc958489addbbe32552c9bc785f83c9">
+        <source>Replenishment required</source>
+        <target>Replenishment required</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="dd099f9c8d04d30fa277471417a372be">
+        <source>Unfortunately, one or more items are currently out of stock and this may cause a slight delay for delivery. Please accept our apologies for this inconvenience and be sure we are doing our best to correct the situation.</source>
+        <target>Unfortunately, one or more items are currently out of stock and this may cause a slight delay for delivery. Please accept our apologies for this inconvenience and be sure we are doing our best to correct the situation.</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="0d2b8d4d6cdd2cc0b8da74fdb143654b">
+        <source><![CDATA[Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.]]></source>
+        <target><![CDATA[Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.]]></target>
+        <note>Line: 310</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/password.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dc647eb65e6711e155375218212b3964">
+        <source>Password</source>
+        <target>Password</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="fa71c1a4010fb64e8968708b3f1e50ca">
+        <source>Your password has been correctly updated.</source>
+        <target>Your password has been correctly updated.</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/password_query.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="09ce893cc7228918df5657665b899249">
+        <source>Please note that this will change your current password.</source>
+        <target>Please note that this will change your current password.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="3516ed9d771d15439e2ac9d3bf81ad84">
+        <source>You have requested to reset your [1]{shop_name}[/1] login details.</source>
+        <target>You have requested to reset your [1]{shop_name}[/1] login details.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="de148dcf9a5a0f2de3a65c36f9991f42">
+        <source>Password Query</source>
+        <target>Password Query</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="87a8bbd45aa2890a2929c07d49fa64f1">
+        <source>Confirmation of password request on {shop_name}</source>
+        <target>Confirmation of password request on {shop_name}</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="bdf92bd43402eeabaaa7e643e30607c1">
+        <source>In order to confirm this action, click on the following link:</source>
+        <target>In order to confirm this action, click on the following link:</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="0b0df2fff267640acf7f0d03a9b90aa6">
+        <source>If you did not make this request, just ignore this email.</source>
+        <target>If you did not make this request, just ignore this email.</target>
+        <note>Line: 313</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/payment.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da">
+        <source>Payment</source>
+        <target>Payment</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="3444682d2f753ddc0a602ea92891f3b1">
+        <source>Your payment for order with the reference [1]{order_name}[/1] was successfully processed.</source>
+        <target>Your payment for order with the reference [1]{order_name}[/1] was successfully processed.</target>
+        <note>Line: 241</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/payment_error.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b06c5ecc37b9cd61a0cab0534ed1f15d">
+        <source>Payment Error</source>
+        <target>Payment Error</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="1e97d97a923eaddd810e056c828e99ea">
+        <source>Payment error</source>
+        <target>Payment error</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="e1a66dba9aa7c8399229122ca7528b77">
+        <source>We have encountered an error while processing your payment for your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1]. Please contact us as soon as possible.</source>
+        <target>We have encountered an error while processing your payment for your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1]. Please contact us as soon as possible.</target>
+        <note>Line: 241</note>
+      </trans-unit>
+      <trans-unit id="b8dfec752b0cb58a3bc3c7479e4dd44c">
+        <source>You can expect delivery as soon as your payment is received.</source>
+        <target>You can expect delivery as soon as your payment is received.</target>
+        <note>Line: 243</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/preparation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9a5f09cf66e692efdae493ce4c9aa64f">
+        <source>Preparation</source>
+        <target>Preparation</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="6ae0cf64b3eeb821a73550fab5ea13bd">
+        <source>Processing order</source>
+        <target>Processing order</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="67b9a4d1678e24c00ddce83b7005b8a3">
+        <source>We are currently processing your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1].</source>
+        <target>We are currently processing your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1].</target>
+        <note>Line: 241</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/productoutofstock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fdabff209ef55c524b662ea9f2991ad3">
+        <source>There are now less than [1]{last_qty}[/1] of [1]{product}[/1] in stock.</source>
+        <target>There are now less than [1]{last_qty}[/1] of [1]{product}[/1] in stock.</target>
+        <note>Line: 176</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/refund.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b45ae8a346e0587013cdb1494e113d8">
+        <source>Refund processed</source>
+        <target>Refund processed</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="76f0ed934de85cc7131910b32ede7714">
+        <source>Refund</source>
+        <target>Refund</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="6063c9fb7f9ad1d1a235c24bfcbf5522">
+        <source>We have processed your refund for your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1].</source>
+        <target>We have processed your refund for your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1].</target>
+        <note>Line: 183</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/reply_msg.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2ddbd3a9b06eadccdea8e1b372830d69">
+        <source>Please do not reply directly to this email, we will not receive it.</source>
+        <target>Please do not reply directly to this email, we will not receive it.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="b0faef9417304909de0960b57582cd1c">
+        <source>Reply msg</source>
+        <target>Reply msg</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="7e4e256f10a59674290c89dd1bba1312">
+        <source><![CDATA[In order to reply, click on the following link: <a href="{link}" target="_blank">{link}</a>]]></source>
+        <target><![CDATA[In order to reply, click on the following link: <a href="{link}" target="_blank">{link}</a>]]></target>
+        <note>Line: 243</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/shipped.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="747cf5c8587184b9e489ff897d97c20d">
+        <source>Shipped</source>
+        <target>Shipped</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="da825075a1643697f1540f1c946c01f1">
+        <source>Your order with the reference [1]{order_name}[/1] has been shipped.</source>
+        <target>Your order with the reference [1]{order_name}[/1] has been shipped.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/test.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0cbc6611f5540bd0809a388dc95a615b">
+        <source>Test</source>
+        <target>Test</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="8afe3c369cb4d2e723edabf14b8d8db8">
+        <source>Here is a test [1]email[/1] from your shop.</source>
+        <target>Here is a test [1]email[/1] from your shop.</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="a6ec75fcb2240ccd4ea29549ee413885">
+        <source>If you can read this, it means the test is successful!</source>
+        <target>If you can read this, it means the test is successful!</target>
+        <note>Line: 182</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/voucher.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bba6345ca09bf0e21cb502bc6d960cde">
+        <source>In order to use it, just copy/paste this code during check out.</source>
+        <target>In order to use it, just copy/paste this code during check out.</target>
+        <note>Line: 251</note>
+      </trans-unit>
+      <trans-unit id="be686376cddb23d0227444ccc3c4b5b7">
+        <source>Voucher</source>
+        <target>Voucher</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="3e943dfae35fac1a61b30da7f27f2204">
+        <source>Voucher code generated</source>
+        <target>Voucher code generated</target>
+        <note>Line: 176</note>
+      </trans-unit>
+      <trans-unit id="0482c9e34db0bf16ec3a09c4dc7c3b0b">
+        <source>We are pleased to inform you that a voucher has been generated in your name for order with the reference [1]{order_name}[/1].</source>
+        <target>We are pleased to inform you that a voucher has been generated in your name for order with the reference [1]{order_name}[/1].</target>
+        <note>Line: 241</note>
+      </trans-unit>
+      <trans-unit id="5dc1b3e639ee30637424bd07af99154d">
+        <source>[1]VOUCHER CODE: {voucher_num}[/1] in the amount of [1]{voucher_amount}[/1]</source>
+        <target>[1]VOUCHER CODE: {voucher_num}[/1] in the amount of [1]{voucher_amount}[/1]</target>
+        <note>Line: 246</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/voucher_new.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0b04d9ad5743989471141ab21edd64fd">
+        <source>Voucher new</source>
+        <target>Voucher new</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="68b8413e263842c318e66fc6b29144da">
+        <source>Voucher code has been generated</source>
+        <target>Voucher code has been generated</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="af4667c3d9a39bfa5ce658080730210a">
+        <source>Here is your new voucher code:</source>
+        <target>Here is your new voucher code:</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_1.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="784e102689c17fd18fe94135d4fa864d">
+        <source>Your cart at {shop_name}</source>
+        <target>Your cart at {shop_name}</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="804e4e067b0e61e122e1a35771fcf144">
+        <source>Follow up 1</source>
+        <target>Follow up 1</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="b9018fa1aff4ac6de7e50d6a8f1c9e4a">
+        <source>Thanks for your visit. However, it looks like you did not complete your purchase.</source>
+        <target>Thanks for your visit. However, it looks like you did not complete your purchase.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="14c90ec7c3372b9f39c9cf24323bd959">
+        <source>Your cart has been saved, you can go back to your order on our shop:</source>
+        <target>Your cart has been saved, you can go back to your order on our shop:</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="938ad8b6f0f1e5c4663bc171ad56822e">
+        <source>Your voucher code on {shop_name}</source>
+        <target>Your voucher code on {shop_name}</target>
+        <note>Line: 317</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_2.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7ff89d85f528f79efd0a85c01a43cb62">
+        <source>Follow up 2</source>
+        <target>Follow up 2</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="605fc3ecd313608fe8c6cbbed5a25261">
+        <source>Thanks for your order.</source>
+        <target>Thanks for your order.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_3.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="66472df69ec288388183a74a6e34e942">
+        <source>Thanks for your trust.</source>
+        <target>Thanks for your trust.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="383126b6a239da6f7d483220c63a46e2">
+        <source>Follow up 3</source>
+        <target>Follow up 3</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_4.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="8dec16ec73558f6fb2515cce4293ce6f">
+        <source>Your cart has been saved, you can resume your order by visiting our shop:</source>
+        <target>Your cart has been saved, you can resume your order by visiting our shop:</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="18df3f8153de940176206b06a3610f80">
+        <source>We are pleased to offer you a discount of [1]{amount}%[/1] off your next order. And this offer is valid for [1]{days}[/1] days, so do not wait any longer!</source>
+        <target>We are pleased to offer you a discount of [1]{amount}%[/1] off your next order. And this offer is valid for [1]{days}[/1] days, so do not wait any longer!</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="5416511766be8537f357142a81ccd7a7">
+        <source>Here is your VOUCHER CODE:</source>
+        <target>Here is your VOUCHER CODE:</target>
+        <note>Line: 317</note>
+      </trans-unit>
+      <trans-unit id="ececa54d96395d3afa79cdce8e7e0bd6">
+        <source>Enter this code in your shopping cart to get the discount.</source>
+        <target>Enter this code in your shopping cart to get the discount.</target>
+        <note>Line: 322</note>
+      </trans-unit>
+      <trans-unit id="a5672f20db3e09abb35f909cf56f3b23">
+        <source>Follow up 4</source>
+        <target>Follow up 4</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="1e6f48752a20a5c6dc2f387c18777136">
+        <source>Your cart on {shop_name}</source>
+        <target>Your cart on {shop_name}</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="8dfa91d2853e941e80553ab1336b6459">
+        <source>Congratulations, you are one of our best customers! However, it looks like you have not placed an order since {days_threshold} days.</source>
+        <target>Congratulations, you are one of our best customers! However, it looks like you have not placed an order since {days_threshold} days.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/customer_qty.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9b096ae55ce4d2bb889392144c104069">
+        <source>{product} is now available.</source>
+        <target>{product} is now available.</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="583b02c0b2f05171037b58c186a5461d">
+        <source>Customer Quantity</source>
+        <target>Customer Quantity</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="61a517de529038e441a1f6ada3f5a196">
+        <source>Good news, this item is back in stock!</source>
+        <target>Good news, this item is back in stock!</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="fb0e8fc6b59dac729bb483b2c617adf2">
+        <source>Click on the following link to visit the product page and order it:</source>
+        <target>Click on the following link to visit the product page and order it:</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/new_order.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5c1cc11c191c9a0f32d16439618ed3bb">
+        <source>Customer message:</source>
+        <target>Customer message:</target>
+        <note>Line: 655</note>
+      </trans-unit>
+      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3">
+        <source>Order details</source>
+        <target>Order details</target>
+        <note>Line: 184</note>
+      </trans-unit>
+      <trans-unit id="2ca3deb5cd68fa9119b285804fab572f">
+        <source>Order:</source>
+        <target>Order:</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="101f2450ccefbd344b37971c5d27f96d">
+        <source>Placed on</source>
+        <target>Placed on</target>
+        <note>Line: 249</note>
+      </trans-unit>
+      <trans-unit id="a0e8e26f6f9354192425b9a23227a5ba">
+        <source>Payment:</source>
+        <target>Payment:</target>
+        <note>Line: 499</note>
+      </trans-unit>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
+        <source>Reference</source>
+        <target>Reference</target>
+        <note>Line: 324</note>
+      </trans-unit>
+      <trans-unit id="deb10517653c255364175796ace3553f">
+        <source>Product</source>
+        <target>Product</target>
+        <note>Line: 325</note>
+      </trans-unit>
+      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
+        <source>Unit price</source>
+        <target>Unit price</target>
+        <note>Line: 326</note>
+      </trans-unit>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 327</note>
+      </trans-unit>
+      <trans-unit id="0eede552438475bdfe820c13f24c9399">
+        <source>Total price</source>
+        <target>Total price</target>
+        <note>Line: 328</note>
+      </trans-unit>
+      <trans-unit id="068f80c7519d0528fb08e82137a72131">
+        <source>Products</source>
+        <target>Products</target>
+        <note>Line: 333</note>
+      </trans-unit>
+      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3">
+        <source>Discounts</source>
+        <target>Discounts</target>
+        <note>Line: 339</note>
+      </trans-unit>
+      <trans-unit id="41c1d61bfff3fc9b1fd8f195061b8caa">
+        <source>Gift-wrapping</source>
+        <target>Gift-wrapping</target>
+        <note>Line: 345</note>
+      </trans-unit>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6">
+        <source>Shipping</source>
+        <target>Shipping</target>
+        <note>Line: 351</note>
+      </trans-unit>
+      <trans-unit id="ea067eb37801c5aab1a1c685eb97d601">
+        <source>Total paid</source>
+        <target>Total paid</target>
+        <note>Line: 363</note>
+      </trans-unit>
+      <trans-unit id="f8617a92ba0a0a4eabee724eab7c9f48">
+        <source>Carrier:</source>
+        <target>Carrier:</target>
+        <note>Line: 494</note>
+      </trans-unit>
+      <trans-unit id="af0f5bdc5be121b9307687aeeae38c17">
+        <source>Delivery address</source>
+        <target>Delivery address</target>
+        <note>Line: 569</note>
+      </trans-unit>
+      <trans-unit id="1fbc7e5f1b92c7ec072397b59a0bb5da">
+        <source>Billing address</source>
+        <target>Billing address</target>
+        <note>Line: 585</note>
+      </trans-unit>
+      <trans-unit id="5c9412907a7aabeea3491fafec5c082e">
+        <source>Including total tax</source>
+        <target>Including total tax</target>
+        <note>Line: 357</note>
+      </trans-unit>
+      <trans-unit id="6810a1cc40329a394b9d73b5f8dac744">
+        <source>New Order</source>
+        <target>New Order</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="ea1fc6431869b331e6db01a2f6ca921f">
+        <source>A new order was placed on [1]{shop_name}[/1] by the following customer:</source>
+        <target>A new order was placed on [1]{shop_name}[/1] by the following customer:</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb">
+        <source>Carrier</source>
+        <target>Carrier</target>
+        <note>Line: 429</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/order_changed.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ac32eb3619340a6b6aff41d9797665d4">
+        <source>Order changed</source>
+        <target>Order changed</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="681a0aa2d158085f63f86c84900fa989">
+        <source>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been changed by the merchant.</source>
+        <target>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been changed by the merchant.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="869a6d7d8b6af1ca14f874356141ac45">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.]]></source>
+        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.]]></target>
+        <note>Line: 317</note>
+      </trans-unit>
+      <trans-unit id="af6c5b694abbb964eec098febaa5d31d">
+        <source>Order ID {order_name}</source>
+        <target>Order ID {order_name}</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="c03924df23d22785084b06a548ca9976">
+        <source>Go to your customer account to learn more about it.</source>
+        <target>Go to your customer account to learn more about it.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="a1985adc2a7be8af1d6beafa7527c062">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.]]></source>
+        <target><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.]]></target>
+        <note>Line: 308</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/productcoverage.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="81899e9a62d3f952e81d5f72437470f9">
+        <source>Current stock cover:</source>
+        <target>Current stock cover:</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="fdf4e97dcf4ad98512050ab60cf91bc3">
+        <source>Product coverage</source>
+        <target>Product coverage</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="906898f022140256a84c9429a3fcf4d8">
+        <source>Your stock cover is now less than the specified minimum of:</source>
+        <target>Your stock cover is now less than the specified minimum of:</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/productoutofstock.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6983ddb3442f4ad4a3b94e94a1ebd3dc">
+        <source>{product} is almost out of stock.</source>
+        <target>{product} is almost out of stock.</target>
+        <note>Line: 175</note>
+      </trans-unit>
+      <trans-unit id="ab8f74636fc3f34b09b1300a2393a0b8">
+        <source>Remaining stock:</source>
+        <target>Remaining stock:</target>
+        <note>Line: 245</note>
+      </trans-unit>
+      <trans-unit id="d3f03e2edd35c99abb3fd3d9bc51706e">
+        <source><![CDATA[Replenish your inventory, go to the [1]Catalog > Stocks[/1] section of your back office to manage your stock.]]></source>
+        <target><![CDATA[Replenish your inventory, go to the [1]Catalog > Stocks[/1] section of your back office to manage your stock.]]></target>
+        <note>Line: 250</note>
+      </trans-unit>
+      <trans-unit id="644f9c907ef5a8315916bd1e2f61f783">
+        <source>Product out of stock</source>
+        <target>Product out of stock</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="9300ac228fc7c8ec8d970d862d68432c">
+        <source>There are now less than [1]{last_qty}[/1] items in stock.</source>
+        <target>There are now less than [1]{last_qty}[/1] items in stock.</target>
+        <note>Line: 240</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/return_slip.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5eea367ea73b909880393bd1ae79fc67">
+        <source>Customer:</source>
+        <target>Customer:</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="f285446f60a203b0f7c3ad0b14d13d29">
+        <source>You have received a new return request for {shop_name}.</source>
+        <target>You have received a new return request for {shop_name}.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="6773c510bcd24041ed4d515b65358e96">
+        <source>Return Slip</source>
+        <target>Return Slip</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="9b600ac4bf14f6e3919b919893bae7f8">
+        <source>Return Details</source>
+        <target>Return Details</target>
+        <note>Line: 184</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailsubscription/newsletter_conf.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4e1c51e233f1ed368c58db9ef09010ba">
+        <source>Thank you for subscribing to our newsletter.</source>
+        <target>Thank you for subscribing to our newsletter.</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="bb372ddf88ad8fcc480f7a8599a92abc">
+        <source>Hi,</source>
+        <target>Hi,</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="c9a257051d205ce3d0f4078b53dd4512">
+        <source>Newsletter Confirmation</source>
+        <target>Newsletter Confirmation</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailsubscription/newsletter_verif.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32e00ed1f8f1062378ba2c47ac75de9d">
+        <source>Newsletter Verification</source>
+        <target>Newsletter Verification</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="3b3d69d6a53f5cb28d8867f5aeb1aa78">
+        <source>Thank you for subscribing to our newsletter. Please click on the following link to confirm your request:</source>
+        <target>Thank you for subscribing to our newsletter. Please click on the following link to confirm your request:</target>
+        <note>Line: 177</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailsubscription/newsletter_voucher.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2eb58792075fb4bea9ad03b6da20ec05">
+        <source>Newsletter Voucher</source>
+        <target>Newsletter Voucher</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="fb85495b4c45ce28e7a1521017326c5a">
+        <source>Subscribing to newsletter</source>
+        <target>Subscribing to newsletter</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="f6c3e4834d385f4923121b89bdee29c0">
+        <source>Thank you for subscribing to our newsletter. We are pleased to offer you the following voucher:</source>
+        <target>Thank you for subscribing to our newsletter. We are pleased to offer you the following voucher:</target>
+        <note>Line: 242</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/referralprogram/referralprogram-congratulations.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1a81759353d36dbd31059fc261af0aa2">
+        <source>Congratulations!</source>
+        <target>Congratulations!</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="0920dd6cc2680f2a960c59f757d5184d">
+        <source><![CDATA[Your referred friend [1]{sponsored_firstname}[/1] [1]{sponsored_lastname}[/1] has placed his/her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your referred friend [1]{sponsored_firstname}[/1] [1]{sponsored_lastname}[/1] has placed his/her first order on <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="4461931aad93f10308121eb94ce7be47">
+        <source>We are pleased to offer you a voucher worth [1]{discount_display}[/1] (VOUCHER # [1]{discount_name}[/1]) that you can use on your next order.</source>
+        <target>We are pleased to offer you a voucher worth [1]{discount_display}[/1] (VOUCHER # [1]{discount_name}[/1]) that you can use on your next order.</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="49af6950c9d9101af9ae958b4426c6b9">
+        <source>Referral program Congratulations</source>
+        <target>Referral program Congratulations</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/referralprogram/referralprogram-invitation.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="677182971924ee6799eb365f688c5572">
+        <source>Best regards,</source>
+        <target>Best regards,</target>
+        <note>Line: 305</note>
+      </trans-unit>
+      <trans-unit id="4a898b178164591fca68f786e164927d">
+        <source>We are pleased to offer you a voucher worth [1]{discount}[/1] that you can use on your next order.</source>
+        <target>We are pleased to offer you a voucher worth [1]{discount}[/1] that you can use on your next order.</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="814fd45dff3fa38cc8114bc0d6c9020a">
+        <source>Join us!</source>
+        <target>Join us!</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="a2ca20d3687abde01edc72cb7c1c5600">
+        <source><![CDATA[Your friend [1]{firstname} {lastname}[/1] wants to refer you on <a href="{shop_url}" target="_blank">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your friend [1]{firstname} {lastname}[/1] wants to refer you on <a href="{shop_url}" target="_blank">{shop_name}</a>!]]></target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="b37f4e64c7473dac9931e0fabf536ef3">
+        <source>Get referred and earn a discount voucher of [1]{discount}[/1]!</source>
+        <target>Get referred and earn a discount voucher of [1]{discount}[/1]!</target>
+        <note>Line: 183</note>
+      </trans-unit>
+      <trans-unit id="48f75fa6577e9a8b1a43268ac9844494">
+        <source>It's very easy to sign up, just click here!</source>
+        <target>It's very easy to sign up, just click here!</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="a0d3fa1d46da3bd234eb873154675d8e">
+        <source>When signing up, don't forget to provide the email address of your referring friend:</source>
+        <target>When signing up, don't forget to provide the email address of your referring friend:</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="a9f8dbec69378bc1c5b1e9d144bd2412">
+        <source>Referral program Invitation</source>
+        <target>Referral program Invitation</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/referralprogram/referralprogram-voucher.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="31ee1241ee08294dfc2ca85698fda2a1">
+        <source>Hi {firstname} {lastname},</source>
+        <target>Hi {firstname} {lastname},</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="f4f614c22d9d2cbd0f9aa08cd59600d2">
+        <source>Simply copy/paste this code during the payment process for your next order.</source>
+        <target>Simply copy/paste this code during the payment process for your next order.</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="abe1585bf97403d8a9a01a272183585a">
+        <source>Here is the code of your voucher:</source>
+        <target>Here is the code of your voucher:</target>
+        <note>Line: 243</note>
+      </trans-unit>
+      <trans-unit id="dd863685846fc4eddcc9d6d09ddd5264">
+        <source>We have created a voucher in your name for referring a friend.</source>
+        <target>We have created a voucher in your name for referring a friend.</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="389df865c60c8fc7b86bf773eb5b121c">
+        <source>, with an amount of</source>
+        <target>, with an amount of</target>
+        <note>Line: 243</note>
+      </trans-unit>
+      <trans-unit id="cb3374f4e7a0afb61e63d0ee694ad501">
+        <source>Sponsorship Program</source>
+        <target>Sponsorship Program</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="f38a99a3e90333bd34a64e90f03960f4">
+        <source>Referral program Voucher</source>
+        <target>Referral program Voucher</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/cheque.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3f8b7a7948f4fd5d9bb34d63746dfd23">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/credit_slip.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b1c95c88d55558a6c04dea50425199df">
+        <source><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/credit_slip.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/download_product.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="afae9cdc5d9b4583915a579cb0c67788">
+        <source><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></source>
+        <target><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/download_product.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/employee_password.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a1fd16fcb98f1a6ec4312a10e6a3acba">
+        <source><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></source>
+        <target><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/employee_password.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/footer.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1c65ac2c128f4835c77d0c7aefccb7e">
+        <source><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></source>
+        <target><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/footer.php:6</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/forward_msg.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="85ae5cfc68837cc8e50609b84babba09">
+        <source><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></source>
+        <target><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:24</note>
+      </trans-unit>
+      <trans-unit id="f4df87e5e465151ae8d5954bec01d9ec">
+        <source><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></source>
+        <target><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/guest_to_customer.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="499e229d39934f1a36f3f48718cc19cc">
+        <source><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></source>
+        <target><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/in_transit.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="873a6c9ce4b0711161105e4a6d943bb6">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/in_transit.php:49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/log_alert.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="17357f0ed7c82a1620f4311667886a63">
+        <source><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></source>
+        <target><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:24</note>
+      </trans-unit>
+      <trans-unit id="ba00a1816b599684def5ff1d312ef5ed">
+        <source><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></source>
+        <target><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_canceled.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="50651089ed12eb33b55394a0a17618de">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_canceled.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_changed.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0e6321e9d36186e957652f07d88116a5">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_changed.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_merchant_comment.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad9fd7d0fe973ddaef093d912d0b57e2">
+        <source><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_merchant_comment.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/password_query.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="18f3152ffe51f0d446558f666dc8d5ea">
+        <source><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></source>
+        <target><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password_query.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/shipped.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e9933131bfeef332fc84561f8e23aeba">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/shipped.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/test.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0afa69e0eb948ce9fb81e14cc0c7cf0b">
+        <source><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></source>
+        <target><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/test.php:14</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/voucher.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="17ab9221f0e6cb342a02d31c56c79c2b">
+        <source><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:24</note>
+      </trans-unit>
+      <trans-unit id="25cecf399c0cd872952ced4a7d150e0d">
+        <source><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></source>
+        <target><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_1.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2213ab34c63663d94f96efdb6a9be339">
+        <source><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_2.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3a5fa552bd31ebcceae0973cd384406b">
+        <source><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_2.php:22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_3.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="86736a3055a9913b2c64671cd333e159">
+        <source><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_4.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="08706a0434d504af130649d9fd74ca54">
+        <source><![CDATA[We wish to thank you for the trust you have placed in us and want to give you a discount of {amount}% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target><![CDATA[We wish to thank you for the trust you have placed in us and want to give you a discount of {amount}% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_4.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fe61da38922f840543c9f7a4f5dc8140">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></source>
+        <target><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/productoutofstock.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a36e5157843703cdad66073626eb54cb">
+        <source><![CDATA[You are advised to open the product&#039;s admin Product Page in order to replenish your inventory.]]></source>
+        <target><![CDATA[You are advised to open the product&#039;s admin Product Page in order to replenish your inventory.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productoutofstock.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="90e0a7c3c7230e2188794af89350ea7b">
+        <source><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:21</note>
+      </trans-unit>
+      <trans-unit id="eb7c04362c657d5651703a43307e61c2">
+        <source><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></source>
+        <target><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9607a6790558da43af7334b50dfb5354">
+        <source><![CDATA[Your friend <span><strong>{firstname} {lastname}</strong></span> wants to refer you on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target><![CDATA[Your friend <span><strong>{firstname} {lastname}</strong></span> wants to refer you on <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:21</note>
+      </trans-unit>
+      <trans-unit id="a234487df6f91f04f3d99a597681a4ac">
+        <source><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount}</strong></span> that you can use on your next order.]]></source>
+        <target><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount}</strong></span> that you can use on your next order.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:22</note>
+      </trans-unit>
+      <trans-unit id="99c81bae8075078e8af2bccbdd5e98b6">
+        <source><![CDATA[Get referred and earn a discount voucher of <span><strong>{discount}!</strong></span>]]></source>
+        <target><![CDATA[Get referred and earn a discount voucher of <span><strong>{discount}!</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:23</note>
+      </trans-unit>
+      <trans-unit id="36791224f527482e84d2ff30fbb3c699">
+        <source><![CDATA[It&#039;s very easy to sign up. Just click here!]]></source>
+        <target><![CDATA[It&#039;s very easy to sign up. Just click here!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:24</note>
+      </trans-unit>
+      <trans-unit id="edfb7a07b2d6386a1308f34c1a08aa0e">
+        <source><![CDATA[When signing up, don&#039;t forget to provide the e-mail address of your referring friend:]]></source>
+        <target><![CDATA[When signing up, don&#039;t forget to provide the e-mail address of your referring friend:]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:39</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/translations/default/EmailsSubject.xlf
+++ b/tests/Resources/translations/default/EmailsSubject.xlf
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/Customer.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32e8a8d9ed872f16d6dae0dc5fd4bb71">
+        <source>Your guest account has been transformed into a customer account</source>
+        <target>Your guest account has been transformed into a customer account</target>
+        <note>Line: 1144</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/PaymentModule.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fca7e8d1c86db11246e429e40aa10c81">
+        <source>New voucher for your order %s</source>
+        <target>New voucher for your order %s</target>
+        <note>Line: 1206</note>
+      </trans-unit>
+      <trans-unit id="fb077ecba55e5552916bde26d8b9e794">
+        <source>Order confirmation</source>
+        <target>Order confirmation</target>
+        <note>Line: 672</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/PrestaShopLogger.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="caedcb9e2005bf6e522cf4536a1885bd">
+        <source>Log: You have a new alert from your shop</source>
+        <target>Log: You have a new alert from your shop</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/form/CustomerPersister.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9a843f20677a52ca79af903123147af0">
+        <source>Welcome!</source>
+        <target>Welcome!</target>
+        <note>Line: 219</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderCarrier.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="87405e011a2c4166bb685336827fbe81">
+        <source>Package in transit</source>
+        <target>Package in transit</target>
+        <note>Line: 149</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderHistory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3cf100d3725155b75779945680651f3d">
+        <source>The virtual product that you bought is available for download</source>
+        <target>The virtual product that you bought is available for download</target>
+        <note>Line: 175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a218495ad30949e8ea1f64a261e37463">
+        <source>Import complete</source>
+        <target>Import complete</target>
+        <note>Line: 4894</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2328a3f139e31d53016f94ea9477124">
+        <source>Your order return status has changed</source>
+        <target>Your order return status has changed</target>
+        <note>Line: 264</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderDetailController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="381fc38b470ed543424afbd43f224453">
+        <source>Message from a customer</source>
+        <target>Message from a customer</target>
+        <note>Line: 110</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PasswordController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="61afad00abe3639b3ead655a1e8696d9">
+        <source>Password query confirmation</source>
+        <target>Password query confirmation</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="c5f4622e4a63b41e7c0ddc100583ee6b">
+        <source>Your new password</source>
+        <target>Your new password</target>
+        <note>Line: 200</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/contactform/contactform.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e03c4150db1c72add84ba520ee589aa">
+        <source>Message from contact form</source>
+        <target>Message from contact form</target>
+        <note>Line: 625</note>
+      </trans-unit>
+      <trans-unit id="55c19f9aec68a1a320cbeba663f1e4c0">
+        <source>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</source>
+        <target>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</target>
+        <note>Line: 654</note>
+      </trans-unit>
+      <trans-unit id="d40cb87db94e750405e7b20a8a043d81">
+        <source>Your message has been correctly sent</source>
+        <target>Your message has been correctly sent</target>
+        <note>Line: 660</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a95bc59685fb4546de3884a5fbe474ea">
+        <source>Newsletter voucher</source>
+        <target>Newsletter voucher</target>
+        <note>Line: 761</note>
+      </trans-unit>
+      <trans-unit id="efabbb0eb84d3c8e487a72e879953673">
+        <source>Newsletter confirmation</source>
+        <target>Newsletter confirmation</target>
+        <note>Line: 796</note>
+      </trans-unit>
+      <trans-unit id="732f1aa49f17856ff55a5aa0a88374d9">
+        <source>Email verification</source>
+        <target>Email verification</target>
+        <note>Line: 835</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cad374f43e79ca774b2e8e00dcd8b842">
+        <source>Process the payment of your order</source>
+        <target>Process the payment of your order</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/CustomerService/CommandHandler/AddOrderCustomerMessageHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="abe01af80b6bc9f1fa34feaa068336b2">
+        <source>New message regarding your order</source>
+        <target>New message regarding your order</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/CustomerService/CommandHandler/ForwardCustomerThreadHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f55e8d67e33d354a5273eb87c903980">
+        <source>Fwd: Customer message</source>
+        <target>Fwd: Customer message</target>
+        <note>Line: 174</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/CustomerService/CommandHandler/ReplyToCustomerThreadHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="26fabd8660373b86b9288dd72fd40e13">
+        <source>An answer to your message is available #ct%thread_id% #tc%thread_token%</source>
+        <target>An answer to your message is available #ct%thread_id% #tc%thread_token%</target>
+        <note>Line: 154</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Refund/OrderSlipCreator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10e7889bf2e6fd95e25936d2c11e92be">
+        <source>New credit slip regarding your order</source>
+        <target>New credit slip regarding your order</target>
+        <note>Line: 132</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Refund/VoucherGenerator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b360ddde7a5a70304c005e45e141cf9d">
+        <source>New voucher for your order #%s</source>
+        <target>New voucher for your order #%s</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/translations/default/messages.xlf
+++ b/tests/Resources/translations/default/messages.xlf
@@ -1,0 +1,2963 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="admin-dev/themes/default/template/controllers/attribute_generator/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="32aa6a8b290538b9af3531ea1e1a9dbf">
+        <source>Tax Excluded</source>
+        <target>Tax Excluded</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="8794a5dad880ed1a30d82081872b050e">
+        <source>Tax Included</source>
+        <target>Tax Included</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="181ba1a9e1a38f1a83277046cdbbc2bc">
+        <source>%d product(s) successfully created.</source>
+        <target>%d product(s) successfully created.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="81315cfd898aada1e99e0034b4b078c3">
+        <source>Attributes generator</source>
+        <target>Attributes generator</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="422f3f656e1a5f95e8b5cf7565d815b5">
+        <source>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</source>
+        <target>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="cfe938f78378cfd9739d4321cfa7ff78">
+        <source>You're currently generating combinations for the following product:</source>
+        <target>You're currently generating combinations for the following product:</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="31fd7663706f9829ba8e64b229df4e3f">
+        <source>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</source>
+        <target>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="928929ae9eb360f552df9c62c5fef6e2">
+        <source>Impact on the product price</source>
+        <target>Impact on the product price</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="2cbb96b1bb8e0942f609bba818277f7c">
+        <source>Impact on the product weight</source>
+        <target>Impact on the product weight</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="4e927d0c87a6edc742e9c664f18a53c7">
+        <source>Select a default quantity, and reference, for each combination the generator will create for this product.</source>
+        <target>Select a default quantity, and reference, for each combination the generator will create for this product.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="1b8bea6c0d2655c4e2c1070c9beee03a">
+        <source>Default Quantity:</source>
+        <target>Default Quantity:</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="49d079be0fc1fcccefdee6bdf67b02ff">
+        <source>Default Reference:</source>
+        <target>Default Reference:</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="fb6d5b178b6f3ce02379006b7610ed6d">
+        <source>Please click on "Generate these combinations".</source>
+        <target>Please click on "Generate these combinations".</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="e3c57b7da599fa0a9410c456b59f6dd3">
+        <source>Generate these combinations</source>
+        <target>Generate these combinations</target>
+        <note>Line: 139</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="62acf0bc057112bf91cd1ff9f1426c6c">
+        <source>[undefined]</source>
+        <target>[undefined]</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bcca39c6f36c3085c46429511614b227">
+        <source>If enabled, the voucher will not apply to products already on sale.</source>
+        <target>If enabled, the voucher will not apply to products already on sale.</target>
+        <note>Line: 145</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d6d9190e86f812c0490da9360e12cee1">
+        <source>Add a rule concerning</source>
+        <target>Add a rule concerning</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="c5536e008327e8873c8daf321a088873">
+        <source>The product(s) are matching one of these:</source>
+        <target>The product(s) are matching one of these:</target>
+        <note>Line: 65</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f14b582c1b0eab88ed5904fb781568c0">
+        <source>Discount name</source>
+        <target>Discount name</target>
+        <note>Line: 203</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1e65b02f3464a517e0946a46d496327c">
+        <source>Sync success</source>
+        <target>Sync success</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3d2e617335f08df83599665eef8a418">
+        <source>Close</source>
+        <target>Close</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3bf63a999cda6c9d95c3827e7942f41d">
+        <source>Customer since: %s</source>
+        <target>Customer since: %s</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="8df41ed5ebc778c45f74a201e822613a">
+        <source>Choose a template</source>
+        <target>Choose a template</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3">
+        <source>Send</source>
+        <target>Send</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="2605a817441c19cc88eb9e5d17845dc0">
+        <source>You can add a comment here.</source>
+        <target>You can add a comment here.</target>
+        <note>Line: 155</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d13d8380c3f4de07fef91a42fe6c60d7">
+        <source>Customer ID:</source>
+        <target>Customer ID:</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="d1228f5476d15142b1358ae4b5fa2454">
+        <source>Order #</source>
+        <target>Order #</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="c851a34d4806acb02a55df148f9d7f25">
+        <source>Product #</source>
+        <target>Product #</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="47a0be8d1015d526a1fbaa56c3102135">
+        <source>Subject:</source>
+        <target>Subject:</target>
+        <note>Line: 147</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d1554912e46f8d36a800ad8b604225f1">
+        <source>Valid orders:</source>
+        <target>Valid orders:</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="0c71153e10e4cca705c7de8625f23344">
+        <source>%firstname% %lastname% has not registered any addresses yet</source>
+        <target>%firstname% %lastname% has not registered any addresses yet</target>
+        <note>Line: 654</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="908f8d9f34f375a55dd5b6a86489d364">
+        <source>No result</source>
+        <target>No result</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="37a502907cd750af8c65517a75d00030">
+        <source>Real Time</source>
+        <target>Real Time</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a1e7379abfdbc3b8e03506e5489c6110">
+        <source>Discount:</source>
+        <target>Discount:</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d">
+        <source>Download</source>
+        <target>Download</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="3bb4a695db0c87a3d70a2deffddeb743">
+        <source>Read more about the CSV format at:</source>
+        <target>Read more about the CSV format at:</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b">
+        <source>or</source>
+        <target>or</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="e4cdcd51e6cf787d4ecc7d813f0c23cb">
+        <source>The locale must be installed</source>
+        <target>The locale must be installed</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="e08caeac3f80ffa7889cdf1c8f30111f">
+        <source>Multiple value separator</source>
+        <target>Multiple value separator</target>
+        <note>Line: 208</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5f613cee6c941423b73e1f87ea3b99bc">
+        <source>Please name your data matching configuration in order to save it.</source>
+        <target>Please name your data matching configuration in order to save it.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="43a37c093f7655efe882a7ffd7ce2e8d">
+        <source>Match your data</source>
+        <target>Match your data</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="e275f3b49dc3286ef66d7c2774a1f79b">
+        <source>Please match each column of your source file to one of the destination columns.</source>
+        <target>Please match each column of your source file to one of the destination columns.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="4d83ebfaf28dd4436e1165a1764750db">
+        <source>Load a data matching configuration</source>
+        <target>Load a data matching configuration</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="f19dbf2edb3a0bd74b0524d960ff21eb">
+        <source>Load</source>
+        <target>Load</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="e195639ebd7491676218b40af7aeafe3">
+        <source>Save your data matching configuration</source>
+        <target>Save your data matching configuration</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="371ed088d2c0e456f5cae0bb97fe7c4b">
+        <source>Two columns cannot have the same type of values</source>
+        <target>Two columns cannot have the same type of values</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="6a00e03023004b3330275e8d9842b54c">
+        <source>This column must be set:</source>
+        <target>This column must be set:</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="3b057f0f92ac8d274701c269ac00c5fa">
+        <source>Rows to skip</source>
+        <target>Rows to skip</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="225ba2bdb1c56af16651110411fc21b1">
+        <source>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</source>
+        <target>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/login/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dc647eb65e6711e155375218212b3964">
+        <source>Password</source>
+        <target>Password</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="685de99eb748aa2bba879a87af2ffed4">
+        <source>Your password has been successfully changed.</source>
+        <target>Your password has been successfully changed.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0071aa279bd1583754a544277740f047">
+        <source>Delete item #</source>
+        <target>Delete item #</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/ad_bar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4df29b3cd68e3d8e40be0ad31188f17c">
+        <source>You might be interested in</source>
+        <target>You might be interested in</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="deccbe4e9083c3b5f7cd2632722765bb">
+        <source>Translate</source>
+        <target>Translate</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="06933067aafd48425d67bcb01bba5cb6">
+        <source>Update</source>
+        <target>Update</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="c439b45b0a80369402e0d6158b55590f">
+        <source>Generate RTL Stylesheets</source>
+        <target>Generate RTL Stylesheets</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="53103fcc4656f55c219b600ded3c7438">
+        <source>Manage hooks</source>
+        <target>Manage hooks</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="a27dfe771799a09fd55fea73286eb6ab">
+        <source>Uninstall</source>
+        <target>Uninstall</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/content-legacy.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fe6b7985acf4b17efbfe1b38545299d9">
+        <source>See all modules</source>
+        <target>See all modules</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="4181fcfe54e8fadc0644e1cadde3483f">
+        <source>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</source>
+        <target>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="82010160301993d2d752d8f185b31d0c">
+        <source>Can I add my own modules?</source>
+        <target>Can I add my own modules?</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="bb2ee5b5f12b6eae3c1716d26cddeab7">
+        <source>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</source>
+        <target>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="95e3873b64426add2f3818e6a98dc9fb">
+        <source>Search on PrestaShop Marketplace:</source>
+        <target>Search on PrestaShop Marketplace:</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="3a2d5fe857d8f9541136a124c2edec6c">
+        <source>Or</source>
+        <target>Or</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/favorites.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42">
+        <source>Module</source>
+        <target>Module</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="7e4a9cd054588a95b0394d92a2030e72">
+        <source>Normal view</source>
+        <target>Normal view</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="d7af23f5f349f2c4eace4927943b2760">
+        <source>Favorites view</source>
+        <target>Favorites view</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="5c6ba25104401c9ee0650230fc6ba413">
+        <source>Tab</source>
+        <target>Tab</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="920beb5dda21b04a332e0457cb0cfbec">
+        <source>Interest</source>
+        <target>Interest</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="01165dcf77c191e6c69b31d98b0ec6ff">
+        <source>Favorite</source>
+        <target>Favorite</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3182ea023795eb83ed0ce3beea5beb73">
+        <source>Other Modules</source>
+        <target>Other Modules</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="d9e87fc7a13ba398295447791c67b586">
+        <source>Installed Modules</source>
+        <target>Installed Modules</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="a0f454ebaee933c7791ffcdda76944b3">
+        <source>Disabled Modules</source>
+        <target>Disabled Modules</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="1f0e9c979b965d24aa3c2c4b832c3ba1">
+        <source>Filter by</source>
+        <target>Filter by</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="7b4d2812164df0dceca0b53bb650e52d">
+        <source><![CDATA[Installed & Not Installed]]></source>
+        <target><![CDATA[Installed & Not Installed]]></target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="94c8dec8d2fcfa80c9b6f4669be43eb0">
+        <source>Modules Not Installed </source>
+        <target>Modules Not Installed </target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="6b8f34307b46c249a91d84e52ae94caf">
+        <source><![CDATA[Enabled & Disabled]]></source>
+        <target><![CDATA[Enabled & Disabled]]></target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="dfe6e46e2d3e3ba76b5d9aee197c0747">
+        <source>Enabled Modules</source>
+        <target>Enabled Modules</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="02684cc6b6ea1811a064f475a5fd1d18">
+        <source>Authors</source>
+        <target>Authors</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="00c3388449f7c4d73cc8c417d7d38554">
+        <source>All Modules</source>
+        <target>All Modules</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="d546df356f9b15d6d20b1e5d8b310fed">
+        <source>Free Modules</source>
+        <target>Free Modules</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="d071f451a57ab54fa6890d0f501a99d4">
+        <source>Partner Modules (Free)</source>
+        <target>Partner Modules (Free)</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="02ae741da806bbeafc0ae6a84ce752d3">
+        <source>Must Have</source>
+        <target>Must Have</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="174704dbe8a3a7d144b0ce840e734077">
+        <source>Modules purchased on Addons</source>
+        <target>Modules purchased on Addons</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="fbdc9a432c8e6a94bb54864ae4f5fb7f">
+        <source>All authors</source>
+        <target>All authors</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="c3987e4cac14a8456515f0d200da04ee">
+        <source>All countries</source>
+        <target>All countries</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="d188407e1d066cd41925efebe2dab3da">
+        <source>Current country:</source>
+        <target>Current country:</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/js.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="45e06e5610d29d675a875a6f7731b73d">
+        <source>Would you like to delete the content related to this module ?</source>
+        <target>Would you like to delete the content related to this module ?</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c0d19e251d0ff55ecb860e7349f779a4">
+        <source>Confirm reset</source>
+        <target>Confirm reset</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d65c99010166606287266e4af4f0b934">
+        <source>No - reset only the parameters</source>
+        <target>No - reset only the parameters</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="0426ba52f94430cf093652d1ea18fedf">
+        <source>Yes - reset everything</source>
+        <target>Yes - reset everything</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="25b22a00db3085743f478140b8281a26">
+        <source>Preferences saved</source>
+        <target>Preferences saved</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f9b5fa08f2ef86fdc5d0ceefc271981">
+        <source>Remove from Favorites</source>
+        <target>Remove from Favorites</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="7263f59f5d8aeaf7d2117fcd4b70930a">
+        <source>Mark as Favorite</source>
+        <target>Mark as Favorite</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="59fcbc24a474d290fa540a3a27e2ff05">
+        <source>Module %1s </source>
+        <target>Module %1s </target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="3846bafee4cc9ce49c24a0b499d3e08d">
+        <source>Official, PrestaShop certified module. Free, secure and includes updates!</source>
+        <target>Official, PrestaShop certified module. Free, secure and includes updates!</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="52dd3893c24e9cf4be761dcaee6bea39">
+        <source>Update it!</source>
+        <target>Update it!</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="29c632cf1c7f140b6e86f3af04df48d4">
+        <source>Install the selection</source>
+        <target>Install the selection</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="7245ac07bbd56e6d0f7489a7dddb836f">
+        <source>Uninstall the selection</source>
+        <target>Uninstall the selection</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="df3f079de6961496f0460dcfdbf9bca3">
+        <source>by</source>
+        <target>by</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="ba6b1bc4d8bfe5e6e835afa72f102a02">
+        <source>You bought this module on PrestaShop Addons. Thank You.</source>
+        <target>You bought this module on PrestaShop Addons. Thank You.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="fe5a7fc9d9c907efdf6a384a71cd53fc">
+        <source>Bought</source>
+        <target>Bought</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="0461779839539a8ee8fb2dca43cf5bec">
+        <source>This module is available on PrestaShop Addons</source>
+        <target>This module is available on PrestaShop Addons</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="2cc1943d4c0b46bfcf503a75c44f988b">
+        <source>Popular</source>
+        <target>Popular</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="0008feba81a131902ece95d59f1b8f21">
+        <source>Official</source>
+        <target>Official</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="28f60d4760851bab00345a3cb86871f7">
+        <source>Need update</source>
+        <target>Need update</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594">
+        <source>Free</source>
+        <target>Free</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="43340e6cc4e88197d57f8d6d5ea50a46">
+        <source>Read more</source>
+        <target>Read more</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="349838fb1d851d3e2014b9fe39203275">
+        <source>Install</source>
+        <target>Install</target>
+        <note>Line: 115</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/login_addons.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ee0e3cf3fd1a733924756c6534826843">
+        <source>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</source>
+        <target>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="c84172ea13aaad319bfb3324c8fda5ed">
+        <source>Enable PHP's allow_url_fopen setting</source>
+        <target>Enable PHP's allow_url_fopen setting</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="27d8cabeab5ec86130d0e9048a085b57">
+        <source>Enable PHP's OpenSSL extension</source>
+        <target>Enable PHP's OpenSSL extension</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="40218c0320e986d6b29fde4259ac43c2">
+        <source>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</source>
+        <target>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="a5f61298da21626d0f490ebd06ecd811">
+        <source>Don't have an account?</source>
+        <target>Don't have an account?</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="030547d47b4cb2e88a3c9a581a61487a">
+        <source>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</source>
+        <target>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="74ec9ffc8d108924d191065b416d8544">
+        <source>Connect to PrestaShop Addons</source>
+        <target>Connect to PrestaShop Addons</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="b05d72142020283dc6812fd3a9bc691c">
+        <source>I forgot my password</source>
+        <target>I forgot my password</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="2fe4fe0a0ebea41ce43eb3dc3fce4ea3">
+        <source>Create an Account</source>
+        <target>Create an Account</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5">
+        <source>Sign in</source>
+        <target>Sign in</target>
+        <note>Line: 80</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5724be5bf0b6c384f8f0e4ec5c56960e">
+        <source>What Should I Do?</source>
+        <target>What Should I Do?</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="34afcb42ab73990082d328d9b34811b5">
+        <source>Proceed with the installation</source>
+        <target>Proceed with the installation</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9c4573ad0738d689dcb4dfb11ea6ce5a">
+        <source>Do you want to install this module that could not be verified by PrestaShop?</source>
+        <target>Do you want to install this module that could not be verified by PrestaShop?</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="cff96407d828626ba1219454e9dde40c">
+        <source>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</source>
+        <target>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="cb6c308b881809f8ab33d50efad0b665">
+        <source>What's the risk?</source>
+        <target>What's the risk?</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="b1c3bf188b7df9285d57df41f00c7041">
+        <source>Am I at Risk?</source>
+        <target>Am I at Risk?</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="144f70b53defb91dacdb0a4ac79b7e70">
+        <source>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</source>
+        <target>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="50d39ed39f0e1c95d185acc6b89de6f8">
+        <source>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</source>
+        <target>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="9bbcbf7c1f7c1df3c3d9d3b7767fac09">
+        <source>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</source>
+        <target>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="67afee0d8b56356469f89525a1423331">
+        <source>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</source>
+        <target>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f">
+        <source>Back</source>
+        <target>Back</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e88e176e72b122566ada523a7297e4e5">
+        <source>This module could not be verified by PrestaShop.</source>
+        <target>This module could not be verified by PrestaShop.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d16d7b2c414d4750596290776d0bfbf7">
+        <source>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</source>
+        <target>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="64b9168c0ef9c05d1568a15c6e273bf1">
+        <source>You can search for similar modules on the official marketplace.</source>
+        <target>You can search for similar modules on the official marketplace.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="57acfffeede560e141ea67a4487fe065">
+        <source>[1]Click here to browse our catalog on PrestaShop Addons[/1].</source>
+        <target>[1]Click here to browse our catalog on PrestaShop Addons[/1].</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6754e4799f554bcdf4fef4782bf4d7de">
+        <source>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</source>
+        <target>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="a517747c3d12f99244ae598910d979c5">
+        <source>Author</source>
+        <target>Author</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="249212ebba2907c6087887db076179e6">
+        <source>Back to modules list</source>
+        <target>Back to modules list</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="54752f2f929b686b98ddb16e40c4a1be">
+        <source>You are about to install "%s", a module which is not compatible with your country.</source>
+        <target>You are about to install "%s", a module which is not compatible with your country.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="1a56544ab8d473b3383731fbe3fc9d07">
+        <source>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</source>
+        <target>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="d1ce387d44c3dc9cdc4e30ad64dbf47e">
+        <source>Use at your own risk.</source>
+        <target>Use at your own risk.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="080e6f65e34e2ffe7162beb258f4577d">
+        <source>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</source>
+        <target>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="17e8aa9ff6f7c374738eb3a15270583c">
+        <source>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</source>
+        <target>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="1de1cd538749db5ea85a79c300b092e3">
+        <source>If you are unsure about this module, you can look for similar modules on the official marketplace.</source>
+        <target>If you are unsure about this module, you can look for similar modules on the official marketplace.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="f7df37601ea653a7a5bf63e3556772d3">
+        <source>Click here to browse PrestaShop Addons.</source>
+        <target>Click here to browse PrestaShop Addons.</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_translation.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1311e5ddedf25a4f6cd6059cbf04c21e">
+        <source>Manage translations</source>
+        <target>Manage translations</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/page.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b10a51e4d433fa3330b26d266502db00">
+        <source>Addons membership provides access to all our PrestaShop modules.</source>
+        <target>Addons membership provides access to all our PrestaShop modules.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="20afba9e56de0c1da3d5188111d72947">
+        <source>Once connected, your new modules will be automatically installed.</source>
+        <target>Once connected, your new modules will be automatically installed.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="d9776f0775997b2e698c6975420b5c5d">
+        <source>Sign up</source>
+        <target>Sign up</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bce8bac0184c6cd6d977e8a42a99aa99">
+        <source>Connect to PrestaShop Marketplace account</source>
+        <target>Connect to PrestaShop Marketplace account</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911">
+        <source>Log in</source>
+        <target>Log in</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="6dc2462f2851bdac265c852f023b6d3f">
+        <source>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</source>
+        <target>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="6779ef184c16fbd18a0bc13ebda839c5">
+        <source>Upload a module from your computer.</source>
+        <target>Upload a module from your computer.</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="5b48d0f5735d2f9b73a8f3ec7c4858ba">
+        <source>Module file</source>
+        <target>Module file</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb">
+        <source>Choose a file</source>
+        <target>Choose a file</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="8634e049945e0e8562673698a1abb485">
+        <source>Upload this module</source>
+        <target>Upload this module</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="f2063dc3ff5945f5bf0c430da46e1109">
+        <source>An upgrade is available for some of your modules!</source>
+        <target>An upgrade is available for some of your modules!</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d78986947356ddd37b43d57df289dee9">
+        <source>Favorites</source>
+        <target>Favorites</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680">
+        <source>All</source>
+        <target>All</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="96e36efe70e72835ae51946e2650f9e7">
+        <source>Add a new module</source>
+        <target>Add a new module</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="28080c3603fb7e10f228381b181cae2c">
+        <source>List of modules</source>
+        <target>List of modules</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="71803586f945801418d03befeb4acd99">
+        <source>Update all</source>
+        <target>Update all</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="a3105b7aa9edb1c07765bfdcdc2405b8">
+        <source>Check for update</source>
+        <target>Check for update</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="6a26f548831e6a8c26bfbbd9f6ec61e0">
+        <source>Help</source>
+        <target>Help</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/readmore-body.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3424c86a3f3fdfcff4d8f310912ee82b">
+        <source>(%s votes)</source>
+        <target>(%s votes)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="268cb3857932e260b03bf1334220f3bc">
+        <source>(%s vote)</source>
+        <target>(%s vote)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
+        <source>Description</source>
+        <target>Description</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="7a66d21cf5a4354933980f6d79ec78a4">
+        <source>Merchant benefits</source>
+        <target>Merchant benefits</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="8530d0ebaf22889c1b42061824f3769b">
+        <source>Install module</source>
+        <target>Install module</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="a6642661dcfc0e354c61f4e8b8b9ec5a">
+        <source>View on PrestaShop Addons</source>
+        <target>View on PrestaShop Addons</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/readmore-header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e3669d19b675bd57058fd4664205d2a">
+        <source>v</source>
+        <target>v</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f248df0d4d7e4ae98485c5df8af58945">
+        <source>This module is available for free thanks to our partner.</source>
+        <target>This module is available for free thanks to our partner.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ddd8eef6f86868a07f62b0e3810711f0">
+        <source>Not Installed</source>
+        <target>Not Installed</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="98dd43dfae05b11befe1f140e0ec787a">
+        <source>Installed</source>
+        <target>Installed</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="4d2fa24347806e2bcc9925a040f78382">
+        <source>More modules on addons.prestashop.com</source>
+        <target>More modules on addons.prestashop.com</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="83057027f6b988dd2dbe422f6f3ddd21">
+        <source>No module was found for this hook.</source>
+        <target>No module was found for this hook.</target>
+        <note>Line: 161</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/not_found/content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="efc54df619cd3792c98805fba1ee5ff7">
+        <source>The controller %s is missing or invalid.</source>
+        <target>The controller %s is missing or invalid.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="9178de10abf6a1368e7a73ec0adb0e8e">
+        <source>Back to the previous page</source>
+        <target>Back to the previous page</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="585c732d00a27a32cd9585fe481964cf">
+        <source>Go to the dashboard</source>
+        <target>Go to the dashboard</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="585bc67adbb73dcca638b897fb73a900">
+        <source>See the document</source>
+        <target>See the document</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="8b3e7bc0ed634c2bc8ac54a4cc2e781f">
+        <source>Set payment form</source>
+        <target>Set payment form</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="50cd1871f950375eef4e2efce35366c6">
+        <source>Add note</source>
+        <target>Add note</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="71e2851d86b252a44c658b896c486921">
+        <source>Edit note</source>
+        <target>Edit note</target>
+        <note>Line: 121</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa52110dbfce51cc1ec8a163264151e2">
+        <source>Existing</source>
+        <target>Existing</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
+        <source>New</source>
+        <target>New</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a6361d40d23154d7d8fc801ae8bf9554">
+        <source>%refund_date% - %refund_amount%</source>
+        <target>%refund_date% - %refund_amount%</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="26b26b0e309da0b8abbf624a57601f4c">
+        <source>%return_date% - %return_quantity% - %return_state%</source>
+        <target>%return_date% - %return_quantity% - %return_state%</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="3d0d1f906e27800531e054a3b6787b7c">
+        <source>Quantity:</source>
+        <target>Quantity:</target>
+        <note>Line: 175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7315d80cbbbb36fdcd92ba46a6384eff">
+        <source>Show carts and orders for this customer.</source>
+        <target>Show carts and orders for this customer.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="1e504df905c966d01e09188c5ebd451f">
+        <source>Hide carts and orders for this customer.</source>
+        <target>Hide carts and orders for this customer.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9">
+        <source>Change</source>
+        <target>Change</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a">
+        <source>Gift</source>
+        <target>Gift</target>
+        <note>Line: 777</note>
+      </trans-unit>
+      <trans-unit id="c78ba40a94a132dc170cba2f8c66f310">
+        <source>Search for an existing product by typing the first letters of its name.</source>
+        <target>Search for an existing product by typing the first letters of its name.</target>
+        <note>Line: 1214</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="730224c4825ae2c174f4cdaff321520e">
+        <source>Transform a guest into a customer</source>
+        <target>Transform a guest into a customer</target>
+        <note>Line: 599</note>
+      </trans-unit>
+      <trans-unit id="e5bd639f4d74cf2c52afada77086f788">
+        <source>Process a standard refund</source>
+        <target>Process a standard refund</target>
+        <note>Line: 906</note>
+      </trans-unit>
+      <trans-unit id="c4b689eeebf8e942907a1cc1d086dba6">
+        <source>Process a partial refund</source>
+        <target>Process a partial refund</target>
+        <note>Line: 907</note>
+      </trans-unit>
+      <trans-unit id="cc61945cbbf46721a053467c395c666f">
+        <source>Refunded</source>
+        <target>Refunded</target>
+        <note>Line: 935</note>
+      </trans-unit>
+      <trans-unit id="6a5efd211a422296eab4adc476c98f0e">
+        <source>Return products</source>
+        <target>Return products</target>
+        <note>Line: 1200</note>
+      </trans-unit>
+      <trans-unit id="74c06eb18eeb118d7b3c623d0c717290">
+        <source>Refund products</source>
+        <target>Refund products</target>
+        <note>Line: 1200</note>
+      </trans-unit>
+      <trans-unit id="4b8def9be8f45a8d6baea36b26868965">
+        <source>Cancel products</source>
+        <target>Cancel products</target>
+        <note>Line: 1200</note>
+      </trans-unit>
+      <trans-unit id="867343577fa1f33caa632a19543bd252">
+        <source>Keywords</source>
+        <target>Keywords</target>
+        <note>Line: 1269</note>
+      </trans-unit>
+      <trans-unit id="6416e8cb5fc0a208d94fa7f5a300dbc4">
+        <source>Warehouse</source>
+        <target>Warehouse</target>
+        <note>Line: 934</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f2bbdf9f72c085adc4d0404e370f0f4c">
+        <source>Attribute</source>
+        <target>Attribute</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e9cb217697088a98b1937d111d936281">
+        <source>Attachment</source>
+        <target>Attachment</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873">
+        <source>Category</source>
+        <target>Category</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 251</note>
+      </trans-unit>
+      <trans-unit id="ec136b444eede3bc85639fac0dd06229">
+        <source>Supplier</source>
+        <target>Supplier</target>
+        <note>Line: 262</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="38f06ccd27281c8fc66e11581798ec06">
+        <source>Number of products:</source>
+        <target>Number of products:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="df644ae155e79abf54175bd15d75f363">
+        <source>Product name</source>
+        <target>Product name</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="1caa6ff629641a4eb20f190f7a0539ca">
+        <source>Attribute name</source>
+        <target>Attribute name</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="bc67a1507258a758c3a31e66d7ceff8f">
+        <source>Supplier Reference</source>
+        <target>Supplier Reference</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="c804723ccdde3d7a46933b208c6f928d">
+        <source>Wholesale price</source>
+        <target>Wholesale price</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b">
+        <source>EAN13</source>
+        <target>EAN13</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065">
+        <source>UPC</source>
+        <target>UPC</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="c8c5918f1175c1296d19755b2f49d1c9">
+        <source>Available Quantity</source>
+        <target>Available Quantity</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="382b0f5185773fa0f67a8ed8056c7759">
+        <source>N/A</source>
+        <target>N/A</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ebd9bec4d70abc789d439c1f136b0538">
+        <source>Layout</source>
+        <target>Layout</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1beaf22ea4850d25af342d91b0f25624">
+        <source>See all themes</source>
+        <target>See all themes</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="ae0e265c94eec2c38690ada171d60a4d">
+        <source>Add a new theme</source>
+        <target>Add a new theme</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="26a278c1e0598e21f7c1ed7ab113e6ac">
+        <source>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</source>
+        <target>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="a5ed2b9ca9427746aced5b4037560434">
+        <source>You can choose among 1,500+ professional templates!</source>
+        <target>You can choose among 1,500+ professional templates!</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="dc9ac2e66cddf6e2c64e1c72b18ae130">
+        <source>Can I add my own theme?</source>
+        <target>Can I add my own theme?</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="7c854ab311760ecb245fb938378cd4e9">
+        <source>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</source>
+        <target>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="80bf7b97a380d8d8aa29993fa61ab5e5">
+        <source>You can also create a new theme below.</source>
+        <target>You can also create a new theme below.</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f0dbca7d922e4e759a1e3b512b9be852">
+        <source>Choose layouts</source>
+        <target>Choose layouts</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="b6ba229b668e5a7b6700e4d275683084">
+        <source>Use this theme</source>
+        <target>Use this theme</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="e169a8fe61809e3679a424bf27166a78">
+        <source>Delete this theme</source>
+        <target>Delete this theme</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="837a54ae4874c4501c804173cd3c0fdf">
+        <source>Designed by %s</source>
+        <target>Designed by %s</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="8ef656f84513928ea1b0c2f1735b62e9">
+        <source>Configure your page layouts</source>
+        <target>Configure your page layouts</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="4459ae4e873177642b30e9fc8b821d2f">
+        <source>Each page can use a different layout, choose it among the layouts bundled in your theme.</source>
+        <target>Each page can use a different layout, choose it among the layouts bundled in your theme.</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="21e2bb42873eddcb9b476b8eafbe0c18">
+        <source>Reset to defaults</source>
+        <target>Reset to defaults</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f1246f9ac6a7094789c17068713ebfe6">
+        <source>The "%1$s" theme has been successfully installed.</source>
+        <target>The "%1$s" theme has been successfully installed.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="623a0df3a4b9fcca8e08c9ed1a07bba1">
+        <source>The following module(s) were not installed properly:</source>
+        <target>The following module(s) were not installed properly:</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="940d7a8d6502a022e8eb2d8a090b1a05">
+        <source>Warning: You may have to regenerate images to fit with this new theme.</source>
+        <target>Warning: You may have to regenerate images to fit with this new theme.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="aedd6903868a8d6c7b01e0754fb56336">
+        <source>Go to the thumbnails regeneration page</source>
+        <target>Go to the thumbnails regeneration page</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="ce72a3420348d5b0bcd1382b1c88f553">
+        <source>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</source>
+        <target>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="3b90370ac32dead2af37eabe3bdbb97f">
+        <source>Name image type:</source>
+        <target>Name image type:</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="c6ec097a1c02ee4db0dda78b98f4c08c">
+        <source>(width: %1$spx, height: %2$spx).</source>
+        <target>(width: %1$spx, height: %2$spx).</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="8f1cda3b6ae2df7c2c152cfeffaea57a">
+        <source>Images have been correctly updated in the database:</source>
+        <target>Images have been correctly updated in the database:</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="a20ddccbb6f808ec42cd66323e6c6061">
+        <source>Finish</source>
+        <target>Finish</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bbfb7a636f839052067cc86c39fa595a">
+        <source>%limit% for suhosin.post.max_vars.</source>
+        <target>%limit% for suhosin.post.max_vars.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="e97da54b23c78752578cd7fa01e8866d">
+        <source>%limit% for suhosin.request.max_vars.</source>
+        <target>%limit% for suhosin.request.max_vars.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="f324bbd9de83d61ccb5f7d5593aec5b3">
+        <source>You MUST use this syntax in your translations. Here are several examples:</source>
+        <target>You MUST use this syntax in your translations. Here are several examples:</target>
+        <note>Line: 86</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a7bd935a88c629dc11c52e0c16c2a8a0">
+        <source>%d</source>
+        <target>%d</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="be8545ae7ab0276e15898aae7acfbd7a">
+        <source>Resource</source>
+        <target>Resource</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/calendar/calendar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="08ee10c9fa141c53ae44667dcc1adf1e">
+        <source>Date range</source>
+        <target>Date range</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="90589c47f06eb971d548591f23c285af">
+        <source>Custom</source>
+        <target>Custom</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="01b6e20344b68835c5ed1ddedf20d531">
+        <source>to</source>
+        <target>to</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="0c031866121d4fc6d21d0f524d0091e4">
+        <source>Compare to</source>
+        <target>Compare to</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="97bf2dbc7a13706eeb1eac149bd2d130">
+        <source>Previous period</source>
+        <target>Previous period</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="635f2145a06da2d4ce2c355bf94da6ed">
+        <source>Previous Year</source>
+        <target>Previous Year</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="3ca6ac2463aa0dc57452cf676723b79f">
+        <source>Previous year</source>
+        <target>Previous year</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177">
+        <source>Sunday</source>
+        <target>Sunday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6">
+        <source>Monday</source>
+        <target>Monday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="5792315f09a5d54fb7e3d066672b507f">
+        <source>Tuesday</source>
+        <target>Tuesday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="796c163589f295373e171842f37265d5">
+        <source>Wednesday</source>
+        <target>Wednesday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="78ae6f0cd191d25147e252dc54768238">
+        <source>Thursday</source>
+        <target>Thursday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4">
+        <source>Friday</source>
+        <target>Friday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc">
+        <source>Saturday</source>
+        <target>Saturday</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="ef6572e4cd58bb39a3f4e82fc64fe9f0">
+        <source>Sun</source>
+        <target>Sun</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="fd29458ae58ac32a2d8734ed90ad51ec">
+        <source>Mon</source>
+        <target>Mon</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="2ddecde85408faf230652444db78cb72">
+        <source>Tue</source>
+        <target>Tue</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="510c292b1686eb070d9e90a575f74106">
+        <source>Wed</source>
+        <target>Wed</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="ed5e8353dfc585f4c6b3a55d1a9fc01d">
+        <source>Thu</source>
+        <target>Thu</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="ac616f844b9a5ea5a827bf7fb99b1ad5">
+        <source>Fri</source>
+        <target>Fri</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="13c7d2d737f81f7bf89aed9fbcd0ad55">
+        <source>Sat</source>
+        <target>Sat</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="f72c915d8f575a5c0999b5f37b6d99b7">
+        <source>Su</source>
+        <target>Su</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="c08df9bb5fb44242a6291b1eee5d09ad">
+        <source>Mo</source>
+        <target>Mo</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="080502c4fa636ac639bf42b6d2ba01d7">
+        <source>Tu</source>
+        <target>Tu</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="485c47a81eb6e3998ec05aca48eda184">
+        <source>We</source>
+        <target>We</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="eeeb9a8eb45dd351d9ec0eb4acce66ce">
+        <source>Th</source>
+        <target>Th</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="fa717ba17306cd76900510df8ac8013e">
+        <source>Fr</source>
+        <target>Fr</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="e55bb1ae59b6a64858a85a2f48c53036">
+        <source>Sa</source>
+        <target>Sa</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="86f5978d9b80124f509bdb71786e929e">
+        <source>January</source>
+        <target>January</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="659e59f062c75f81259d22786d6c44aa">
+        <source>February</source>
+        <target>February</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="fa3e5edac607a88d8fd7ecb9d6d67424">
+        <source>March</source>
+        <target>March</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="3fcf026bbfffb63fb24b8de9d0446949">
+        <source>April</source>
+        <target>April</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="195fbb57ffe7449796d23466085ce6d8">
+        <source>May</source>
+        <target>May</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="688937ccaf2a2b0c45a1c9bbba09698d">
+        <source>June</source>
+        <target>June</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="1b539f6f34e8503c97f6d3421346b63c">
+        <source>July</source>
+        <target>July</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="41ba70891fb6f39327d8ccb9b1dafb84">
+        <source>August</source>
+        <target>August</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="cc5d90569e1c8313c2b1c2aab1401174">
+        <source>September</source>
+        <target>September</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="eca60ae8611369fe28a02e2ab8c5d12e">
+        <source>October</source>
+        <target>October</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="7e823b37564da492ca1629b4732289a8">
+        <source>November</source>
+        <target>November</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="82331503174acbae012b2004f6431fa5">
+        <source>December</source>
+        <target>December</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="e68564f23e0e939acea76dc3d2bc01bf">
+        <source>Jan</source>
+        <target>Jan</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="ea171d540ccd5f0669171ef06d3cd848">
+        <source>Feb</source>
+        <target>Feb</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="7ce6b2286a5396e614b8484105d277e0">
+        <source>Mar</source>
+        <target>Mar</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="6d7215c4b3bc4716d026ac46c6d9ae64">
+        <source>Apr</source>
+        <target>Apr</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="e7f8f5c51fe3a6d48a79c6ede9112b7a">
+        <source>May </source>
+        <target>May </target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="eb4b40c1221dad5b23fe7ef84d292be1">
+        <source>Jun</source>
+        <target>Jun</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="a2866cd6efaa65c92278d4771a9eaec7">
+        <source>Jul</source>
+        <target>Jul</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="22f1a4667604b8557c9b209c201b4bc6">
+        <source>Aug</source>
+        <target>Aug</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="f04aa7019c490474fa3ce16e93501b57">
+        <source>Sep</source>
+        <target>Sep</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="594be08882c8e9d5efb9eeb62f303744">
+        <source>Oct</source>
+        <target>Oct</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="343e6957be77c6247aa2b8d0deb68bd6">
+        <source>Nov</source>
+        <target>Nov</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="d207b4e0bce42a8f1555ce3a05e287f6">
+        <source>Dec</source>
+        <target>Dec</target>
+        <note>Line: 117</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/dataviz/graph.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88">
+        <source>Customers</source>
+        <target>Customers</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc">
+        <source>Orders</source>
+        <target>Orders</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="1f08d08fd864b99cbeebd88b9a0784a7">
+        <source>Income</source>
+        <target>Income</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4">
+        <source>Message</source>
+        <target>Message</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="e7935ae6c516d89405ec532359d2d75a">
+        <source>Traffic</source>
+        <target>Traffic</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="3bb1503332637805beddb73a2dd1fe1b">
+        <source>Conversion</source>
+        <target>Conversion</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/assoshop.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1aa4c641d6920ddb97a2562f8ec53853">
+        <source>Group:</source>
+        <target>Group:</target>
+        <note>Line: 99</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2efd89b3ccc76b0b03a34196fc6d1c8b">
+        <source>Add tag</source>
+        <target>Add tag</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="1063e38cb53d94d386f21227fcd84717">
+        <source>Remove</source>
+        <target>Remove</target>
+        <note>Line: 329</note>
+      </trans-unit>
+      <trans-unit id="26ce1315d2bff025e8fb8a0c6259e58c">
+        <source>Change password...</source>
+        <target>Change password...</target>
+        <note>Line: 525</note>
+      </trans-unit>
+      <trans-unit id="d9c2d86a66aa5a45326c3757f3a272cc">
+        <source>Current password</source>
+        <target>Current password</target>
+        <note>Line: 530</note>
+      </trans-unit>
+      <trans-unit id="98a6ee4b0f0e346c15ab21a289165a2d">
+        <source>Password should be at least 8 characters long.</source>
+        <target>Password should be at least 8 characters long.</target>
+        <note>Line: 544</note>
+      </trans-unit>
+      <trans-unit id="3544848f820b9d94a3f3871a382cf138">
+        <source>New password</source>
+        <target>New password</target>
+        <note>Line: 545</note>
+      </trans-unit>
+      <trans-unit id="4c231e0da3eaaa6a9752174f7f9cfb31">
+        <source>Confirm password</source>
+        <target>Confirm password</target>
+        <note>Line: 560</note>
+      </trans-unit>
+      <trans-unit id="2871afea416378d2772937c4d67d6c2c">
+        <source>Generate password</source>
+        <target>Generate password</target>
+        <note>Line: 576</note>
+      </trans-unit>
+      <trans-unit id="4bbb8f967da6d1a610596d7257179c2b">
+        <source>Invalid</source>
+        <target>Invalid</target>
+        <note>Line: 601</note>
+      </trans-unit>
+      <trans-unit id="26b63f278101527e06a5547719568bb5">
+        <source>Okay</source>
+        <target>Okay</target>
+        <note>Line: 602</note>
+      </trans-unit>
+      <trans-unit id="0c6ad70beb3a7e76c3fc7adab7c46acc">
+        <source>Good</source>
+        <target>Good</target>
+        <note>Line: 603</note>
+      </trans-unit>
+      <trans-unit id="b8dc7c80939667637db7ac31ece215b9">
+        <source>Fabulous</source>
+        <target>Fabulous</target>
+        <note>Line: 604</note>
+      </trans-unit>
+      <trans-unit id="01e8202cf69f19ea7cf3a80f7673066a">
+        <source>Invalid password confirmation</source>
+        <target>Invalid password confirmation</target>
+        <note>Line: 641</note>
+      </trans-unit>
+      <trans-unit id="1e1cc9bdeb2f29f5480106aec7e9bc48">
+        <source>Now</source>
+        <target>Now</target>
+        <note>Line: 967</note>
+      </trans-unit>
+      <trans-unit id="f92965e2c8a7afb3c1b9a5c09a263636">
+        <source>Done</source>
+        <target>Done</target>
+        <note>Line: 968</note>
+      </trans-unit>
+      <trans-unit id="3964fd83339fec5014c831822005653a">
+        <source>Choose Time</source>
+        <target>Choose Time</target>
+        <note>Line: 974</note>
+      </trans-unit>
+      <trans-unit id="a76d4ef5f3f6a672bbfab2865563e530">
+        <source>Time</source>
+        <target>Time</target>
+        <note>Line: 975</note>
+      </trans-unit>
+      <trans-unit id="b55e509c697e4cca0e1d160a7806698f">
+        <source>Hour</source>
+        <target>Hour</target>
+        <note>Line: 976</note>
+      </trans-unit>
+      <trans-unit id="62902641c38f3a4a8eb3212454360e24">
+        <source>Minute</source>
+        <target>Minute</target>
+        <note>Line: 977</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form_group.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c6155aaecccf794cd2a00fcc35898022">
+        <source>Group name</source>
+        <target>Group name</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="69e62346c35bc63795db142cfbb0af66">
+        <source>No group created</source>
+        <target>No group created</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_content.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="087fb8756d4add87f2d162304ccd486b">
+        <source>No records found</source>
+        <target>No records found</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="0bcef9c45bd8a48eda1b26eb0c61c869">
+        <source>%</source>
+        <target>%</target>
+        <note>Line: 119</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4c41e0bd957698b58100a5c687d757d9">
+        <source>Select all</source>
+        <target>Select all</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="237c7b6874386141a095e321c9fdfd38">
+        <source>Unselect all</source>
+        <target>Unselect all</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb">
+        <source>Display</source>
+        <target>Display</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="dd8921b41e0279a02c6a26a509241700">
+        <source>result(s)</source>
+        <target>result(s)</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6ccfec41b65de46efeb7ca242341e8ea">
+        <source>Please fill at least one field to perform a search in this list.</source>
+        <target>Please fill at least one field to perform a search in this list.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="e129ae480280e47ef82fc7702f8321ba">
+        <source>Refresh list</source>
+        <target>Refresh list</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="dbcd43f8ba2bafd1bccc57fe9c8b5d7b">
+        <source>Show SQL query</source>
+        <target>Show SQL query</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="351b6d570b6ba15fe66e85c1eaf9ec64">
+        <source>Export to SQL Manager</source>
+        <target>Export to SQL Manager</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="4493e821e06072415518bd7ae4077996">
+        <source>Shop group</source>
+        <target>Shop group</target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53">
+        <source>To</source>
+        <target>To</target>
+        <note>Line: 350</note>
+      </trans-unit>
+      <trans-unit id="e9c7e4df74077626f7e42797c65273c4">
+        <source>and stay</source>
+        <target>and stay</target>
+        <note>Line: 203</note>
+      </trans-unit>
+      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142">
+        <source>From</source>
+        <target>From</target>
+        <note>Line: 343</note>
+      </trans-unit>
+      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d">
+        <source>Reset</source>
+        <target>Reset</target>
+        <note>Line: 402</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/modules_list/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6afd80bf62a1b8bdfe729af8a0159fee">
+        <source>Modules list</source>
+        <target>Modules list</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="2c422a499f038293ed0c5a1e085cd827">
+        <source>No modules available in this section.</source>
+        <target>No modules available in this section.</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="c0ebffb294bb46f8800a899e04c73f17">
+        <source>View all available payments solutions</source>
+        <target>View all available payments solutions</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="98a52c00a9fb228601f8b423436d36e0">
+        <source>It seems there are no recommended payment solutions for your country.</source>
+        <target>It seems there are no recommended payment solutions for your country.</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="39efbaa2f3600dd82a031d7ab5138f73">
+        <source>Do you think there should be one? Let us know!</source>
+        <target>Do you think there should be one? Let us know!</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/modules_list/modal.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4b33fbf5ea2c4ced9800228574cfcc50">
+        <source>Recommended Modules and Services</source>
+        <target>Recommended Modules and Services</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/options/options.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0">
+        <source>(tax excl.)</source>
+        <target>(tax excl.)</target>
+        <note>Line: 220</note>
+      </trans-unit>
+      <trans-unit id="c103bafd6451f1f08200bebff539606f">
+        <source>Multistore</source>
+        <target>Multistore</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="50de2399e96ac57bed17e95376046c3b">
+        <source>Check / Uncheck all</source>
+        <target>Check / Uncheck all</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="ff8ff5e54a1832486773ec48b8f8175d">
+        <source>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</source>
+        <target>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d97ccb3e617d930d52ffd95e5db2c101">
+        <source>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</source>
+        <target>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="a157a50f5a421a7dfbdf280f3ff9d56e">
+        <source>You can't change the value of this configuration field in the context of this shop.</source>
+        <target>You can't change the value of this configuration field in the context of this shop.</target>
+        <note>Line: 331</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/required_fields.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="0470d45929f27e1161330164c423b415">
+        <source>Set required fields for this section</source>
+        <target>Set required fields for this section</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="e54b38290c8bdd95e8bc10412c9cc096">
+        <source>Required Fields</source>
+        <target>Required Fields</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="81f32b96f6626b8968e6a0f4a9bce62e">
+        <source>Select the fields you would like to be required for this section.</source>
+        <target>Select the fields you would like to be required for this section.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="ee9b2f3cf31c23c944b15fb0b33d6a77">
+        <source>Field Name</source>
+        <target>Field Name</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/shops_list/list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="804ccd6219996d12eda865d1c0707423">
+        <source>All shops</source>
+        <target>All shops</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="93f04304c09d561ed79442ea9ee722d4">
+        <source>%s group</source>
+        <target>%s group</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="24fc6fbf93a9d551ea7da4cd69f3da3e">
+        <source>(%s selected)</source>
+        <target>(%s selected)</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bebe39eef720d7cbb479d8b3428e4c04">
+        <source>Group: %s</source>
+        <target>Group: %s</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d77a48a51f8c62087570ab8f9d6ca55a">
+        <source>search...</source>
+        <target>search...</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/ajax.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="86d3852bba89bf82128c3e156624ad08">
+        <source>Add files...</source>
+        <target>Add files...</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="9e74a55bb862a98723f9cf3f868d837e">
+        <source>Add file...</source>
+        <target>Add file...</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="c7de86f69db264c3950d8ae46ed2e33f">
+        <source>Upload files</source>
+        <target>Upload files</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="ffeed24e8e4fd763c1d0d02c6e5d6e15">
+        <source>Upload file</source>
+        <target>Upload file</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="6dc85b454944660cf96e7d0c2d171ee3">
+        <source>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</source>
+        <target>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="b21f085d08623fc7a5a9da204cc66c8c">
+        <source>Remove file</source>
+        <target>Remove file</target>
+        <note>Line: 178</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/simple.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1908624a0bca678cd26b99bfd405324e">
+        <source>File size</source>
+        <target>File size</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="3fcbe6bd34e9279ec2c7b13adf7e4095">
+        <source>You have reached the limit (%s) of files to upload, please remove files to continue uploading</source>
+        <target>You have reached the limit (%s) of files to upload, please remove files to continue uploading</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="d39ec66f08507e26fe86aa5325d070df">
+        <source>Add files</source>
+        <target>Add files</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="58be4de806253a6ee411b6c0c99296c7">
+        <source>Add file</source>
+        <target>Add file</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="09942cec33b5becdf3e2275913b818e2">
+        <source>Download current file (%skb)</source>
+        <target>Download current file (%skb)</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="c2299e6abb73991105dfacfb6fdd6dd4">
+        <source>Download current file</source>
+        <target>Download current file</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="009044df8c709bfdefa065ae7fa733e1">
+        <source>You can upload a maximum of %s files</source>
+        <target>You can upload a maximum of %s files</target>
+        <note>Line: 134</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/layout-ajax.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="23a61fdb216b255d81b0d49ca1abb8a4">
+        <source>There are %d warnings.</source>
+        <target>There are %d warnings.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="8a3cfd894d57e33c55400fc9d76aa08a">
+        <source>Click here to see more</source>
+        <target>Click here to see more</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="a92269f5f14ac147a821728c23204c0b">
+        <source>Hide warning</source>
+        <target>Hide warning</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="406cabb68a6d8f9f7ebbb3c10cd535ef">
+        <source>There is %d warning.</source>
+        <target>There is %d warning.</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/layout.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2169b4627df97333ed94d1e30a9b8148">
+        <source>%d errors</source>
+        <target>%d errors</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="e112201196d8a38cfe15031655647cb6">
+        <source>There are %d warnings:</source>
+        <target>There are %d warnings:</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/search_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="03de6422045e4ed3ac822c673ace32d1">
+        <source>123.45.67.89</source>
+        <target>123.45.67.89</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3d8de6fcc09baf73f7175fe59f278ced">
+        <source>Your profile</source>
+        <target>Your profile</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="c87aacf5673fada1108c9f809d354311">
+        <source>Sign out</source>
+        <target>Sign out</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ed95254a7068ffd8729fd94d07347d67">
+        <source>Oh no!</source>
+        <target>Oh no!</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="93e2c2e3d9591e5d54b0e5e6f81d36e0">
+        <source>The mobile version of this page is not available yet.</source>
+        <target>The mobile version of this page is not available yet.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="56c42d822d794bc33d5e25bc53cd385b">
+        <source>Please use a desktop computer to access this page, until is adapted to mobile.</source>
+        <target>Please use a desktop computer to access this page, until is adapted to mobile.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="2d439011ecebc222e1feb2e3e005c0ac">
+        <source>Thank you.</source>
+        <target>Thank you.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/quick_access.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0">
+        <source>Quick Access</source>
+        <target>Quick Access</target>
+        <note>Line: 4</note>
+      </trans-unit>
+      <trans-unit id="6f7579a25b7aba443386a5b86a7900b4">
+        <source>Please name this shortcut:</source>
+        <target>Please name this shortcut:</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="f5c26758149849ee0f84a2eceaf0acfd">
+        <source>Remove from QuickAccess</source>
+        <target>Remove from QuickAccess</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="383247a8cb198be4042d128986100cea">
+        <source>Add current page to QuickAccess</source>
+        <target>Add current page to QuickAccess</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="165122309e15dc09c30b78951e53cb5a">
+        <source>Manage quick accesses</source>
+        <target>Manage quick accesses</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/search_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f5945546981ef6e50e1fade1b386da04">
+        <source>Search (e.g.: product reference, customer name…)</source>
+        <target>Search (e.g.: product reference, customer name…)</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="13787cfb1a15ae6690a29d3895c54de9">
+        <source>Everywhere</source>
+        <target>Everywhere</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="2e67c0a79d35c15af2436c8d80ca072d">
+        <source>What are you looking for?</source>
+        <target>What are you looking for?</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="c32516babc5b6c47eb8ce1bfc223253c">
+        <source>Catalog</source>
+        <target>Catalog</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="7f704ff8964f7b5f3f9a6444d450b5f7">
+        <source>Product name, SKU, reference...</source>
+        <target>Product name, SKU, reference...</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="855d2bf59043b81e76bc931e685a4f58">
+        <source>by name</source>
+        <target>by name</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="a3681587c5320489b6a3dd21282e254d">
+        <source>Email, name...</source>
+        <target>Email, name...</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="399574be0ed95657dfac0e8d38374c62">
+        <source>by ip address</source>
+        <target>by ip address</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="16b2494238f8f996b09417d1dc56c795">
+        <source>by IP address</source>
+        <target>by IP address</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="d79cf3f429596f77db95c65074663a54">
+        <source>Order ID</source>
+        <target>Order ID</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="fce9a6a1bd2a2050eb86d33103f46fd3">
+        <source>Invoices</source>
+        <target>Invoices</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="4e065ba1bec1d62b2d5450256612fa96">
+        <source>Invoice Number</source>
+        <target>Invoice Number</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="fc26e55e0993a75e892175deb02aae15">
+        <source>Carts</source>
+        <target>Carts</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="fc6dfe4f8b07fc04c99e27425f780754">
+        <source>Cart ID</source>
+        <target>Cart ID</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2">
+        <source>Modules</source>
+        <target>Modules</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="07403a8bc81d7865c8e040e718ec7828">
+        <source>Module name</source>
+        <target>Module name</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="0f544d682c3a664870f025f48c4b04b5">
+        <source>SEARCH</source>
+        <target>SEARCH</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/shop_list.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d70861cbe7f8c9a1241c39b3e7ef5ef2">
+        <source>View my shop</source>
+        <target>View my shop</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/error.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd">
+        <source>%1$s on line %2$s in file %3$s</source>
+        <target>%1$s on line %2$s in file %3$s</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/header.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2fc6204d2ca7e856d9e4844d2786f053">
+        <source>This field will be modified for all your shops.</source>
+        <target>This field will be modified for all your shops.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="7ac170f2b47dbf7d4c5cd38449093c2b">
+        <source>This field will be modified for all shops in this shop group:</source>
+        <target>This field will be modified for all shops in this shop group:</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="fe0ae15c8f93a5335f0991accadd13ca">
+        <source>This field will be modified for this shop:</source>
+        <target>This field will be modified for this shop:</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="0a71c80de89d7b2d3e6b22974a4a7548">
+        <source>A new order has been placed on your shop.</source>
+        <target>A new order has been placed on your shop.</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="3df406952f3377a5e419d4d63abb1b1d">
+        <source>Order number:</source>
+        <target>Order number:</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="66c4c5112f455a19afde47829df363fa">
+        <source>Total:</source>
+        <target>Total:</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="1e6d57e813355689e9c77e947d73ad8f">
+        <source>From:</source>
+        <target>From:</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="c112bd7d596888979be02bd780e6a94f">
+        <source>View this order</source>
+        <target>View this order</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="d2d2000f7fa636acd871f43c085a75dc">
+        <source>A new customer registered on your shop.</source>
+        <target>A new customer registered on your shop.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="7a2e40e90ddbc145f11afacb5eb83ae2">
+        <source>Customer name:</source>
+        <target>Customer name:</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="d48549659ae6cc81e7d4729b068ba4b9">
+        <source>A new message was posted on your shop.</source>
+        <target>A new message was posted on your shop.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6fab17d3dc1147f9b170fb8e1aac2fa8">
+        <source>Read this message</source>
+        <target>Read this message</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="a8d69cdfad4c19ed22bf693b8871064e">
+        <source>Choose language</source>
+        <target>Choose language</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="151648106e4bf98297882ea2ea1c4b0e">
+        <source>Update successful</source>
+        <target>Update successful</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea">
+        <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
+        <target>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28">
+        <source>Search for a product</source>
+        <target>Search for a product</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/layout.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c821206b336b401bccf058f664f8255d">
+        <source>Your shop is in debug mode.</source>
+        <target>Your shop is in debug mode.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="13886bc255a80b7c11e0585013feeb30">
+        <source>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</source>
+        <target>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e">
+        <source>Debug mode</source>
+        <target>Debug mode</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="67a33d40bef41c3b79d6b973bfcbc89a">
+        <source>Your shop is in maintenance.</source>
+        <target>Your shop is in maintenance.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="929f5283d0fa1e9eecf20cc294f981e5">
+        <source><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></source>
+        <target><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="38a27c0c7ef7a05e13efa2798ee21533">
+        <source>Maintenance mode</source>
+        <target>Maintenance mode</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9ff082251dea737459c9f32e73ca7a62">
+        <source>For security reasons, you must also delete the /install folder.</source>
+        <target>For security reasons, you must also delete the /install folder.</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9">
+        <source>Add</source>
+        <target>Add</target>
+        <note>Line: 608</note>
+      </trans-unit>
+      <trans-unit id="7dce122004969d56ae2e0245cb754d35">
+        <source>Edit</source>
+        <target>Edit</target>
+        <note>Line: 664</note>
+      </trans-unit>
+      <trans-unit id="4ee29ca12c7d126654bd0e5275de6135">
+        <source>List</source>
+        <target>List</target>
+        <note>Line: 619</note>
+      </trans-unit>
+      <trans-unit id="6e9783376d951cfd780e9fdb67a0f02c">
+        <source>View details</source>
+        <target>View details</target>
+        <note>Line: 625</note>
+      </trans-unit>
+      <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8">
+        <source>Options</source>
+        <target>Options</target>
+        <note>Line: 630</note>
+      </trans-unit>
+      <trans-unit id="92a8f0b9d28a89b480bd1d29f46f0484">
+        <source>Generator</source>
+        <target>Generator</target>
+        <note>Line: 635</note>
+      </trans-unit>
+      <trans-unit id="ef61fb324d729c341ea8ab9901e23566">
+        <source>Add new</source>
+        <target>Add new</target>
+        <note>Line: 1690</note>
+      </trans-unit>
+      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005">
+        <source>View</source>
+        <target>View</target>
+        <note>Line: 676</note>
+      </trans-unit>
+      <trans-unit id="a6105c0a611b41b08f1209506350279e">
+        <source>yes</source>
+        <target>yes</target>
+        <note>Line: 703</note>
+      </trans-unit>
+      <trans-unit id="7fa3b767c460b54a2be4d49030b349c7">
+        <source>no</source>
+        <target>no</target>
+        <note>Line: 703</note>
+      </trans-unit>
+      <trans-unit id="7d341c08fd102f0b86285b5ff2e26ea7">
+        <source>%s: %s</source>
+        <target>%s: %s</target>
+        <note>Line: 727</note>
+      </trans-unit>
+      <trans-unit id="921d54865f8169b84c90d4335c256494">
+        <source>filter by %s</source>
+        <target>filter by %s</target>
+        <note>Line: 734</note>
+      </trans-unit>
+      <trans-unit id="a333339eb21abf3d5a04f5ede8f73ae9">
+        <source>%s deletion</source>
+        <target>%s deletion</target>
+        <note>Line: 4075</note>
+      </trans-unit>
+      <trans-unit id="6ca3b11e4d89a7649d10c2d70d98612f">
+        <source>%s addition</source>
+        <target>%s addition</target>
+        <note>Line: 1181</note>
+      </trans-unit>
+      <trans-unit id="0919680b340ae0ac8d1a804c4c69b0ba">
+        <source>%s modification</source>
+        <target>%s modification</target>
+        <note>Line: 1289</note>
+      </trans-unit>
+      <trans-unit id="f7931413dee107ddf5289c8886baf7ec">
+        <source>Edit: %s</source>
+        <target>Edit: %s</target>
+        <note>Line: 1604</note>
+      </trans-unit>
+      <trans-unit id="0095a9fa74d1713e43e370a7d7846224">
+        <source>Export</source>
+        <target>Export</target>
+        <note>Line: 1695</note>
+      </trans-unit>
+      <trans-unit id="4668a49dfb4ba4ff7fa8019e7e5c28af">
+        <source>Recommended Modules</source>
+        <target>Recommended Modules</target>
+        <note>Line: 2249</note>
+      </trans-unit>
+      <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613">
+        <source>Bad SQL query</source>
+        <target>Bad SQL query</target>
+        <note>Line: 2406</note>
+      </trans-unit>
+      <trans-unit id="431accab7897f05b0424e002ca30391d">
+        <source>Operational</source>
+        <target>Operational</target>
+        <note>Line: 2683</note>
+      </trans-unit>
+      <trans-unit id="fb381d41e52b0dc68e684c01decfe2ec">
+        <source>Degraded Performance</source>
+        <target>Degraded Performance</target>
+        <note>Line: 2684</note>
+      </trans-unit>
+      <trans-unit id="7c30b2ec6e5e59c7c327f7098fe36f36">
+        <source>Partial Outage</source>
+        <target>Partial Outage</target>
+        <note>Line: 2685</note>
+      </trans-unit>
+      <trans-unit id="b101c07e257875658c454fe5caef1db0">
+        <source>Major Outage</source>
+        <target>Major Outage</target>
+        <note>Line: 2686</note>
+      </trans-unit>
+      <trans-unit id="ea4788705e6873b424c65e91c2846b19">
+        <source>Cancel</source>
+        <target>Cancel</target>
+        <note>Line: 1657</note>
+      </trans-unit>
+      <trans-unit id="c9cc8cce247e49bae79f15173ce97354">
+        <source>Save</source>
+        <target>Save</target>
+        <note>Line: 1682</note>
+      </trans-unit>
+      <trans-unit id="b9804794cbfeea33c6d9b2ce85100b48">
+        <source>Do you really want to uninstall this module?</source>
+        <target>Do you really want to uninstall this module?</target>
+        <note>Line: 4376</note>
+      </trans-unit>
+      <trans-unit id="b2f31ef3065bf40b2da9fa8525c6adb9">
+        <source>Disable this module</source>
+        <target>Disable this module</target>
+        <note>Line: 4378</note>
+      </trans-unit>
+      <trans-unit id="668c99c1164d5348f99c0878770b53a8">
+        <source>Enable this module for all shops</source>
+        <target>Enable this module for all shops</target>
+        <note>Line: 4379</note>
+      </trans-unit>
+      <trans-unit id="bcfaccebf745acfd5e75351095a5394a">
+        <source>Disable</source>
+        <target>Disable</target>
+        <note>Line: 4380</note>
+      </trans-unit>
+      <trans-unit id="2faec1f9f8cc7f8f40d521c4dd574f49">
+        <source>Enable</source>
+        <target>Enable</target>
+        <note>Line: 4381</note>
+      </trans-unit>
+      <trans-unit id="112b842b7d5dda8d3fed05c0e5aaf983">
+        <source>Disable on mobiles</source>
+        <target>Disable on mobiles</target>
+        <note>Line: 4382</note>
+      </trans-unit>
+      <trans-unit id="2ef92962bd1ac0c81675f10568ad5cca">
+        <source>Disable on tablets</source>
+        <target>Disable on tablets</target>
+        <note>Line: 4383</note>
+      </trans-unit>
+      <trans-unit id="5e3ffb3123b3f23a33804d41e38745a0">
+        <source>Disable on computers</source>
+        <target>Disable on computers</target>
+        <note>Line: 4384</note>
+      </trans-unit>
+      <trans-unit id="862e2caedb77ba14d86f180ca7fa90a8">
+        <source>Display on mobiles</source>
+        <target>Display on mobiles</target>
+        <note>Line: 4385</note>
+      </trans-unit>
+      <trans-unit id="732ebdb0f33a8153b51ac58cac8f3563">
+        <source>Display on tablets</source>
+        <target>Display on tablets</target>
+        <note>Line: 4386</note>
+      </trans-unit>
+      <trans-unit id="7f0f7c79f1d7b01b1d8a89f392e93d36">
+        <source>Display on computers</source>
+        <target>Display on computers</target>
+        <note>Line: 4387</note>
+      </trans-unit>
+      <trans-unit id="f1206f9fadc5ce41694f69129aecac26">
+        <source>Configure</source>
+        <target>Configure</target>
+        <note>Line: 4389</note>
+      </trans-unit>
+      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18">
+        <source>Delete</source>
+        <target>Delete</target>
+        <note>Line: 4390</note>
+      </trans-unit>
+      <trans-unit id="85687c63fd82afbc21632f288e53a6e4">
+        <source>This action will permanently remove the module from the server. Are you sure you want to do this?</source>
+        <target>This action will permanently remove the module from the server. Are you sure you want to do this?</target>
+        <note>Line: 4394</note>
+      </trans-unit>
+      <trans-unit id="630f6dc397fe74e52d5189e2c80f282b">
+        <source>Back to list</source>
+        <target>Back to list</target>
+        <note>Line: 1674</note>
+      </trans-unit>
+      <trans-unit id="ede4759c9afae620fd586628789fa304">
+        <source>Enable selection</source>
+        <target>Enable selection</target>
+        <note>Line: 3061</note>
+      </trans-unit>
+      <trans-unit id="ab7fd6e250b64a46027a996088fdff74">
+        <source>Disable selection</source>
+        <target>Disable selection</target>
+        <note>Line: 3065</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/HelperOptions.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c770d8e0d1d1943ce239c64dbd6acc20">
+        <source>Add my IP</source>
+        <target>Add my IP</target>
+        <note>Line: 212</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="193cfc9be3b995831c6af2fea6650e60">
+        <source>Page</source>
+        <target>Page</target>
+        <note>Line: 159</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="240f3031f25601fa128bd4e15f0a37de">
+        <source>Comment:</source>
+        <target>Comment:</target>
+        <note>Line: 423</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7258e7251413465e0a3eb58094430bde">
+        <source>Administration</source>
+        <target>Administration</target>
+        <note>Line: 85
+Comment: Set the modules categories</note>
+      </trans-unit>
+      <trans-unit id="3defbfac3fcbea45049cddcf80aa9f21">
+        <source>Advertising and Marketing</source>
+        <target>Advertising and Marketing</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="a99118454f54727d280e3d2d9c7ea0e3">
+        <source>Analytics and Stats</source>
+        <target>Analytics and Stats</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="e09d0a51d181ee0b28180946f2af0f95">
+        <source><![CDATA[Taxes & Invoicing]]></source>
+        <target><![CDATA[Taxes & Invoicing]]></target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="6ff063fbc860a79759a7369ac32cee22">
+        <source>Checkout</source>
+        <target>Checkout</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="5dc6d69e21ca0f5779b9cfeae1154f05">
+        <source>Content Management</source>
+        <target>Content Management</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="d8b5985b4baa0bfe0ce6734f99b22e6e">
+        <source>Customer Reviews</source>
+        <target>Customer Reviews</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="e00dfb7a37c4f39c748f459e69fadb96">
+        <source>Front office Features</source>
+        <target>Front office Features</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="a8cf512208bee5db82f968d2dc247c5f">
+        <source>Internationalization and Localization</source>
+        <target>Internationalization and Localization</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="825896e7e83eff50879ed00cba2f9414">
+        <source>Merchandising</source>
+        <target>Merchandising</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="5b985caa89b2ca61bbeee91a896c610d">
+        <source>Migration Tools</source>
+        <target>Migration Tools</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="286030724099ebb1518552eeb8b00bd7">
+        <source>Payments and Gateways</source>
+        <target>Payments and Gateways</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="dd05711d44de1fa4bf31303915bd41bc">
+        <source><![CDATA[Site certification & Fraud prevention]]></source>
+        <target><![CDATA[Site certification & Fraud prevention]]></target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="54f65da381d43abf769b7ac2cb3a8270">
+        <source>Pricing and Promotion</source>
+        <target>Pricing and Promotion</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="a9964513dc046a2cd404413f77b4656e">
+        <source>Quick / Bulk update</source>
+        <target>Quick / Bulk update</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="d88946b678e4c2f251d4e292e8142291">
+        <source>SEO</source>
+        <target>SEO</target>
+        <note><![CDATA[Line: 102
+Comment: $this->list_modules_categories['search_filter']['name'] = $this->l('Search and Filter');]]></note>
+      </trans-unit>
+      <trans-unit id="19e295f6e2c8774937dd5144ce6aed23">
+        <source>Shipping and Logistics</source>
+        <target>Shipping and Logistics</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="5f17a788546ddb43236732f8b0bdfd7e">
+        <source>Slideshows</source>
+        <target>Slideshows</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="b93d83bd882a9507436946da114a9c25">
+        <source><![CDATA[Comparison site & Feed management]]></source>
+        <target><![CDATA[Comparison site & Feed management]]></target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="675e31b94580e2642405e2f8586d112e">
+        <source>Marketplace</source>
+        <target>Marketplace</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="87d17f4624a514e81dc7c8e016a7405c">
+        <source>Mobile</source>
+        <target>Mobile</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834">
+        <source>Dashboard</source>
+        <target>Dashboard</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="44f9bbe73101a9c7842e9384e0db70c9">
+        <source><![CDATA[Internationalization & Localization]]></source>
+        <target><![CDATA[Internationalization & Localization]]></target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="e7e5eafdb7b6b3bbb9e38e9ae8a35094">
+        <source><![CDATA[Emailing & SMS]]></source>
+        <target><![CDATA[Emailing & SMS]]></target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="222e1825c6eb93a516fba01be7861ddd">
+        <source>Social Networks</source>
+        <target>Social Networks</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="06c21841ec088f9c8cbfb82946cf203b">
+        <source><![CDATA[Social & Community]]></source>
+        <target><![CDATA[Social & Community]]></target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8290fb626ffacf21450997f25967efeb">
+        <source>Module not found</source>
+        <target>Module not found</target>
+        <note>Line: 860</note>
+      </trans-unit>
+      <trans-unit id="0c81f6a8e4b7b1d0a812d7285289f17d">
+        <source>Modules to update</source>
+        <target>Modules to update</target>
+        <note>Line: 1396</note>
+      </trans-unit>
+      <trans-unit id="0f0c014bcfe255c6749d8e665ff8bb4e">
+        <source>Translate this module</source>
+        <target>Translate this module</target>
+        <note>Line: 1456</note>
+      </trans-unit>
+      <trans-unit id="7602b3edb382cf12573e156623fe9468">
+        <source>This module cannot be installed</source>
+        <target>This module cannot be installed</target>
+        <note>Line: 1464</note>
+      </trans-unit>
+      <trans-unit id="ac8f751177ba1d91a0ab11d3650cdfaf">
+        <source>Important Notice</source>
+        <target>Important Notice</target>
+        <note>Line: 1464</note>
+      </trans-unit>
+      <trans-unit id="c472f22a7459a000f0177a23fdc4212b">
+        <source>This module is Untrusted for your country</source>
+        <target>This module is Untrusted for your country</target>
+        <note>Line: 1466</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTabsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f">
+        <source>Delete selected</source>
+        <target>Delete selected</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7">
+        <source>Delete selected items?</source>
+        <target>Delete selected items?</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9bd81329febf6efe22788e03ddeaf0af">
+        <source>Class</source>
+        <target>Class</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881">
+        <source>Position</source>
+        <target>Position</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="06145a21dcec7395085b033e6e169b61">
+        <source>Menus</source>
+        <target>Menus</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="0164b35f3cbc5cbf9bf58abeb4bc14df">
+        <source>Add new menu</source>
+        <target>Add new menu</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5">
+        <source>Home</source>
+        <target>Home</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb">
+        <source>Invalid characters:</source>
+        <target>Invalid characters:</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be">
+        <source>Status</source>
+        <target>Status</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="fe513725b21a16ced7d05b454e74a33e">
+        <source>Show or hide menu.</source>
+        <target>Show or hide menu.</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="30269022e9d8f51beaabb52e5d0de2b7">
+        <source>Parent</source>
+        <target>Parent</target>
+        <note>Line: 198</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/translations/fr-FR/EmailsBody.fr-FR.xlf
+++ b/tests/Resources/translations/fr-FR/EmailsBody.fr-FR.xlf
@@ -1,0 +1,2252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/PaymentModule.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="44aa13304026bb46ad79f4151f16634a" approved="yes">
+        <source>(waiting for validation)</source>
+        <target state="final">(en attente de validation)</target>
+        <note>Line: 630</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/components/footer.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="96dad7f0d711c3408786ba1ee05402b3" approved="yes">
+        <source><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="{prestashop_url}">PrestaShop™</a>]]></source>
+        <target state="final"><![CDATA[<a href="{shop_url}">{shop_name}</a> propulsé par <a href="{prestashop_url}">PrestaShop™</a>]]></target>
+        <note>Line: 6</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/account.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2498c963bfc06e8fca88007ec322b769" approved="yes">
+        <source>Your login email address on {shop_name}</source>
+        <target state="final">Votre adresse e-mail de connexion sur {shop_name}</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="7cfb9d536fcd7aa70c333e8e73b287e2" approved="yes">
+        <source>Here is your login email address:</source>
+        <target state="final">Voici votre adresse e-mail de connexion :</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/backoffice_order.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bffeb374bf71938ffc4faa42afbf1679" approved="yes">
+        <source><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to finalize the payment.]]></source>
+        <target state="final"><![CDATA[Veuillez vous rendre sur <a href="{order_link}">{order_link}</a> pour finaliser votre paiement.]]></target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/bankwire.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9b33ea5c9409a67cb6e1f6bc3f0828f0" approved="yes">
+        <source>Awaiting wire payment</source>
+        <target state="final">En attente du paiement</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="f4a6af01d092af11dca29cb89578b124" approved="yes">
+        <source>You have selected to pay by wire transfer.</source>
+        <target state="final">Pour rappel, vous avez sélectionné le mode de paiement par virement bancaire.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="fc1ae3c1dd1d9d9a44da719fa9966f0e" approved="yes">
+        <source>Here are the bank details for your transfer:</source>
+        <target state="final">Voici les informations dont vous avez besoin pour effectuer votre virement :</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/cheque.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a51341e25ff7710496cf86468d797169" approved="yes">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}">"Guest Tracking"</a> section on our shop.]]></source>
+        <target state="final"><![CDATA[Si vous avez un compte invité, vous pouvez suivre votre commande via la section <a href="{guest_tracking_url}">"Suivi invité"</a> sur notre boutique.]]></target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="d698e777b19f6f487ae0490950174fde" approved="yes">
+        <source>Awaiting check payment</source>
+        <target state="final">En attente du paiement par chèque</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="ecf01c46965fdfd36eb98b271276c0d5" approved="yes">
+        <source>You have selected to pay by check.</source>
+        <target state="final">Vous avez choisi de payer par chèque.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="b6592595266708e46d1d420ab7153213" approved="yes">
+        <source>Here are the bank details for your check:</source>
+        <target state="final">Voici les informations dont vous avez besoin pour effectuer le paiement :</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="ed750ed3b775eb7ed37644ceb05c713b" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] has been placed successfully and will be [1]shipped as soon as we receive your payment[/1].</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] a bien été prise en compte, elle sera [1]expédiée dès réception de votre paiement[/1].</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/contact.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="31e15b28c2f071f74f47eb8bcd612d94" approved="yes">
+        <source>Customer e-mail address:</source>
+        <target state="final">Adresse e-mail du client :</target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="83fa39a28a4d159061c408fbd6a249e7" approved="yes">
+        <source>Order ID:</source>
+        <target state="final">Commande # :</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/contact_form.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1edbec13a38606f19c0bae544a7c6552" approved="yes">
+        <source>Your message to {shop_name} Customer Service</source>
+        <target state="final">Votre message à l'attention du service client de {shop_name}</target>
+        <note>Line: 7</note>
+      </trans-unit>
+      <trans-unit id="e92ba0cecb0593f537515b2aa2d1c701" approved="yes">
+        <source>Your message has been sent successfully.</source>
+        <target state="final">Votre message a bien été envoyé à notre service client.</target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="76890cf906149b370ea6f7d1bd8eaf9a" approved="yes">
+        <source>We will answer as soon as possible.</source>
+        <target state="final">Nous vous répondrons dans les meilleurs délais.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/credit_slip.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="72dbe899c04eb3875b29b5b274340dac" approved="yes">
+        <source>Credit slip created</source>
+        <target state="final">Nouvel avoir</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="99f89e9a116e1c07f62ba17fb0312db6" approved="yes">
+        <source><![CDATA[You can review this credit slip and download your invoice from the <a href="{history_url}">"My credit slips"</a> section of your account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
+        <target state="final"><![CDATA[Vous pouvez accéder à cet avoir et télécharger votre facture dans <a href="{history_url}">"Historique des commandes"</a> de la rubrique  <a href="{my_account_url}">"Mon compte"</a> sur notre site.]]></target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="4c15700279d273ce67d98810a4b87943" approved="yes">
+        <source>We have generated a credit slip in your name for order with the reference [1]{order_name}[/1].</source>
+        <target state="final">Nous avons généré un avoir à votre nom relatif à votre commande ayant pour référence [1]{order_name}[/1].</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/download_product.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5f55a607fea61a402ceac66cc99f1e9e" approved="yes">
+        <source><![CDATA[Thank you for your order with the reference {order_name} from <strong>{shop_name}</strong>]]></source>
+        <target state="final"><![CDATA[Merci pour votre commande portant la référence {order_name} sur <strong>{shop_name}</strong>]]></target>
+        <note>Line: 8</note>
+      </trans-unit>
+      <trans-unit id="30acb55a5efc4a32a30a0c3db85f37d1" approved="yes">
+        <source>Product(s) now available for download</source>
+        <target state="final">Produit(s) à télécharger</target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/employee_password.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4785f7efb27f2905a05564903db18b23" approved="yes">
+        <source>Your {shop_name} login information</source>
+        <target state="final">Voici vos informations personnelles pour {shop_name}</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="e2fa64dedc8a3422d409cbe4eebd19bb" approved="yes">
+        <source>Here is your personal login information for [1]{shop_name}[/1]:</source>
+        <target state="final">Voici vos identifiants de connexion sur [1]{shop_name}[/1] :</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="78e365acb087fd1f8d494dae0001de10" approved="yes">
+        <source>E-mail address:</source>
+        <target state="final">Adresse e-mail :</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/forward_msg.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="8595a98bbe6d6b0e3b9b0681b3b4aa71" approved="yes">
+        <source>Customer service - Forwarded discussion</source>
+        <target state="final">Service client - Discussion transférée</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="2bf185aaec7301d0862e4d69fce26d60" approved="yes">
+        <source>[1]{employee}[/1] added [1]"{comment}"[/1]</source>
+        <target state="final">[1]{employee}[/1] a ajouté [1]"{comment}"[/1]</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/guest_to_customer.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9893de883531529d4a66a3851265f02e" approved="yes">
+        <source>Your customer account creation</source>
+        <target state="final">Votre compte invité a été transformé en compte client</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="49bea2c7e271e5cd440a295dd6fadc72" approved="yes">
+        <source>Please be careful when sharing these login details with others.</source>
+        <target state="final">Conservez ces informations confidentielles.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="f4938f5d59c6c3adc14bf0cc30bc37f5" approved="yes">
+        <source>Your guest account for [1]{shop_name}[/1] has been transformed into a customer account.</source>
+        <target state="final">Votre compte invité sur [1]{shop_name}[/1] a été transformé en compte client.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/import.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a218495ad30949e8ea1f64a261e37463" approved="yes">
+        <source>Import complete</source>
+        <target state="final">Import terminé</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/in_transit.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1b0d1cd23421d9cea08507e950e87094" approved="yes">
+        <source>{followup}</source>
+        <target state="final">{followup}</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="2fe643b2ef0a5fd0e912cd9a784510a7" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] is currently in transit.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] est en cours.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/log_alert.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="07e3b33fd6a9b33d3d9cacea26dc1899" approved="yes">
+        <source>You have received a new log alert</source>
+        <target state="final">Nouveau message d'alerte enregistré</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="6c1d03a23b1b8a7eeec963fdfa8e95c5" approved="yes">
+        <source>[1]Warning:[/1] you have received a new log alert in your Back Office.</source>
+        <target state="final">[1]Attention[/1] : vous avez reçu un nouveau message d'alerte dans votre back office.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/order_canceled.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d9081e325264b44431f85a40bdca4985" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been canceled.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] sur [1]{shop_name}[/1] a été annulée.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/order_customer_comment.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="381fc38b470ed543424afbd43f224453" approved="yes">
+        <source>Message from a customer</source>
+        <target state="final">Message d'un client</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/order_return_state.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="34d125dc458bced25eaf5e2e272c0d75" approved="yes">
+        <source>Return #{id_order_return} - update</source>
+        <target state="final">Retour de commande #{id_order_return} - mise à jour</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/outofstock.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e25d137c27dca2618629678d2df71113" approved="yes">
+        <source>Item(s) out of stock</source>
+        <target state="final">Réapprovisionnement nécessaire</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="5468cd18ba24d269db5ebe9177abca4a" approved="yes">
+        <source>Unfortunately, one or more items are currently out of stock. This may cause a slight delay in your delivery. Please accept our apologies and rest assured that we are working hard to rectify this.</source>
+        <target state="final">Malheureusement, un ou plusieurs des produits que vous avez commandés sont actuellement en rupture de stock. Ceci peut entraîner un léger retard de livraison. Veuillez nous excuser pour ce délai et soyez assurés que nous faisons nos meilleurs efforts pour rectifier la situation rapidement.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/password.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="53423ed6d9f522de8d41539456628786" approved="yes">
+        <source>Your new {shop_name} login details</source>
+        <target state="final">Vos nouvelles informations d'identification sur {shop_name}</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/password_query.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="280f51a8705636bd7e7ba595529411d4" approved="yes">
+        <source>Password reset request for {shop_name}</source>
+        <target state="final">Confirmation de demande de mot de passe sur {shop_name}</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="278b2a400e176e90d476fb69cb881f59" approved="yes">
+        <source>To confirm this action, please use the following link:</source>
+        <target state="final">Si vous souhaitez confirmer cette demande, cliquez sur le lien suivant :</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/payment.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6daabaab43cdbd67346ae71828b1710c" approved="yes">
+        <source>Payment processed</source>
+        <target state="final">Paiement accepté</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="2762264cddd3133c3486886e31681873" approved="yes">
+        <source><![CDATA[Your payment for order with the reference <strong><span>{order_name}</span></strong> was successfully processed.]]></source>
+        <target state="final"><![CDATA[Le paiement pour votre commande ayant pour référence <strong><span>{order_name}</span></strong> a été accepté.]]></target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/payment_error.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3dd0be333980f0b0f0895cdb6322d117" approved="yes">
+        <source>Payment processing error</source>
+        <target state="final">Erreur de paiement</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="96c8c962f040049e80bccbea08e2d776" approved="yes">
+        <source><![CDATA[There is a problem with your payment for <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>. Please contact us at your earliest convenience.]]></source>
+        <target state="final"><![CDATA[Un problème a été constaté pour le paiement de votre commande sur <strong><span>{shop_name}</span></strong> ayant pour référence <strong><span>{order_name}</span></strong>. Veuillez nous contacter le plus rapidement possible.]]></target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="5f2142258e3f214d12efeb927f2a7aef" approved="yes">
+        <source>We cannot ship your order until we receive your payment.</source>
+        <target state="final">Nous ne pouvons malheureusement pas expédier votre commande tant que nous n'avons pas reçu votre paiement.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/preparation.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="643562a9ae7099c8aabfdc93478db117" approved="yes">
+        <source>Processing</source>
+        <target state="final">En cours de préparation</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="d87f9ab0faa0b39a5240d1ce19529905" approved="yes">
+        <source><![CDATA[We are currently processing your <strong><span>{shop_name}</span></strong> order with the reference <strong><span>{order_name}</span></strong>.]]></source>
+        <target state="final"><![CDATA[Votre commande sur <strong><span>{shop_name}</span></strong> ayant pour référence <strong><span>{order_name}</span></strong> est en cours de préparation.]]></target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/refund.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="b3e67c974cc0ca43712679a17bedf6db" approved="yes">
+        <source><![CDATA[We have processed your <strong><span>{shop_name}</span></strong> refund for order with the reference <strong><span>{order_name}</span></strong>.]]></source>
+        <target state="final"><![CDATA[Nous avons procédé au remboursement de votre commande sur <strong><span>{shop_name}</span></strong> portant la référence <strong><span>{order_name}</span></strong>.]]></target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/reply_msg.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="95d1732a1f5200c8e176bea0a5562804" approved="yes">
+        <source><![CDATA[In order to reply, please use the following link: <a href="{link}">{link}</a>]]></source>
+        <target state="final"><![CDATA[Pour répondre, veuillez utiliser le lien suivant : <a href="{link}">{link}</a>]]></target>
+        <note>Line: 25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/shipped.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d0cc952b66ca292a2e4a1bc53453b287" approved="yes">
+        <source>Your order has been shipped</source>
+        <target state="final">Votre commande a été expédiée</target>
+        <note>Line: 8</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/test.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="8b1a9953c4611296a827abf8c47804d7" approved="yes">
+        <source>Hello</source>
+        <target state="final">Bonjour</target>
+        <note>Line: 6</note>
+      </trans-unit>
+      <trans-unit id="632f6256903fd72ff83498831d2999b6" approved="yes">
+        <source>This is a [1]test e-mail[/1] from your shop.</source>
+        <target state="final">Ceci est un [1]e-mail de test[/1] depuis votre boutique.</target>
+        <note>Line: 15</note>
+      </trans-unit>
+      <trans-unit id="79986d6ab2382663070d8cd7e31f2287" approved="yes">
+        <source>If you can read this, the test was successful!</source>
+        <target state="final">Si vous pouvez le lire, le test a réussi !</target>
+        <note>Line: 17</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/voucher.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6edfaaf163aab585fb50f909e6f2cadf" approved="yes">
+        <source>Voucher created</source>
+        <target state="final">Bon de réduction créé</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="6e27b373aa04d07be7c5a65bbd9f45ed" approved="yes">
+        <source>A voucher has been created in your name as a result of your order with the reference [1]{order_name}[/1].</source>
+        <target state="final">Un bon de réduction a été généré à votre nom relatif à votre commande ayant pour référence [1]{order_name}[/1].</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="f210a22fd1ec8eddd8236938d009f3a6" approved="yes">
+        <source>[1]Voucher code: {voucher_num}[/1] in the amount of [1]{voucher_amount}[/1]</source>
+        <target state="final">[1]Code de réduction : {voucher_num}[/1] d'un montant de [1]{voucher_amount}[/1]</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/core/voucher_new.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5bb0c38774ca650d9548d682e175dc75" approved="yes">
+        <source>This is to inform you about the creation of a voucher.</source>
+        <target state="final">Nous vous informons de la génération d'un bon de réduction.</target>
+        <note>Line: 24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_1.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a037426f7ede13b30759469aaca5ad91" approved="yes">
+        <source>Your {shop_name} login details</source>
+        <target state="final">Vos codes d'accès sur {shop_name}.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="ca0c09ad63f8cd2f732058be8d2b3a97" approved="yes">
+        <source>We noticed that during your last visit on {shop_name}, you did not complete the order you had started.</source>
+        <target state="final">Nous avons remarqué que lors de votre dernier passage chez {shop_name}, vous n'avez pas validé la commande que vous aviez entamée.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="85fa10f1ee5c7941ec596c4247c8102b" approved="yes">
+        <source>As an incentive, we can give you a discount of [1]{amount}%[/1] off your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target state="final">À titre exceptionnel, nous pouvons vous accorder une remise de [1]{amount}%[/1] sur votre prochaine commande ! Cette offre est valable [1]{days}[/1] jours, ne perdez plus un instant !</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_2.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="212dcee7c3ca3ee5fbae444b2f07c62d" approved="yes">
+        <source>Thank you for your order at {shop_name}.</source>
+        <target state="final">Merci d'avoir passé commande sur {shop_name}</target>
+        <note>Line: 8</note>
+      </trans-unit>
+      <trans-unit id="0930414a3b73fde90cef246f0f70a1c8" approved="yes">
+        <source>As our way of saying thanks, we want to give you a discount of [1]{amount}%[/1] off your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target state="final">Pour vous remercier, nous souhaitons vous offrir une remise de [1]{amount}%[/1] sur votre prochaine commande ! Cette offre est valable [1]{days}[/1] jours, ne perdez plus un instant !</target>
+        <note>Line: 23</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_3.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5a230b8b0490a33cf1fa3a577e1b4ef3" approved="yes">
+        <source>You are one of our best customers and as such we want to thank you for your continued patronage.</source>
+        <target state="final">Vous faites partie de nos meilleurs clients et à ce titre, nous souhaitons vous remercier pour la confiance dont vous nous faites part.</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="fb143851ff94b8816192dd378774d266" approved="yes">
+        <source>As appreciation for your loyalty, we want to give you a discount of [1]{amount}%[/1] valid on your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target state="final">Pour vous remercier de votre fidélité, nous souhaitons vous offrir une remise de [1]{amount}%[/1] sur votre prochaine commande ! Cette offre est valable [1]{days}[/1] jours, ne perdez plus un instant !</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/followup/followup_4.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="42578524d7fb1953f903bcc5160495ea" approved="yes">
+        <source>Here is your coupon:</source>
+        <target state="final">Voici votre bon de réduction :</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="24986b852e72fcfba407bd807f790abd" approved="yes">
+        <source>Enter this code in your shopping cart to get your discount.</source>
+        <target state="final">Saisissez ce code dans votre panier afin d'obtenir votre réduction.</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="7ed5b90c2f87440a6e83fc35dca83242" approved="yes">
+        <source>You are one of our best customers, however you have not placed an order in {days_threshold} days.</source>
+        <target state="final">Vous faites partie de nos meilleurs clients cependant vous n'avez pas passé de commande depuis {days_threshold} jours.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="fa0d0ed10aae850868404d1a9e7a66b2" approved="yes">
+        <source>We wish to thank you for the trust you have placed in us and want to give you a discount of [1]{amount}%[/1] valid on your next order! This offer is valid for [1]{days}[/1] days, so do not waste a moment!</source>
+        <target state="final">Nous souhaitons vous remercier pour votre confiance et vous offrir une remise de [1]{amount}%[/1] sur votre prochaine commande ! Cette offre est valable [1]{days}[/1] jours, ne perdez plus un instant !</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/customer_qty.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5b736bebe50e10240ff58d486494dc7b" approved="yes">
+        <source>This item is once again in-stock.</source>
+        <target state="final">Le stock a été réapprovisionné.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="16ce091d5fafd5b92941221eab85f3af" approved="yes">
+        <source>You can access the product page by clicking on the link:</source>
+        <target state="final">Vous pouvez accéder à la fiche produit en cliquant sur le lien suivant:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="d5c8de069674d35946f2e88642635485" approved="yes">
+        <source>You can order it right now from our online shop.</source>
+        <target state="final">Vous pouvez donc de nouveau commander ce produit depuis notre catalogue en ligne.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/new_order.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bb09440b8cab954c036c4a45558857a5" approved="yes">
+        <source>Total Tax paid</source>
+        <target state="final">TVA totale</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="6881c1c321e65a31d35137f960022cf7" approved="yes">
+        <source>A new order was placed on {shop_name} by the following customer: {firstname} {lastname} ({email})</source>
+        <target state="final">Une nouvelle commande a été passée sur votre boutique {shop_name} par ce client : {firstname} {lastname} ({email})</target>
+        <note>Line: 14</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/order_changed.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="fce4d5217e51f199cfbd10ae913cc5dd" approved="yes">
+        <source><![CDATA[You can review your order and download your invoice from the <a href="{history_url}">"Order history"</a> section of your customer account by clicking <a href="{my_account_url}">"My account"</a> on our shop.]]></source>
+        <target state="final"><![CDATA[Vous pouvez accéder à tout moment au suivi de votre commande et télécharger votre facture dans <a href="{history_url}">"Historique des commandes"</a> de la rubrique <a href="{my_account_url}">"Mon compte"</a> sur notre site.]]></target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="008400d8db73946ba53b2d7f091eb845" approved="yes">
+        <source>Order {order_name}</source>
+        <target state="final">Commande {order_name}</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="992ed3f1f7ce7be683fd4051138b693e" approved="yes">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}?id_order={order_name}">"Guest Tracking"</a> section on our shop.]]></source>
+        <target state="final"><![CDATA[Si vous avez un compte invité, vous pouvez suivre votre commande dans la section <a href="{guest_tracking_url}?id_order={order_name}">"Suivi invité"</a> de notre site.]]></target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="6eaf1dae59f88437851d95f504f9cb3c" approved="yes">
+        <source>Order edited</source>
+        <target state="final">Commande modifiée</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="26b5ca3acdfdbd5fe92a5cb24dcc204e" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] has been modified.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] a été modifiée.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/productcoverage.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="22609de33e6e9ee1be5b2bf9ae16514c" approved="yes">
+        <source>The stock cover is now less than the specified minimum of:</source>
+        <target state="final">En effet, la quantité disponible est maintenant inférieure au minimum de :</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/productoutofstock.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="756a94b60256e8aacdf10706925eb01e" approved="yes">
+        <source>{product} is nearly out of stock.</source>
+        <target state="final">{product} est presque en rupture de stock.</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="72943b79a01324b1875811ff792bdad0" approved="yes">
+        <source>The remaining stock is now less than the specified minimum of</source>
+        <target state="final">Le stock restant est maintenant inférieur au minimum de</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailalerts/return_slip.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="cd8ee64ef80cd6bb4e320a7d0563b56f" approved="yes">
+        <source>Return details</source>
+        <target state="final">Détails du retour</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="f2d476bf166cc31b450908f8606b0fd5" approved="yes">
+        <source>{order_name} Placed on {date}</source>
+        <target state="final">{order_name} passée le {date}</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailsubscription/newsletter_verif.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3f796454690dc2d7f26db5d45c48b187" approved="yes">
+        <source>Thank you for subscribing to our newsletter, please confirm your request by clicking the link below :</source>
+        <target state="final">Merci de vous être inscrit à notre newsletter, veuillez confirmer votre inscription en cliquant sur le lien ci-dessous :</target>
+        <note>Line: 22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/ps_emailsubscription/newsletter_voucher.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7bf7f18afabb5122fa68fbab617e509b" approved="yes">
+        <source>Newsletter subscription</source>
+        <target state="final">Inscription à la newsletter</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="289f1fb0b0a7ed1c03d1f1f597666f67" approved="yes">
+        <source>Regarding your newsletter subscription, we are pleased to offer you the following voucher:</source>
+        <target state="final">En remerciement pour votre inscription à notre newsletter nous avons le plaisir de vous offrir un bon de réduction :</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/referralprogram/referralprogram-congratulations.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="43614475dd83d9e6b291a2805ee620fc" approved="yes">
+        <source><![CDATA[Your referred friend [1]{sponsored_firstname} {sponsored_lastname}[/1] has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target state="final"><![CDATA[Votre filleul(e) [1]{sponsored_firstname} {sponsored_lastname}[/1] a effectué son premier achat sur <a href="{shop_url}">{shop_name}</a> !]]></target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="1b9efd76beb745e43205f60167621060" approved="yes">
+        <source>We are pleased to offer you a voucher worth [1]{discount_display} (voucher # {discount_name})[/1] that you can use on your next order.</source>
+        <target state="final">Nous avons le plaisir de vous offrir un bon d'achat de [1]{discount_display} (bon de réduction # {discount_name})[/1] à utiliser sur votre prochaine commande.</target>
+        <note>Line: 23</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/referralprogram/referralprogram-invitation.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="efd0d72633aeb91f063cfa143f56ca6b" approved="yes">
+        <source>join us!</source>
+        <target state="final">Rejoignez-nous !</target>
+        <note>Line: 7</note>
+      </trans-unit>
+      <trans-unit id="c4ae632d712131d48fcb9c6197933fe6" approved="yes">
+        <source><![CDATA[Your friend [1]{firstname} {lastname}[/1] wants to refer you on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target state="final"><![CDATA[Votre ami [1]{firstname} {lastname}[/1] souhaite vous parrainer sur <a href="{shop_url}">{shop_name}</a> !]]></target>
+        <note>Line: 22</note>
+      </trans-unit>
+      <trans-unit id="dbec0bbd293d01bb529aceafda9d0af0" approved="yes">
+        <source>Get referred and earn a discount voucher of [1]{discount}![/1]</source>
+        <target state="final">Devenez son(sa) filleul(e) et remportez un bon d'achat de [1]{discount}[/1] !</target>
+        <note>Line: 24</note>
+      </trans-unit>
+      <trans-unit id="34ef083263a212936be7907709faab44" approved="yes">
+        <source>It's very easy to sign up. Just click here!</source>
+        <target state="final">Pour nous rejoindre, rien de plus simple, cliquez ici !</target>
+        <note>Line: 25</note>
+      </trans-unit>
+      <trans-unit id="ba14b0fd8b7764d2fdf225b11b6e3fc3" approved="yes">
+        <source>When signing up, don't forget to provide the e-mail address of your referring friend:</source>
+        <target state="final">N'oubliez pas de renseigner l'adresse e-mail de l'ami qui vous parraine lors de votre inscription :</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/classic/modules/referralprogram/referralprogram-voucher.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6540b502e953f4c05abeb8f234cd50bf" approved="yes">
+        <source>Referral Program</source>
+        <target state="final">Programme de parrainage</target>
+        <note>Line: 22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/account.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="22a9d6a64a74d0f58a11fa7013f4b83a" approved="yes">
+        <source>Thank you for creating a customer account at {shop_name}.</source>
+        <target state="final">Merci d'avoir créé votre compte client sur {shop_name}.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="d5b14d16c4008efddbee79cb56af5455" approved="yes">
+        <source>Here are your login details:</source>
+        <target state="final">Vos codes d'accès :</target>
+        <note>Line: 256</note>
+      </trans-unit>
+      <trans-unit id="d70650ce5612f05bfe75c1962fa1e519" approved="yes">
+        <source>Important Security Tips:</source>
+        <target state="final">Conseils de sécurité importants :</target>
+        <note>Line: 330</note>
+      </trans-unit>
+      <trans-unit id="def00214a95442dc7899951abd9a6104" approved="yes">
+        <source>Always keep your account details safe.</source>
+        <target state="final">Vos informations de compte doivent rester confidentielles.</target>
+        <note>Line: 397</note>
+      </trans-unit>
+      <trans-unit id="1559b55f6ea1de9f9b8826e9be306e6f" approved="yes">
+        <source>Never disclose your login details to anyone.</source>
+        <target state="final">Ne les communiquez jamais à qui que ce soit.</target>
+        <note>Line: 404</note>
+      </trans-unit>
+      <trans-unit id="7601ee5e7968d91a7b4f099f4b4b84d0" approved="yes">
+        <source>Change your password regularly.</source>
+        <target state="final">Changez votre mot de passe régulièrement.</target>
+        <note>Line: 411</note>
+      </trans-unit>
+      <trans-unit id="8f9011f4a1219e51c8a0638d2af3f29a" approved="yes">
+        <source>Should you suspect someone is using your account illegally, please notify us immediately.</source>
+        <target state="final">Si vous pensez que quelqu'un utilise votre compte illégalement, veuillez nous prévenir immédiatement.</target>
+        <note>Line: 418</note>
+      </trans-unit>
+      <trans-unit id="de421ce3bebc9b5a2ee30fcf0312cb68" approved="yes">
+        <source>You can now place orders on our shop:</source>
+        <target state="final">Vous pouvez dès à présent passer commande sur notre boutique :</target>
+        <note>Line: 481</note>
+      </trans-unit>
+      <trans-unit id="08bd40c7543007ad06e4fce31618f6ec" approved="yes">
+        <source>Account</source>
+        <target state="final">Compte</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="edccc47e82abb1a733820982878c5fb0" approved="yes">
+        <source>Your login details on {shop_name}</source>
+        <target state="final">Vos identifiants de connexion sur {shop_name}</target>
+        <note>Line: 189</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/backoffice_order.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="abc81c0d865925584b1269c996d7b297" approved="yes">
+        <source>A new order has been generated on your behalf.</source>
+        <target state="final">Une nouvelle commande a été générée à votre demande.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="fb08925252dd912f564413fb5109eb06" approved="yes">
+        <source>Back Office Order</source>
+        <target state="final">Commande du back office</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="bfa8b60dbfd44914f8cf61b57c641784" approved="yes">
+        <source><![CDATA[Please go on <a href="{order_link}">{order_link}</a> to complete the payment.]]></source>
+        <target state="final"><![CDATA[Veuillez vous rendre sur <a href="{order_link}">{order_link}</a> pour finaliser le paiement.]]></target>
+        <note>Line: 237</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/bankwire.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="21e4851289ecc91b65023c2563344aa7" approved="yes">
+        <source>Account owner:</source>
+        <target state="final">Titulaire du compte :</target>
+        <note>Line: 406</note>
+      </trans-unit>
+      <trans-unit id="20a650d87733bd5895c979de29864a73" approved="yes">
+        <source>Account details:</source>
+        <target state="final">Détails du compte :</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="312d898d92d8ba90499ef0dac27270be" approved="yes">
+        <source>Bank address:</source>
+        <target state="final">Adresse de la banque :</target>
+        <note>Line: 421</note>
+      </trans-unit>
+      <trans-unit id="b8f05e3501f419f9f7ec08026a9342be" approved="yes">
+        <source>Please specify your order reference in the bankwire description.</source>
+        <target state="final">Veuillez préciser votre numéro de commande dans la description du virement.</target>
+        <note>Line: 428</note>
+      </trans-unit>
+      <trans-unit id="35b4b09d5d0686ec5c2e2cc9f3d9039c" approved="yes">
+        <source>Bankwire</source>
+        <target state="final">Virement</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="e59458c2ad3850466357a1cd342adc51" approved="yes">
+        <source>Pending payment</source>
+        <target state="final">En attente de paiement</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="8f4dccd9e6900a3bbae488901ba81ce5" approved="yes">
+        <source>Payment method: bank wire</source>
+        <target state="final">Moyen de paiement : virement bancaire</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="b59639f1f1bf84129e44b83fe192b10a" approved="yes">
+        <source>You have decided to pay by bank wire.</source>
+        <target state="final">Vous avez choisi de régler par virement bancaire.</target>
+        <note>Line: 390</note>
+      </trans-unit>
+      <trans-unit id="920fcf4696dd1caa2d08eae6ebc8d29a" approved="yes">
+        <source>Here is the information you need for your transfer:</source>
+        <target state="final">Voici les informations requises pour votre virement :</target>
+        <note>Line: 391</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/cheque.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6702a6e3bc2dce95c3e3b61fe578f29c" approved="yes">
+        <source>Amount:</source>
+        <target state="final">Montant :</target>
+        <note>Line: 398</note>
+      </trans-unit>
+      <trans-unit id="1c3bd8f6bd066270354607c08f930baf" approved="yes">
+        <source>Payable to the order of:</source>
+        <target state="final">À l'ordre de :</target>
+        <note>Line: 406</note>
+      </trans-unit>
+      <trans-unit id="8f1fb2295c4289bae9fc26549b4b45f2" approved="yes">
+        <source>Please mail your check to:</source>
+        <target state="final">Veuillez envoyer votre chèque à l'adresse suivante :</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="b4556791acee238c77be9ed338a29e80" approved="yes">
+        <source>Thank you for shopping with {shop_name}!</source>
+        <target state="final">Merci d'avoir effectué vos achats sur {shop_name}!</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="97b07b4e5caa086464d9f38956718d2b" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] has been placed successfully. You can expect [1]delivery as soon as your payment is received[/1].</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] a bien été prise en compte, elle sera [1]expédiée dès réception de votre paiement[/1].</target>
+        <note>Line: 256</note>
+      </trans-unit>
+      <trans-unit id="060bf2d587991d8f090a1309b285291c" approved="yes">
+        <source>Check</source>
+        <target state="final">chèque</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="0664188509e5edc8daac0d8c80bc05b3" approved="yes">
+        <source>Awaiting payment by check</source>
+        <target state="final">En attente de paiement par chèque</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="6a9e91ee7fe91c99fc2b5915a2555a57" approved="yes">
+        <source>Payment method: check</source>
+        <target state="final">Moyen de paiement : chèque</target>
+        <note>Line: 323</note>
+      </trans-unit>
+      <trans-unit id="0cce70a6fc36b8ed06d4a0241b36eecb" approved="yes">
+        <source>You have decided to pay by bank check.</source>
+        <target state="final">Vous avez choisi de régler par chèque.</target>
+        <note>Line: 390</note>
+      </trans-unit>
+      <trans-unit id="10766e013f1b6a5cbc249604bb7fc286" approved="yes">
+        <source>Here is the information you need for your check:</source>
+        <target state="final">Voici les informations requises pour votre chèque :</target>
+        <note>Line: 391</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/contact.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a1cee0a898793ad5101154ac97984d8a" approved="yes">
+        <source>Message from a {shop_name} customer</source>
+        <target state="final">Message de la part d'un client de {shop_name}</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="53659d236625358b98797389fd2504fa" approved="yes">
+        <source>Attached file:</source>
+        <target state="final">Pièce jointe :</target>
+        <note>Line: 195</note>
+      </trans-unit>
+      <trans-unit id="c1ebb17bfd89ea960194a6162b299cda" approved="yes">
+        <source>Order ID #:</source>
+        <target state="final">ID commande # :</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="bbaff12800505b22a853e8b7f4eb6a22" approved="yes">
+        <source>Contact</source>
+        <target state="final">Contact</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="482757e4afa747b69445ed1bfa8ea542" approved="yes">
+        <source>Customer Email Address:</source>
+        <target state="final">Adresse e-mail du client :</target>
+        <note>Line: 180</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/contact_form.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="465d60b936c982d7b57674f30ba022d0" approved="yes">
+        <source>Product:</source>
+        <target state="final">Produit :</target>
+        <note>Line: 195</note>
+      </trans-unit>
+      <trans-unit id="3f65d6e17a11466983fd177702cf6a71" approved="yes">
+        <source>Contact Form</source>
+        <target state="final">Formulaire de contact</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="608a2464e2d26ee3b336400c920f87d0" approved="yes">
+        <source>Your message has been sent successfully, thank you for taking the time to write!</source>
+        <target state="final">Votre message a bien été envoyé, merci d'avoir pris le temps de nous écrire !</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="7897b8cbc40618fdd3c1ad502ba47faa" approved="yes">
+        <source>We will reply as soon as possible.</source>
+        <target state="final">Nous vous répondrons dans les meilleurs délais.</target>
+        <note>Line: 266</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/credit_slip.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f53e8d0e97c47ce70ca9c5eaa08a00d0" approved="yes">
+        <source>Credit Slip</source>
+        <target state="final">Avoir</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="cf3bae95c5f6023d5a10fe415b205a45" approved="yes">
+        <source>Credit slip</source>
+        <target state="final">Avoir</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="c44669ebfaeb42d8895e332f6199688e" approved="yes">
+        <source>A credit slip has been generated in your name for order with the reference [1]{order_name}[/1].</source>
+        <target state="final">Un avoir a été généré à votre nom relatif à votre commande ayant pour référence [1]{order_name}[/1].</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="933bd01e99683693ad9ddf8405040681" approved="yes">
+        <source><![CDATA[Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Credit slips</a> section of your customer account.]]></source>
+        <target state="final"><![CDATA[Accédez à cet avoir et téléchargez votre facture sur notre site, rendez-vous dans la section <a href="{history_url}" target="_blank">Avoirs</a> de votre compte client.]]></target>
+        <note>Line: 310</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/download_product.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c4e48432bc1c131388456f9fca605baf" approved="yes">
+        <source>Download products</source>
+        <target state="final">Télécharger vos produits</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="a6c40a67df49207ba0519d1bee14a484" approved="yes">
+        <source>Thank you for your order with the reference {order_name} from [1]{shop_name}[/1]</source>
+        <target state="final">Merci pour votre commande ayant pour référence {order_name} sur [1]{shop_name}[/1]</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9e81969b0d999f5daa0d37ce13fb7001" approved="yes">
+        <source>Product(s) to download</source>
+        <target state="final">Produit(s) à télécharger</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="8bbeb216836330d437043e36617d5325" approved="yes">
+        <source>You have [1]{nbProducts}[/1] product(s) now available for download using the following link(s):</source>
+        <target state="final">Vous avez [1]{nbProducts}[/1] produit(s) à télécharger à l'aide du/des lien(s) suivant(s) :</target>
+        <note>Line: 256</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/employee_password.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="668a8d8d7ffe5da112b266e46b79b685" approved="yes">
+        <source>First name:</source>
+        <target state="final">Prénom :</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="be5e0b5d50d48b049bd0f7b57cd163f9" approved="yes">
+        <source>Last name:</source>
+        <target state="final">Nom :</target>
+        <note>Line: 262</note>
+      </trans-unit>
+      <trans-unit id="a3b24a2a75c846bdf0bc8449746a8637" approved="yes">
+        <source>Employee password</source>
+        <target state="final">Mot de passe employé</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="02fef144b687c453c4a1ae7c4e3e150b" approved="yes">
+        <source>Here is your personal login information for {shop_name}</source>
+        <target state="final">Voici vos identifiants de connexion sur {shop_name}</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="0b937cfeb30c586cd659a58173bd37c7" approved="yes">
+        <source>Here is your identification information on [1]{shop_name}[/1]</source>
+        <target state="final">Voici vos identifiants de connexion sur [1]{shop_name}[/1]</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/forward_msg.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a9854b516855755f7a9246d781d4f57b" approved="yes">
+        <source>Discussion history:</source>
+        <target state="final">Historique de la discussion :</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="5a02acdd25040de97181665e4e84caa4" approved="yes">
+        <source>[1]{employee}[/1] wanted to forward this discussion to you.</source>
+        <target state="final">[1]{employee}[/1] souhaiterait vous transférer cette discussion.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="459ea98b5f18960e8c26da4754208f75" approved="yes">
+        <source>Forward message</source>
+        <target state="final">Transférer le message</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="c413b39ac8eea02ebfbee487d1d9ea16" approved="yes">
+        <source>Customer Service - Discussion Forwarded</source>
+        <target state="final">SAV - Discussion transférée</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="638dae1199098a2faffc18b14086ecc5" approved="yes">
+        <source>[1]{employee}[/1] added [1]{comment}[/1]</source>
+        <target state="final">[1]{employee}[/1] a ajouté [1]{comment}[/1]</target>
+        <note>Line: 261</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/guest_to_customer.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="b75184fa489c948c6debc4d635fefa5a" approved="yes">
+        <source>You can access your customer account on our shop:</source>
+        <target state="final">Vous pouvez accéder à votre compte sur notre site Internet :</target>
+        <note>Line: 311</note>
+      </trans-unit>
+      <trans-unit id="2df994fe4798f819768c87824ec15ced" approved="yes">
+        <source>Email address:</source>
+        <target state="final">Adresse e-mail :</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="016878df57341f82e0702d9259bfb7d8" approved="yes">
+        <source>Guest to customer</source>
+        <target state="final">Invité à client</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="387c721c8acb98382f1d18feccf3dd55" approved="yes">
+        <source>Your guest account has been turned into a customer account</source>
+        <target state="final">Votre compte invité a été transformé en compte client</target>
+        <note>Line: 177</note>
+      </trans-unit>
+      <trans-unit id="3008c9316cf28c5f439bbcc2e43b2e3e" approved="yes">
+        <source>Congratulations, your guest account for [1]{shop_name}[/1] has been turned into a customer account!</source>
+        <target state="final">Félicitations, votre compte invité sur [1]{shop_name}[/1] a bien été transformé en compte client !</target>
+        <note>Line: 242</note>
+      </trans-unit>
+      <trans-unit id="9964a987c88f49c4be016b1af2801403" approved="yes">
+        <source>Click on the following link to set up your password:</source>
+        <target state="final">Cliquez sur le lien suivant pour créer votre mot de passe :</target>
+        <note>Line: 249</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/import.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="293a2b3dd4b7fb2d950c8128be6d14f7" approved="yes">
+        <source>The file {filename} has been successfully imported to your shop.</source>
+        <target state="final">Le fichier {filename} a bien été importé dans votre boutique.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="72d6d7a1885885bb55a565fd1070581a" approved="yes">
+        <source>Import</source>
+        <target state="final">Importer</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="23e7f4b70281e1293a4985626589aeee" approved="yes">
+        <source>Import finished</source>
+        <target state="final">Import terminé</target>
+        <note>Line: 180</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/in_transit.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7ec4f8b296984ffe6ea829b7e1743577" approved="yes">
+        <source>In transit</source>
+        <target state="final">En cours d'expédition</target>
+        <note>Line: 185</note>
+      </trans-unit>
+      <trans-unit id="34f49f671cedfb2d5f8080ec14120281" approved="yes">
+        <source>You can track your package using the following link:</source>
+        <target state="final">Vous pouvez suivre la progression de votre livraison à l'adresse suivante:</target>
+        <note>Line: 259</note>
+      </trans-unit>
+      <trans-unit id="b395812bfd92c9b2c5cce4335dbdf404" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] is on its way.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] est en route.</target>
+        <note>Line: 252</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/log_alert.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ad69fd3d0352d7e45ccca96a1048a747" approved="yes">
+        <source><![CDATA[You can check for it in the [1]Advanced Parameters > Logs[/1] section of your back office.]]></source>
+        <target state="final"><![CDATA[Vous pouvez le consulter dans la section [1]Paramètres Avancés > Logs[/1] de votre back office.]]></target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="0f170325fe7cbbbd2be4d705b277650e" approved="yes">
+        <source>Log Alert</source>
+        <target state="final">Message d'alerte</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="223e2a86894ef6ae6d9a96b2d4f53acf" approved="yes">
+        <source>New alert message saved</source>
+        <target state="final">Nouveau message d'alerte enregistré</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="3cfb2805cc4075e0a98e932afb94d132" approved="yes">
+        <source>[1]WARNING:[/1] you have received a new log alert in your back office.</source>
+        <target state="final">[1]ATTENTION[/1] : vous avez reçu un nouveau message d'alerte dans votre back office.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/newsletter.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ffb7e666a70151215b4c55c6268d7d72" approved="yes">
+        <source>Newsletter</source>
+        <target state="final">Lettre d'informations</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_canceled.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3baf03ed2980c9f339731f052c12b37d" approved="yes">
+        <source>Order canceled</source>
+        <target state="final">Commande annulée</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="059b64746023360b7ab478fd850ffeb3" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been canceled by the merchant.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] sur [1]{shop_name}[/1] a été annulée par le marchand.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_conf.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="fb077ecba55e5552916bde26d8b9e794" approved="yes">
+        <source>Order confirmation</source>
+        <target state="final">Confirmation de commande</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="ca102bf009d3e0d62a4fc6918b20110e" approved="yes">
+        <source>Thank you for shopping on [1]{shop_name}[/1]!</source>
+        <target state="final">Merci d'avoir effectué vos achats sur [1]{shop_name}[/1] !</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="ff2fa78f07ffe4ac52c0d0b5ff7f0baa" approved="yes">
+        <source>Thank you for your order on [1]{shop_name}[/1]!</source>
+        <target state="final">Merci pour votre commande sur [1]{shop_name}[/1] !</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="96b0141273eabab320119c467cdcaf17" approved="yes">
+        <source>Total</source>
+        <target state="final">Total</target>
+        <note>Line: 382</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_customer_comment.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1607c3534ee9bdb8638858fa4bb9261b" approved="yes">
+        <source>You have received a new message regarding order with the reference</source>
+        <target state="final">Vous avez reçu un nouveau message concernant la commande ayant pour référence :</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="fa44c7d88039cc2a3caf05195e1e45bb" approved="yes">
+        <source>Order customer comment</source>
+        <target state="final">Commentaire client</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="c744bfa52ba85ff901bab4ed9319978e" approved="yes">
+        <source>Message from customer</source>
+        <target state="final">Message d'un client</target>
+        <note>Line: 180</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_merchant_comment.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2769d37f4eb00f2c9b940ee928f1b426" approved="yes">
+        <source>Message from {shop_name}</source>
+        <target state="final">Message de {shop_name}</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="940663fd4428d2c86f9a4780b6574028" approved="yes">
+        <source>Message:</source>
+        <target state="final">Message :</target>
+        <note>Line: 314</note>
+      </trans-unit>
+      <trans-unit id="15c197c97ee33f7da7df21d315fb7f71" approved="yes">
+        <source>You have received a new message from [1]{shop_name}[/1] regarding order with the reference [1]{order_name}[/1].</source>
+        <target state="final">Vous avez reçu un nouveau message depuis [1]{shop_name}[/1] concernant la commande ayant pour référence [1]{order_name}[/1].</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="371e76fdc916e1fc3818f6b96dee5219" approved="yes">
+        <source>Order merchant comment</source>
+        <target state="final">Commentaire marchand</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/order_return_state.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="96aac675caae8b0ca0a5227ce8a6a7c6" approved="yes">
+        <source>We have updated the progress on your return #{id_order_return}, the new status is:</source>
+        <target state="final">Votre bon de retour #{id_order_return} est passé à l'état :</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="3bc517b4a402645da419438914f481c6" approved="yes">
+        <source>Order return #{id_order_return} - Update</source>
+        <target state="final">Retour de commande #{id_order_return} - Mis à jour</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="d28c38eafee0f9e02256b284275603f9" approved="yes">
+        <source>Order return state</source>
+        <target state="final">État de retour de commande</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/outofstock.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="be07158cdaa6c7244af799f3cdd6dad5" approved="yes">
+        <source>Thanks for your order with the reference {order_name} from {shop_name}.</source>
+        <target state="final">Merci pour votre commande ayant pour référence {order_name} sur {shop_name}</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="e57e950cfde3e24c3674f9266753edec" approved="yes">
+        <source><![CDATA[Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.]]></source>
+        <target state="final"><![CDATA[Suivez votre commande et téléchargez votre facture sur notre site, rendez-vous dans la section <a href="{history_url}" target="_blank">Historique et détails de mes commandes</a> de votre compte client.]]></target>
+        <note>Line: 319</note>
+      </trans-unit>
+      <trans-unit id="b55197a49e8c4cd8c314bc2aa39d6feb" approved="yes">
+        <source>Out of stock</source>
+        <target state="final">Rupture de stock</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="cfc958489addbbe32552c9bc785f83c9" approved="yes">
+        <source>Replenishment required</source>
+        <target state="final">Réassort nécessaire</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="dd099f9c8d04d30fa277471417a372be" approved="yes">
+        <source>Unfortunately, one or more items are currently out of stock and this may cause a slight delay for delivery. Please accept our apologies for this inconvenience and be sure we are doing our best to correct the situation.</source>
+        <target state="final">Malheureusement, un ou plusieurs produits sont actuellement en rupture de stock, cela peut entraîner un léger retard de livraison. Veuillez nous excuser pour le dérangement, soyez assurés que nous faisons notre possible pour rétablir la situation.</target>
+        <note>Line: 256</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/password.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="dc647eb65e6711e155375218212b3964" approved="yes">
+        <source>Password</source>
+        <target state="final">Mot de passe</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="fa71c1a4010fb64e8968708b3f1e50ca" approved="yes">
+        <source>Your password has been correctly updated.</source>
+        <target state="final">Votre mot de passe a bien été mis à jour.</target>
+        <note>Line: 180</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/password_query.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="09ce893cc7228918df5657665b899249" approved="yes">
+        <source>Please note that this will change your current password.</source>
+        <target state="final">Cette opération vous attribuera un nouveau mot de passe.</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="3516ed9d771d15439e2ac9d3bf81ad84" approved="yes">
+        <source>You have requested to reset your [1]{shop_name}[/1] login details.</source>
+        <target state="final">Vous avez demandé à réinitialiser vos identifiants de connexion sur [1]{shop_name}[/1].</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="de148dcf9a5a0f2de3a65c36f9991f42" approved="yes">
+        <source>Password Query</source>
+        <target state="final">Requête mot de passe</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="87a8bbd45aa2890a2929c07d49fa64f1" approved="yes">
+        <source>Confirmation of password request on {shop_name}</source>
+        <target state="final">Confirmation de récupération de mot de passe sur {shop_name}</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="bdf92bd43402eeabaaa7e643e30607c1" approved="yes">
+        <source>In order to confirm this action, click on the following link:</source>
+        <target state="final">Pour confirmer cette action, cliquez sur le lien suivant :</target>
+        <note>Line: 261</note>
+      </trans-unit>
+      <trans-unit id="0b0df2fff267640acf7f0d03a9b90aa6" approved="yes">
+        <source>If you did not make this request, just ignore this email.</source>
+        <target state="final">Si vous n'êtes pas à l'origine de cette demande, ignorez cet e-mail.</target>
+        <note>Line: 324</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/payment.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c453a4b8e8d98e82f35b67f433e3b4da" approved="yes">
+        <source>Payment</source>
+        <target state="final">Paiement</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="3444682d2f753ddc0a602ea92891f3b1" approved="yes">
+        <source>Your payment for order with the reference [1]{order_name}[/1] was successfully processed.</source>
+        <target state="final">Le paiement pour votre commande ayant pour référence [1]{order_name}[/1] a bien été effectué.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/payment_error.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="b06c5ecc37b9cd61a0cab0534ed1f15d" approved="yes">
+        <source>Payment Error</source>
+        <target state="final">Erreur lors du paiement</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="1e97d97a923eaddd810e056c828e99ea" approved="yes">
+        <source>Payment error</source>
+        <target state="final">Erreur de paiement</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="e1a66dba9aa7c8399229122ca7528b77" approved="yes">
+        <source>We have encountered an error while processing your payment for your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1]. Please contact us as soon as possible.</source>
+        <target state="final">Nous avons rencontré une erreur lors du paiement de votre commande ayant pour référence [1]{order_name}[/1] depuis [1]{shop_name}[/1]. Veuillez nous contacter dès que possible.</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="b8dfec752b0cb58a3bc3c7479e4dd44c" approved="yes">
+        <source>You can expect delivery as soon as your payment is received.</source>
+        <target state="final">La livraison sera effectuée une fois le paiement reçu.</target>
+        <note>Line: 248</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/preparation.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9a5f09cf66e692efdae493ce4c9aa64f" approved="yes">
+        <source>Preparation</source>
+        <target state="final">Préparation</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="6ae0cf64b3eeb821a73550fab5ea13bd" approved="yes">
+        <source>Processing order</source>
+        <target state="final">Commande en cours de traitement</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="67b9a4d1678e24c00ddce83b7005b8a3" approved="yes">
+        <source>We are currently processing your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1].</source>
+        <target state="final">Nous traitons actuellement votre commande ayant pour référence [1]{order_name}[/1] de [1]{shop_name}[/1].</target>
+        <note>Line: 246</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/refund.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9b45ae8a346e0587013cdb1494e113d8" approved="yes">
+        <source>Refund processed</source>
+        <target state="final">Remboursement effectué</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="76f0ed934de85cc7131910b32ede7714" approved="yes">
+        <source>Refund</source>
+        <target state="final">Rembourser</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="6063c9fb7f9ad1d1a235c24bfcbf5522" approved="yes">
+        <source>We have processed your refund for your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1].</source>
+        <target state="final">Nous avons traité le remboursement de votre commande ayant pour référence [1]{order_name}[/1] sur [1]{shop_name}[/1].</target>
+        <note>Line: 188</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/reply_msg.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2ddbd3a9b06eadccdea8e1b372830d69" approved="yes">
+        <source>Please do not reply directly to this email, we will not receive it.</source>
+        <target state="final">Veuillez ne pas répondre directement à ce message, nous ne recevrons pas votre réponse.</target>
+        <note>Line: 245</note>
+      </trans-unit>
+      <trans-unit id="b0faef9417304909de0960b57582cd1c" approved="yes">
+        <source>Reply msg</source>
+        <target state="final">Message de réponse</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="7e4e256f10a59674290c89dd1bba1312" approved="yes">
+        <source><![CDATA[In order to reply, click on the following link: <a href="{link}" target="_blank">{link}</a>]]></source>
+        <target state="final"><![CDATA[Pour répondre, cliquer sur le lien suivant : <a href="{link}" target="_blank">{link}</a>]]></target>
+        <note>Line: 246</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/shipped.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="747cf5c8587184b9e489ff897d97c20d" approved="yes">
+        <source>Shipped</source>
+        <target state="final">Expédié</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="da825075a1643697f1540f1c946c01f1" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] has been shipped.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] a été expédiée.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/test.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0cbc6611f5540bd0809a388dc95a615b" approved="yes">
+        <source>Test</source>
+        <target state="final">Test</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="8afe3c369cb4d2e723edabf14b8d8db8" approved="yes">
+        <source>Here is a test [1]email[/1] from your shop.</source>
+        <target state="final">Ceci est un [1]e-mail[/1] de test depuis votre boutique.</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="a6ec75fcb2240ccd4ea29549ee413885" approved="yes">
+        <source>If you can read this, it means the test is successful!</source>
+        <target state="final">Si vous pouvez le lire, cela veut dire que le test a réussi !</target>
+        <note>Line: 187</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/voucher.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bba6345ca09bf0e21cb502bc6d960cde" approved="yes">
+        <source>In order to use it, just copy/paste this code during check out.</source>
+        <target state="final">Pour en bénéficier, copier/coller ce code lors de l'achat.</target>
+        <note>Line: 260</note>
+      </trans-unit>
+      <trans-unit id="be686376cddb23d0227444ccc3c4b5b7" approved="yes">
+        <source>Voucher</source>
+        <target state="final">Bon de réduction</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="3e943dfae35fac1a61b30da7f27f2204" approved="yes">
+        <source>Voucher code generated</source>
+        <target state="final">Bon de réduction généré</target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="0482c9e34db0bf16ec3a09c4dc7c3b0b" approved="yes">
+        <source>We are pleased to inform you that a voucher has been generated in your name for order with the reference [1]{order_name}[/1].</source>
+        <target state="final">Nous avons le plaisir de vous informer qu'un bon de réduction a été généré à votre nom relatif à votre commande ayant pour référence [1]{order_name}[/1].</target>
+        <note>Line: 246</note>
+      </trans-unit>
+      <trans-unit id="5dc1b3e639ee30637424bd07af99154d" approved="yes">
+        <source>[1]VOUCHER CODE: {voucher_num}[/1] in the amount of [1]{voucher_amount}[/1]</source>
+        <target state="final">[1]BON DE REDUCTION : {voucher_num}[/1] d'un montant de [1]{voucher_amount}[/1]</target>
+        <note>Line: 253</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/core/voucher_new.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0b04d9ad5743989471141ab21edd64fd" approved="yes">
+        <source>Voucher new</source>
+        <target state="final">Nouveau bon de réduction</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="68b8413e263842c318e66fc6b29144da" approved="yes">
+        <source>Voucher code has been generated</source>
+        <target state="final">Le bon de réduction a été généré</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="af4667c3d9a39bfa5ce658080730210a" approved="yes">
+        <source>Here is your new voucher code:</source>
+        <target state="final">Voici votre nouveau bon de réduction :</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_1.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="784e102689c17fd18fe94135d4fa864d" approved="yes">
+        <source>Your cart at {shop_name}</source>
+        <target state="final">Votre panier chez {shop_name}</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="804e4e067b0e61e122e1a35771fcf144" approved="yes">
+        <source>Follow up 1</source>
+        <target state="final">Suivi 1</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="b9018fa1aff4ac6de7e50d6a8f1c9e4a" approved="yes">
+        <source>Thanks for your visit. However, it looks like you did not complete your purchase.</source>
+        <target state="final">Merci de votre visite. Cependant, vous n'avez pas finalisé votre commande.  </target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="14c90ec7c3372b9f39c9cf24323bd959" approved="yes">
+        <source>Your cart has been saved, you can go back to your order on our shop:</source>
+        <target state="final">Vous panier a été conservé, vous pouvez reprendre votre commande depuis notre boutique :</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="938ad8b6f0f1e5c4663bc171ad56822e" approved="yes">
+        <source>Your voucher code on {shop_name}</source>
+        <target state="final">Votre bon de réduction sur {shop_name}</target>
+        <note>Line: 328</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_2.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7ff89d85f528f79efd0a85c01a43cb62" approved="yes">
+        <source>Follow up 2</source>
+        <target state="final">Suivi 2</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="605fc3ecd313608fe8c6cbbed5a25261" approved="yes">
+        <source>Thanks for your order.</source>
+        <target state="final">Merci pour votre commande.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_3.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="66472df69ec288388183a74a6e34e942" approved="yes">
+        <source>Thanks for your trust.</source>
+        <target state="final">Merci pour votre confiance.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="383126b6a239da6f7d483220c63a46e2" approved="yes">
+        <source>Follow up 3</source>
+        <target state="final">Suivi 3</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/followup/followup_4.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="8dec16ec73558f6fb2515cce4293ce6f" approved="yes">
+        <source>Your cart has been saved, you can resume your order by visiting our shop:</source>
+        <target state="final">Vous panier a été conservé, vous pouvez reprendre votre commande en vous rendant sur notre boutique :</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="18df3f8153de940176206b06a3610f80" approved="yes">
+        <source>We are pleased to offer you a discount of [1]{amount}%[/1] off your next order. And this offer is valid for [1]{days}[/1] days, so do not wait any longer!</source>
+        <target state="final">Nous avons le plaisir de vous offrir une réduction de [1]{amount}%[/1] sur votre prochaine commande. Cette offre est valable [1]{days}[/1] jours alors n'attendez plus !</target>
+        <note>Line: 261</note>
+      </trans-unit>
+      <trans-unit id="5416511766be8537f357142a81ccd7a7" approved="yes">
+        <source>Here is your VOUCHER CODE:</source>
+        <target state="final">Voici votre BON DE REDUCTION :</target>
+        <note>Line: 328</note>
+      </trans-unit>
+      <trans-unit id="ececa54d96395d3afa79cdce8e7e0bd6" approved="yes">
+        <source>Enter this code in your shopping cart to get the discount.</source>
+        <target state="final">Saisissez ce code dans votre panier pour bénéficier de la réduction.</target>
+        <note>Line: 334</note>
+      </trans-unit>
+      <trans-unit id="a5672f20db3e09abb35f909cf56f3b23" approved="yes">
+        <source>Follow up 4</source>
+        <target state="final">Suivi 4</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="1e6f48752a20a5c6dc2f387c18777136" approved="yes">
+        <source>Your cart on {shop_name}</source>
+        <target state="final">Votre panier chez {shop_name}</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="8dfa91d2853e941e80553ab1336b6459" approved="yes">
+        <source>Congratulations, you are one of our best customers! However, it looks like you have not placed an order since {days_threshold} days.</source>
+        <target state="final">Félicitations, vous faites partie de nos meilleurs clients ! Cependant, vous n'avez pas commandé depuis {days_threshold} jours.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/customer_qty.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9b096ae55ce4d2bb889392144c104069" approved="yes">
+        <source>{product} is now available.</source>
+        <target state="final">{product} est maintenant disponible.</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="583b02c0b2f05171037b58c186a5461d" approved="yes">
+        <source>Customer Quantity</source>
+        <target state="final">Quantité client</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="61a517de529038e441a1f6ada3f5a196" approved="yes">
+        <source>Good news, this item is back in stock!</source>
+        <target state="final">Bonne nouvelle, cet article est de nouveau en stock !</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="fb0e8fc6b59dac729bb483b2c617adf2" approved="yes">
+        <source>Click on the following link to visit the product page and order it:</source>
+        <target state="final">Cliquez sur le lien suivant pour accéder à la page produit et le commander :</target>
+        <note>Line: 254</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/new_order.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5c1cc11c191c9a0f32d16439618ed3bb" approved="yes">
+        <source>Customer message:</source>
+        <target state="final">Message du client :</target>
+        <note>Line: 667</note>
+      </trans-unit>
+      <trans-unit id="f5d74ea75357b5e139854c14f8e24fe3" approved="yes">
+        <source>Order details</source>
+        <target state="final">Détails de la commande</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="2ca3deb5cd68fa9119b285804fab572f" approved="yes">
+        <source>Order:</source>
+        <target state="final">Commande :</target>
+        <note>Line: 255</note>
+      </trans-unit>
+      <trans-unit id="101f2450ccefbd344b37971c5d27f96d" approved="yes">
+        <source>Placed on</source>
+        <target state="final">passée le</target>
+        <note>Line: 255</note>
+      </trans-unit>
+      <trans-unit id="a0e8e26f6f9354192425b9a23227a5ba" approved="yes">
+        <source>Payment:</source>
+        <target state="final">Paiement :</target>
+        <note>Line: 510</note>
+      </trans-unit>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca" approved="yes">
+        <source>Reference</source>
+        <target state="final">Référence</target>
+        <note>Line: 331</note>
+      </trans-unit>
+      <trans-unit id="deb10517653c255364175796ace3553f" approved="yes">
+        <source>Product</source>
+        <target state="final">Produit</target>
+        <note>Line: 332</note>
+      </trans-unit>
+      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2" approved="yes">
+        <source>Unit price</source>
+        <target state="final">Prix unitaire</target>
+        <note>Line: 333</note>
+      </trans-unit>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73" approved="yes">
+        <source>Quantity</source>
+        <target state="final">Quantité</target>
+        <note>Line: 334</note>
+      </trans-unit>
+      <trans-unit id="0eede552438475bdfe820c13f24c9399" approved="yes">
+        <source>Total price</source>
+        <target state="final">Prix total</target>
+        <note>Line: 335</note>
+      </trans-unit>
+      <trans-unit id="068f80c7519d0528fb08e82137a72131" approved="yes">
+        <source>Products</source>
+        <target state="final">Produits</target>
+        <note>Line: 340</note>
+      </trans-unit>
+      <trans-unit id="9d5bf15117441a1b52eb1f0808e4aad3" approved="yes">
+        <source>Discounts</source>
+        <target state="final">Réductions</target>
+        <note>Line: 346</note>
+      </trans-unit>
+      <trans-unit id="41c1d61bfff3fc9b1fd8f195061b8caa" approved="yes">
+        <source>Gift-wrapping</source>
+        <target state="final">Paquet cadeau</target>
+        <note>Line: 352</note>
+      </trans-unit>
+      <trans-unit id="ea9cf7e47ff33b2be14e6dd07cbcefc6" approved="yes">
+        <source>Shipping</source>
+        <target state="final">Livraison</target>
+        <note>Line: 358</note>
+      </trans-unit>
+      <trans-unit id="ea067eb37801c5aab1a1c685eb97d601" approved="yes">
+        <source>Total paid</source>
+        <target state="final">Total payé</target>
+        <note>Line: 370</note>
+      </trans-unit>
+      <trans-unit id="f8617a92ba0a0a4eabee724eab7c9f48" approved="yes">
+        <source>Carrier:</source>
+        <target state="final">Transporteur :</target>
+        <note>Line: 504</note>
+      </trans-unit>
+      <trans-unit id="af0f5bdc5be121b9307687aeeae38c17" approved="yes">
+        <source>Delivery address</source>
+        <target state="final">Adresse de livraison</target>
+        <note>Line: 580</note>
+      </trans-unit>
+      <trans-unit id="1fbc7e5f1b92c7ec072397b59a0bb5da" approved="yes">
+        <source>Billing address</source>
+        <target state="final">Adresse de facturation</target>
+        <note>Line: 596</note>
+      </trans-unit>
+      <trans-unit id="5c9412907a7aabeea3491fafec5c082e" approved="yes">
+        <source>Including total tax</source>
+        <target state="final">Incluant un total de taxes</target>
+        <note>Line: 364</note>
+      </trans-unit>
+      <trans-unit id="6810a1cc40329a394b9d73b5f8dac744" approved="yes">
+        <source>New Order</source>
+        <target state="final">Nouvelle commande</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="ea1fc6431869b331e6db01a2f6ca921f" approved="yes">
+        <source>A new order was placed on [1]{shop_name}[/1] by the following customer:</source>
+        <target state="final">Une nouvelle commande a été effectuée sur [1]{shop_name}[/1] par le client suivant :</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="914419aa32f04011357d3b604a86d7eb" approved="yes">
+        <source>Carrier</source>
+        <target state="final">Transporteur</target>
+        <note>Line: 437</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/order_changed.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ac32eb3619340a6b6aff41d9797665d4" approved="yes">
+        <source>Order changed</source>
+        <target state="final">Commande modifiée</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="681a0aa2d158085f63f86c84900fa989" approved="yes">
+        <source>Your order with the reference [1]{order_name}[/1] from [1]{shop_name}[/1] has been changed by the merchant.</source>
+        <target state="final">Votre commande ayant pour référence [1]{order_name}[/1] sur [1]{shop_name}[/1] a été modifiée par le marchand.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="869a6d7d8b6af1ca14f874356141ac45" approved="yes">
+        <source><![CDATA[If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.]]></source>
+        <target state="final"><![CDATA[Si vous avez un compte invité, vous pouvez suivre votre commande via la section <a href="{guest_tracking_url}" target="_blank">Suivi invité</a> sur notre boutique.]]></target>
+        <note>Line: 317</note>
+      </trans-unit>
+      <trans-unit id="af6c5b694abbb964eec098febaa5d31d" approved="yes">
+        <source>Order ID {order_name}</source>
+        <target state="final">Identifiant de commande {order_name}</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="c03924df23d22785084b06a548ca9976" approved="yes">
+        <source>Go to your customer account to learn more about it.</source>
+        <target state="final">Pour en savoir plus, rendez-vous sur votre compte client.</target>
+        <note>Line: 254</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/productcoverage.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="81899e9a62d3f952e81d5f72437470f9" approved="yes">
+        <source>Current stock cover:</source>
+        <target state="final">Couverture actuelle :</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="fdf4e97dcf4ad98512050ab60cf91bc3" approved="yes">
+        <source>Product coverage</source>
+        <target state="final">Stock restant</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="906898f022140256a84c9429a3fcf4d8" approved="yes">
+        <source>Your stock cover is now less than the specified minimum of:</source>
+        <target state="final">Le stock restant est maintenant inférieur au minimum défini de :</target>
+        <note>Line: 180</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/productoutofstock.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6983ddb3442f4ad4a3b94e94a1ebd3dc" approved="yes">
+        <source>{product} is almost out of stock.</source>
+        <target state="final">{product} est en rupture de stock.</target>
+        <note>Line: 178</note>
+      </trans-unit>
+      <trans-unit id="ab8f74636fc3f34b09b1300a2393a0b8" approved="yes">
+        <source>Remaining stock:</source>
+        <target state="final">Stock restant :</target>
+        <note>Line: 252</note>
+      </trans-unit>
+      <trans-unit id="d3f03e2edd35c99abb3fd3d9bc51706e" approved="yes">
+        <source><![CDATA[Replenish your inventory, go to the [1]Catalog > Stocks[/1] section of your back office to manage your stock.]]></source>
+        <target state="final"><![CDATA[Renouvelez vos stocks, rendez-vous dans la section [1]Catalogue > Stocks[/1] de votre back office pour gérer les quantités de vos articles.]]></target>
+        <note>Line: 258</note>
+      </trans-unit>
+      <trans-unit id="644f9c907ef5a8315916bd1e2f61f783" approved="yes">
+        <source>Product out of stock</source>
+        <target state="final">Produit en rupture de stock</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="9300ac228fc7c8ec8d970d862d68432c" approved="yes">
+        <source>There are now less than [1]{last_qty}[/1] items in stock.</source>
+        <target state="final">Il y a maintenant moins de [1]{last_qty}[/1] articles en stock.</target>
+        <note>Line: 245</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailalerts/return_slip.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5eea367ea73b909880393bd1ae79fc67" approved="yes">
+        <source>Customer:</source>
+        <target state="final">Client :</target>
+        <note>Line: 262</note>
+      </trans-unit>
+      <trans-unit id="f285446f60a203b0f7c3ad0b14d13d29" approved="yes">
+        <source>You have received a new return request for {shop_name}.</source>
+        <target state="final">Vous avez reçu une nouvelle demande de retour pour {shop_name}.</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="6773c510bcd24041ed4d515b65358e96" approved="yes">
+        <source>Return Slip</source>
+        <target state="final">Étiquette de retour</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="9b600ac4bf14f6e3919b919893bae7f8" approved="yes">
+        <source>Return Details</source>
+        <target state="final">Détails du retour</target>
+        <note>Line: 189</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailsubscription/newsletter_conf.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4e1c51e233f1ed368c58db9ef09010ba" approved="yes">
+        <source>Thank you for subscribing to our newsletter.</source>
+        <target state="final">Merci de vous être inscrit à notre newsletter.</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="bb372ddf88ad8fcc480f7a8599a92abc" approved="yes">
+        <source>Hi,</source>
+        <target state="final">Bonjour,</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="c9a257051d205ce3d0f4078b53dd4512" approved="yes">
+        <source>Newsletter Confirmation</source>
+        <target state="final">Confirmation newsletter</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailsubscription/newsletter_verif.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="32e00ed1f8f1062378ba2c47ac75de9d" approved="yes">
+        <source>Newsletter Verification</source>
+        <target state="final">Vérification newsletter</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="3b3d69d6a53f5cb28d8867f5aeb1aa78" approved="yes">
+        <source>Thank you for subscribing to our newsletter. Please click on the following link to confirm your request:</source>
+        <target state="final">Merci de vous être abonné à notre newsletter. Veuillez cliquer sur le lien suivant pour confirmer :</target>
+        <note>Line: 180</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/ps_emailsubscription/newsletter_voucher.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2eb58792075fb4bea9ad03b6da20ec05" approved="yes">
+        <source>Newsletter Voucher</source>
+        <target state="final">Bon de réduction newsletter</target>
+        <note>Line: 3</note>
+      </trans-unit>
+      <trans-unit id="fb85495b4c45ce28e7a1521017326c5a" approved="yes">
+        <source>Subscribing to newsletter</source>
+        <target state="final">S'abonner à la newsletter</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="f6c3e4834d385f4923121b89bdee29c0" approved="yes">
+        <source>Thank you for subscribing to our newsletter. We are pleased to offer you the following voucher:</source>
+        <target state="final">Merci de vous êtes abonné à notre newsletter. Nous avons le plaisir de vous offrir le bon de réduction suivant :</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/referralprogram/referralprogram-congratulations.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1a81759353d36dbd31059fc261af0aa2" approved="yes">
+        <source>Congratulations!</source>
+        <target state="final">Bravo !</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="0920dd6cc2680f2a960c59f757d5184d" approved="yes">
+        <source><![CDATA[Your referred friend [1]{sponsored_firstname}[/1] [1]{sponsored_lastname}[/1] has placed his/her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target state="final"><![CDATA[Votre filleul(e) [1]{sponsored_firstname}[/1] [1]{sponsored_lastname}[/1] a effectué son premier achat sur <a href="{shop_url}">{shop_name}</a> !]]></target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="4461931aad93f10308121eb94ce7be47" approved="yes">
+        <source>We are pleased to offer you a voucher worth [1]{discount_display}[/1] (VOUCHER # [1]{discount_name}[/1]) that you can use on your next order.</source>
+        <target state="final">Nous avons le plaisir de vous offrir un bon d'achat de [1]{discount_display}[/1] (BON DE REDUCTION # [1]{discount_name}[/1]) à utiliser sur votre prochaine commande.</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="49af6950c9d9101af9ae958b4426c6b9" approved="yes">
+        <source>Referral program Congratulations</source>
+        <target state="final">Programme de parrainage Félicitations</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/referralprogram/referralprogram-invitation.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="677182971924ee6799eb365f688c5572" approved="yes">
+        <source>Best regards,</source>
+        <target state="final">Bien cordialement,</target>
+        <note>Line: 311</note>
+      </trans-unit>
+      <trans-unit id="4a898b178164591fca68f786e164927d" approved="yes">
+        <source>We are pleased to offer you a voucher worth [1]{discount}[/1] that you can use on your next order.</source>
+        <target state="final">Nous avons le plaisir de vous offrir un bon d'achat de [1]{discount}[/1] à utiliser sur votre prochaine commande.</target>
+        <note>Line: 186</note>
+      </trans-unit>
+      <trans-unit id="814fd45dff3fa38cc8114bc0d6c9020a" approved="yes">
+        <source>Join us!</source>
+        <target state="final">Rejoignez-nous !</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="a2ca20d3687abde01edc72cb7c1c5600" approved="yes">
+        <source><![CDATA[Your friend [1]{firstname} {lastname}[/1] wants to refer you on <a href="{shop_url}" target="_blank">{shop_name}</a>!]]></source>
+        <target state="final"><![CDATA[Votre ami [1]{firstname} {lastname}[/1] souhaite vous parrainer sur <a href="{shop_url}" target="_blank">{shop_name}</a> !]]></target>
+        <note>Line: 179</note>
+      </trans-unit>
+      <trans-unit id="b37f4e64c7473dac9931e0fabf536ef3" approved="yes">
+        <source>Get referred and earn a discount voucher of [1]{discount}[/1]!</source>
+        <target state="final">Devenez son(sa) filleul(e) et remportez un bon d'achat de [1]{discount}[/1] !</target>
+        <note>Line: 187</note>
+      </trans-unit>
+      <trans-unit id="48f75fa6577e9a8b1a43268ac9844494" approved="yes">
+        <source>It's very easy to sign up, just click here!</source>
+        <target state="final">Pour nous rejoindre, rien de plus simple, cliquez ici !</target>
+        <note>Line: 189</note>
+      </trans-unit>
+      <trans-unit id="a0d3fa1d46da3bd234eb873154675d8e" approved="yes">
+        <source>When signing up, don't forget to provide the email address of your referring friend:</source>
+        <target state="final">N'oubliez pas de renseigner l'adresse e-mail de l'ami qui vous parraine lors de votre inscription :</target>
+        <note>Line: 253</note>
+      </trans-unit>
+      <trans-unit id="a9f8dbec69378bc1c5b1e9d144bd2412" approved="yes">
+        <source>Referral program Invitation</source>
+        <target state="final">Programme de parrainage Invitation</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="mails/themes/modern/modules/referralprogram/referralprogram-voucher.html.twig" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="31ee1241ee08294dfc2ca85698fda2a1" approved="yes">
+        <source>Hi {firstname} {lastname},</source>
+        <target state="final">Bonjour {firstname} {lastname},</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="f4f614c22d9d2cbd0f9aa08cd59600d2" approved="yes">
+        <source>Simply copy/paste this code during the payment process for your next order.</source>
+        <target state="final">Copiez-collez ce numéro dans le panier de votre prochain achat avant de régler la commande.</target>
+        <note>Line: 255</note>
+      </trans-unit>
+      <trans-unit id="abe1585bf97403d8a9a01a272183585a" approved="yes">
+        <source>Here is the code of your voucher:</source>
+        <target state="final">Voici le numéro de votre bon de réduction :</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="dd863685846fc4eddcc9d6d09ddd5264" approved="yes">
+        <source>We have created a voucher in your name for referring a friend.</source>
+        <target state="final">Nous vous informons de la génération d'un bon de réduction à votre nom relatif à votre parrainage.</target>
+        <note>Line: 247</note>
+      </trans-unit>
+      <trans-unit id="389df865c60c8fc7b86bf773eb5b121c" approved="yes">
+        <source>, with an amount of</source>
+        <target state="final">, d'un montant total de</target>
+        <note>Line: 248</note>
+      </trans-unit>
+      <trans-unit id="cb3374f4e7a0afb61e63d0ee694ad501" approved="yes">
+        <source>Sponsorship Program</source>
+        <target state="final">Programme de parrainage</target>
+        <note>Line: 180</note>
+      </trans-unit>
+      <trans-unit id="f38a99a3e90333bd34a64e90f03960f4" approved="yes">
+        <source>Referral program Voucher</source>
+        <target state="final">Programme de parrainage Réduction</target>
+        <note>Line: 3</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/cheque.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3f8b7a7948f4fd5d9bb34d63746dfd23" approved="yes">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been placed successfully and will be <strong>shipped as soon as we receive your payment</strong>.]]></source>
+        <target state="final"><![CDATA[Nous avons bien enregistré votre commande ayant pour référence <span><strong>{order_name}</strong></span>. Celle-ci vous sera <strong>envoyée dès réception de votre paiement</strong>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/cheque.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/credit_slip.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="b1c95c88d55558a6c04dea50425199df" approved="yes">
+        <source><![CDATA[We have generated a credit slip in your name for order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target state="final"><![CDATA[Nous vous informons de la génération d'un avoir à votre nom relatif à votre commande ayant pour référence <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/credit_slip.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/download_product.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="afae9cdc5d9b4583915a579cb0c67788" approved="yes">
+        <source><![CDATA[You have <span><strong>{nbProducts}</strong></span> product(s) now available for download using the following link(s):]]></source>
+        <target state="final"><![CDATA[Vous avez <span><strong>{nbProducts}</span></strong> produit(s) à télécharger.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/download_product.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/employee_password.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a1fd16fcb98f1a6ec4312a10e6a3acba" approved="yes">
+        <source><![CDATA[Here is your personal login information for <span><strong>{shop_name}</strong></span>:]]></source>
+        <target state="final"><![CDATA[Voici vos informations d'identification sur <span><strong>{shop_name}</strong></span> :]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/employee_password.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/footer.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e1c65ac2c128f4835c77d0c7aefccb7e" approved="yes">
+        <source><![CDATA[<a href="{shop_url}">{shop_name}</a> powered by <a href="http://www.prestashop.com/">PrestaShop™</a>]]></source>
+        <target state="final"><![CDATA[<a href="{shop_url}">{shop_name}</a> propulsé par <a href="http://www.prestashop.com/">PrestaShop™</a>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/footer.php:6</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/forward_msg.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="85ae5cfc68837cc8e50609b84babba09" approved="yes">
+        <source><![CDATA[<span><strong>{employee}</strong></span> wanted to forward this discussion to you.]]></source>
+        <target state="final"><![CDATA[<span><strong>{employee}</strong></span> souhaite vous transférer cette discussion.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:24</note>
+      </trans-unit>
+      <trans-unit id="f4df87e5e465151ae8d5954bec01d9ec" approved="yes">
+        <source><![CDATA[<span><strong>{employee}</strong></span> added <span><strong>"{comment}"</strong></span>]]></source>
+        <target state="final"><![CDATA[<span><strong>{employee}</strong></span> a ajouté <span><strong>"{comment}"</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/forward_msg.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/guest_to_customer.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="499e229d39934f1a36f3f48718cc19cc" approved="yes">
+        <source><![CDATA[Your guest account for <span><strong>{shop_name}</strong></span> has been transformed into a customer account.]]></source>
+        <target state="final"><![CDATA[Votre compte invité sur <span><strong>{shop_name}</strong></span> a été transformé en compte client.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/guest_to_customer.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/in_transit.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="873a6c9ce4b0711161105e4a6d943bb6" approved="yes">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> is currently in transit.]]></source>
+        <target state="final"><![CDATA[La livraison de votre commande ayant pour référence <span><strong>{order_name}</strong></span> est en cours.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/in_transit.php:49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/log_alert.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="17357f0ed7c82a1620f4311667886a63" approved="yes">
+        <source><![CDATA[<span><strong>Warning:</strong></span> you have received a new log alert in your Back Office.]]></source>
+        <target state="final"><![CDATA[<span><strong>Attention :</strong></span> vous avez reçu un nouveau message d'alerte dans votre back-office.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:24</note>
+      </trans-unit>
+      <trans-unit id="ba00a1816b599684def5ff1d312ef5ed" approved="yes">
+        <source><![CDATA[You can check for it in the <span><strong>"Tools" > "Logs"</strong></span> section of your Back Office.]]></source>
+        <target state="final"><![CDATA[Vous pouvez consulter les messages d'alerte grâce à la page <span><strong>Paramètres de la boutique > Logs</strong></span> de votre back office.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/log_alert.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_canceled.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="50651089ed12eb33b55394a0a17618de" approved="yes">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been canceled.]]></source>
+        <target state="final"><![CDATA[Votre commande sur  <span><strong>{shop_name}</strong></span> ayant pour référence <span><strong>{order_name}</strong></span> a été annulée.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_canceled.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_changed.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0e6321e9d36186e957652f07d88116a5" approved="yes">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> from <span><strong>{shop_name}</strong></span> has been changed by the merchant.]]></source>
+        <target state="final"><![CDATA[Votre commande sur <span><strong>{shop_name}</strong></span> ayant pour référence <span><strong>{order_name}</strong></span> a été modifiée par le marchand.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_changed.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/order_merchant_comment.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ad9fd7d0fe973ddaef093d912d0b57e2" approved="yes">
+        <source><![CDATA[You have received a new message from <span><strong>{shop_name}</strong></span> regarding order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target state="final"><![CDATA[Vous avez reçu un nouveau message de <span><strong>{shop_name}</strong></span> concernant la commande ayant pour référence <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/order_merchant_comment.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/password_query.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="18f3152ffe51f0d446558f666dc8d5ea" approved="yes">
+        <source><![CDATA[You have requested to reset your <span><strong>{shop_name}</strong></span> login details.]]></source>
+        <target state="final"><![CDATA[Vous avez demandé à récupérer vos codes d'accès sur <span><strong>{shop_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/password_query.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/shipped.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e9933131bfeef332fc84561f8e23aeba" approved="yes">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been shipped.]]></source>
+        <target state="final"><![CDATA[Votre commande ayant la référence <span><strong>{order_name}</strong></span> vient d'être expédiée.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/shipped.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/test.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0afa69e0eb948ce9fb81e14cc0c7cf0b" approved="yes">
+        <source><![CDATA[This is a <strong>test e-mail</strong> from your shop.<br /><br /> If you can read this, the test was successful!]]></source>
+        <target state="final"><![CDATA[Voici un <strong>e-mail</strong> de test de votre boutique. <br /><br />Si vous parvenez à lire ceci, le test a réussi!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/test.php:14</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/core/voucher.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="17ab9221f0e6cb342a02d31c56c79c2b" approved="yes">
+        <source><![CDATA[A voucher has been created in your name as a result of your order with the reference <span><strong>{order_name}</strong></span>.]]></source>
+        <target state="final"><![CDATA[Nous vous informons de la génération d'un bon de réduction à votre nom relatif à votre commande ayant pour référence <span><strong>{order_name}</strong></span>.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:24</note>
+      </trans-unit>
+      <trans-unit id="25cecf399c0cd872952ced4a7d150e0d" approved="yes">
+        <source><![CDATA[<span><strong>Voucher code: {voucher_num}</strong></span> in the amount of <span><strong>{voucher_amount}</strong></span>]]></source>
+        <target state="final"><![CDATA[<span><strong>Code du bon de réduction : {voucher_num}</strong></span> Montant: <span><strong>{voucher_amount}</strong></span>]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/core/voucher.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_1.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2213ab34c63663d94f96efdb6a9be339" approved="yes">
+        <source><![CDATA[As an incentive, we can give you a discount of {amount}% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target state="final"><![CDATA[A titre exceptionnel, nous vous accordons également une remise de {amount}% sur votre commande ! Cette offre est valable <span><strong>{days}</strong></span> jours, ne perdez plus un instant !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_1.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_2.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3a5fa552bd31ebcceae0973cd384406b" approved="yes">
+        <source><![CDATA[As our way of saying thanks, we want to give you a discount of <span><strong>{amount}</strong></span>% off your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target state="final"><![CDATA[À titre exceptionnel, nous vous accordons une remise de <span><strong>{amount}%</strong></span> sur votre prochaine commande ! Cette offre est valable <span><strong>{days}</strong></span> jours, ne perdez plus un instant !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_2.php:22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_3.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="86736a3055a9913b2c64671cd333e159" approved="yes">
+        <source><![CDATA[As appreciation for your loyalty, we want to give you a discount of <span><strong>{amount}</strong></span>% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target state="final"><![CDATA[Pour vous remercier de votre fidélité, nous vous accordons une remise de <span><strong>{amount}%</strong></span> valable sur votre prochaine commande ! Cette offre est valable <span><strong>{days}</strong></span> jours, ne perdez plus un instant !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_3.php:25</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/followup/followup_4.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="08706a0434d504af130649d9fd74ca54" approved="yes">
+        <source><![CDATA[We wish to thank you for the trust you have placed in us and want to give you a discount of {amount}% valid on your next order! This offer is valid for <span><strong>{days}</strong></span> days, so do not waste a moment!]]></source>
+        <target state="final"><![CDATA[Nous souhaitons vous remercier pour la confiance dont vous nous faites part et à ce titre, nous vous accordons une remise de <span><strong>{amount}%</strong></span> valable sur votre prochaine commande ! Cette offre est valable {days} jours, ne perdez plus un instant !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/followup/followup_4.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="fe61da38922f840543c9f7a4f5dc8140" approved="yes">
+        <source><![CDATA[Your order with the reference <span><strong>{order_name}</strong></span> has been modified.]]></source>
+        <target state="final"><![CDATA[Votre commande référence <span><strong>{order_name}</strong></span> a été modifiée.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/order_changed.php:24</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/ps_emailalerts/productoutofstock.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a36e5157843703cdad66073626eb54cb" approved="yes">
+        <source><![CDATA[You are advised to open the product&#039;s admin Product Page in order to replenish your inventory.]]></source>
+        <target state="final"><![CDATA[Nous vous conseillons de vous rendre sur la page produit du panneau d'administration afin de renouveler vos stocks.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/ps_emailalerts/productoutofstock.php:26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="90e0a7c3c7230e2188794af89350ea7b" approved="yes">
+        <source><![CDATA[Your referred friend <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> has placed his or her first order on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target state="final"><![CDATA[Votre filleul(e) <span><strong>{sponsored_firstname} {sponsored_lastname}</strong></span> a effectué son premier achat sur <a href="{shop_url}">{shop_name}</a>!]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:21</note>
+      </trans-unit>
+      <trans-unit id="eb7c04362c657d5651703a43307e61c2" approved="yes">
+        <source><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount_display} (voucher # {discount_name})</strong></span> that you can use on your next order.]]></source>
+        <target state="final"><![CDATA[Nous avons le plaisir de vous offrir un bon d'achat de <span><strong>{discount_display} (bon de réduction # {discount_name})</strong></span>, que vous pourrez utiliser à l'occasion de votre prochaine commande.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-congratulations.php:22</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9607a6790558da43af7334b50dfb5354" approved="yes">
+        <source><![CDATA[Your friend <span><strong>{firstname} {lastname}</strong></span> wants to refer you on <a href="{shop_url}">{shop_name}</a>!]]></source>
+        <target state="final"><![CDATA[Votre ami(e) <span><strong>{firstname} {lastname}</strong></span> vous a parrainé depuis le site <a href="{shop_url}">{shop_name}</a> !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:21</note>
+      </trans-unit>
+      <trans-unit id="a234487df6f91f04f3d99a597681a4ac" approved="yes">
+        <source><![CDATA[We are pleased to offer you a voucher worth <span><strong>{discount}</strong></span> that you can use on your next order.]]></source>
+        <target state="final"><![CDATA[Nous avons le plaisir de vous offrir un bon d'achat de <span><strong>{discount}</strong></span> que vous pourrez utiliser à l'occasion de votre prochaine commande.]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:22</note>
+      </trans-unit>
+      <trans-unit id="99c81bae8075078e8af2bccbdd5e98b6" approved="yes">
+        <source><![CDATA[Get referred and earn a discount voucher of <span><strong>{discount}!</strong></span>]]></source>
+        <target state="final"><![CDATA[Devenez son(sa) filleul(e) afin de gagner un bon d'achat de <span><strong>{discount}!</strong></span> !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:23</note>
+      </trans-unit>
+      <trans-unit id="36791224f527482e84d2ff30fbb3c699" approved="yes">
+        <source><![CDATA[It&#039;s very easy to sign up. Just click here!]]></source>
+        <target state="final"><![CDATA[Pour nous rejoindre, rien de plus simple : cliquez ici !]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:24</note>
+      </trans-unit>
+      <trans-unit id="edfb7a07b2d6386a1308f34c1a08aa0e" approved="yes">
+        <source><![CDATA[When signing up, don&#039;t forget to provide the e-mail address of your referring friend:]]></source>
+        <target state="final"><![CDATA[N'oubliez pas d'y préciser l'e-mail de votre ami en tant que parrain lors de votre inscription :]]></target>
+        <note>Context:
+File: modules/ps_emailgenerator/templates/modules/referralprogram/referralprogram-invitation.php:39</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/translations/fr-FR/EmailsSubject.fr-FR.xlf
+++ b/tests/Resources/translations/fr-FR/EmailsSubject.fr-FR.xlf
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/Customer.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="32e8a8d9ed872f16d6dae0dc5fd4bb71" approved="yes">
+        <source>Your guest account has been transformed into a customer account</source>
+        <target state="final">Votre compte invité a été transformé en compte client</target>
+        <note>Line: 1144</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/PaymentModule.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="fca7e8d1c86db11246e429e40aa10c81" approved="yes">
+        <source>New voucher for your order %s</source>
+        <target state="final">Nouveau bon de réduction pour votre commande %s</target>
+        <note>Line: 1174</note>
+      </trans-unit>
+      <trans-unit id="fb077ecba55e5552916bde26d8b9e794" approved="yes">
+        <source>Order confirmation</source>
+        <target state="final">Confirmation de commande</target>
+        <note>Line: 672</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/PrestaShopLogger.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="caedcb9e2005bf6e522cf4536a1885bd" approved="yes">
+        <source>Log: You have a new alert from your shop</source>
+        <target state="final">Log : Vous avez un nouveau message d'alerte dans votre boutique</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/form/CustomerPersister.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9a843f20677a52ca79af903123147af0" approved="yes">
+        <source>Welcome!</source>
+        <target state="final">Bienvenue !</target>
+        <note>Line: 219</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderCarrier.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="87405e011a2c4166bb685336827fbe81" approved="yes">
+        <source>Package in transit</source>
+        <target state="final">Livraison en cours</target>
+        <note>Line: 149</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderHistory.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3cf100d3725155b75779945680651f3d" approved="yes">
+        <source>The virtual product that you bought is available for download</source>
+        <target state="final">Le produit  que vous avez acheté est prêt à être téléchargé</target>
+        <note>Line: 175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminImportController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a218495ad30949e8ea1f64a261e37463" approved="yes">
+        <source>Import complete</source>
+        <target state="final">Import terminé</target>
+        <note>Line: 4894</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f2328a3f139e31d53016f94ea9477124" approved="yes">
+        <source>Your order return status has changed</source>
+        <target state="final">L'état de votre retour produit a été modifié</target>
+        <note>Line: 264</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/OrderDetailController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="381fc38b470ed543424afbd43f224453" approved="yes">
+        <source>Message from a customer</source>
+        <target state="final">Message d'un client</target>
+        <note>Line: 110</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/PasswordController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="61afad00abe3639b3ead655a1e8696d9" approved="yes">
+        <source>Password query confirmation</source>
+        <target state="final">Confirmation de demande de mot de passe</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="c5f4622e4a63b41e7c0ddc100583ee6b" approved="yes">
+        <source>Your new password</source>
+        <target state="final">Votre nouveau mot de passe</target>
+        <note>Line: 200</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/contactform/contactform.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9e03c4150db1c72add84ba520ee589aa" approved="yes">
+        <source>Message from contact form</source>
+        <target state="final">Message depuis le formulaire de contact</target>
+        <note>Line: 614</note>
+      </trans-unit>
+      <trans-unit id="55c19f9aec68a1a320cbeba663f1e4c0" approved="yes">
+        <source>Your message has been correctly sent #ct%thread_id% #tc%thread_token%</source>
+        <target state="final">Votre message a été correctement envoyé #ct%thread_id% #tc%thread_token%</target>
+        <note>Line: 643</note>
+      </trans-unit>
+      <trans-unit id="d40cb87db94e750405e7b20a8a043d81" approved="yes">
+        <source>Your message has been correctly sent</source>
+        <target state="final">Votre message a bien été envoyé</target>
+        <note>Line: 649</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_emailsubscription/ps_emailsubscription.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a95bc59685fb4546de3884a5fbe474ea" approved="yes">
+        <source>Newsletter voucher</source>
+        <target state="final">Bon de réduction newsletter</target>
+        <note>Line: 730</note>
+      </trans-unit>
+      <trans-unit id="efabbb0eb84d3c8e487a72e879953673" approved="yes">
+        <source>Newsletter confirmation</source>
+        <target state="final">Confirmation newsletter</target>
+        <note>Line: 765</note>
+      </trans-unit>
+      <trans-unit id="732f1aa49f17856ff55a5aa0a88374d9" approved="yes">
+        <source>Email verification</source>
+        <target state="final">E-mail de vérification</target>
+        <note>Line: 804</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Cart/CommandHandler/SendCartToCustomerHandler.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="cad374f43e79ca774b2e8e00dcd8b842" approved="yes">
+        <source>Process the payment of your order</source>
+        <target state="final">Régler votre commande</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/CustomerService/CommandHandler/AddOrderCustomerMessageHandler.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="abe01af80b6bc9f1fa34feaa068336b2" approved="yes">
+        <source>New message regarding your order</source>
+        <target state="final">Nouveau message concernant votre commande</target>
+        <note>Line: 247</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/CustomerService/CommandHandler/ForwardCustomerThreadHandler.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4f55e8d67e33d354a5273eb87c903980" approved="yes">
+        <source>Fwd: Customer message</source>
+        <target state="final">TR: Message d'un client</target>
+        <note>Line: 174</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/CustomerService/CommandHandler/ReplyToCustomerThreadHandler.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="26fabd8660373b86b9288dd72fd40e13" approved="yes">
+        <source>An answer to your message is available #ct%thread_id% #tc%thread_token%</source>
+        <target state="final">Une réponse à votre message est disponible #ct%thread_id% #tc%thread_token%</target>
+        <note>Line: 154</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Refund/OrderSlipCreator.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="10e7889bf2e6fd95e25936d2c11e92be" approved="yes">
+        <source>New credit slip regarding your order</source>
+        <target state="final">Nouvel avoir concernant votre commande</target>
+        <note>Line: 133</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Refund/VoucherGenerator.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="b360ddde7a5a70304c005e45e141cf9d" approved="yes">
+        <source>New voucher for your order #%s</source>
+        <target state="final">Nouveau bon de réduction pour votre commande %s</target>
+        <note>Line: 150</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Resources/translations/fr-FR/messages.fr-FR.xlf
+++ b/tests/Resources/translations/fr-FR/messages.fr-FR.xlf
@@ -1,0 +1,2963 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="admin-dev/themes/default/template/controllers/attribute_generator/content.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="32aa6a8b290538b9af3531ea1e1a9dbf" approved="yes">
+        <source>Tax Excluded</source>
+        <target state="final">HT</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="8794a5dad880ed1a30d82081872b050e" approved="yes">
+        <source>Tax Included</source>
+        <target state="final">TTC</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="181ba1a9e1a38f1a83277046cdbbc2bc" approved="yes">
+        <source>%d product(s) successfully created.</source>
+        <target state="final">%d produit(s) créé(s) avec succès.</target>
+        <note>Line: 66</note>
+      </trans-unit>
+      <trans-unit id="81315cfd898aada1e99e0034b4b078c3" approved="yes">
+        <source>Attributes generator</source>
+        <target state="final">Générateur de déclinaisons de produits</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="422f3f656e1a5f95e8b5cf7565d815b5" approved="yes">
+        <source>The Combinations Generator is a tool that allows you to easily create a series of combinations by selecting the related attributes. For example, if you're selling t-shirts in three different sizes and two different colors, the generator will create six combinations for you.</source>
+        <target state="final">Le générateur de déclinaisons est un outil qui vous permet de créer facilement une série de déclinaisons en sélectionnant les attributs associés. Par exemple, si vous vendez des T-shirts, en 3 tailles différentes et 2 couleurs différentes, le générateur va créer 6 déclinaisons pour vous.</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="cfe938f78378cfd9739d4321cfa7ff78" approved="yes">
+        <source>You're currently generating combinations for the following product:</source>
+        <target state="final">Vous êtes actuellement en train de générer des combinaisons pour ce produit :</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="31fd7663706f9829ba8e64b229df4e3f" approved="yes">
+        <source>Step 1: On the left side, select the attributes you want to use (Hold down the "Ctrl" key on your keyboard and validate by clicking on "Add")</source>
+        <target state="final">Étape 1 : Sur le côté gauche, sélectionnez les attributs que vous souhaitez utiliser (en maintenant la touche "CTRL" de votre clavier et de valider en cliquant sur "Ajouter")</target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="928929ae9eb360f552df9c62c5fef6e2" approved="yes">
+        <source>Impact on the product price</source>
+        <target state="final">Impact sur le prix du produit</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="2cbb96b1bb8e0942f609bba818277f7c" approved="yes">
+        <source>Impact on the product weight</source>
+        <target state="final">Impact sur le poids du produit</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="4e927d0c87a6edc742e9c664f18a53c7" approved="yes">
+        <source>Select a default quantity, and reference, for each combination the generator will create for this product.</source>
+        <target state="final">Sélectionnez une quantité et une référence par défaut pour toutes les déclinaisons que le générateur va créer pour ce produit.</target>
+        <note>Line: 125</note>
+      </trans-unit>
+      <trans-unit id="1b8bea6c0d2655c4e2c1070c9beee03a" approved="yes">
+        <source>Default Quantity:</source>
+        <target state="final">Quantité par défaut :</target>
+        <note>Line: 129</note>
+      </trans-unit>
+      <trans-unit id="49d079be0fc1fcccefdee6bdf67b02ff" approved="yes">
+        <source>Default Reference:</source>
+        <target state="final">Référence par défaut :</target>
+        <note>Line: 133</note>
+      </trans-unit>
+      <trans-unit id="fb6d5b178b6f3ce02379006b7610ed6d" approved="yes">
+        <source>Please click on "Generate these combinations".</source>
+        <target state="final">Veuillez cliquer sur "Générer ces déclinaisons".</target>
+        <note>Line: 138</note>
+      </trans-unit>
+      <trans-unit id="e3c57b7da599fa0a9410c456b59f6dd3" approved="yes">
+        <source>Generate these combinations</source>
+        <target state="final">Générer ces combinaisons</target>
+        <note>Line: 139</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="62acf0bc057112bf91cd1ff9f1426c6c" approved="yes">
+        <source>[undefined]</source>
+        <target state="final">[indéfini]</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/actions.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bcca39c6f36c3085c46429511614b227" approved="yes">
+        <source>If enabled, the voucher will not apply to products already on sale.</source>
+        <target state="final">Si activé, le bon de réduction ne s'appliquera pas aux produits déjà en promotion.</target>
+        <note>Line: 145</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/cart_rules/product_rule_group.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d6d9190e86f812c0490da9360e12cee1" approved="yes">
+        <source>Add a rule concerning</source>
+        <target state="final">Ajouter une règle qui concerne</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="c5536e008327e8873c8daf321a088873" approved="yes">
+        <source>The product(s) are matching one of these:</source>
+        <target state="final">Les produits correspondent à l'un de ces critères :</target>
+        <note>Line: 65</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f14b582c1b0eab88ed5904fb781568c0" approved="yes">
+        <source>Discount name</source>
+        <target state="final">Nom de la réduction</target>
+        <note>Line: 203</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/options/options.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1e65b02f3464a517e0946a46d496327c" approved="yes">
+        <source>Sync success</source>
+        <target state="final">Synchronisation effectuée avec succès</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/modal.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d3d2e617335f08df83599665eef8a418" approved="yes">
+        <source>Close</source>
+        <target state="final">Fermer</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3bf63a999cda6c9d95c3827e7942f41d" approved="yes">
+        <source>Customer since: %s</source>
+        <target state="final">Client depuis : %s</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="8df41ed5ebc778c45f74a201e822613a" approved="yes">
+        <source>Choose a template</source>
+        <target state="final">Choisir un modèle </target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="94966d90747b97d1f0f206c98a8b1ac3" approved="yes">
+        <source>Send</source>
+        <target state="final">Envoyer</target>
+        <note>Line: 119</note>
+      </trans-unit>
+      <trans-unit id="2605a817441c19cc88eb9e5d17845dc0" approved="yes">
+        <source>You can add a comment here.</source>
+        <target state="final">Vous pouvez ajouter un commentaire ici.</target>
+        <note>Line: 155</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customer_threads/message.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d13d8380c3f4de07fef91a42fe6c60d7" approved="yes">
+        <source>Customer ID:</source>
+        <target state="final">ID client :</target>
+        <note>Line: 127</note>
+      </trans-unit>
+      <trans-unit id="d1228f5476d15142b1358ae4b5fa2454" approved="yes">
+        <source>Order #</source>
+        <target state="final">Commande n°</target>
+        <note>Line: 134</note>
+      </trans-unit>
+      <trans-unit id="c851a34d4806acb02a55df148f9d7f25" approved="yes">
+        <source>Product #</source>
+        <target state="final">Produit n°</target>
+        <note>Line: 141</note>
+      </trans-unit>
+      <trans-unit id="47a0be8d1015d526a1fbaa56c3102135" approved="yes">
+        <source>Subject:</source>
+        <target state="final">Sujet :</target>
+        <note>Line: 147</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/customers/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d1554912e46f8d36a800ad8b604225f1" approved="yes">
+        <source>Valid orders:</source>
+        <target state="final">Commandes valides :</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="0c71153e10e4cca705c7de8625f23344" approved="yes">
+        <source>%firstname% %lastname% has not registered any addresses yet</source>
+        <target state="final">%firstname% %lastname% n'a pas encore enregistré d'adresse</target>
+        <note>Line: 654</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="908f8d9f34f375a55dd5b6a86489d364" approved="yes">
+        <source>No result</source>
+        <target state="final">Aucun résultat</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="37a502907cd750af8c65517a75d00030" approved="yes">
+        <source>Real Time</source>
+        <target state="final">Temps Réel</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/groups/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a1e7379abfdbc3b8e03506e5489c6110" approved="yes">
+        <source>Discount:</source>
+        <target state="final">Remise :</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="801ab24683a4a8c433c6eb40c48bcd9d" approved="yes">
+        <source>Download</source>
+        <target state="final">Téléchargement</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="3bb4a695db0c87a3d70a2deffddeb743" approved="yes">
+        <source>Read more about the CSV format at:</source>
+        <target state="final">Plus d'informations sur le format CSV sur :</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="e81c4e4f2b7b93b481e13a8553c2ae1b" approved="yes">
+        <source>or</source>
+        <target state="final">OU</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="e4cdcd51e6cf787d4ecc7d813f0c23cb" approved="yes">
+        <source>The locale must be installed</source>
+        <target state="final">Les locales doivent être installées</target>
+        <note>Line: 188</note>
+      </trans-unit>
+      <trans-unit id="e08caeac3f80ffa7889cdf1c8f30111f" approved="yes">
+        <source>Multiple value separator</source>
+        <target state="final">Séparateur de champs à valeurs multiples</target>
+        <note>Line: 208</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5f613cee6c941423b73e1f87ea3b99bc" approved="yes">
+        <source>Please name your data matching configuration in order to save it.</source>
+        <target state="final">Veuillez saisir un nom pour l'enregistrement de votre configuration.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="43a37c093f7655efe882a7ffd7ce2e8d" approved="yes">
+        <source>Match your data</source>
+        <target state="final">Correspondance des données</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="e275f3b49dc3286ef66d7c2774a1f79b" approved="yes">
+        <source>Please match each column of your source file to one of the destination columns.</source>
+        <target state="final">Veuillez faire correspondre chaque colonne de votre fichier source avec l'une des colonnes cibles.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="4d83ebfaf28dd4436e1165a1764750db" approved="yes">
+        <source>Load a data matching configuration</source>
+        <target state="final">Charger une configuration d'import</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="f19dbf2edb3a0bd74b0524d960ff21eb" approved="yes">
+        <source>Load</source>
+        <target state="final">Charger</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="e195639ebd7491676218b40af7aeafe3" approved="yes">
+        <source>Save your data matching configuration</source>
+        <target state="final">Sauvegarder votre configuration d'import</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="371ed088d2c0e456f5cae0bb97fe7c4b" approved="yes">
+        <source>Two columns cannot have the same type of values</source>
+        <target state="final">Deux colonnes ne peuvent pas être mise en correspondance avec le même champ.</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="6a00e03023004b3330275e8d9842b54c" approved="yes">
+        <source>This column must be set:</source>
+        <target state="final">Cette colonne est requise :</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="3b057f0f92ac8d274701c269ac00c5fa" approved="yes">
+        <source>Rows to skip</source>
+        <target state="final">Lignes à passer</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="225ba2bdb1c56af16651110411fc21b1" approved="yes">
+        <source>Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.</source>
+        <target state="final">Indiquez combien de lignes parmi les premières lignes du fichier doivent être ignorées lors de l'import des données. Par exemple, indiquez 1 si la première ligne de votre fichier contient les en-têtes.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/login/content.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="dc647eb65e6711e155375218212b3964" approved="yes">
+        <source>Password</source>
+        <target state="final">Mot de passe</target>
+        <note>Line: 68</note>
+      </trans-unit>
+      <trans-unit id="685de99eb748aa2bba879a87af2ffed4" approved="yes">
+        <source>Your password has been successfully changed.</source>
+        <target state="final">Votre mot de passe a été modifié avec succès.</target>
+        <note>Line: 118</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/manufacturers/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0071aa279bd1583754a544277740f047" approved="yes">
+        <source>Delete item #</source>
+        <target state="final">Supprimer l'élément n°</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/ad_bar.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4df29b3cd68e3d8e40be0ad31188f17c" approved="yes">
+        <source>You might be interested in</source>
+        <target state="final">Vous serez peut-être intéressé par</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/configure.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="deccbe4e9083c3b5f7cd2632722765bb" approved="yes">
+        <source>Translate</source>
+        <target state="final">Traduire</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="06933067aafd48425d67bcb01bba5cb6" approved="yes">
+        <source>Update</source>
+        <target state="final">Mettre à jour</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="c439b45b0a80369402e0d6158b55590f" approved="yes">
+        <source>Generate RTL Stylesheets</source>
+        <target state="final">Générer des feuilles de style RTL</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="53103fcc4656f55c219b600ded3c7438" approved="yes">
+        <source>Manage hooks</source>
+        <target state="final">Points d'accroche</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="a27dfe771799a09fd55fea73286eb6ab" approved="yes">
+        <source>Uninstall</source>
+        <target state="final">Désinstaller</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/content-legacy.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="fe6b7985acf4b17efbfe1b38545299d9" approved="yes">
+        <source>See all modules</source>
+        <target state="final">Voir tous les modules</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="4181fcfe54e8fadc0644e1cadde3483f" approved="yes">
+        <source>To add a new module, simply connect to your PrestaShop Addons account and all your purchases will be automatically imported.</source>
+        <target state="final">Pour ajouter un nouveau module, connectez-vous simplement à votre compte PrestaShop Addons et tous vos achats seront automatiquement importés.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="82010160301993d2d752d8f185b31d0c" approved="yes">
+        <source>Can I add my own modules?</source>
+        <target state="final">Puis-je ajouter mes propres modules ?</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="bb2ee5b5f12b6eae3c1716d26cddeab7" approved="yes">
+        <source>Please note that for security reasons, you can only add modules that are being distributed on PrestaShop Addons, the official marketplace.</source>
+        <target state="final">Pour des raisons de sécurité, nous pouvez ajouter uniquement des modules qui sont distribués sur PrestaShop Addons, notre place de marché officielle.</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="95e3873b64426add2f3818e6a98dc9fb" approved="yes">
+        <source>Search on PrestaShop Marketplace:</source>
+        <target state="final">Rechercher sur la marketplace de PrestaShop :</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="3a2d5fe857d8f9541136a124c2edec6c" approved="yes">
+        <source>Or</source>
+        <target state="final">Ou</target>
+        <note>Line: 53</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/favorites.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e55f75a29310d7b60f7ac1d390c8ae42" approved="yes">
+        <source>Module</source>
+        <target state="final">Module</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="7e4a9cd054588a95b0394d92a2030e72" approved="yes">
+        <source>Normal view</source>
+        <target state="final">Vue normale</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="d7af23f5f349f2c4eace4927943b2760" approved="yes">
+        <source>Favorites view</source>
+        <target state="final">Vue par favoris</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="5c6ba25104401c9ee0650230fc6ba413" approved="yes">
+        <source>Tab</source>
+        <target state="final">Menu</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0" approved="yes">
+        <source>Categories</source>
+        <target state="final">Catégories</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="920beb5dda21b04a332e0457cb0cfbec" approved="yes">
+        <source>Interest</source>
+        <target state="final">Intérêt</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="01165dcf77c191e6c69b31d98b0ec6ff" approved="yes">
+        <source>Favorite</source>
+        <target state="final">Favoris</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/filters.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3182ea023795eb83ed0ce3beea5beb73" approved="yes">
+        <source>Other Modules</source>
+        <target state="final">Autres modules</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="d9e87fc7a13ba398295447791c67b586" approved="yes">
+        <source>Installed Modules</source>
+        <target state="final">Modules installés</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="a0f454ebaee933c7791ffcdda76944b3" approved="yes">
+        <source>Disabled Modules</source>
+        <target state="final">Modules désactivés</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="1f0e9c979b965d24aa3c2c4b832c3ba1" approved="yes">
+        <source>Filter by</source>
+        <target state="final">Filtrer par</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="7b4d2812164df0dceca0b53bb650e52d" approved="yes">
+        <source><![CDATA[Installed & Not Installed]]></source>
+        <target state="final"><![CDATA[Installés et non installés]]></target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="94c8dec8d2fcfa80c9b6f4669be43eb0" approved="yes">
+        <source>Modules Not Installed </source>
+        <target state="final">Modules non installés</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="6b8f34307b46c249a91d84e52ae94caf" approved="yes">
+        <source><![CDATA[Enabled & Disabled]]></source>
+        <target state="final"><![CDATA[Activés & désactivés]]></target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="dfe6e46e2d3e3ba76b5d9aee197c0747" approved="yes">
+        <source>Enabled Modules</source>
+        <target state="final">Modules activés</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="02684cc6b6ea1811a064f475a5fd1d18" approved="yes">
+        <source>Authors</source>
+        <target state="final">Auteurs</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="00c3388449f7c4d73cc8c417d7d38554" approved="yes">
+        <source>All Modules</source>
+        <target state="final">Tous les modules</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="d546df356f9b15d6d20b1e5d8b310fed" approved="yes">
+        <source>Free Modules</source>
+        <target state="final">Modules gratuits</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="d071f451a57ab54fa6890d0f501a99d4" approved="yes">
+        <source>Partner Modules (Free)</source>
+        <target state="final">Modules partenaires (Gratuits)</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="02ae741da806bbeafc0ae6a84ce752d3" approved="yes">
+        <source>Must Have</source>
+        <target state="final">Incontournable</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="174704dbe8a3a7d144b0ce840e734077" approved="yes">
+        <source>Modules purchased on Addons</source>
+        <target state="final">Modules achetés sur Addons</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="fbdc9a432c8e6a94bb54864ae4f5fb7f" approved="yes">
+        <source>All authors</source>
+        <target state="final">Tous</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="c3987e4cac14a8456515f0d200da04ee" approved="yes">
+        <source>All countries</source>
+        <target state="final">Tous les pays</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="d188407e1d066cd41925efebe2dab3da" approved="yes">
+        <source>Current country:</source>
+        <target state="final">Pays actuel :</target>
+        <note>Line: 68</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/js.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="45e06e5610d29d675a875a6f7731b73d" approved="yes">
+        <source>Would you like to delete the content related to this module ?</source>
+        <target state="final">Souhaitez-vous supprimer le contenu lié à ce module ?</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c0d19e251d0ff55ecb860e7349f779a4" approved="yes">
+        <source>Confirm reset</source>
+        <target state="final">Confirmer la réinitialisation</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d65c99010166606287266e4af4f0b934" approved="yes">
+        <source>No - reset only the parameters</source>
+        <target state="final">Non - réinitialiser seulement les paramètres</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="0426ba52f94430cf093652d1ea18fedf" approved="yes">
+        <source>Yes - reset everything</source>
+        <target state="final">Oui - tout réinitialiser</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="25b22a00db3085743f478140b8281a26" approved="yes">
+        <source>Preferences saved</source>
+        <target state="final">Préférences enregistrées</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/list.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4f9b5fa08f2ef86fdc5d0ceefc271981" approved="yes">
+        <source>Remove from Favorites</source>
+        <target state="final">Supprimer des favoris</target>
+        <note>Line: 168</note>
+      </trans-unit>
+      <trans-unit id="7263f59f5d8aeaf7d2117fcd4b70930a" approved="yes">
+        <source>Mark as Favorite</source>
+        <target state="final">Ajouter aux favoris</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="59fcbc24a474d290fa540a3a27e2ff05" approved="yes">
+        <source>Module %1s </source>
+        <target state="final">Module %1s</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="3846bafee4cc9ce49c24a0b499d3e08d" approved="yes">
+        <source>Official, PrestaShop certified module. Free, secure and includes updates!</source>
+        <target state="final">Module Officiel gratuit, validé par PrestaShop et mis à jour régulièrement !</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="52dd3893c24e9cf4be761dcaee6bea39" approved="yes">
+        <source>Update it!</source>
+        <target state="final">Mettre à jour !</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="29c632cf1c7f140b6e86f3af04df48d4" approved="yes">
+        <source>Install the selection</source>
+        <target state="final">Installer la sélection</target>
+        <note>Line: 196</note>
+      </trans-unit>
+      <trans-unit id="7245ac07bbd56e6d0f7489a7dddb836f" approved="yes">
+        <source>Uninstall the selection</source>
+        <target state="final">Désinstaller la sélection</target>
+        <note>Line: 202</note>
+      </trans-unit>
+      <trans-unit id="df3f079de6961496f0460dcfdbf9bca3" approved="yes">
+        <source>by</source>
+        <target state="final">par</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="ba6b1bc4d8bfe5e6e835afa72f102a02" approved="yes">
+        <source>You bought this module on PrestaShop Addons. Thank You.</source>
+        <target state="final">Vous avez acheté ce module sur PrestaShop Addons. Merci !</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="fe5a7fc9d9c907efdf6a384a71cd53fc" approved="yes">
+        <source>Bought</source>
+        <target state="final">Acheté</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="0461779839539a8ee8fb2dca43cf5bec" approved="yes">
+        <source>This module is available on PrestaShop Addons</source>
+        <target state="final">Ce module est disponible sur PrestaShop Addons.</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="2cc1943d4c0b46bfcf503a75c44f988b" approved="yes">
+        <source>Popular</source>
+        <target state="final">Populaire</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="0008feba81a131902ece95d59f1b8f21" approved="yes">
+        <source>Official</source>
+        <target state="final">Officiel</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="28f60d4760851bab00345a3cb86871f7" approved="yes">
+        <source>Need update</source>
+        <target state="final">Nécessite une mise à jour</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="b24ce0cd392a5b0b8dedc66c25213594" approved="yes">
+        <source>Free</source>
+        <target state="final">gratuit</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="43340e6cc4e88197d57f8d6d5ea50a46" approved="yes">
+        <source>Read more</source>
+        <target state="final">En savoir plus</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="349838fb1d851d3e2014b9fe39203275" approved="yes">
+        <source>Install</source>
+        <target state="final">Installer</target>
+        <note>Line: 115</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/login_addons.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ee0e3cf3fd1a733924756c6534826843" approved="yes">
+        <source>If you want to be able to fully use the AdminModules panel and have free modules available, you should enable the following configuration on your server:</source>
+        <target state="final">Si vous souhaitez utiliser pleinement le panneau AdminModules et afficher les modules libres, vous devriez activer la configuration suivante sur votre serveur :</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="c84172ea13aaad319bfb3324c8fda5ed" approved="yes">
+        <source>Enable PHP's allow_url_fopen setting</source>
+        <target state="final">Activer allow_url_fopen</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="27d8cabeab5ec86130d0e9048a085b57" approved="yes">
+        <source>Enable PHP's OpenSSL extension</source>
+        <target state="final">Activer l'extension OpenSSL de PHP</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="40218c0320e986d6b29fde4259ac43c2" approved="yes">
+        <source>Connect your shop to PrestaShop's marketplace in order to automatically import all your Addons purchases.</source>
+        <target state="final">Connectez-vous à la place de marché de PrestaShop afin d'importer automatiquement tous vos achats.</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="a5f61298da21626d0f490ebd06ecd811" approved="yes">
+        <source>Don't have an account?</source>
+        <target state="final">Vous n'avez pas de compte ?</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="030547d47b4cb2e88a3c9a581a61487a" approved="yes">
+        <source>Discover the Power of PrestaShop Addons! Explore the PrestaShop Official Marketplace and find over 3 500 innovative modules and themes that optimize conversion rates, increase traffic, build customer loyalty and maximize your productivity</source>
+        <target state="final">Les clés pour réussir votre boutique sont sur PrestaShop Addons ! Découvrez sur la place de marché officielle de PrestaShop plus de 3 500 modules et thèmes pour augmenter votre trafic, optimiser vos conversions, fidéliser vos clients et vous faciliter l’e-commerce.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="74ec9ffc8d108924d191065b416d8544" approved="yes">
+        <source>Connect to PrestaShop Addons</source>
+        <target state="final">Connectez-vous à PrestaShop Addons</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="b05d72142020283dc6812fd3a9bc691c" approved="yes">
+        <source>I forgot my password</source>
+        <target state="final">Mot de passe oublié</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="2fe4fe0a0ebea41ce43eb3dc3fce4ea3" approved="yes">
+        <source>Create an Account</source>
+        <target state="final">Créer un compte</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="b6d4223e60986fa4c9af77ee5f7149c5" approved="yes">
+        <source>Sign in</source>
+        <target state="final">Connexion</target>
+        <note>Line: 80</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="5724be5bf0b6c384f8f0e4ec5c56960e" approved="yes">
+        <source>What Should I Do?</source>
+        <target state="final">Que devrais-je faire ?</target>
+        <note>Line: 79</note>
+      </trans-unit>
+      <trans-unit id="34afcb42ab73990082d328d9b34811b5" approved="yes">
+        <source>Proceed with the installation</source>
+        <target state="final">Continuer l'installation</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9c4573ad0738d689dcb4dfb11ea6ce5a" approved="yes">
+        <source>Do you want to install this module that could not be verified by PrestaShop?</source>
+        <target state="final">Souhaitez-vous installer ce module qui n'a pas pu être vérifié par PrestaShop ?</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="cff96407d828626ba1219454e9dde40c" approved="yes">
+        <source>Since you may not have downloaded this module from PrestaShop Addons, we cannot assert that the module is not adding some undisclosed functionalities. We advise you to install it only if you trust the source of the content.</source>
+        <target state="final">Vous n'avez probablement pas téléchargé ce module depuis PrestaShop Addons, nous ne pouvons garantir qu'il n'ajoute pas certaines fonctionnalités cachées. Nous vous conseillons de l'installer uniquement si vous faites confiance à son auteur.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="cb6c308b881809f8ab33d50efad0b665" approved="yes">
+        <source>What's the risk?</source>
+        <target state="final">Quel est le risque ?</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="b1c3bf188b7df9285d57df41f00c7041" approved="yes">
+        <source>Am I at Risk?</source>
+        <target state="final">Suis-je concerné ?</target>
+        <note>Line: 73</note>
+      </trans-unit>
+      <trans-unit id="144f70b53defb91dacdb0a4ac79b7e70" approved="yes">
+        <source>A module that hasn't been verified may be dangerous and could add hidden functionalities like backdoors, ads, hidden links, spam, etc. Don’t worry, this alert is simply a warning.</source>
+        <target state="final">Un module qui n'a pas pu être vérifié peut être dangereux et ajouter des fonctionnalités cachées comme des portes dérobées, publicités, lien cachés, spam, etc. Pas d'inquiétude, cette alerte est un simple avertissement.</target>
+        <note>Line: 75</note>
+      </trans-unit>
+      <trans-unit id="50d39ed39f0e1c95d185acc6b89de6f8" approved="yes">
+        <source>PrestaShop, being an open-source software, has an awesome community with a long history of developing and sharing high quality modules. Before installing this module, making sure its author is a known community member is always a good idea (by checking [1]our forum[/1] for instance).</source>
+        <target state="final">Étant un logiciel open-source, PrestaShop possède une fabuleuse communauté riche d'une longue expérience en développement et partage de modules de qualité. Avant d'installer un module, s'assurer que son auteur est un membre reconnu de la communauté est toujours une bonne idée (en parcourant [1]notre forum[/1] par exemple).</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="9bbcbf7c1f7c1df3c3d9d3b7767fac09" approved="yes">
+        <source>If you trust or find the author of this module to be an active community member, you can proceed with the installation.</source>
+        <target state="final">Si vous connaissez l'auteur de ce module ou qu'il est un membre actif de la communauté, vous pouvez continuer l'installation en toute confiance.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="67afee0d8b56356469f89525a1423331" approved="yes">
+        <source>Otherwise you can look for similar modules on the official marketplace. [1]Click here to browse PrestaShop Addons[/1].</source>
+        <target state="final">Vous pouvez sinon rechercher des modules similaires sur notre place de marché officielle. [1]Cliquez ici pour parcourir le catalogue de PrestaShop Addons[/1].</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="0557fa923dcee4d0f86b1409f5c2167f" approved="yes">
+        <source>Back</source>
+        <target state="final">Précédent</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_blocked.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e88e176e72b122566ada523a7297e4e5" approved="yes">
+        <source>This module could not be verified by PrestaShop.</source>
+        <target state="final">Ce module n'a pas vu être vérifié par PrestaShop.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="d16d7b2c414d4750596290776d0bfbf7" approved="yes">
+        <source>Since you may not have installed this module from PrestaShop Addons, we cannot assert that the module is complying with our safety requirements (e.g. that it is not adding some undisclosed functionalities such as ads, hidden links, spam, etc...).</source>
+        <target state="final">Il semblerait que nous n'ayez pas installé ce module depuis PrestaShop Addons, aussi nous ne pouvons garantir qu'il réponde à nos critères de sécurité (par ex. qu'il n'ajoute pas des fonctionnalités dissimulées comme de la publicité, des liens cachés, du spam, etc...).</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="64b9168c0ef9c05d1568a15c6e273bf1" approved="yes">
+        <source>You can search for similar modules on the official marketplace.</source>
+        <target state="final">Vous pouvez rechercher des modules similaires sur la place de marché officielle.</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="57acfffeede560e141ea67a4487fe065" approved="yes">
+        <source>[1]Click here to browse our catalog on PrestaShop Addons[/1].</source>
+        <target state="final">[1]Cliquez ici pour parcourir le catalogue de PrestaShop Addons[/1].</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6754e4799f554bcdf4fef4782bf4d7de" approved="yes">
+        <source>This generally happens when the module isn't distributed through our official marketplace, PrestaShop Addons - or when your server failed to communicate with PrestaShop Addons.</source>
+        <target state="final">Ceci se produit généralement lorsque le module n'est pas distribué via notre place de marché officielle PrestaShop Addons, ou quand votre serveur n'arrive pas à communiquer avec PrestaShop Addons.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="a517747c3d12f99244ae598910d979c5" approved="yes">
+        <source>Author</source>
+        <target state="final">Auteur</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="249212ebba2907c6087887db076179e6" approved="yes">
+        <source>Back to modules list</source>
+        <target state="final">Retour à la liste des modules</target>
+        <note>Line: 51</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_not_trusted_country.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="54752f2f929b686b98ddb16e40c4a1be" approved="yes">
+        <source>You are about to install "%s", a module which is not compatible with your country.</source>
+        <target state="final">Vous êtes sur le point d'installer "%s", un module qui n'est pas compatible avec votre pays.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="1a56544ab8d473b3383731fbe3fc9d07" approved="yes">
+        <source>This module was not verified by PrestaShop hence we cannot certify that it works well in your country and that it complies with our quality requirements.</source>
+        <target state="final">Ce module n'est pas vérifié par PrestaShop, nous ne pouvons donc certifier qu'il fonctionnera correctement dans votre pays ni qu'il répond à nos critères de qualité.</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="d1ce387d44c3dc9cdc4e30ad64dbf47e" approved="yes">
+        <source>Use at your own risk.</source>
+        <target state="final">Vous l'utilisez à vos propres risques.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="080e6f65e34e2ffe7162beb258f4577d" approved="yes">
+        <source>If you are unsure about this, you should contact the Customer Service of %s to ask them to make the module compatible with your country.</source>
+        <target state="final">Si vous n'êtes pas sûr de vous, vous pouvez contacter le Service Client de %s pour leur demander un module compatible avec votre pays.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="17e8aa9ff6f7c374738eb3a15270583c" approved="yes">
+        <source>Moreover, we recommend that you use an equivalent module: compatible modules for your country are listed in the "Modules" tab of your back office.</source>
+        <target state="final">De plus, nous vous recommandons d'utiliser un module équivalent : les modules compatibles avec votre pays sont listés dans l'onglet "Modules" de votre back-office.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="1de1cd538749db5ea85a79c300b092e3" approved="yes">
+        <source>If you are unsure about this module, you can look for similar modules on the official marketplace.</source>
+        <target state="final">Si vous n'êtes pas sûr de ce module, vous pouvez aussi rechercher des modules similaires sur la place de marché officielle.</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="f7df37601ea653a7a5bf63e3556772d3" approved="yes">
+        <source>Click here to browse PrestaShop Addons.</source>
+        <target state="final">Cliquez ici pour parcourir le catalogue de PrestaShop Addons.</target>
+        <note>Line: 43</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/modal_translation.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1311e5ddedf25a4f6cd6059cbf04c21e" approved="yes">
+        <source>Manage translations</source>
+        <target state="final">Gérer les traductions</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/page.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="b10a51e4d433fa3330b26d266502db00" approved="yes">
+        <source>Addons membership provides access to all our PrestaShop modules.</source>
+        <target state="final">Se connecter à Addons permet d'accéder à tous nos modules PrestaShop.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="20afba9e56de0c1da3d5188111d72947" approved="yes">
+        <source>Once connected, your new modules will be automatically installed.</source>
+        <target state="final">Une fois connecté, vos nouveaux modules seront automatiquement installés.</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="d9776f0775997b2e698c6975420b5c5d" approved="yes">
+        <source>Sign up</source>
+        <target state="final">S'inscrire</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bce8bac0184c6cd6d977e8a42a99aa99" approved="yes">
+        <source>Connect to PrestaShop Marketplace account</source>
+        <target state="final">Connectez-vous à la place de marché de PrestaShop</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="bffe9a3c9a7e00ba00a11749e022d911" approved="yes">
+        <source>Log in</source>
+        <target state="final">Se connecter</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="6dc2462f2851bdac265c852f023b6d3f" approved="yes">
+        <source>The module must either be a Zip file (.zip) or a tarball file (.tar, .tar.gz, .tgz).</source>
+        <target state="final">Le fichier contenant le module doit être soit une archive ZIP (.zip) soit un fichier "tarball" (.tar, .tar.gz, .tgz).</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="6779ef184c16fbd18a0bc13ebda839c5" approved="yes">
+        <source>Upload a module from your computer.</source>
+        <target state="final">Mettez en ligne le module depuis votre ordinateur</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="5b48d0f5735d2f9b73a8f3ec7c4858ba" approved="yes">
+        <source>Module file</source>
+        <target state="final">Fichier du module</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="92fbf0e5d97b8afd7e73126b52bdc4bb" approved="yes">
+        <source>Choose a file</source>
+        <target state="final">Choisissez un fichier</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="8634e049945e0e8562673698a1abb485" approved="yes">
+        <source>Upload this module</source>
+        <target state="final">Charger le module</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="f2063dc3ff5945f5bf0c430da46e1109" approved="yes">
+        <source>An upgrade is available for some of your modules!</source>
+        <target state="final">Des mises à jour sont disponibles pour certains de vos modules !</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d78986947356ddd37b43d57df289dee9" approved="yes">
+        <source>Favorites</source>
+        <target state="final">Favoris</target>
+        <note>Line: 107</note>
+      </trans-unit>
+      <trans-unit id="b1c94ca2fbc3e78fc30069c8d0f01680" approved="yes">
+        <source>All</source>
+        <target state="final">Tous</target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="96e36efe70e72835ae51946e2650f9e7" approved="yes">
+        <source>Add a new module</source>
+        <target state="final">Ajouter un nouveau module</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/page_header_toolbar-legacy.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="28080c3603fb7e10f228381b181cae2c" approved="yes">
+        <source>List of modules</source>
+        <target state="final">Liste des modules</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="71803586f945801418d03befeb4acd99" approved="yes">
+        <source>Update all</source>
+        <target state="final">Mettre à jour tous les modules</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="a3105b7aa9edb1c07765bfdcdc2405b8" approved="yes">
+        <source>Check for update</source>
+        <target state="final">Vérifier les mises à jour</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="6a26f548831e6a8c26bfbbd9f6ec61e0" approved="yes">
+        <source>Help</source>
+        <target state="final">Aide</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/readmore-body.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3424c86a3f3fdfcff4d8f310912ee82b" approved="yes">
+        <source>(%s votes)</source>
+        <target state="final">(%s votes)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="268cb3857932e260b03bf1334220f3bc" approved="yes">
+        <source>(%s vote)</source>
+        <target state="final">(%s vote)</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39" approved="yes">
+        <source>Description</source>
+        <target state="final">Description</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="7a66d21cf5a4354933980f6d79ec78a4" approved="yes">
+        <source>Merchant benefits</source>
+        <target state="final">Bénéfices pour le marchand</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="8530d0ebaf22889c1b42061824f3769b" approved="yes">
+        <source>Install module</source>
+        <target state="final">Installer le module</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="a6642661dcfc0e354c61f4e8b8b9ec5a" approved="yes">
+        <source>View on PrestaShop Addons</source>
+        <target state="final">Voir sur PrestaShop Addons</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/readmore-header.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="9e3669d19b675bd57058fd4664205d2a" approved="yes">
+        <source>v</source>
+        <target state="final">v</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/tab_module_line.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f248df0d4d7e4ae98485c5df8af58945" approved="yes">
+        <source>This module is available for free thanks to our partner.</source>
+        <target state="final">Ce module est disponible gratuitement grâce à notre partenaire.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules/tab_modules_list.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ddd8eef6f86868a07f62b0e3810711f0" approved="yes">
+        <source>Not Installed</source>
+        <target state="final">Non installé</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="98dd43dfae05b11befe1f140e0ec787a" approved="yes">
+        <source>Installed</source>
+        <target state="final">Installé</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="4d2fa24347806e2bcc9925a040f78382" approved="yes">
+        <source>More modules on addons.prestashop.com</source>
+        <target state="final">Encore plus de modules sur addons.prestashop.com</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/modules_positions/list_modules.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="83057027f6b988dd2dbe422f6f3ddd21" approved="yes">
+        <source>No module was found for this hook.</source>
+        <target state="final">Aucun module pour ce point d'accroche.</target>
+        <note>Line: 161</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/not_found/content.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="efc54df619cd3792c98805fba1ee5ff7" approved="yes">
+        <source>The controller %s is missing or invalid.</source>
+        <target state="final">Le contrôleur %s est manquant ou non valable.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="9178de10abf6a1368e7a73ec0adb0e8e" approved="yes">
+        <source>Back to the previous page</source>
+        <target state="final">Retour à la page précédente</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="585c732d00a27a32cd9585fe481964cf" approved="yes">
+        <source>Go to the dashboard</source>
+        <target state="final">Aller au tableau de bord</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_documents.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="585bc67adbb73dcca638b897fb73a900" approved="yes">
+        <source>See the document</source>
+        <target state="final">Voir le document</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="8b3e7bc0ed634c2bc8ac54a4cc2e781f" approved="yes">
+        <source>Set payment form</source>
+        <target state="final">Mise en place d'un formulaire de paiement</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="50cd1871f950375eef4e2efce35366c6" approved="yes">
+        <source>Add note</source>
+        <target state="final">Ajouter une note</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="71e2851d86b252a44c658b896c486921" approved="yes">
+        <source>Edit note</source>
+        <target state="final">Modifier une note</target>
+        <note>Line: 121</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_new_product.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="aa52110dbfce51cc1ec8a163264151e2" approved="yes">
+        <source>Existing</source>
+        <target state="final">Existant</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e" approved="yes">
+        <source>New</source>
+        <target state="final">Neuf</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a6361d40d23154d7d8fc801ae8bf9554" approved="yes">
+        <source>%refund_date% - %refund_amount%</source>
+        <target state="final">%refund_date% - %refund_amount%</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="26b26b0e309da0b8abbf624a57601f4c" approved="yes">
+        <source>%return_date% - %return_quantity% - %return_state%</source>
+        <target state="final">%return_date% - %return_quantity% - %return_state%</target>
+        <note>Line: 121</note>
+      </trans-unit>
+      <trans-unit id="3d0d1f906e27800531e054a3b6787b7c" approved="yes">
+        <source>Quantity:</source>
+        <target state="final">Quantité :</target>
+        <note>Line: 175</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7315d80cbbbb36fdcd92ba46a6384eff" approved="yes">
+        <source>Show carts and orders for this customer.</source>
+        <target state="final">Montrer les paniers et commandes pour ce client.</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="1e504df905c966d01e09188c5ebd451f" approved="yes">
+        <source>Hide carts and orders for this customer.</source>
+        <target state="final">Cacher les paniers et commandes pour ce client.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="f4ec5f57bd4d31b803312d873be40da9" approved="yes">
+        <source>Change</source>
+        <target state="final">Modifier</target>
+        <note>Line: 254</note>
+      </trans-unit>
+      <trans-unit id="0d9175fe89fb80d815e7d03698b6e83a" approved="yes">
+        <source>Gift</source>
+        <target state="final">Cadeau</target>
+        <note>Line: 777</note>
+      </trans-unit>
+      <trans-unit id="c78ba40a94a132dc170cba2f8c66f310" approved="yes">
+        <source>Search for an existing product by typing the first letters of its name.</source>
+        <target state="final">Rechercher un produit en saisissant les premières lettres de son nom.</target>
+        <note>Line: 1214</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="730224c4825ae2c174f4cdaff321520e" approved="yes">
+        <source>Transform a guest into a customer</source>
+        <target state="final">Transformer en compte client</target>
+        <note>Line: 599</note>
+      </trans-unit>
+      <trans-unit id="e5bd639f4d74cf2c52afada77086f788" approved="yes">
+        <source>Process a standard refund</source>
+        <target state="final">Procéder à un remboursement</target>
+        <note>Line: 906</note>
+      </trans-unit>
+      <trans-unit id="c4b689eeebf8e942907a1cc1d086dba6" approved="yes">
+        <source>Process a partial refund</source>
+        <target state="final">Procéder à un remboursement partiel</target>
+        <note>Line: 907</note>
+      </trans-unit>
+      <trans-unit id="cc61945cbbf46721a053467c395c666f" approved="yes">
+        <source>Refunded</source>
+        <target state="final">Remboursé</target>
+        <note>Line: 935</note>
+      </trans-unit>
+      <trans-unit id="6a5efd211a422296eab4adc476c98f0e" approved="yes">
+        <source>Return products</source>
+        <target state="final">Retourner les produits</target>
+        <note>Line: 1200</note>
+      </trans-unit>
+      <trans-unit id="74c06eb18eeb118d7b3c623d0c717290" approved="yes">
+        <source>Refund products</source>
+        <target state="final">Rembourser les produits</target>
+        <note>Line: 1200</note>
+      </trans-unit>
+      <trans-unit id="4b8def9be8f45a8d6baea36b26868965" approved="yes">
+        <source>Cancel products</source>
+        <target state="final">Annuler les produits</target>
+        <note>Line: 1200</note>
+      </trans-unit>
+      <trans-unit id="867343577fa1f33caa632a19543bd252" approved="yes">
+        <source>Keywords</source>
+        <target state="final">Mots clés</target>
+        <note>Line: 1269</note>
+      </trans-unit>
+      <trans-unit id="6416e8cb5fc0a208d94fa7f5a300dbc4" approved="yes">
+        <source>Warehouse</source>
+        <target state="final">Entrepôt</target>
+        <note>Line: 934</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/request_sql/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f2bbdf9f72c085adc4d0404e370f0f4c" approved="yes">
+        <source>Attribute</source>
+        <target state="final">Attribut</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/return/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e9cb217697088a98b1937d111d936281" approved="yes">
+        <source>Attachment</source>
+        <target state="final">Document joint</target>
+        <note>Line: 83</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3adbdb3ac060038aa0e6e6c138ef9873" approved="yes">
+        <source>Category</source>
+        <target state="final">Catégorie</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9" approved="yes">
+        <source>Brand</source>
+        <target state="final">Marque</target>
+        <note>Line: 251</note>
+      </trans-unit>
+      <trans-unit id="ec136b444eede3bc85639fac0dd06229" approved="yes">
+        <source>Supplier</source>
+        <target state="final">Fournisseurs</target>
+        <note>Line: 262</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/suppliers/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="38f06ccd27281c8fc66e11581798ec06" approved="yes">
+        <source>Number of products:</source>
+        <target state="final">Nombre de produits :</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="df644ae155e79abf54175bd15d75f363" approved="yes">
+        <source>Product name</source>
+        <target state="final">Article</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="1caa6ff629641a4eb20f190f7a0539ca" approved="yes">
+        <source>Attribute name</source>
+        <target state="final">Nom de l'attribut</target>
+        <note>Line: 35</note>
+      </trans-unit>
+      <trans-unit id="bc67a1507258a758c3a31e66d7ceff8f" approved="yes">
+        <source>Supplier Reference</source>
+        <target state="final">Référence fournisseur</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="c804723ccdde3d7a46933b208c6f928d" approved="yes">
+        <source>Wholesale price</source>
+        <target state="final">Prix d'achat</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="52eb5928a34db3e3da7ba52b0644273b" approved="yes">
+        <source>EAN13</source>
+        <target state="final">EAN-13</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="fbd99ad01b92dbafc686772a39e3d065" approved="yes">
+        <source>UPC</source>
+        <target state="final">UPC</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="c8c5918f1175c1296d19755b2f49d1c9" approved="yes">
+        <source>Available Quantity</source>
+        <target state="final">Quantités disponibles</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="382b0f5185773fa0f67a8ed8056c7759" approved="yes">
+        <source>N/A</source>
+        <target state="final">N/D</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/configurelayouts.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ebd9bec4d70abc789d439c1f136b0538" approved="yes">
+        <source>Layout</source>
+        <target state="final">Mise en page</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1beaf22ea4850d25af342d91b0f25624" approved="yes">
+        <source>See all themes</source>
+        <target state="final">Voir tous les thèmes</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="ae0e265c94eec2c38690ada171d60a4d" approved="yes">
+        <source>Add a new theme</source>
+        <target state="final">Ajouter un thème</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="26a278c1e0598e21f7c1ed7ab113e6ac" approved="yes">
+        <source>To add a new theme, simply connect to your PrestaShop Addons account: your new theme will be automatically imported to your shop.</source>
+        <target state="final">Pour ajouter un nouveau thème, connectez-vous simplement à votre compte PrestaShop Addons depuis votre boutique: votre nouveau thème sera automatiquement importé pour vous.</target>
+        <note>Line: 64</note>
+      </trans-unit>
+      <trans-unit id="a5ed2b9ca9427746aced5b4037560434" approved="yes">
+        <source>You can choose among 1,500+ professional templates!</source>
+        <target state="final">Vous pouvez choisir parmi plus de 1500 templates professionnels !</target>
+        <note>Line: 65</note>
+      </trans-unit>
+      <trans-unit id="dc9ac2e66cddf6e2c64e1c72b18ae130" approved="yes">
+        <source>Can I add my own theme?</source>
+        <target state="final">Puis-je ajouter mon propre thème ?</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="7c854ab311760ecb245fb938378cd4e9" approved="yes">
+        <source>Please note that for security reasons, you can only add themes that are being distributed on PrestaShop Addons, the official marketplace.</source>
+        <target state="final">Pour des raisons de sécurité, nous pouvez ajouter uniquement des thèmes qui sont distribués sur PrestaShop Addons, notre place de marché officielle.</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="80bf7b97a380d8d8aa29993fa61ab5e5" approved="yes">
+        <source>You can also create a new theme below.</source>
+        <target state="final">Vous pouvez aussi créer un nouveau thème ci-dessous.</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f0dbca7d922e4e759a1e3b512b9be852" approved="yes">
+        <source>Choose layouts</source>
+        <target state="final">Choisir la mise en page</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="b6ba229b668e5a7b6700e4d275683084" approved="yes">
+        <source>Use this theme</source>
+        <target state="final">Utiliser ce thème</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="e169a8fe61809e3679a424bf27166a78" approved="yes">
+        <source>Delete this theme</source>
+        <target state="final">Supprimer ce thème</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="837a54ae4874c4501c804173cd3c0fdf" approved="yes">
+        <source>Designed by %s</source>
+        <target state="final">Conçu par %s</target>
+        <note>Line: 92</note>
+      </trans-unit>
+      <trans-unit id="8ef656f84513928ea1b0c2f1735b62e9" approved="yes">
+        <source>Configure your page layouts</source>
+        <target state="final">Configurez la disposition de vos pages</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="4459ae4e873177642b30e9fc8b821d2f" approved="yes">
+        <source>Each page can use a different layout, choose it among the layouts bundled in your theme.</source>
+        <target state="final">Chaque page peut utiliser une mise en page différente, il suffit de sélectionner celle qui vous intéresse parmi les mises en page fournies avec votre thème.</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="21e2bb42873eddcb9b476b8eafbe0c18" approved="yes">
+        <source>Reset to defaults</source>
+        <target state="final">Réinitialiser</target>
+        <note>Line: 108</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/themes/helpers/view/view.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f1246f9ac6a7094789c17068713ebfe6" approved="yes">
+        <source>The "%1$s" theme has been successfully installed.</source>
+        <target state="final">Le thème "%1$s" a été installé avec succès.</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="623a0df3a4b9fcca8e08c9ed1a07bba1" approved="yes">
+        <source>The following module(s) were not installed properly:</source>
+        <target state="final">Le ou les module(s) suivant(s) n'ont pas été correctement installé(s) :</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="940d7a8d6502a022e8eb2d8a090b1a05" approved="yes">
+        <source>Warning: You may have to regenerate images to fit with this new theme.</source>
+        <target state="final">Attention : vous pourriez avoir à régénérer les images pour qu'elles correspondent à votre nouveau thème.</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="aedd6903868a8d6c7b01e0754fb56336" approved="yes">
+        <source>Go to the thumbnails regeneration page</source>
+        <target state="final">Aller à la page de génération des miniatures</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="ce72a3420348d5b0bcd1382b1c88f553" approved="yes">
+        <source>Warning: This image type doesn’t exist. To manually set it, use the values below to create a new image type (in the "Images" page under the "Design" menu):</source>
+        <target state="final">Attention : ce type d'image n'existe pas. Pour le créer manuellement, reprenez les valeurs ci-dessous pour les ajouter à un nouveau type d'image (dans la page "Images" du menu "Apparence") :</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="3b90370ac32dead2af37eabe3bdbb97f" approved="yes">
+        <source>Name image type:</source>
+        <target state="final">Nom du type d'image :</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="c6ec097a1c02ee4db0dda78b98f4c08c" approved="yes">
+        <source>(width: %1$spx, height: %2$spx).</source>
+        <target state="final">(largeur: %1$spx, hauteur: %2$spx).</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="8f1cda3b6ae2df7c2c152cfeffaea57a" approved="yes">
+        <source>Images have been correctly updated in the database:</source>
+        <target state="final">Les images ont bien été mises à jour dans la base de données :</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="a20ddccbb6f808ec42cd66323e6c6061" approved="yes">
+        <source>Finish</source>
+        <target state="final">Terminer</target>
+        <note>Line: 90</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bbfb7a636f839052067cc86c39fa595a" approved="yes">
+        <source>%limit% for suhosin.post.max_vars.</source>
+        <target state="final">%limit% pour suhosin.post.max_vars.</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="e97da54b23c78752578cd7fa01e8866d" approved="yes">
+        <source>%limit% for suhosin.request.max_vars.</source>
+        <target state="final">%limit% pour suhosin.request.max_vars.</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="f324bbd9de83d61ccb5f7d5593aec5b3" approved="yes">
+        <source>You MUST use this syntax in your translations. Here are several examples:</source>
+        <target state="final">Vous devez utiliser cette syntaxe dans vos traductions. Voici quelques exemples :</target>
+        <note>Line: 86</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="a7bd935a88c629dc11c52e0c16c2a8a0" approved="yes">
+        <source>%d</source>
+        <target state="final">%d</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/webservice/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="be8545ae7ab0276e15898aae7acfbd7a" approved="yes">
+        <source>Resource</source>
+        <target state="final">Ressource</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/calendar/calendar.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="08ee10c9fa141c53ae44667dcc1adf1e" approved="yes">
+        <source>Date range</source>
+        <target state="final">Plage de dates</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="90589c47f06eb971d548591f23c285af" approved="yes">
+        <source>Custom</source>
+        <target state="final">Personnalisé</target>
+        <note>Line: 83</note>
+      </trans-unit>
+      <trans-unit id="01b6e20344b68835c5ed1ddedf20d531" approved="yes">
+        <source>to</source>
+        <target state="final">jusqu'au</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="0c031866121d4fc6d21d0f524d0091e4" approved="yes">
+        <source>Compare to</source>
+        <target state="final">Comparer avec</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="97bf2dbc7a13706eeb1eac149bd2d130" approved="yes">
+        <source>Previous period</source>
+        <target state="final">Période précédente</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="635f2145a06da2d4ce2c355bf94da6ed" approved="yes">
+        <source>Previous Year</source>
+        <target state="final">Année précédente</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="3ca6ac2463aa0dc57452cf676723b79f" approved="yes">
+        <source>Previous year</source>
+        <target state="final">Année précédente</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="9d1a0949c39e66a0cd65240bc0ac9177" approved="yes">
+        <source>Sunday</source>
+        <target state="final">Dimanche</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="6f8522e0610541f1ef215a22ffa66ff6" approved="yes">
+        <source>Monday</source>
+        <target state="final">Lundi</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="5792315f09a5d54fb7e3d066672b507f" approved="yes">
+        <source>Tuesday</source>
+        <target state="final">Mardi</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="796c163589f295373e171842f37265d5" approved="yes">
+        <source>Wednesday</source>
+        <target state="final">Mercredi</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="78ae6f0cd191d25147e252dc54768238" approved="yes">
+        <source>Thursday</source>
+        <target state="final">Jeudi</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="c33b138a163847cdb6caeeb7c9a126b4" approved="yes">
+        <source>Friday</source>
+        <target state="final">Vendredi</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8b7051187b9191cdcdae6ed5a10e5adc" approved="yes">
+        <source>Saturday</source>
+        <target state="final">Samedi</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="ef6572e4cd58bb39a3f4e82fc64fe9f0" approved="yes">
+        <source>Sun</source>
+        <target state="final">dim.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="fd29458ae58ac32a2d8734ed90ad51ec" approved="yes">
+        <source>Mon</source>
+        <target state="final">lun.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="2ddecde85408faf230652444db78cb72" approved="yes">
+        <source>Tue</source>
+        <target state="final">mar.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="510c292b1686eb070d9e90a575f74106" approved="yes">
+        <source>Wed</source>
+        <target state="final">mer.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="ed5e8353dfc585f4c6b3a55d1a9fc01d" approved="yes">
+        <source>Thu</source>
+        <target state="final">jeu.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="ac616f844b9a5ea5a827bf7fb99b1ad5" approved="yes">
+        <source>Fri</source>
+        <target state="final">ven.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="13c7d2d737f81f7bf89aed9fbcd0ad55" approved="yes">
+        <source>Sat</source>
+        <target state="final">sam.</target>
+        <note>Line: 114</note>
+      </trans-unit>
+      <trans-unit id="f72c915d8f575a5c0999b5f37b6d99b7" approved="yes">
+        <source>Su</source>
+        <target state="final">D.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="c08df9bb5fb44242a6291b1eee5d09ad" approved="yes">
+        <source>Mo</source>
+        <target state="final">L.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="080502c4fa636ac639bf42b6d2ba01d7" approved="yes">
+        <source>Tu</source>
+        <target state="final">M.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="485c47a81eb6e3998ec05aca48eda184" approved="yes">
+        <source>We</source>
+        <target state="final">M.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="eeeb9a8eb45dd351d9ec0eb4acce66ce" approved="yes">
+        <source>Th</source>
+        <target state="final">J.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="fa717ba17306cd76900510df8ac8013e" approved="yes">
+        <source>Fr</source>
+        <target state="final">V.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="e55bb1ae59b6a64858a85a2f48c53036" approved="yes">
+        <source>Sa</source>
+        <target state="final">S.</target>
+        <note>Line: 115</note>
+      </trans-unit>
+      <trans-unit id="86f5978d9b80124f509bdb71786e929e" approved="yes">
+        <source>January</source>
+        <target state="final">Janvier</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="659e59f062c75f81259d22786d6c44aa" approved="yes">
+        <source>February</source>
+        <target state="final">Février</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="fa3e5edac607a88d8fd7ecb9d6d67424" approved="yes">
+        <source>March</source>
+        <target state="final">Mars</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="3fcf026bbfffb63fb24b8de9d0446949" approved="yes">
+        <source>April</source>
+        <target state="final">Avril</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="195fbb57ffe7449796d23466085ce6d8" approved="yes">
+        <source>May</source>
+        <target state="final">Mai</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="688937ccaf2a2b0c45a1c9bbba09698d" approved="yes">
+        <source>June</source>
+        <target state="final">Juin</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="1b539f6f34e8503c97f6d3421346b63c" approved="yes">
+        <source>July</source>
+        <target state="final">Juillet</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="41ba70891fb6f39327d8ccb9b1dafb84" approved="yes">
+        <source>August</source>
+        <target state="final">Août</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="cc5d90569e1c8313c2b1c2aab1401174" approved="yes">
+        <source>September</source>
+        <target state="final">Septembre</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="eca60ae8611369fe28a02e2ab8c5d12e" approved="yes">
+        <source>October</source>
+        <target state="final">Octobre</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="7e823b37564da492ca1629b4732289a8" approved="yes">
+        <source>November</source>
+        <target state="final">Novembre</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="82331503174acbae012b2004f6431fa5" approved="yes">
+        <source>December</source>
+        <target state="final">Décembre</target>
+        <note>Line: 116</note>
+      </trans-unit>
+      <trans-unit id="e68564f23e0e939acea76dc3d2bc01bf" approved="yes">
+        <source>Jan</source>
+        <target state="final">janv.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="ea171d540ccd5f0669171ef06d3cd848" approved="yes">
+        <source>Feb</source>
+        <target state="final">févr.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="7ce6b2286a5396e614b8484105d277e0" approved="yes">
+        <source>Mar</source>
+        <target state="final">mars</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="6d7215c4b3bc4716d026ac46c6d9ae64" approved="yes">
+        <source>Apr</source>
+        <target state="final">avr.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="e7f8f5c51fe3a6d48a79c6ede9112b7a" approved="yes">
+        <source>May </source>
+        <target state="final">Mai </target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="eb4b40c1221dad5b23fe7ef84d292be1" approved="yes">
+        <source>Jun</source>
+        <target state="final">juin</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="a2866cd6efaa65c92278d4771a9eaec7" approved="yes">
+        <source>Jul</source>
+        <target state="final">juil.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="22f1a4667604b8557c9b209c201b4bc6" approved="yes">
+        <source>Aug</source>
+        <target state="final">août</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="f04aa7019c490474fa3ce16e93501b57" approved="yes">
+        <source>Sep</source>
+        <target state="final">sept.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="594be08882c8e9d5efb9eeb62f303744" approved="yes">
+        <source>Oct</source>
+        <target state="final">oct.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="343e6957be77c6247aa2b8d0deb68bd6" approved="yes">
+        <source>Nov</source>
+        <target state="final">nov.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+      <trans-unit id="d207b4e0bce42a8f1555ce3a05e287f6" approved="yes">
+        <source>Dec</source>
+        <target state="final">déc.</target>
+        <note>Line: 117</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/dataviz/graph.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="e6d0e1c8fc6a4fcf47869df87e04cd88" approved="yes">
+        <source>Customers</source>
+        <target state="final">Clients</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="7442e29d7d53e549b78d93c46b8cdcfc" approved="yes">
+        <source>Orders</source>
+        <target state="final">Commandes</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="1f08d08fd864b99cbeebd88b9a0784a7" approved="yes">
+        <source>Income</source>
+        <target state="final">Revenus</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="4c2a8fe7eaf24721cc7a9f0175115bd4" approved="yes">
+        <source>Message</source>
+        <target state="final">Message</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="e7935ae6c516d89405ec532359d2d75a" approved="yes">
+        <source>Traffic</source>
+        <target state="final">Trafic</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="3bb1503332637805beddb73a2dd1fe1b" approved="yes">
+        <source>Conversion</source>
+        <target state="final">Transformation</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/assoshop.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1aa4c641d6920ddb97a2562f8ec53853" approved="yes">
+        <source>Group:</source>
+        <target state="final">Groupe :</target>
+        <note>Line: 99</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2efd89b3ccc76b0b03a34196fc6d1c8b" approved="yes">
+        <source>Add tag</source>
+        <target state="final">Ajouter un mot-clé</target>
+        <note>Line: 194</note>
+      </trans-unit>
+      <trans-unit id="1063e38cb53d94d386f21227fcd84717" approved="yes">
+        <source>Remove</source>
+        <target state="final">Retirer</target>
+        <note>Line: 329</note>
+      </trans-unit>
+      <trans-unit id="26ce1315d2bff025e8fb8a0c6259e58c" approved="yes">
+        <source>Change password...</source>
+        <target state="final">Changer le mot de passe...</target>
+        <note>Line: 525</note>
+      </trans-unit>
+      <trans-unit id="d9c2d86a66aa5a45326c3757f3a272cc" approved="yes">
+        <source>Current password</source>
+        <target state="final">Mot de passe actuel</target>
+        <note>Line: 530</note>
+      </trans-unit>
+      <trans-unit id="98a6ee4b0f0e346c15ab21a289165a2d" approved="yes">
+        <source>Password should be at least 8 characters long.</source>
+        <target state="final">Le mot de passe doit comporter au moins 8 caractères.</target>
+        <note>Line: 544</note>
+      </trans-unit>
+      <trans-unit id="3544848f820b9d94a3f3871a382cf138" approved="yes">
+        <source>New password</source>
+        <target state="final">Nouveau mot de passe</target>
+        <note>Line: 545</note>
+      </trans-unit>
+      <trans-unit id="4c231e0da3eaaa6a9752174f7f9cfb31" approved="yes">
+        <source>Confirm password</source>
+        <target state="final">Confirmer le mot de passe</target>
+        <note>Line: 560</note>
+      </trans-unit>
+      <trans-unit id="2871afea416378d2772937c4d67d6c2c" approved="yes">
+        <source>Generate password</source>
+        <target state="final">Générer un mot de passe</target>
+        <note>Line: 576</note>
+      </trans-unit>
+      <trans-unit id="4bbb8f967da6d1a610596d7257179c2b" approved="yes">
+        <source>Invalid</source>
+        <target state="final">Invalide</target>
+        <note>Line: 601</note>
+      </trans-unit>
+      <trans-unit id="26b63f278101527e06a5547719568bb5" approved="yes">
+        <source>Okay</source>
+        <target state="final">OK</target>
+        <note>Line: 602</note>
+      </trans-unit>
+      <trans-unit id="0c6ad70beb3a7e76c3fc7adab7c46acc" approved="yes">
+        <source>Good</source>
+        <target state="final">bon</target>
+        <note>Line: 603</note>
+      </trans-unit>
+      <trans-unit id="b8dc7c80939667637db7ac31ece215b9" approved="yes">
+        <source>Fabulous</source>
+        <target state="final">Formidable</target>
+        <note>Line: 604</note>
+      </trans-unit>
+      <trans-unit id="01e8202cf69f19ea7cf3a80f7673066a" approved="yes">
+        <source>Invalid password confirmation</source>
+        <target state="final">Confirmation de mot de passe invalide</target>
+        <note>Line: 641</note>
+      </trans-unit>
+      <trans-unit id="1e1cc9bdeb2f29f5480106aec7e9bc48" approved="yes">
+        <source>Now</source>
+        <target state="final">Maintenant</target>
+        <note>Line: 967</note>
+      </trans-unit>
+      <trans-unit id="f92965e2c8a7afb3c1b9a5c09a263636" approved="yes">
+        <source>Done</source>
+        <target state="final">Valider</target>
+        <note>Line: 968</note>
+      </trans-unit>
+      <trans-unit id="3964fd83339fec5014c831822005653a" approved="yes">
+        <source>Choose Time</source>
+        <target state="final">Choisir l'heure</target>
+        <note>Line: 974</note>
+      </trans-unit>
+      <trans-unit id="a76d4ef5f3f6a672bbfab2865563e530" approved="yes">
+        <source>Time</source>
+        <target state="final">Heure</target>
+        <note>Line: 975</note>
+      </trans-unit>
+      <trans-unit id="b55e509c697e4cca0e1d160a7806698f" approved="yes">
+        <source>Hour</source>
+        <target state="final">Heure</target>
+        <note>Line: 976</note>
+      </trans-unit>
+      <trans-unit id="62902641c38f3a4a8eb3212454360e24" approved="yes">
+        <source>Minute</source>
+        <target state="final">Minute</target>
+        <note>Line: 977</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/form/form_group.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c6155aaecccf794cd2a00fcc35898022" approved="yes">
+        <source>Group name</source>
+        <target state="final">Nom du groupe</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="69e62346c35bc63795db142cfbb0af66" approved="yes">
+        <source>No group created</source>
+        <target state="final">Aucun groupe créé</target>
+        <note>Line: 64</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_content.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="087fb8756d4add87f2d162304ccd486b" approved="yes">
+        <source>No records found</source>
+        <target state="final">Aucun enregistrement trouvé</target>
+        <note>Line: 209</note>
+      </trans-unit>
+      <trans-unit id="0bcef9c45bd8a48eda1b26eb0c61c869" approved="yes">
+        <source>%</source>
+        <target state="final">%</target>
+        <note>Line: 119</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_footer.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4c41e0bd957698b58100a5c687d757d9" approved="yes">
+        <source>Select all</source>
+        <target state="final">Tout sélectionner</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="237c7b6874386141a095e321c9fdfd38" approved="yes">
+        <source>Unselect all</source>
+        <target state="final">Tous désélectionner</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="b9987a246a537f4fe86f1f2e3d10dbdb" approved="yes">
+        <source>Display</source>
+        <target state="final">Affichage</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="dd8921b41e0279a02c6a26a509241700" approved="yes">
+        <source>result(s)</source>
+        <target state="final">résultat(s)</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/list/list_header.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6ccfec41b65de46efeb7ca242341e8ea" approved="yes">
+        <source>Please fill at least one field to perform a search in this list.</source>
+        <target state="final">Veuillez renseigner au moins un champ pour effectuer une recherche dans cette liste.</target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="e129ae480280e47ef82fc7702f8321ba" approved="yes">
+        <source>Refresh list</source>
+        <target state="final">Rafraîchir la liste</target>
+        <note>Line: 157</note>
+      </trans-unit>
+      <trans-unit id="dbcd43f8ba2bafd1bccc57fe9c8b5d7b" approved="yes">
+        <source>Show SQL query</source>
+        <target state="final">Voir la requête SQL</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="351b6d570b6ba15fe66e85c1eaf9ec64" approved="yes">
+        <source>Export to SQL Manager</source>
+        <target state="final">Exporter vers le gestionnaire SQL</target>
+        <note>Line: 171</note>
+      </trans-unit>
+      <trans-unit id="4493e821e06072415518bd7ae4077996" approved="yes">
+        <source>Shop group</source>
+        <target state="final">Groupe de boutiques</target>
+        <note>Line: 310</note>
+      </trans-unit>
+      <trans-unit id="e12167aa0a7698e6ebc92b4ce3909b53" approved="yes">
+        <source>To</source>
+        <target state="final">Au</target>
+        <note>Line: 350</note>
+      </trans-unit>
+      <trans-unit id="e9c7e4df74077626f7e42797c65273c4" approved="yes">
+        <source>and stay</source>
+        <target state="final">et rester</target>
+        <note>Line: 203</note>
+      </trans-unit>
+      <trans-unit id="5da618e8e4b89c66fe86e32cdafde142" approved="yes">
+        <source>From</source>
+        <target state="final">Du</target>
+        <note>Line: 343</note>
+      </trans-unit>
+      <trans-unit id="526d688f37a86d3c3f27d0c5016eb71d" approved="yes">
+        <source>Reset</source>
+        <target state="final">Réinitialiser</target>
+        <note>Line: 402</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/modules_list/list.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="6afd80bf62a1b8bdfe729af8a0159fee" approved="yes">
+        <source>Modules list</source>
+        <target state="final">Liste des modules</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="2c422a499f038293ed0c5a1e085cd827" approved="yes">
+        <source>No modules available in this section.</source>
+        <target state="final">Aucun module disponible dans cette section.</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="c0ebffb294bb46f8800a899e04c73f17" approved="yes">
+        <source>View all available payments solutions</source>
+        <target state="final">Afficher toutes les solutions de paiement</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="98a52c00a9fb228601f8b423436d36e0" approved="yes">
+        <source>It seems there are no recommended payment solutions for your country.</source>
+        <target state="final">Il semble qu'il n'y ait pas de module de paiement recommandé pour votre pays.</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="39efbaa2f3600dd82a031d7ab5138f73" approved="yes">
+        <source>Do you think there should be one? Let us know!</source>
+        <target state="final">Pensez-vous qu'il devrait y en avoir un ? Faites-le nous savoir !</target>
+        <note>Line: 57</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/modules_list/modal.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4b33fbf5ea2c4ced9800228574cfcc50" approved="yes">
+        <source>Recommended Modules and Services</source>
+        <target state="final">Modules et services recommandés</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/options/options.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="21034ae6d01a83e702839a72ba8a77b0" approved="yes">
+        <source>(tax excl.)</source>
+        <target state="final">(HT)</target>
+        <note>Line: 220</note>
+      </trans-unit>
+      <trans-unit id="c103bafd6451f1f08200bebff539606f" approved="yes">
+        <source>Multistore</source>
+        <target state="final">Multiboutique</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="50de2399e96ac57bed17e95376046c3b" approved="yes">
+        <source>Check / Uncheck all</source>
+        <target state="final">Tout sélectionner / Tout désélectionner</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="ff8ff5e54a1832486773ec48b8f8175d" approved="yes">
+        <source>You are editing this page for a specific shop or group. Click "Yes" to check all fields, "No" to uncheck all.</source>
+        <target state="final">Vous modifiez cette page pour une boutique ou un groupe de boutiques en particulier. Cliquez sur "Oui" pour sélectionner tous les champs, sur "Non" pour n'en sélectionner aucun.</target>
+        <note>Line: 81</note>
+      </trans-unit>
+      <trans-unit id="d97ccb3e617d930d52ffd95e5db2c101" approved="yes">
+        <source>If you check a field, change its value, and save, the multistore behavior will not apply to this shop (or group), for this particular parameter.</source>
+        <target state="final">Si vous sélectionnez un champ, modifiez sa valeur, et sauvegardez, le comportement multiboutique ne s'appliquera pas à cette boutique (ou ce groupe), pour ce paramètre-ci.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="a157a50f5a421a7dfbdf280f3ff9d56e" approved="yes">
+        <source>You can't change the value of this configuration field in the context of this shop.</source>
+        <target state="final">Vous ne pouvez pas changer la valeur de ce champ de configuration dans le contexte de la boutique actuelle.</target>
+        <note>Line: 331</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/required_fields.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="0470d45929f27e1161330164c423b415" approved="yes">
+        <source>Set required fields for this section</source>
+        <target state="final">Définir les champs requis pour cette section</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="e54b38290c8bdd95e8bc10412c9cc096" approved="yes">
+        <source>Required Fields</source>
+        <target state="final">Champs requis</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="81f32b96f6626b8968e6a0f4a9bce62e" approved="yes">
+        <source>Select the fields you would like to be required for this section.</source>
+        <target state="final">Sélectionnez les champs que vous voulez rendre obligatoires pour cette section.</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="ee9b2f3cf31c23c944b15fb0b33d6a77" approved="yes">
+        <source>Field Name</source>
+        <target state="final">Nom du champ</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/shops_list/list.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="804ccd6219996d12eda865d1c0707423" approved="yes">
+        <source>All shops</source>
+        <target state="final">Toutes les boutiques</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="93f04304c09d561ed79442ea9ee722d4" approved="yes">
+        <source>%s group</source>
+        <target state="final">groupe %s</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="24fc6fbf93a9d551ea7da4cd69f3da3e" approved="yes">
+        <source>(%s selected)</source>
+        <target state="final">(%s sélectionnés)</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="bebe39eef720d7cbb479d8b3428e4c04" approved="yes">
+        <source>Group: %s</source>
+        <target state="final">Groupe : %s</target>
+        <note>Line: 29</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d77a48a51f8c62087570ab8f9d6ca55a" approved="yes">
+        <source>search...</source>
+        <target state="final">chercher...</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/ajax.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="86d3852bba89bf82128c3e156624ad08" approved="yes">
+        <source>Add files...</source>
+        <target state="final">Ajouter des fichiers...</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="9e74a55bb862a98723f9cf3f868d837e" approved="yes">
+        <source>Add file...</source>
+        <target state="final">Ajouter un fichier...</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="c7de86f69db264c3950d8ae46ed2e33f" approved="yes">
+        <source>Upload files</source>
+        <target state="final">Télécharger des fichiers vers le serveur</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="ffeed24e8e4fd763c1d0d02c6e5d6e15" approved="yes">
+        <source>Upload file</source>
+        <target state="final">Télécharger un fichier vers le serveur</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="6dc85b454944660cf96e7d0c2d171ee3" approved="yes">
+        <source>You cannot have more than %s images in total. Please remove some of the current images before adding new ones.</source>
+        <target state="final">Au total, vous ne pouvez pas avoir plus de %s images. Veuillez supprimer des images pour pouvoir en ajouter des nouvelles.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+      <trans-unit id="b21f085d08623fc7a5a9da204cc66c8c" approved="yes">
+        <source>Remove file</source>
+        <target state="final">Supprimer le fichier</target>
+        <note>Line: 178</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/helpers/uploader/simple.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="1908624a0bca678cd26b99bfd405324e" approved="yes">
+        <source>File size</source>
+        <target state="final">Taille de l'image</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="3fcbe6bd34e9279ec2c7b13adf7e4095" approved="yes">
+        <source>You have reached the limit (%s) of files to upload, please remove files to continue uploading</source>
+        <target state="final">Vous avez atteint le nombre maximal (%s) de fichiers que vous pouvez télécharger sur le serveur en une fois. Veuillez enlever des fichiers avant de continuer</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="d39ec66f08507e26fe86aa5325d070df" approved="yes">
+        <source>Add files</source>
+        <target state="final">Ajouter des fichiers</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="58be4de806253a6ee411b6c0c99296c7" approved="yes">
+        <source>Add file</source>
+        <target state="final">Ajouter un fichier</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="09942cec33b5becdf3e2275913b818e2" approved="yes">
+        <source>Download current file (%skb)</source>
+        <target state="final">Télécharger le fichier courant (%s ko)</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="c2299e6abb73991105dfacfb6fdd6dd4" approved="yes">
+        <source>Download current file</source>
+        <target state="final">Télécharger le fichier courant</target>
+        <note>Line: 72</note>
+      </trans-unit>
+      <trans-unit id="009044df8c709bfdefa065ae7fa733e1" approved="yes">
+        <source>You can upload a maximum of %s files</source>
+        <target state="final">Vous pouvez ajouter %s images au maximum.</target>
+        <note>Line: 134</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/layout-ajax.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="23a61fdb216b255d81b0d49ca1abb8a4" approved="yes">
+        <source>There are %d warnings.</source>
+        <target state="final">Il y a %d avertissements.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="8a3cfd894d57e33c55400fc9d76aa08a" approved="yes">
+        <source>Click here to see more</source>
+        <target state="final">Cliquez ici pour en savoir plus</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="a92269f5f14ac147a821728c23204c0b" approved="yes">
+        <source>Hide warning</source>
+        <target state="final">Masquer l'avertissement</target>
+        <note>Line: 85</note>
+      </trans-unit>
+      <trans-unit id="406cabb68a6d8f9f7ebbb3c10cd535ef" approved="yes">
+        <source>There is %d warning.</source>
+        <target state="final">Il y a %d avertissement.</target>
+        <note>Line: 88</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/layout.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2169b4627df97333ed94d1e30a9b8148" approved="yes">
+        <source>%d errors</source>
+        <target state="final">%d erreurs</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="e112201196d8a38cfe15031655647cb6" approved="yes">
+        <source>There are %d warnings:</source>
+        <target state="final">Il y a %d avertissements :</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/search_form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="03de6422045e4ed3ac822c673ace32d1" approved="yes">
+        <source>123.45.67.89</source>
+        <target state="final">123.45.67.89</target>
+        <note>Line: 50</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="3d8de6fcc09baf73f7175fe59f278ced" approved="yes">
+        <source>Your profile</source>
+        <target state="final">Votre profil</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="c87aacf5673fada1108c9f809d354311" approved="yes">
+        <source>Sign out</source>
+        <target state="final">Déconnexion</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/non-responsive.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ed95254a7068ffd8729fd94d07347d67" approved="yes">
+        <source>Oh no!</source>
+        <target state="final">Oh non !</target>
+        <note>Line: 26</note>
+      </trans-unit>
+      <trans-unit id="93e2c2e3d9591e5d54b0e5e6f81d36e0" approved="yes">
+        <source>The mobile version of this page is not available yet.</source>
+        <target state="final">La version mobile de cette page n'est pas encore disponible.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="56c42d822d794bc33d5e25bc53cd385b" approved="yes">
+        <source>Please use a desktop computer to access this page, until is adapted to mobile.</source>
+        <target state="final">En attendant que cette page soit adaptée au mobile, vous êtes invité à la consulter sur ordinateur.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="2d439011ecebc222e1feb2e3e005c0ac" approved="yes">
+        <source>Thank you.</source>
+        <target state="final">Merci.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/quick_access.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="4f32a32dea642737580dd71cdfd8d3c0" approved="yes">
+        <source>Quick Access</source>
+        <target state="final">Accès rapide</target>
+        <note>Line: 4</note>
+      </trans-unit>
+      <trans-unit id="6f7579a25b7aba443386a5b86a7900b4" approved="yes">
+        <source>Please name this shortcut:</source>
+        <target state="final">Veuillez nommer ce raccourci :</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="f5c26758149849ee0f84a2eceaf0acfd" approved="yes">
+        <source>Remove from QuickAccess</source>
+        <target state="final">Supprimer de l'Accès Rapide</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="383247a8cb198be4042d128986100cea" approved="yes">
+        <source>Add current page to QuickAccess</source>
+        <target state="final">Ajouter cette page à l'Accès Rapide</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="165122309e15dc09c30b78951e53cb5a" approved="yes">
+        <source>Manage quick accesses</source>
+        <target state="final">Gérer les accès rapides</target>
+        <note>Line: 49</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/search_form.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="f5945546981ef6e50e1fade1b386da04" approved="yes">
+        <source>Search (e.g.: product reference, customer name…)</source>
+        <target state="final">Rechercher (ex. : référence produit, nom du client, etc.)</target>
+        <note>Line: 36</note>
+      </trans-unit>
+      <trans-unit id="13787cfb1a15ae6690a29d3895c54de9" approved="yes">
+        <source>Everywhere</source>
+        <target state="final">Partout</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="2e67c0a79d35c15af2436c8d80ca072d" approved="yes">
+        <source>What are you looking for?</source>
+        <target state="final">Que souhaitez-vous trouver ?</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="c32516babc5b6c47eb8ce1bfc223253c" approved="yes">
+        <source>Catalog</source>
+        <target state="final">Catalogue</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="7f704ff8964f7b5f3f9a6444d450b5f7" approved="yes">
+        <source>Product name, SKU, reference...</source>
+        <target state="final">Nom du produit, unité de gestion des stocks (SKU), référence...</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="855d2bf59043b81e76bc931e685a4f58" approved="yes">
+        <source>by name</source>
+        <target state="final">par nom</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="a3681587c5320489b6a3dd21282e254d" approved="yes">
+        <source>Email, name...</source>
+        <target state="final">E-mail, nom...</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="399574be0ed95657dfac0e8d38374c62" approved="yes">
+        <source>by ip address</source>
+        <target state="final">par adresse IP</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="16b2494238f8f996b09417d1dc56c795" approved="yes">
+        <source>by IP address</source>
+        <target state="final">par adresse IP</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="d79cf3f429596f77db95c65074663a54" approved="yes">
+        <source>Order ID</source>
+        <target state="final">ID commande</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="fce9a6a1bd2a2050eb86d33103f46fd3" approved="yes">
+        <source>Invoices</source>
+        <target state="final">Factures</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="4e065ba1bec1d62b2d5450256612fa96" approved="yes">
+        <source>Invoice Number</source>
+        <target state="final">Numéro de facture</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="fc26e55e0993a75e892175deb02aae15" approved="yes">
+        <source>Carts</source>
+        <target state="final">Paniers</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="fc6dfe4f8b07fc04c99e27425f780754" approved="yes">
+        <source>Cart ID</source>
+        <target state="final">ID panier</target>
+        <note>Line: 49</note>
+      </trans-unit>
+      <trans-unit id="bf17ac149e2e7a530c677e9bd51d3fd2" approved="yes">
+        <source>Modules</source>
+        <target state="final">Modules</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="07403a8bc81d7865c8e040e718ec7828" approved="yes">
+        <source>Module name</source>
+        <target state="final">Nom du module</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="0f544d682c3a664870f025f48c4b04b5" approved="yes">
+        <source>SEARCH</source>
+        <target state="final">RECHERCHE</target>
+        <note>Line: 52</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/components/layout/shop_list.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d70861cbe7f8c9a1241c39b3e7ef5ef2" approved="yes">
+        <source>View my shop</source>
+        <target state="final">Voir ma boutique</target>
+        <note>Line: 54</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/error.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ecdb1f330299c20ac9897cd73f92c8cd" approved="yes">
+        <source>%1$s on line %2$s in file %3$s</source>
+        <target state="final">%1$s à la ligne %2$s du fichier %3$s</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/header.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="2fc6204d2ca7e856d9e4844d2786f053" approved="yes">
+        <source>This field will be modified for all your shops.</source>
+        <target state="final">Ce champ sera modifié pour toutes vos boutiques.</target>
+        <note>Line: 48</note>
+      </trans-unit>
+      <trans-unit id="7ac170f2b47dbf7d4c5cd38449093c2b" approved="yes">
+        <source>This field will be modified for all shops in this shop group:</source>
+        <target state="final">Ce champ sera modifié pour toutes les boutiques de ce groupe :</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="fe0ae15c8f93a5335f0991accadd13ca" approved="yes">
+        <source>This field will be modified for this shop:</source>
+        <target state="final">Ce champ sera modifié pour cette boutique :</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="0a71c80de89d7b2d3e6b22974a4a7548" approved="yes">
+        <source>A new order has been placed on your shop.</source>
+        <target state="final">Une nouvelle commande a été passée sur votre boutique.</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="3df406952f3377a5e419d4d63abb1b1d" approved="yes">
+        <source>Order number:</source>
+        <target state="final">Numéro de commande :</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="66c4c5112f455a19afde47829df363fa" approved="yes">
+        <source>Total:</source>
+        <target state="final">Total :</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="1e6d57e813355689e9c77e947d73ad8f" approved="yes">
+        <source>From:</source>
+        <target state="final">Du</target>
+        <note>Line: 58</note>
+      </trans-unit>
+      <trans-unit id="c112bd7d596888979be02bd780e6a94f" approved="yes">
+        <source>View this order</source>
+        <target state="final">Afficher cette commande</target>
+        <note>Line: 59</note>
+      </trans-unit>
+      <trans-unit id="d2d2000f7fa636acd871f43c085a75dc" approved="yes">
+        <source>A new customer registered on your shop.</source>
+        <target state="final">Un nouveau client s'est inscrit sur votre boutique</target>
+        <note>Line: 60</note>
+      </trans-unit>
+      <trans-unit id="7a2e40e90ddbc145f11afacb5eb83ae2" approved="yes">
+        <source>Customer name:</source>
+        <target state="final">Nom du client :</target>
+        <note>Line: 61</note>
+      </trans-unit>
+      <trans-unit id="d48549659ae6cc81e7d4729b068ba4b9" approved="yes">
+        <source>A new message was posted on your shop.</source>
+        <target state="final">Un nouveau message a été posté sur votre boutique.</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6fab17d3dc1147f9b170fb8e1aac2fa8" approved="yes">
+        <source>Read this message</source>
+        <target state="final">Lire le message</target>
+        <note>Line: 63</note>
+      </trans-unit>
+      <trans-unit id="a8d69cdfad4c19ed22bf693b8871064e" approved="yes">
+        <source>Choose language</source>
+        <target state="final">Choisissez la langue</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="151648106e4bf98297882ea2ea1c4b0e" approved="yes">
+        <source>Update successful</source>
+        <target state="final">Mise à jour réussie</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="358cc9ee3a3d23d3390e5043122d9bea" approved="yes">
+        <source>PrestaShop was unable to log in to Addons. Please check your credentials and your Internet connection.</source>
+        <target state="final">PrestaShop n'a pas pu se connecter à Addons. Veuillez vérifier vos identifiants et votre connexion Internet.</target>
+        <note>Line: 77</note>
+      </trans-unit>
+      <trans-unit id="7bb36e0f484d91aeba5d83fe2af63d28" approved="yes">
+        <source>Search for a product</source>
+        <target state="final">Rechercher un produit</target>
+        <note>Line: 78</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/new-theme/template/layout.tpl" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c821206b336b401bccf058f664f8255d" approved="yes">
+        <source>Your shop is in debug mode.</source>
+        <target state="final">Votre boutique est en mode de debug.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="13886bc255a80b7c11e0585013feeb30" approved="yes">
+        <source>All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.</source>
+        <target state="final">Tous les messages et erreurs PHP sont affichés. Lorsque vous n'en avez plus besoin, [1]désactivez[/1] ce mode.</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="ec3028a12402ab7f43962a6f3a667b6e" approved="yes">
+        <source>Debug mode</source>
+        <target state="final">Mode debug</target>
+        <note>Line: 38</note>
+      </trans-unit>
+      <trans-unit id="67a33d40bef41c3b79d6b973bfcbc89a" approved="yes">
+        <source>Your shop is in maintenance.</source>
+        <target state="final">Votre boutique est en maintenance.</target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="929f5283d0fa1e9eecf20cc294f981e5" approved="yes">
+        <source><![CDATA[Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.]]></source>
+        <target state="final"><![CDATA[Vos clients et visiteurs ne peuvent y accéder actuellement. %s Vous pouvez gérer les paramètres de maintenance dans l'onglet Maintenance de la page Paramètres de la boutique.]]></target>
+        <note>Line: 50</note>
+      </trans-unit>
+      <trans-unit id="38a27c0c7ef7a05e13efa2798ee21533" approved="yes">
+        <source>Maintenance mode</source>
+        <target state="final">Mode maintenance</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9ff082251dea737459c9f32e73ca7a62" approved="yes">
+        <source>For security reasons, you must also delete the /install folder.</source>
+        <target state="final">Pour des raisons de sécurité, vous devez aussi supprimer le dossier /install.</target>
+        <note>Line: 84</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/controller/AdminController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="ec211f7c20af43e742bf2570c3cb84f9" approved="yes">
+        <source>Add</source>
+        <target state="final">Ajouter</target>
+        <note>Line: 611</note>
+      </trans-unit>
+      <trans-unit id="7dce122004969d56ae2e0245cb754d35" approved="yes">
+        <source>Edit</source>
+        <target state="final">Modifier</target>
+        <note>Line: 667</note>
+      </trans-unit>
+      <trans-unit id="4ee29ca12c7d126654bd0e5275de6135" approved="yes">
+        <source>List</source>
+        <target state="final">Liste</target>
+        <note>Line: 622</note>
+      </trans-unit>
+      <trans-unit id="6e9783376d951cfd780e9fdb67a0f02c" approved="yes">
+        <source>View details</source>
+        <target state="final">Afficher les détails</target>
+        <note>Line: 628</note>
+      </trans-unit>
+      <trans-unit id="dae8ace18bdcbcc6ae5aece263e14fe8" approved="yes">
+        <source>Options</source>
+        <target state="final">Options</target>
+        <note>Line: 633</note>
+      </trans-unit>
+      <trans-unit id="92a8f0b9d28a89b480bd1d29f46f0484" approved="yes">
+        <source>Generator</source>
+        <target state="final">Générateur</target>
+        <note>Line: 638</note>
+      </trans-unit>
+      <trans-unit id="ef61fb324d729c341ea8ab9901e23566" approved="yes">
+        <source>Add new</source>
+        <target state="final">Ajouter</target>
+        <note>Line: 1695</note>
+      </trans-unit>
+      <trans-unit id="4351cfebe4b61d8aa5efa1d020710005" approved="yes">
+        <source>View</source>
+        <target state="final">Afficher</target>
+        <note>Line: 679</note>
+      </trans-unit>
+      <trans-unit id="a6105c0a611b41b08f1209506350279e" approved="yes">
+        <source>yes</source>
+        <target state="final">oui</target>
+        <note>Line: 706</note>
+      </trans-unit>
+      <trans-unit id="7fa3b767c460b54a2be4d49030b349c7" approved="yes">
+        <source>no</source>
+        <target state="final">non</target>
+        <note>Line: 706</note>
+      </trans-unit>
+      <trans-unit id="7d341c08fd102f0b86285b5ff2e26ea7" approved="yes">
+        <source>%s: %s</source>
+        <target state="final">%s : %s</target>
+        <note>Line: 730</note>
+      </trans-unit>
+      <trans-unit id="921d54865f8169b84c90d4335c256494" approved="yes">
+        <source>filter by %s</source>
+        <target state="final">Filtrer par %s</target>
+        <note>Line: 737</note>
+      </trans-unit>
+      <trans-unit id="a333339eb21abf3d5a04f5ede8f73ae9" approved="yes">
+        <source>%s deletion</source>
+        <target state="final">Suppression : %s</target>
+        <note>Line: 4139</note>
+      </trans-unit>
+      <trans-unit id="6ca3b11e4d89a7649d10c2d70d98612f" approved="yes">
+        <source>%s addition</source>
+        <target state="final">Création : %s</target>
+        <note>Line: 1184</note>
+      </trans-unit>
+      <trans-unit id="0919680b340ae0ac8d1a804c4c69b0ba" approved="yes">
+        <source>%s modification</source>
+        <target state="final">modification %s</target>
+        <note>Line: 1292</note>
+      </trans-unit>
+      <trans-unit id="f7931413dee107ddf5289c8886baf7ec" approved="yes">
+        <source>Edit: %s</source>
+        <target state="final">Modifier : %s</target>
+        <note>Line: 1607</note>
+      </trans-unit>
+      <trans-unit id="0095a9fa74d1713e43e370a7d7846224" approved="yes">
+        <source>Export</source>
+        <target state="final">Exporter</target>
+        <note>Line: 1700</note>
+      </trans-unit>
+      <trans-unit id="4668a49dfb4ba4ff7fa8019e7e5c28af" approved="yes">
+        <source>Recommended Modules</source>
+        <target state="final">Modules recommandés</target>
+        <note>Line: 2249</note>
+      </trans-unit>
+      <trans-unit id="ee77ea46b0c548ed60eadf31bdd68613" approved="yes">
+        <source>Bad SQL query</source>
+        <target state="final">Mauvaise requête SQL</target>
+        <note>Line: 2469</note>
+      </trans-unit>
+      <trans-unit id="431accab7897f05b0424e002ca30391d" approved="yes">
+        <source>Operational</source>
+        <target state="final">Opérationnel</target>
+        <note>Line: 2745</note>
+      </trans-unit>
+      <trans-unit id="fb381d41e52b0dc68e684c01decfe2ec" approved="yes">
+        <source>Degraded Performance</source>
+        <target state="final">Performance dégradée</target>
+        <note>Line: 2746</note>
+      </trans-unit>
+      <trans-unit id="7c30b2ec6e5e59c7c327f7098fe36f36" approved="yes">
+        <source>Partial Outage</source>
+        <target state="final">Interruption partielle</target>
+        <note>Line: 2747</note>
+      </trans-unit>
+      <trans-unit id="b101c07e257875658c454fe5caef1db0" approved="yes">
+        <source>Major Outage</source>
+        <target state="final">Interruption majeure</target>
+        <note>Line: 2748</note>
+      </trans-unit>
+      <trans-unit id="ea4788705e6873b424c65e91c2846b19" approved="yes">
+        <source>Cancel</source>
+        <target state="final">Annuler</target>
+        <note>Line: 1662</note>
+      </trans-unit>
+      <trans-unit id="c9cc8cce247e49bae79f15173ce97354" approved="yes">
+        <source>Save</source>
+        <target state="final">Enregistrer</target>
+        <note>Line: 1687</note>
+      </trans-unit>
+      <trans-unit id="b9804794cbfeea33c6d9b2ce85100b48" approved="yes">
+        <source>Do you really want to uninstall this module?</source>
+        <target state="final">Voulez-vous vraiment désinstaller ce module ?</target>
+        <note>Line: 4448</note>
+      </trans-unit>
+      <trans-unit id="b2f31ef3065bf40b2da9fa8525c6adb9" approved="yes">
+        <source>Disable this module</source>
+        <target state="final">Désactiver ce module</target>
+        <note>Line: 4450</note>
+      </trans-unit>
+      <trans-unit id="668c99c1164d5348f99c0878770b53a8" approved="yes">
+        <source>Enable this module for all shops</source>
+        <target state="final">Activer ce module pour toutes les boutiques</target>
+        <note>Line: 4451</note>
+      </trans-unit>
+      <trans-unit id="bcfaccebf745acfd5e75351095a5394a" approved="yes">
+        <source>Disable</source>
+        <target state="final">Désactiver</target>
+        <note>Line: 4452</note>
+      </trans-unit>
+      <trans-unit id="2faec1f9f8cc7f8f40d521c4dd574f49" approved="yes">
+        <source>Enable</source>
+        <target state="final">Activer</target>
+        <note>Line: 4453</note>
+      </trans-unit>
+      <trans-unit id="112b842b7d5dda8d3fed05c0e5aaf983" approved="yes">
+        <source>Disable on mobiles</source>
+        <target state="final">Désactiver sur mobile</target>
+        <note>Line: 4454</note>
+      </trans-unit>
+      <trans-unit id="2ef92962bd1ac0c81675f10568ad5cca" approved="yes">
+        <source>Disable on tablets</source>
+        <target state="final">Désactiver sur tablettes</target>
+        <note>Line: 4455</note>
+      </trans-unit>
+      <trans-unit id="5e3ffb3123b3f23a33804d41e38745a0" approved="yes">
+        <source>Disable on computers</source>
+        <target state="final">Désactiver sur ordinateurs</target>
+        <note>Line: 4456</note>
+      </trans-unit>
+      <trans-unit id="862e2caedb77ba14d86f180ca7fa90a8" approved="yes">
+        <source>Display on mobiles</source>
+        <target state="final">Afficher sur mobiles</target>
+        <note>Line: 4457</note>
+      </trans-unit>
+      <trans-unit id="732ebdb0f33a8153b51ac58cac8f3563" approved="yes">
+        <source>Display on tablets</source>
+        <target state="final">Afficher sur tablettes</target>
+        <note>Line: 4458</note>
+      </trans-unit>
+      <trans-unit id="7f0f7c79f1d7b01b1d8a89f392e93d36" approved="yes">
+        <source>Display on computers</source>
+        <target state="final">Affichage sur ordinateurs</target>
+        <note>Line: 4459</note>
+      </trans-unit>
+      <trans-unit id="f1206f9fadc5ce41694f69129aecac26" approved="yes">
+        <source>Configure</source>
+        <target state="final">Configurer</target>
+        <note>Line: 4461</note>
+      </trans-unit>
+      <trans-unit id="f2a6c498fb90ee345d997f888fce3b18" approved="yes">
+        <source>Delete</source>
+        <target state="final">Supprimer</target>
+        <note>Line: 4462</note>
+      </trans-unit>
+      <trans-unit id="85687c63fd82afbc21632f288e53a6e4" approved="yes">
+        <source>This action will permanently remove the module from the server. Are you sure you want to do this?</source>
+        <target state="final">Cette action supprime définitivement le module sur votre serveur. Êtes-vous vraiment sûr ?</target>
+        <note>Line: 4466</note>
+      </trans-unit>
+      <trans-unit id="630f6dc397fe74e52d5189e2c80f282b" approved="yes">
+        <source>Back to list</source>
+        <target state="final">Retour à la liste</target>
+        <note>Line: 1679</note>
+      </trans-unit>
+      <trans-unit id="ede4759c9afae620fd586628789fa304" approved="yes">
+        <source>Enable selection</source>
+        <target state="final">Activer la sélection</target>
+        <note>Line: 3125</note>
+      </trans-unit>
+      <trans-unit id="ab7fd6e250b64a46027a996088fdff74" approved="yes">
+        <source>Disable selection</source>
+        <target state="final">Désactiver la sélection</target>
+        <note>Line: 3129</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/helper/HelperOptions.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="c770d8e0d1d1943ce239c64dbd6acc20" approved="yes">
+        <source>Add my IP</source>
+        <target state="final">Ajouter mon IP</target>
+        <note>Line: 212</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCmsController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="193cfc9be3b995831c6af2fea6650e60" approved="yes">
+        <source>Page</source>
+        <target state="final">Page</target>
+        <note>Line: 159</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="240f3031f25601fa128bd4e15f0a37de" approved="yes">
+        <source>Comment:</source>
+        <target state="final">Commentaire :</target>
+        <note>Line: 423</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminModulesController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="7258e7251413465e0a3eb58094430bde" approved="yes">
+        <source>Administration</source>
+        <target state="final">Administration</target>
+        <note>Line: 85
+Comment: Set the modules categories</note>
+      </trans-unit>
+      <trans-unit id="3defbfac3fcbea45049cddcf80aa9f21" approved="yes">
+        <source>Advertising and Marketing</source>
+        <target state="final">Publicité et Marketing</target>
+        <note>Line: 86</note>
+      </trans-unit>
+      <trans-unit id="a99118454f54727d280e3d2d9c7ea0e3" approved="yes">
+        <source>Analytics and Stats</source>
+        <target state="final">Statistiques et Analyses</target>
+        <note>Line: 87</note>
+      </trans-unit>
+      <trans-unit id="e09d0a51d181ee0b28180946f2af0f95" approved="yes">
+        <source><![CDATA[Taxes & Invoicing]]></source>
+        <target state="final"><![CDATA[Taxes et Facturation]]></target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="6ff063fbc860a79759a7369ac32cee22" approved="yes">
+        <source>Checkout</source>
+        <target state="final">Commander</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="5dc6d69e21ca0f5779b9cfeae1154f05" approved="yes">
+        <source>Content Management</source>
+        <target state="final">Gestion de contenu</target>
+        <note>Line: 90</note>
+      </trans-unit>
+      <trans-unit id="d8b5985b4baa0bfe0ce6734f99b22e6e" approved="yes">
+        <source>Customer Reviews</source>
+        <target state="final">Avis clients</target>
+        <note>Line: 91</note>
+      </trans-unit>
+      <trans-unit id="e00dfb7a37c4f39c748f459e69fadb96" approved="yes">
+        <source>Front office Features</source>
+        <target state="final">Fonctionnalités Front-office</target>
+        <note>Line: 93</note>
+      </trans-unit>
+      <trans-unit id="a8cf512208bee5db82f968d2dc247c5f" approved="yes">
+        <source>Internationalization and Localization</source>
+        <target state="final">Internationalisation &amp; Localisation</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="825896e7e83eff50879ed00cba2f9414" approved="yes">
+        <source>Merchandising</source>
+        <target state="final">Merchandising</target>
+        <note>Line: 95</note>
+      </trans-unit>
+      <trans-unit id="5b985caa89b2ca61bbeee91a896c610d" approved="yes">
+        <source>Migration Tools</source>
+        <target state="final">Outils de migration</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="286030724099ebb1518552eeb8b00bd7" approved="yes">
+        <source>Payments and Gateways</source>
+        <target state="final">Paiement</target>
+        <note>Line: 97</note>
+      </trans-unit>
+      <trans-unit id="dd05711d44de1fa4bf31303915bd41bc" approved="yes">
+        <source><![CDATA[Site certification & Fraud prevention]]></source>
+        <target state="final"><![CDATA[Certification de site et Lutte contre la fraude]]></target>
+        <note>Line: 98</note>
+      </trans-unit>
+      <trans-unit id="54f65da381d43abf769b7ac2cb3a8270" approved="yes">
+        <source>Pricing and Promotion</source>
+        <target state="final">Prix et Promotions</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="a9964513dc046a2cd404413f77b4656e" approved="yes">
+        <source>Quick / Bulk update</source>
+        <target state="final">Edition rapide / de masse</target>
+        <note>Line: 100</note>
+      </trans-unit>
+      <trans-unit id="d88946b678e4c2f251d4e292e8142291" approved="yes">
+        <source>SEO</source>
+        <target state="final">Référencement - SEO</target>
+        <note><![CDATA[Line: 102
+Comment: $this->list_modules_categories['search_filter']['name'] = $this->l('Search and Filter');]]></note>
+      </trans-unit>
+      <trans-unit id="19e295f6e2c8774937dd5144ce6aed23" approved="yes">
+        <source>Shipping and Logistics</source>
+        <target state="final">Transporteur et Logistique</target>
+        <note>Line: 103</note>
+      </trans-unit>
+      <trans-unit id="5f17a788546ddb43236732f8b0bdfd7e" approved="yes">
+        <source>Slideshows</source>
+        <target state="final">Diaporamas</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="b93d83bd882a9507436946da114a9c25" approved="yes">
+        <source><![CDATA[Comparison site & Feed management]]></source>
+        <target state="final"><![CDATA[Comparateurs et Gestion de flux]]></target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="675e31b94580e2642405e2f8586d112e" approved="yes">
+        <source>Marketplace</source>
+        <target state="final">Places de marché</target>
+        <note>Line: 106</note>
+      </trans-unit>
+      <trans-unit id="87d17f4624a514e81dc7c8e016a7405c" approved="yes">
+        <source>Mobile</source>
+        <target state="final">Mobile</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="2938c7f7e560ed972f8a4f68e80ff834" approved="yes">
+        <source>Dashboard</source>
+        <target state="final">Tableau de bord</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="44f9bbe73101a9c7842e9384e0db70c9" approved="yes">
+        <source><![CDATA[Internationalization & Localization]]></source>
+        <target state="final"><![CDATA[Internationalisation et Localisation]]></target>
+        <note>Line: 110</note>
+      </trans-unit>
+      <trans-unit id="e7e5eafdb7b6b3bbb9e38e9ae8a35094" approved="yes">
+        <source><![CDATA[Emailing & SMS]]></source>
+        <target state="final"><![CDATA[Envoi d'e-mails et SMS]]></target>
+        <note>Line: 111</note>
+      </trans-unit>
+      <trans-unit id="222e1825c6eb93a516fba01be7861ddd" approved="yes">
+        <source>Social Networks</source>
+        <target state="final">Réseaux sociaux</target>
+        <note>Line: 112</note>
+      </trans-unit>
+      <trans-unit id="06c21841ec088f9c8cbfb82946cf203b" approved="yes">
+        <source><![CDATA[Social & Community]]></source>
+        <target state="final"><![CDATA[Réseaux sociaux et Communauté]]></target>
+        <note>Line: 113</note>
+      </trans-unit>
+      <trans-unit id="8290fb626ffacf21450997f25967efeb" approved="yes">
+        <source>Module not found</source>
+        <target state="final">Module non trouvé</target>
+        <note>Line: 860</note>
+      </trans-unit>
+      <trans-unit id="0c81f6a8e4b7b1d0a812d7285289f17d" approved="yes">
+        <source>Modules to update</source>
+        <target state="final">Modules à mettre à jour</target>
+        <note>Line: 1396</note>
+      </trans-unit>
+      <trans-unit id="0f0c014bcfe255c6749d8e665ff8bb4e" approved="yes">
+        <source>Translate this module</source>
+        <target state="final">Traduire ce module</target>
+        <note>Line: 1450</note>
+      </trans-unit>
+      <trans-unit id="7602b3edb382cf12573e156623fe9468" approved="yes">
+        <source>This module cannot be installed</source>
+        <target state="final">Ce module ne peut pas être installé</target>
+        <note>Line: 1458</note>
+      </trans-unit>
+      <trans-unit id="ac8f751177ba1d91a0ab11d3650cdfaf" approved="yes">
+        <source>Important Notice</source>
+        <target state="final">Information importante</target>
+        <note>Line: 1458</note>
+      </trans-unit>
+      <trans-unit id="c472f22a7459a000f0177a23fdc4212b" approved="yes">
+        <source>This module is Untrusted for your country</source>
+        <target state="final">Ce module n'est pas vérifié pour votre pays</target>
+        <note>Line: 1466</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminTabsController.php" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="d3b206d196cd6be3a2764c1fb90b200f" approved="yes">
+        <source>Delete selected</source>
+        <target state="final">Supprimer la sélection</target>
+        <note>Line: 52</note>
+      </trans-unit>
+      <trans-unit id="e25f0ecd41211b01c83e5fec41df4fe7" approved="yes">
+        <source>Delete selected items?</source>
+        <target state="final">Supprimer les éléments sélectionnés ?</target>
+        <note>Line: 53</note>
+      </trans-unit>
+      <trans-unit id="9bd81329febf6efe22788e03ddeaf0af" approved="yes">
+        <source>Class</source>
+        <target state="final">Classe</target>
+        <note>Line: 155</note>
+      </trans-unit>
+      <trans-unit id="52f5e0bc3859bc5f5e25130b6c7e8881" approved="yes">
+        <source>Position</source>
+        <target state="final">Position</target>
+        <note>Line: 80</note>
+      </trans-unit>
+      <trans-unit id="06145a21dcec7395085b033e6e169b61" approved="yes">
+        <source>Menus</source>
+        <target state="final">Menus</target>
+        <note>Line: 136</note>
+      </trans-unit>
+      <trans-unit id="0164b35f3cbc5cbf9bf58abeb4bc14df" approved="yes">
+        <source>Add new menu</source>
+        <target state="final">Ajouter un menu</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="8cf04a9734132302f96da8e113e80ce5" approved="yes">
+        <source>Home</source>
+        <target state="final">Accueil</target>
+        <note>Line: 130</note>
+      </trans-unit>
+      <trans-unit id="6252c0f2c2ed83b7b06dfca86d4650bb" approved="yes">
+        <source>Invalid characters:</source>
+        <target state="final">Caractères interdits:</target>
+        <note>Line: 151</note>
+      </trans-unit>
+      <trans-unit id="ec53a8c4f07baed5d8825072c89799be" approved="yes">
+        <source>Status</source>
+        <target state="final">État</target>
+        <note>Line: 166</note>
+      </trans-unit>
+      <trans-unit id="fe513725b21a16ced7d05b454e74a33e" approved="yes">
+        <source>Show or hide menu.</source>
+        <target state="final">Afficher ou cacher le menu.</target>
+        <note>Line: 182</note>
+      </trans-unit>
+      <trans-unit id="30269022e9d8f51beaabb52e5d0de2b7" approved="yes">
+        <source>Parent</source>
+        <target state="final">Parent</target>
+        <note>Line: 198</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/Unit/Core/Translation/Builder/TranslationCatalogueBuilderTest.php
+++ b/tests/Unit/Core/Translation/Builder/TranslationCatalogueBuilderTest.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Translation\Exception\UnexpectedTranslationTypeEx
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueLayersProviderInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory;
 use PrestaShop\PrestaShop\Core\Translation\Provider\DefaultCatalogueProvider;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\FileTranslatedCatalogueProvider;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -124,7 +125,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             '',
             [],
@@ -137,7 +138,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         $this->expectException(Exception::class);
         $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_THEMES,
+            ProviderDefinitionInterface::TYPE_THEMES,
             'en',
             'domain',
             [],
@@ -150,7 +151,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         $this->expectException(Exception::class);
         $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_MODULES,
+            ProviderDefinitionInterface::TYPE_MODULES,
             'en',
             'domain',
             [],
@@ -162,7 +163,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     public function testGetDomainCatalogueWithNonExistentDomain()
     {
         $catalogue = $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_THEMES,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             'SomeFakeDomain',
             [],
@@ -223,7 +224,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         // Search single word
         $catalogue = $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             'AdminSecondDomain',
             ['First'],
@@ -256,7 +257,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         // Search multiple words and case insensitive
         $catalogue = $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             'AdminSecondDomain',
             ['fIrst wORDING'],
@@ -288,7 +289,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         // Search with multiple results
         $catalogue = $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             'AdminSecondDomain',
             ['Domain'],
@@ -331,7 +332,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         // Search with multiple words
         $catalogue = $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             'AdminSecondDomain',
             [
@@ -378,7 +379,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     {
         // Search no result
         $catalogue = $this->translationCatalogueBuilder->getDomainCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             'en',
             'AdminFirstDomain',
             ['Second Domain'],
@@ -395,7 +396,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     public function testGetCatalogueStructure()
     {
         $messages = $this->translationCatalogueBuilder->getCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             self::LOCALE,
             [],
             'theme',
@@ -420,7 +421,7 @@ class TranslationCatalogueBuilderTest extends TestCase
     public function testGetCatalogue()
     {
         $messages = $this->translationCatalogueBuilder->getCatalogue(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             self::LOCALE,
             [],
             'theme',
@@ -524,7 +525,7 @@ class TranslationCatalogueBuilderTest extends TestCase
         return [
             $translationCatalogueBuilder,
             [
-                'type' => TranslationCatalogueBuilder::TYPE_BACK,
+                'type' => ProviderDefinitionInterface::TYPE_BACK,
                 'locale' => 'en',
                 'domain' => 'AdminSecondDomain',
                 'search' => [],
@@ -583,7 +584,7 @@ class TranslationCatalogueBuilderTest extends TestCase
         return [
             $translationCatalogueBuilder,
             [
-                'type' => TranslationCatalogueBuilder::TYPE_BACK,
+                'type' => ProviderDefinitionInterface::TYPE_BACK,
                 'locale' => 'en',
                 'domain' => 'AdminCatalogFeature',
                 'search' => ['Delivery'],

--- a/tests/Unit/Core/Translation/Builder/TranslationTreeBuilderTest.php
+++ b/tests/Unit/Core/Translation/Builder/TranslationTreeBuilderTest.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Translation\Builder\TranslationCatalogueBuilder;
 use PrestaShop\PrestaShop\Core\Translation\Builder\TranslationsTreeBuilder;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueLayersProviderInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ProviderDefinitionInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -111,7 +112,7 @@ class TranslationTreeBuilderTest extends TestCase
     public function testGetTreeStructure()
     {
         $tree = $this->treeBuilder->getTree(
-             TranslationCatalogueBuilder::TYPE_BACK,
+             ProviderDefinitionInterface::TYPE_BACK,
             self::LOCALE,
             [],
             'theme',
@@ -146,7 +147,7 @@ class TranslationTreeBuilderTest extends TestCase
     public function testGetTreeContent()
     {
         $tree = $this->treeBuilder->getTree(
-            TranslationCatalogueBuilder::TYPE_BACK,
+            ProviderDefinitionInterface::TYPE_BACK,
             self::LOCALE,
             [],
             'theme',

--- a/tests/Unit/Core/Translation/Provider/CatalogueProviderFactoryTest.php
+++ b/tests/Unit/Core/Translation/Provider/CatalogueProviderFactoryTest.php
@@ -28,11 +28,26 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Translation\Provider;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Translation\Builder\TranslationCatalogueBuilder;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Translation\Exception\UnexpectedTranslationTypeException;
-use PrestaShop\PrestaShop\Core\Translation\Provider\BackofficeCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory;
+use PrestaShop\PrestaShop\Core\Translation\Provider\CoreCatalogueLayersProvider;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\BackofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\FrontofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\MailsBodyProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\MailsProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\OthersProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Translation\Provider\Definition\ThemeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Provider\ModuleCatalogueLayersProvider;
+use PrestaShop\PrestaShop\Core\Translation\Provider\ThemeCatalogueLayersProvider;
+use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
+use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
 use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Translation\Loader\LoaderInterface;
 
 class CatalogueProviderFactoryTest extends TestCase
 {
@@ -44,25 +59,81 @@ class CatalogueProviderFactoryTest extends TestCase
     protected function setUp()
     {
         $databaseTranslationLoader = $this->createMock(DatabaseTranslationLoader::class);
+        $legacyModuleExtractor = $this->createMock(LegacyModuleExtractorInterface::class);
+        $legacyFileLoader = $this->createMock(LoaderInterface::class);
+        $themeExtractor = $this->createMock(ThemeExtractor::class);
+        $themeRepository = $this->createMock(ThemeRepository::class);
+        $filesystem = $this->createMock(Filesystem::class);
 
-        $this->factory = new CatalogueProviderFactory($databaseTranslationLoader, 'resourceDirectory');
+        $themeRepository
+            ->method('getInstanceByName')
+            ->willReturn(new Theme([
+                'name' => 'classic',
+                'directory' => '',
+            ])); //doesn't really matter
+
+        $this->factory = new CatalogueProviderFactory(
+            $databaseTranslationLoader,
+            $legacyModuleExtractor,
+            $legacyFileLoader,
+            $themeExtractor,
+            $themeRepository,
+            $filesystem,
+            'themesDirectory',
+            'modulesDirectory',
+            'translationsDirectory',
+            'resourceDirectory'
+        );
     }
 
     public function testGetProviderFailsWhenWrongTypeIsGiven()
     {
         $this->expectException(UnexpectedTranslationTypeException::class);
-        $this->factory->getProvider('wrongType');
+        $this->factory->getProvider(
+            $this->createMock(ProviderDefinitionInterface::class)
+        );
     }
 
-    public function testGetProvider()
+    /**
+     * @dataProvider getProviderData
+     *
+     * @throws UnexpectedTranslationTypeException
+     */
+    public function testGetProvider($providerDefinition, $providerClass)
     {
-        $providersByType = [
-            TranslationCatalogueBuilder::TYPE_BACK => BackofficeCatalogueLayersProvider::class,
-        ];
+        $provider = $this->factory->getProvider($providerDefinition);
+        $this->assertInstanceOf($providerClass, $provider);
+    }
 
-        foreach ($providersByType as $providerType => $providerClass) {
-            $provider = $this->factory->getProvider($providerType);
-            $this->assertInstanceOf($providerClass, $provider);
-        }
+    public function getProviderData()
+    {
+        yield [
+            new BackofficeProviderDefinition(),
+            CoreCatalogueLayersProvider::class,
+        ];
+        yield [
+            new FrontofficeProviderDefinition(),
+            CoreCatalogueLayersProvider::class,
+        ];
+        yield [
+            new MailsProviderDefinition(),
+            CoreCatalogueLayersProvider::class,
+        ];
+        yield [
+            new MailsBodyProviderDefinition(),
+            CoreCatalogueLayersProvider::class,
+        ];
+        yield [
+            new OthersProviderDefinition(),
+            CoreCatalogueLayersProvider::class,
+        ];
+        yield [
+            new ModuleProviderDefinition('module'),
+            ModuleCatalogueLayersProvider::class,
+        ];
+        yield [
+            new ThemeProviderDefinition('classic'),
+            ThemeCatalogueLayersProvider::class,
+        ];
     }
 }

--- a/tests/Unit/Core/Translation/Provider/CatalogueProviderFactoryTest.php
+++ b/tests/Unit/Core/Translation/Provider/CatalogueProviderFactoryTest.php
@@ -81,8 +81,7 @@ class CatalogueProviderFactoryTest extends TestCase
             $filesystem,
             'themesDirectory',
             'modulesDirectory',
-            'translationsDirectory',
-            'resourceDirectory'
+            'translationsDirectory'
         );
     }
 
@@ -99,13 +98,13 @@ class CatalogueProviderFactoryTest extends TestCase
      *
      * @throws UnexpectedTranslationTypeException
      */
-    public function testGetProvider($providerDefinition, $providerClass)
+    public function testGetProvider($providerDefinition, $providerClass): void
     {
         $provider = $this->factory->getProvider($providerDefinition);
         $this->assertInstanceOf($providerClass, $provider);
     }
 
-    public function getProviderData()
+    public function getProviderData(): iterable
     {
         yield [
             new BackofficeProviderDefinition(),

--- a/tests/Unit/Core/Translation/Provider/DefaultCatalogueProviderTest.php
+++ b/tests/Unit/Core/Translation/Provider/DefaultCatalogueProviderTest.php
@@ -29,7 +29,7 @@ namespace Tests\Unit\Core\Translation\Provider;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueLayersProviderInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\DefaultCatalogueProvider;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
@@ -79,7 +79,7 @@ class DefaultCatalogueProviderTest extends TestCase
 
     public function testItFailsWhenDirectoryNotExists()
     {
-        $this->expectException(FileNotFoundException::class);
+        $this->expectException(TranslationFilesNotFoundException::class);
         new DefaultCatalogueProvider('someFakeDirectory', ['filter']);
     }
 

--- a/tests/Unit/Core/Translation/Provider/FileTranslatedCatalogueProviderTest.php
+++ b/tests/Unit/Core/Translation/Provider/FileTranslatedCatalogueProviderTest.php
@@ -29,7 +29,7 @@ namespace Tests\Unit\Core\Translation\Provider;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueLayersProviderInterface;
 use PrestaShop\PrestaShop\Core\Translation\Provider\FileTranslatedCatalogueProvider;
 use Symfony\Component\Translation\Dumper\XliffFileDumper;
@@ -69,7 +69,7 @@ class FileTranslatedCatalogueProviderTest extends TestCase
 
     public function testItFailsWhenDirectoryNotExists()
     {
-        $this->expectException(FileNotFoundException::class);
+        $this->expectException(TranslationFilesNotFoundException::class);
         new FileTranslatedCatalogueProvider('someFakeDirectory', ['filter']);
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | <strong>The content of this PR is to </strong><br><ul><li>Complete the list of providers (only Backoffice one was done before)</li><li>Introduce ProviderDefinitions : A provider definition will contain filenameFilters (to get default and file translated catalogue), translationDomains (to filter catalogue from DB) and any specific data necessary for the provider to get the catalogue (module, theme, ...) </li><li>Group Core translation providers into a single one as they have the same logic : DefaultCatalogue from translationDir/default, FileTranslated from translationDir/locale and they all don't need any specific input (no module, no theme)</li><li>Instantiate the providerDefinitions from TranslationCatalogueBuilder</li><li>Test them all !</li></ul><br><br><br><strong>What's next ?</strong><br>See https://github.com/PrestaShop/PrestaShop/issues/19242#issuecomment-763527778
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23762
| How to test?      | Check that all the required tests are done and check for code coverage


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23296)
<!-- Reviewable:end -->


## BC Breaks (between PR 1 : https://github.com/PrestaShop/PrestaShop/pull/23043 and this one)

### Moved constants

TranslationCatalogueBuilder::TYPE_BACK
TranslationCatalogueBuilder::TYPE_FRONT
TranslationCatalogueBuilder::TYPE_MAILS
TranslationCatalogueBuilder::TYPE_MAILS_BODY
TranslationCatalogueBuilder::TYPE_OTHERS
TranslationCatalogueBuilder::TYPE_MODULES
TranslationCatalogueBuilder::TYPE_THEMES
TranslationCatalogueBuilder::ALLOWED_TYPES

are now declared in **ProviderDefinitionInterface**


### Services signature modifications

**CatalogueProviderFactory**

previously required 
```
- DatabaseTranslationLoader
- string $resourceDirectory
```
now requires

```
- DatabaseTranslationLoader
- LegacyModuleExtractorInterface
- LoaderInterface
- ThemeExtractor
- ThemeRepository
- Filesystem
- string $themesDirectory,
- string $modulesDirectory,
- string $translationsDirectory
```

### Methods signature modifications

CatalogueProviderFactory::getProvider(string $type): CatalogueLayersProviderInterface
becomes 
CatalogueProviderFactory::getProvider(ProviderDefinitionInterface $providerDefinition): CatalogueLayersProviderInterface


### Deleted classes

**BackofficeCatalogueLayersProvider** no longer exists
We have now **CoreCatalogueLayersProvider** which can be used to provide all catalogues for Core translations (Backoffice, Frontoffice, Mails, MailsBody and Others)