### PR TITLE
BO - Dasboard Date, compare period can't be selected

### DIFF
--- a/js/admin/dashboard.js
+++ b/js/admin/dashboard.js
@@ -294,6 +294,10 @@ function saveDashConfig(widget_name) {
 }
 
 $(document).ready( function () {
+    $("#datepicker-compare").on('change', function() {
+        $("#compare-options").prop('disabled', !this.checked);
+    });
+    
 	$('#calendar_form input[type="submit"]').on('click', function(elt) {
 		elt.preventDefault();
 		setDashboardDateRange(elt.currentTarget.name);


### PR DESCRIPTION
Fix for issue 23302

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This will fix issue 23302 where the compare period selector was disabled even when selecting to compare to another period.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23302.
| How to test?      | See details in issue
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23303)
<!-- Reviewable:end -->
