### PR TITLE
Remove unusable code in OrderSlip::getOrdersSlipProducts()

### DIFF
--- a/controllers/admin/AdminPdfController.php
+++ b/controllers/admin/AdminPdfController.php
@@ -72,7 +72,6 @@ class AdminPdfControllerCore extends AdminController
             die($this->trans('The order cannot be found within your database.', [], 'Admin.Orderscustomers.Notification'));
         }
 
-        $order->products = OrderSlip::getOrdersSlipProducts($order_slip->id, $order);
         $this->generatePDF($order_slip, PDF::TEMPLATE_ORDER_SLIP);
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | This change fixes minor code issues I found while working on another bug.
| Type?             | refacto 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Make sure you can generate order slip pdf (BO and FO)
| Possible impacts? | The line of code removed should have no impact on the behavior because it was useless.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23310)
<!-- Reviewable:end -->
