### PR TITLE
Fixed update of the shop name in the table ps_shop when not in multishop enabled

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -566,12 +566,19 @@ class AdminStoresControllerCore extends AdminController
         }
     }
 
-    public function updateOptionPsShopName($value)
+    /**
+     * Update the shop name in the table "shop" if we are not in multishop context
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function updateOptionPsShopName(string $name): void
     {
-        if (!Shop::isFeatureActive() && !$this->errors && $value) {
+        if (!Shop::isFeatureActive() && !$this->errors && $name) {
             Db::getInstance()->execute(
                 'UPDATE `' . _DB_PREFIX_ . 'shop` ' .
-                'SET name = "' . pSQL($value) . '" ' .
+                'SET name = "' . pSQL($name) . '" ' .
                 'WHERE id_shop = ' . (int) $this->context->shop->id
             );
         }

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -569,7 +569,7 @@ class AdminStoresControllerCore extends AdminController
     public function updateOptionPsShopName($value)
     {
         if (!Shop::isFeatureActive() && !$this->errors && $value) {
-            Db::getInstance()->Execute(
+            Db::getInstance()->execute(
                 'UPDATE `' . _DB_PREFIX_ . 'shop` 
                 SET name = "' . pSQL($value) . '" 
                 WHERE id_shop = ' . (int) $this->context->shop->id

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -566,6 +566,17 @@ class AdminStoresControllerCore extends AdminController
         }
     }
 
+    public function updateOptionPsShopName($value)
+    {
+        if (!Shop::isFeatureActive() && !$this->errors && $value) {
+            Db::getInstance()->Execute(
+                'UPDATE `' . _DB_PREFIX_ . 'shop` 
+                SET name = "'.pSQL($value).'" 
+                WHERE id_shop = '.(int)$this->context->shop->id
+            );
+        }
+    }
+    
     public function updateOptionPsShopCountryId($value)
     {
         if (!$this->errors && $value) {

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -570,9 +570,9 @@ class AdminStoresControllerCore extends AdminController
     {
         if (!Shop::isFeatureActive() && !$this->errors && $value) {
             Db::getInstance()->execute(
-                'UPDATE `' . _DB_PREFIX_ . 'shop` 
-                SET name = "' . pSQL($value) . '" 
-                WHERE id_shop = ' . (int) $this->context->shop->id
+                'UPDATE `' . _DB_PREFIX_ . 'shop` ' .
+                'SET name = "' . pSQL($value) . '" ' .
+                'WHERE id_shop = ' . (int) $this->context->shop->id
             );
         }
     }

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -571,12 +571,12 @@ class AdminStoresControllerCore extends AdminController
         if (!Shop::isFeatureActive() && !$this->errors && $value) {
             Db::getInstance()->Execute(
                 'UPDATE `' . _DB_PREFIX_ . 'shop` 
-                SET name = "'.pSQL($value).'" 
-                WHERE id_shop = '.(int)$this->context->shop->id
+                SET name = "' . pSQL($value) . '" 
+                WHERE id_shop = ' . (int) $this->context->shop->id
             );
         }
     }
-    
+
     public function updateOptionPsShopCountryId($value)
     {
         if (!$this->errors && $value) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The shop name in the table ps_shop is not updating, and can't be updated when not in multishop enabled. The correction proposed : if we are not in multishop, we update the table with the value sended for PS_SHOP_NAME. This name is used in mails, maybe elsewhere.
| Type?             | bug fix
| Category?         | BO
| Deprecations?     | no
| How to test?      | Go in Admin tab "Stores", and edit the name of the shop, it won't change the name in "ps_shop" without this patch
| Fixed ticket? | Fixes #23392
| Possible impacts? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23377)
<!-- Reviewable:end -->
