### PR TITLE
Introduce UpdateVirtualProductFileCommand

### DIFF
--- a/src/Adapter/File/Uploader/VirtualProductFileUploader.php
+++ b/src/Adapter/File/Uploader/VirtualProductFileUploader.php
@@ -48,7 +48,7 @@ class VirtualProductFileUploader
     /**
      * @var string
      */
-    private $downloadDir;
+    private $virtualProductFileDir;
 
     /**
      * @param VirtualProductFileValidator $virtualProductFileValidator
@@ -59,7 +59,7 @@ class VirtualProductFileUploader
         string $downloadDir
     ) {
         $this->virtualProductFileValidator = $virtualProductFileValidator;
-        $this->downloadDir = $downloadDir;
+        $this->virtualProductFileDir = $downloadDir;
     }
 
     /**
@@ -70,7 +70,7 @@ class VirtualProductFileUploader
     public function upload(string $filePath): string
     {
         $this->virtualProductFileValidator->validate($filePath);
-        $destination = $this->downloadDir . VirtualProductFile::getNewFilename();
+        $destination = $this->virtualProductFileDir . VirtualProductFile::getNewFilename();
 
         $this->copyFile($filePath, $destination);
         $this->removeFile($filePath);
@@ -83,7 +83,22 @@ class VirtualProductFileUploader
      */
     public function remove(string $filename): void
     {
-        $this->removeFile($this->downloadDir . $filename);
+        $this->removeFile($this->virtualProductFileDir . $filename);
+    }
+
+    /**
+     * @param string $newFilepath
+     * @param string|null $oldFilename
+     *
+     * @return string
+     */
+    public function replace(string $newFilepath, ?string $oldFilename): string
+    {
+        if ($oldFilename) {
+            $this->removeFile($this->virtualProductFileDir . $oldFilename);
+        }
+
+        return $this->upload($newFilepath);
     }
 
     /**

--- a/src/Adapter/Product/VirtualProduct/CommandHandler/UpdateVirtualProductFileHandler.php
+++ b/src/Adapter/Product/VirtualProduct/CommandHandler/UpdateVirtualProductFileHandler.php
@@ -71,7 +71,7 @@ final class UpdateVirtualProductFileHandler implements UpdateVirtualProductFileH
 
         $this->virtualProductUpdater->updateFile(
             $virtualProductFile,
-            $command->getFilePath(),
+            $command->getFilePath()
         );
     }
 

--- a/src/Adapter/Product/VirtualProduct/CommandHandler/UpdateVirtualProductFileHandler.php
+++ b/src/Adapter/Product/VirtualProduct/CommandHandler/UpdateVirtualProductFileHandler.php
@@ -27,8 +27,12 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Repository\VirtualProductFileRepository;
+use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Update\VirtualProductUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\UpdateVirtualProductFileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\CommandHandler\UpdateVirtualProductFileHandlerInterface;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
+use ProductDownload as VirtualProductFile;
 
 /**
  * Updates VirtualProductFile using legacy object model. (ProductDownload is referenced as VirtualProduct in core)
@@ -36,10 +40,58 @@ use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\CommandHandler\
 final class UpdateVirtualProductFileHandler implements UpdateVirtualProductFileHandlerInterface
 {
     /**
+     * @var VirtualProductUpdater
+     */
+    private $virtualProductUpdater;
+
+    /**
+     * @var VirtualProductFileRepository
+     */
+    private $virtualProductFileRepository;
+
+    /**
+     * @param VirtualProductUpdater $virtualProductUpdater
+     * @param VirtualProductFileRepository $virtualProductFileRepository
+     */
+    public function __construct(
+        VirtualProductUpdater $virtualProductUpdater,
+        VirtualProductFileRepository $virtualProductFileRepository
+    ) {
+        $this->virtualProductUpdater = $virtualProductUpdater;
+        $this->virtualProductFileRepository = $virtualProductFileRepository;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(UpdateVirtualProductFileCommand $command): void
     {
-        // TODO: Implement handle() method.
+        $virtualProductFile = $this->virtualProductFileRepository->get($command->getVirtualProductFileId());
+        $this->fillEntityWithCommandData($virtualProductFile, $command);
+
+        $this->virtualProductUpdater->updateFile(
+            $virtualProductFile,
+            $command->getFilePath(),
+        );
+    }
+
+    /**
+     * @param VirtualProductFile $virtualProductFile
+     * @param UpdateVirtualProductFileCommand $command
+     */
+    private function fillEntityWithCommandData(VirtualProductFile $virtualProductFile, UpdateVirtualProductFileCommand $command): void
+    {
+        if (null !== $command->getDisplayName()) {
+            $virtualProductFile->display_filename = $command->getDisplayName();
+        }
+        if (null !== $command->getAccessDays()) {
+            $virtualProductFile->nb_days_accessible = $command->getAccessDays();
+        }
+        if (null !== $command->getDownloadTimesLimit()) {
+            $virtualProductFile->nb_downloadable = $command->getDownloadTimesLimit();
+        }
+        if (null !== $command->getExpirationDate()) {
+            $virtualProductFile->date_expiration = $command->getExpirationDate()->format(DateTime::DEFAULT_DATE_FORMAT);
+        }
     }
 }

--- a/src/Adapter/Product/VirtualProduct/CommandHandler/UpdateVirtualProductFileHandler.php
+++ b/src/Adapter/Product/VirtualProduct/CommandHandler/UpdateVirtualProductFileHandler.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\UpdateVirtualProductFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\CommandHandler\UpdateVirtualProductFileHandlerInterface;
+
+/**
+ * Updates VirtualProductFile using legacy object model. (ProductDownload is referenced as VirtualProduct in core)
+ */
+final class UpdateVirtualProductFileHandler implements UpdateVirtualProductFileHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(UpdateVirtualProductFileCommand $command): void
+    {
+        // TODO: Implement handle() method.
+    }
+}

--- a/src/Adapter/Product/VirtualProduct/Repository/VirtualProductFileRepository.php
+++ b/src/Adapter/Product/VirtualProduct/Repository/VirtualProductFileRepository.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Validate\VirtualProduct
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\CannotAddVirtualProductFileException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\CannotDeleteVirtualProductFileException;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\CannotUpdateVirtualProductFileException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\ValueObject\VirtualProductFileId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
@@ -128,5 +129,14 @@ class VirtualProductFileRepository extends AbstractObjectModelRepository
         $id = $this->addObjectModel($virtualProductFile, CannotAddVirtualProductFileException::class);
 
         return new VirtualProductFileId($id);
+    }
+
+    /**
+     * @param VirtualProductFile $virtualProductFile
+     */
+    public function update(VirtualProductFile $virtualProductFile): void
+    {
+        $this->virtualProductFileValidator->validate($virtualProductFile);
+        $this->updateObjectModel($virtualProductFile, CannotUpdateVirtualProductFileException::class);
     }
 }

--- a/src/Adapter/Product/VirtualProduct/Update/VirtualProductUpdater.php
+++ b/src/Adapter/Product/VirtualProduct/Update/VirtualProductUpdater.php
@@ -28,18 +28,16 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Update;
 
-use PrestaShop\Decimal\Exception\DivisionByZeroException;
 use PrestaShop\PrestaShop\Adapter\File\Uploader\VirtualProductFileUploader;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Repository\VirtualProductFileRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\ValueObject\VirtualProductFileId;
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\File\Exception\CannotUnlinkFileException;
-use PrestaShop\PrestaShop\Core\File\Exception\FileUploadException;
 use ProductDownload as VirtualProductFile;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Provides update methods specific to virtual product
@@ -63,18 +61,50 @@ class VirtualProductUpdater
     private $virtualProductFileRepository;
 
     /**
+     * @var string
+     */
+    private $virtualProductFileDir;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
      * @param ProductRepository $productRepository
      * @param VirtualProductFileUploader $virtualProductFileUploader
      * @param VirtualProductFileRepository $virtualProductFileRepository
+     * @param Filesystem $filesystem
+     * @param string $virtualProductFileDir
      */
     public function __construct(
         ProductRepository $productRepository,
         VirtualProductFileUploader $virtualProductFileUploader,
-        VirtualProductFileRepository $virtualProductFileRepository
+        VirtualProductFileRepository $virtualProductFileRepository,
+        Filesystem $filesystem,
+        string $virtualProductFileDir
     ) {
         $this->productRepository = $productRepository;
         $this->virtualProductFileUploader = $virtualProductFileUploader;
         $this->virtualProductFileRepository = $virtualProductFileRepository;
+        $this->virtualProductFileDir = $virtualProductFileDir;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @param VirtualProductFile $virtualProductFile
+     * @param string|null $newFilePath
+     */
+    public function updateFile(VirtualProductFile $virtualProductFile, ?string $newFilePath): void
+    {
+        $oldFilepath = $this->virtualProductFileDir . $virtualProductFile->filename;
+
+        if ($newFilePath) {
+            $uploadedFilePath = $this->replaceSystemFile($newFilePath, $oldFilepath);
+            $virtualProductFile->filename = pathinfo($uploadedFilePath, PATHINFO_FILENAME);
+        }
+
+        $this->virtualProductFileRepository->update($virtualProductFile);
     }
 
     /**
@@ -86,13 +116,6 @@ class VirtualProductUpdater
      * @param VirtualProductFile $virtualProductFile
      *
      * @return VirtualProductFileId
-     *
-     * @throws VirtualProductFileConstraintException
-     * @throws DivisionByZeroException
-     * @throws VirtualProductFileNotFoundException
-     * @throws CoreException
-     * @throws CannotUnlinkFileException
-     * @throws FileUploadException
      */
     public function addFile(ProductId $productId, string $filePath, VirtualProductFile $virtualProductFile): VirtualProductFileId
     {
@@ -128,5 +151,22 @@ class VirtualProductUpdater
         $this->virtualProductFileUploader->remove($virtualProductFile->filename);
 
         $this->virtualProductFileRepository->delete($virtualProductFileId);
+    }
+
+    /**
+     * @param string $newFilepath
+     * @param string|null $oldFilename
+     */
+    private function replaceSystemFile(string $newFilepath, ?string $oldFilename): string
+    {
+        if ($oldFilename) {
+            try {
+                $this->filesystem->remove($this->virtualProductFileDir . $oldFilename);
+            } catch (IOException $e) {
+                throw new CannotUnlinkFileException($e->getMessage());
+            }
+        }
+
+        return $this->virtualProductFileUploader->upload($newFilepath);
     }
 }

--- a/src/Adapter/Product/VirtualProduct/Update/VirtualProductUpdater.php
+++ b/src/Adapter/Product/VirtualProduct/Update/VirtualProductUpdater.php
@@ -34,9 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Repository\VirtualProdu
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\ValueObject\VirtualProductFileId;
-use PrestaShop\PrestaShop\Core\File\Exception\CannotUnlinkFileException;
 use ProductDownload as VirtualProductFile;
-use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -97,10 +95,8 @@ class VirtualProductUpdater
      */
     public function updateFile(VirtualProductFile $virtualProductFile, ?string $newFilePath): void
     {
-        $oldFilepath = $this->virtualProductFileDir . $virtualProductFile->filename;
-
         if ($newFilePath) {
-            $uploadedFilePath = $this->replaceSystemFile($newFilePath, $oldFilepath);
+            $uploadedFilePath = $this->virtualProductFileUploader->replace($newFilePath, $virtualProductFile->filename);
             $virtualProductFile->filename = pathinfo($uploadedFilePath, PATHINFO_FILENAME);
         }
 
@@ -151,22 +147,5 @@ class VirtualProductUpdater
         $this->virtualProductFileUploader->remove($virtualProductFile->filename);
 
         $this->virtualProductFileRepository->delete($virtualProductFileId);
-    }
-
-    /**
-     * @param string $newFilepath
-     * @param string|null $oldFilename
-     */
-    private function replaceSystemFile(string $newFilepath, ?string $oldFilename): string
-    {
-        if ($oldFilename) {
-            try {
-                $this->filesystem->remove($this->virtualProductFileDir . $oldFilename);
-            } catch (IOException $e) {
-                throw new CannotUnlinkFileException($e->getMessage());
-            }
-        }
-
-        return $this->virtualProductFileUploader->upload($newFilepath);
     }
 }

--- a/src/Core/Domain/Product/VirtualProductFile/Command/UpdateVirtualProductFileCommand.php
+++ b/src/Core/Domain/Product/VirtualProductFile/Command/UpdateVirtualProductFileCommand.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command;
+
+use DateTimeInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\ValueObject\VirtualProductFileId;
+
+class UpdateVirtualProductFileCommand
+{
+    /**
+     * @var VirtualProductFileId
+     */
+    private $virtualProductFileId;
+
+    /**
+     * @var string|null
+     */
+    private $filePath;
+
+    /**
+     * @var string|null
+     */
+    private $displayName;
+
+    /**
+     * @var DateTimeInterface|null
+     */
+    private $expirationDate;
+
+    /**
+     * @var int|null
+     */
+    private $accessDays;
+
+    /**
+     * @var int|null
+     */
+    private $downloadTimesLimit;
+
+    /**
+     * @param int $virtualProductFileId
+     */
+    public function __construct(
+        int $virtualProductFileId
+    ) {
+        $this->virtualProductFileId = new VirtualProductFileId($virtualProductFileId);
+    }
+
+    /**
+     * @return VirtualProductFileId
+     */
+    public function getVirtualProductFileId(): VirtualProductFileId
+    {
+        return $this->virtualProductFileId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFilePath(): ?string
+    {
+        return $this->filePath;
+    }
+
+    /**
+     * @param string|null $filePath
+     */
+    public function setFilePath(?string $filePath): void
+    {
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDisplayName(): ?string
+    {
+        return $this->displayName;
+    }
+
+    /**
+     * @param string|null $displayName
+     */
+    public function setDisplayName(?string $displayName): void
+    {
+        $this->displayName = $displayName;
+    }
+
+    /**
+     * @return DateTimeInterface|null
+     */
+    public function getExpirationDate(): ?DateTimeInterface
+    {
+        return $this->expirationDate;
+    }
+
+    /**
+     * @param DateTimeInterface|null $expirationDate
+     */
+    public function setExpirationDate(?DateTimeInterface $expirationDate): void
+    {
+        $this->expirationDate = $expirationDate;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getAccessDays(): ?int
+    {
+        return $this->accessDays;
+    }
+
+    /**
+     * @param int|null $accessDays
+     */
+    public function setAccessDays(?int $accessDays): void
+    {
+        $this->accessDays = $accessDays;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDownloadTimesLimit(): ?int
+    {
+        return $this->downloadTimesLimit;
+    }
+
+    /**
+     * @param int|null $downloadTimesLimit
+     */
+    public function setDownloadTimesLimit(?int $downloadTimesLimit): void
+    {
+        $this->downloadTimesLimit = $downloadTimesLimit;
+    }
+}

--- a/src/Core/Domain/Product/VirtualProductFile/CommandHandler/UpdateVirtualProductFileHandlerInterface.php
+++ b/src/Core/Domain/Product/VirtualProductFile/CommandHandler/UpdateVirtualProductFileHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\UpdateVirtualProductFileCommand;
+
+/**
+ * Defines contract to handle @see UpdateVirtualProductFileCommand
+ */
+interface UpdateVirtualProductFileHandlerInterface
+{
+    /**
+     * @param UpdateVirtualProductFileCommand $command
+     */
+    public function handle(UpdateVirtualProductFileCommand $command): void;
+}

--- a/src/Core/Domain/Product/VirtualProductFile/Exception/CannotUpdateVirtualProductFileException.php
+++ b/src/Core/Domain/Product/VirtualProductFile/Exception/CannotUpdateVirtualProductFileException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception;
+
+/**
+ * Is thrown when update of VirtualProductFile fails
+ */
+class CannotUpdateVirtualProductFileException extends VirtualProductFileException
+{
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_virtual_product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_virtual_product.yml
@@ -14,10 +14,10 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\CommandHandler\UpdateVirtualProductFileHandler
         arguments:
             - '@prestashop.adapter.product.virtual_product.update.virtual_product_updater'
+            - '@prestashop.adapter.product.virtual_product.repository.virtual_product_file_repository'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\UpdateVirtualProductFileCommand
-
 
     prestashop.adapter.product.virtual_product.update.virtual_product_updater:
         class: PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Update\VirtualProductUpdater
@@ -25,6 +25,8 @@ services:
             - '@prestashop.adapter.product.repository.product_repository'
             - '@prestashop.adapter.file.uploader.virtual_product_file_uploader'
             - '@prestashop.adapter.product.virtual_product.repository.virtual_product_file_repository'
+            - '@filesystem'
+            - !php/const _PS_DOWNLOAD_DIR_
 
     prestashop.adapter.product.virtual_product.validate.virtual_product_file_validator:
         class: PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Validate\VirtualProductFileValidator

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_virtual_product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_virtual_product.yml
@@ -10,6 +10,15 @@ services:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\AddVirtualProductFileCommand
 
+    prestashop.adapter.product.virtual_product.command_handler.update_virtual_product_file_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\CommandHandler\UpdateVirtualProductFileHandler
+        arguments:
+            - '@prestashop.adapter.product.virtual_product.update.virtual_product_updater'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\UpdateVirtualProductFileCommand
+
+
     prestashop.adapter.product.virtual_product.update.virtual_product_updater:
         class: PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Update\VirtualProductUpdater
         arguments:

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
@@ -55,7 +55,7 @@ class VirtualProductFileFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @When I add virtual product file :fileReference to :productReference with following details:
+     * @When I add virtual product file :fileReference to product :productReference with following details:
      *
      * @param string $fileReference
      * @param string $productReference

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
@@ -12,7 +12,7 @@ Feature: Add virtual product file from BO (Back Office).
       | is_virtual  | true        |
     And product "product1" should not have a file
     And product product1 type should be virtual
-    When I add virtual product file "file1" to "product1" with following details:
+    When I add virtual product file "file1" to product "product1" with following details:
       | display name | puffin-logo.png |
       | file name    | app_icon.png    |
     Then product "product1" should have a virtual product file "file1" with following details:
@@ -28,7 +28,7 @@ Feature: Add virtual product file from BO (Back Office).
       | is_virtual  | true          |
     And product "product2" should not have a file
     And product product2 type should be virtual
-    When I add virtual product file "file2" to "product2" with following details:
+    When I add virtual product file "file2" to product "product2" with following details:
       | file name            | app_icon.png        |
       | display name         | puffin-logo2.png    |
       | access days          | 3                   |
@@ -46,7 +46,7 @@ Feature: Add virtual product file from BO (Back Office).
       | is_virtual  | true          |
     And product "product3" should not have a file
     And product product3 type should be virtual
-    When I add virtual product file "file3" to "product3" with following details:
+    When I add virtual product file "file3" to product "product3" with following details:
       | file name            | dummy_zip.zip       |
       | display name         | zipped files pack   |
       | access days          | 5                   |
@@ -65,7 +65,7 @@ Feature: Add virtual product file from BO (Back Office).
       | is_virtual  | false         |
     And product product4 type should be standard
     And product "product4" should not have a file
-    When I add virtual product file "file4" to "product4" with following details:
+    When I add virtual product file "file4" to product "product4" with following details:
       | file name    | dummy_zip.zip     |
       | display name | zipped files pack |
     Then I should get error that only virtual product can have file
@@ -77,7 +77,7 @@ Feature: Add virtual product file from BO (Back Office).
       | is_virtual  | true          |
     And product product5 type should be virtual
     And product "product5" should not have a file
-    When I add virtual product file "file5" to "product5" with following details:
+    When I add virtual product file "file5" to product "product5" with following details:
       | file name    | dummy_zip.zip                      |
       | display name | zipped files pack for fith product |
     Then product "product5" should have a virtual product file "file5" with following details:
@@ -85,7 +85,7 @@ Feature: Add virtual product file from BO (Back Office).
       | access days          | 0                                  |
       | download times limit | 0                                  |
       | expiration date      |                                    |
-    When I add virtual product file "file5-5" to "product5" with following details:
+    When I add virtual product file "file5-5" to product "product5" with following details:
       | file name    | app_icon.png     |
       | display name | puffin-logo2.png |
     Then I should get error that product already has a file
@@ -102,16 +102,16 @@ Feature: Add virtual product file from BO (Back Office).
       | is_virtual  | true         |
     And product product6 type should be virtual
     And product "product6" should not have a file
-    When I add virtual product file "file6" to "product6" with following details:
+    When I add virtual product file "file6" to product "product6" with following details:
       | file name    | dummy_zip.zip |
       | display name | {my filename} |
     Then I should get error that product file "display name" is invalid
-    When I add virtual product file "file6" to "product6" with following details:
+    When I add virtual product file "file6" to product "product6" with following details:
       | file name    | dummy_zip.zip                       |
       | display name | zipped files pack for sixth product |
       | access days  | -1                                  |
     Then I should get error that product file "access days" is invalid
-    When I add virtual product file "file6" to "product6" with following details:
+    When I add virtual product file "file6" to product "product6" with following details:
       | file name            | dummy_zip.zip                       |
       | display name         | zipped files pack for sixth product |
       | download times limit | -10                                 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/delete_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/delete_virtual_product_file.feature
@@ -12,7 +12,7 @@ Feature: Delete virtual product file from BO (Back Office).
       | is_virtual  | true        |
     And product "product1" should not have a file
     And product product1 type should be virtual
-    And I add virtual product file "file1" to "product1" with following details:
+    And I add virtual product file "file1" to product "product1" with following details:
       | filename reference | filename_file1  |
       | display name       | puffin-logo.png |
       | file name          | app_icon.png    |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
@@ -1,0 +1,71 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-virtual-product-file
+@reset-database-before-feature
+@virtual-product-file
+@update-virtual-product-file
+@reset-downloads-after-feature
+Feature: Add virtual product file from BO (Back Office).
+  As an employee I want to be able to add file of virtual product.
+
+  Scenario: I update virtual product file
+    Given I add product "product1" with following information:
+      | name[en-US] | puffin icon |
+      | is_virtual  | true        |
+    And product "product1" should not have a file
+    And product product1 type should be virtual
+    And I add virtual product file "file1" to product "product1" with following details:
+      | display name | puffin-logo.png |
+      | file name    | app_icon.png    |
+    And product "product1" should have a virtual product file "file1" with following details:
+      | display name         | puffin-logo.png |
+      | access days          | 0               |
+      | download times limit | 0               |
+      | expiration date      |                 |
+    And file "file1" for product "product1" should exist in system
+    When I update file "file1" with following details:
+      | display name         | puffin-logo-updated1.png |
+      | access days          | 7                        |
+      | download times limit | 70                       |
+      | expiration date      | 2020-10-10               |
+    Then product "product1" should have a virtual product file "file1" with following details:
+      | display name         | puffin-logo-updated1.png |
+      | access days          | 7                        |
+      | download times limit | 70                       |
+      | expiration date      | 2020-10-10               |
+    And file "file1" for product "product1" should exist in system
+    When I replace product "product1" file "file1" with a new file "file2" named "dummy_zip.zip" and following details:
+      | display name         | puffin-logo-updated3.png |
+      | access days          | 1                        |
+      | download times limit | 5                        |
+      | expiration date      | 2020-11-11               |
+    Then product "product1" should have a virtual product file "file2" with following details:
+      | display name         | puffin-logo-updated3.png |
+      | access days          | 1                        |
+      | download times limit | 5                        |
+      | expiration date      | 2020-11-11               |
+    And file "file2" for product "product1" should exist in system
+    And file "file1" for product "product1" should not exist in system
+
+  Scenario: I should not be able to update a file with invalid details
+    Given product "product1" should have a virtual product file "file2" with following details:
+      | display name         | puffin-logo-updated3.png |
+      | access days          | 1                        |
+      | download times limit | 5                        |
+      | expiration date      | 2020-11-11               |
+    And file "file2" for product "product1" should exist in system
+    When I update file "file2" with following details:
+      | display name | {logo} |
+    Then I should get error that product file "display name" is invalid
+    When I update file "file2" with following details:
+      | display name | ok filename |
+      | access days  | -1          |
+    Then I should get error that product file "access days" is invalid
+    When I update file "file2" with following details:
+      | display name         | zipped files pack for second product |
+      | download times limit | -10                                  |
+    Then I should get error that product file "download times limit" is invalid
+    And product "product1" should have a virtual product file "file2" with following details:
+      | display name         | puffin-logo-updated3.png |
+      | access days          | 1                        |
+      | download times limit | 5                        |
+      | expiration date      | 2020-11-11               |
+    And file "file2" for product "product1" should exist in system


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduce UpdateVirtualProductFileCommand. It updates VirtualProductFile (formerly known as ProductDownload) enity & allows replacing its file. This Pr includes a little feature update - we do not provide ability to delete the file separately from entity, but instead we allow using the replace behavior. So if you want to delete the file you have to delete whole ProductDownload entity, or you can update it and replace current file with another one. Add behat test to cover this command
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of #14772
| How to test?      | CI :heavy_check_mark: 
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23386)
<!-- Reviewable:end -->
