### PR TITLE
Allow module exception to be displayed to make debugging easier

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -631,14 +631,14 @@ class ModuleController extends ModuleAbstractController
                 ),
             ];
         } catch (Exception $e) {
-            if (isset($moduleName)) {
-                $moduleManager->disable($moduleName);
+            try {
+                if (isset($moduleName)) {
+                    $moduleManager->disable($moduleName);
+                }
+            } catch (Exception $subE) {
             }
 
-            $installationResponse = [
-                'status' => false,
-                'msg' => $e->getMessage(),
-            ];
+            throw $e;
         }
 
         return new JsonResponse($installationResponse);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When an exception occurs on a module, PrestaShop tries to disable it and fails one more time, throwing another exception that is not caught. This PRs allows the module disable action to fail, and now displays the full exception to the user. With all the details, a developer can now get the whole call stack that leads to the error, and fix it easily.<br/><br/> :warning: I saw there is an issue to display the whole modal content when it takes too much space, this could be taken in account in a dedicated PR.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| How to test?      | Take any module you want to install on a shop. Add in its constructor `throw new Exception('hello');`, then try to install it. The whole exception should now be displayed while previous versions of PrestaShop, will display "Unable to disable [your module name]"
| Possible impacts? | /

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23409)
<!-- Reviewable:end -->
