### PR TITLE
Make autoloader suffix reproducible

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -506,7 +506,11 @@ class ReleaseCreator
     {
         $this->consoleWriter->displayText("Running composer install...", ConsoleWriter::COLOR_YELLOW);
         $argProjectPath = escapeshellarg($this->tempProjectPath);
-        $command = "cd {$argProjectPath} && export SYMFONY_ENV=prod && composer install --no-dev --optimize-autoloader --no-interaction 2>&1";
+        $autoloaderSuffix = md5($this->version);
+        $command = "cd {$argProjectPath} \
+            && export SYMFONY_ENV=prod \
+            && composer config autoloader-suffix {$autoloaderSuffix} \
+            && composer install --no-dev --optimize-autoloader --no-interaction 2>&1";
         exec($command, $output, $returnCode);
 
         if ($returnCode != 0) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When releasing PrestaShop, a random suffix is used on the autoloader. As this feature is useful to be sure that opcode cache will not be used between 2 versions of PrestaShop, it also make impossible to have reproducible builds. This PR aims to fix this issue by using the PrestaShop version as prefix so it is still unique for each PrestaShop version and make build reproducible.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23342
| How to test?      | Make 2 releases, both generated xml files should be identical
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23343)
<!-- Reviewable:end -->
