### PR TITLE
Fix nightly - Add reset Step in 'Default Pack Stock Management'

### DIFF
--- a/tests/UI/campaigns/functional/BO/13_shopParameters/03_productSettings/03_productsStock/08_defaultPackStockManagement.js
+++ b/tests/UI/campaigns/functional/BO/13_shopParameters/03_productSettings/03_productsStock/08_defaultPackStockManagement.js
@@ -287,6 +287,13 @@ describe('Default pack stock management', async () => {
         const deleteTextResult = await productsPage.deleteProduct(page, test.args.productToCreate);
         await expect(deleteTextResult).to.equal(productsPage.productDeletedSuccessfulMessage);
       });
+
+      it('should reset all filters', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `resetFilters${index}`, baseContext);
+
+        const numberOfProducts = await productsPage.resetAndGetNumberOfLines(page);
+        await expect(numberOfProducts).to.be.above(0);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Add test for reset filter after delete product
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | no tests
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23382)
<!-- Reviewable:end -->
