### PR TITLE
Harden OrderShippingAddressForViewing and OrderInvoiceAddressForViewing against old/messy data ; Fix issue #23336 

### DIFF
--- a/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
@@ -123,19 +123,19 @@ class OrderInvoiceAddressForViewing
         ?string $phoneMobile,
         ?string $vatNumber = null
     ) {
-        $this->addressId	 = $addressId;
-        $this->firstName	 = strval($firstName);
-	$this->lastName		 = strval($lastName);
-	$this->companyName	 = strval($companyName);
-	$this->vatNumber	 = strval($vatNumber);
-	$this->address1		 = strval($address1);
-	$this->address2		 = strval($address2);
-	$this->stateName	 = strval($stateName);
-	$this->cityName		 = strval($cityName);
-	$this->countryName	 = strval($countryName);
-	$this->postCode		 = strval($postCode);
-	$this->phoneNumber	 = strval($phone);
-	$this->mobilePhoneNumber = strval($phoneMobile);
+        $this->addressId = $addressId;
+        $this->firstName = strval($firstName);
+        $this->lastName = strval($lastName);
+        $this->companyName = strval($companyName);
+        $this->vatNumber = strval($vatNumber);
+        $this->address1 = strval($address1);
+        $this->address2 = strval($address2);
+        $this->stateName = strval($stateName);
+        $this->cityName = strval($cityName);
+        $this->countryName = strval($countryName);
+        $this->postCode = strval($postCode);
+        $this->phoneNumber = strval($phone);
+        $this->mobilePhoneNumber = strval($phoneMobile);
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
@@ -110,17 +110,17 @@ class OrderInvoiceAddressForViewing
      */
     public function __construct(
         int $addressId,
-        string $firstName,
-        string $lastName,
-        string $companyName,
-        string $address1,
-        string $address2,
-        string $stateName,
-        string $cityName,
-        string $countryName,
-        string $postCode,
-        string $phone,
-        string $phoneMobile,
+        ?string $firstName,
+        ?string $lastName,
+        ?string $companyName,
+        ?string $address1,
+        ?string $address2,
+        ?string $stateName,
+        ?string $cityName,
+        ?string $countryName,
+        ?string $postCode,
+        ?string $phone,
+        ?string $phoneMobile,
         ?string $vatNumber = null
     ) {
         $this->addressId = $addressId;

--- a/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
@@ -123,19 +123,19 @@ class OrderInvoiceAddressForViewing
         ?string $phoneMobile,
         ?string $vatNumber = null
     ) {
-        $this->addressId = $addressId;
-        $this->firstName = $firstName;
-        $this->lastName = $lastName;
-        $this->companyName = $companyName;
-        $this->vatNumber = $vatNumber;
-        $this->address1 = $address1;
-        $this->address2 = $address2;
-        $this->stateName = $stateName;
-        $this->cityName = $cityName;
-        $this->countryName = $countryName;
-        $this->postCode = $postCode;
-        $this->phoneNumber = $phone;
-        $this->mobilePhoneNumber = $phoneMobile;
+        $this->addressId	 = $addressId;
+        $this->firstName	 = strval($firstName);
+	$this->lastName		 = strval($lastName);
+	$this->companyName	 = strval($companyName);
+	$this->vatNumber	 = strval($vatNumber);
+	$this->address1		 = strval($address1);
+	$this->address2		 = strval($address2);
+	$this->stateName	 = strval($stateName);
+	$this->cityName		 = strval($cityName);
+	$this->countryName	 = strval($countryName);
+	$this->postCode		 = strval($postCode);
+	$this->phoneNumber	 = strval($phone);
+	$this->mobilePhoneNumber = strval($phoneMobile);
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderShippingAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderShippingAddressForViewing.php
@@ -110,32 +110,32 @@ class OrderShippingAddressForViewing
      */
     public function __construct(
         int $addressId,
-        string $firstName,
-        string $lastName,
-        string $companyName,
-        string $address1,
-        string $address2,
-        string $stateName,
-        string $cityName,
-        string $countryName,
-        string $postCode,
-        string $phone,
-        string $phoneMobile,
+        ?string $firstName,
+        ?string $lastName,
+        ?string $companyName,
+        ?string $address1,
+        ?string $address2,
+        ?string $stateName,
+        ?string $cityName,
+        ?string $countryName,
+        ?string $postCode,
+        ?string $phone,
+        ?string $phoneMobile,
         ?string $vatNumber = null
     ) {
-        $this->addressId = $addressId;
-        $this->firstName = $firstName;
-        $this->lastName = $lastName;
-        $this->companyName = $companyName;
-        $this->vatNumber = $vatNumber;
-        $this->address1 = $address1;
-        $this->address2 = $address2;
-        $this->stateName = $stateName;
-        $this->cityName = $cityName;
-        $this->countryName = $countryName;
-        $this->postCode = $postCode;
-        $this->phoneNumber = $phone;
-        $this->mobilePhoneNumber = $phoneMobile;
+        $this->addressId	 = $addressId;
+        $this->firstName	 = strval($firstName);
+	$this->lastName		 = strval($lastName);
+	$this->companyName	 = strval($companyName);
+	$this->vatNumber	 = strval($vatNumber);
+	$this->address1		 = strval($address1);
+	$this->address2		 = strval($address2);
+	$this->stateName	 = strval($stateName);
+	$this->cityName		 = strval($cityName);
+	$this->countryName	 = strval($countryName);
+	$this->postCode		 = strval($postCode);
+	$this->phoneNumber	 = strval($phone);
+	$this->mobilePhoneNumber = strval($phoneMobile);
     }
 
     /**

--- a/src/Core/Domain/Order/QueryResult/OrderShippingAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderShippingAddressForViewing.php
@@ -123,19 +123,19 @@ class OrderShippingAddressForViewing
         ?string $phoneMobile,
         ?string $vatNumber = null
     ) {
-        $this->addressId	 = $addressId;
-        $this->firstName	 = strval($firstName);
-	$this->lastName		 = strval($lastName);
-	$this->companyName	 = strval($companyName);
-	$this->vatNumber	 = strval($vatNumber);
-	$this->address1		 = strval($address1);
-	$this->address2		 = strval($address2);
-	$this->stateName	 = strval($stateName);
-	$this->cityName		 = strval($cityName);
-	$this->countryName	 = strval($countryName);
-	$this->postCode		 = strval($postCode);
-	$this->phoneNumber	 = strval($phone);
-	$this->mobilePhoneNumber = strval($phoneMobile);
+        $this->addressId = $addressId;
+        $this->firstName = strval($firstName);
+        $this->lastName = strval($lastName);
+        $this->companyName = strval($companyName);
+        $this->vatNumber = strval($vatNumber);
+        $this->address1 = strval($address1);
+        $this->address2 = strval($address2);
+        $this->stateName = strval($stateName);
+        $this->cityName = strval($cityName);
+        $this->countryName = strval($countryName);
+        $this->postCode = strval($postCode);
+        $this->phoneNumber = strval($phone);
+        $this->mobilePhoneNumber = strval($phoneMobile);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.7.0 and 1.7.7.1
| Description?      | Harden OrderShippingAddressForViewing and OrderInvoiceAddressForViewing against old/messy data in ps_address, that contains null values, leading to a Server Error 500 in the backend, because of type conversion.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23336
| How to test?      | Create a new object OrderShippingAddressForViewing(1, 'John', 'Doe', null, 'Street 123', null, 'City', 'Country', '12345', null, null) this should not raise TypeError null is not a string.
| Possible impacts? | For the user, null values will be displayed as empty string in the address field or on the invoice.

PS: Fixes #23336 and probably #22386 and #22215 as well 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23354)
<!-- Reviewable:end -->
