### PR TITLE
Allow DKIM signing emails

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/email/EmailPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/email/EmailPageMap.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+export default {
+  dkimEnableRadio: '.js-dkim-enable',
+  dkimConfigurationBlock: '.js-dkim-configuration',
+};

--- a/admin-dev/themes/new-theme/js/pages/email/dkim-configuration-toggler.js
+++ b/admin-dev/themes/new-theme/js/pages/email/dkim-configuration-toggler.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import EmailPageMap from '@pages/email/EmailPageMap';
+
+const {$} = window;
+
+/**
+ * Class DkimConfigurationToggler is responsible for showing/hiding DKIM configuration form
+ */
+class DkimConfigurationToggler {
+  constructor() {
+    $(EmailPageMap.dkimEnableRadio).on('change', (event) => {
+      const dkimEnable = Number($(event.currentTarget).val());
+      $(EmailPageMap.dkimConfigurationBlock).toggleClass('d-none', dkimEnable === 0);
+    });
+  }
+}
+
+export default DkimConfigurationToggler;

--- a/admin-dev/themes/new-theme/js/pages/email/email-sending-test.js
+++ b/admin-dev/themes/new-theme/js/pages/email/email-sending-test.js
@@ -55,6 +55,10 @@ class EmailSendingTest {
     $('#test_email_sending_smtp_password').val($('#form_smtp_config_password').val());
     $('#test_email_sending_smtp_port').val($('#form_smtp_config_port').val());
     $('#test_email_sending_smtp_encryption').val($('#form_smtp_config_encryption').val());
+    $('#test_email_sending_dkim_enable').val($('input[name="form[dkim_enable]"]:checked').val());
+    $('#test_email_sending_dkim_key').val($('#form_dkim_config_key').val());
+    $('#test_email_sending_dkim_selector').val($('#form_dkim_config_selector').val());
+    $('#test_email_sending_dkim_domain').val($('#form_dkim_config_domain').val());
 
     const $testEmailSendingForm = $(event.currentTarget).closest('form');
 

--- a/admin-dev/themes/new-theme/js/pages/email/index.js
+++ b/admin-dev/themes/new-theme/js/pages/email/index.js
@@ -25,6 +25,7 @@
 
 import EmailSendingTest from '@pages/email/email-sending-test';
 import SmtpConfigurationToggler from '@pages/email/smtp-configuration-toggler';
+import DkimConfigurationToggler from '@pages/email/dkim-configuration-toggler';
 import Grid from '@components/grid/grid';
 import ReloadListActionExtension from '@components/grid/extension/reload-list-extension';
 import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
@@ -56,4 +57,5 @@ $(() => {
 
   new EmailSendingTest();
   new SmtpConfigurationToggler();
+  new DkimConfigurationToggler();
 });

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -297,21 +297,20 @@ class MailCore extends ObjectModel
             return false;
         }
 
+        $message = new Swift_Message();
+
         /* Create new message and DKIM sign it, if enabled and all data for signature are provided */
         if ((bool) $configuration['PS_MAIL_DKIM_ENABLE'] === true
             && !empty($configuration['PS_MAIL_DKIM_DOMAIN'])
             && !empty($configuration['PS_MAIL_DKIM_SELECTOR'])
             && !empty($configuration['PS_MAIL_DKIM_KEY'])
         ) {
-            $message = new Swift_SignedMessage();
             $signer = new Swift_Signers_DKIMSigner(
                 $configuration['PS_MAIL_DKIM_KEY'],
                 $configuration['PS_MAIL_DKIM_DOMAIN'],
                 $configuration['PS_MAIL_DKIM_SELECTOR']
             );
             $message->attachSigner($signer);
-        } else {
-            $message = new Swift_Message();
         }
 
         /* Construct multiple recipients list if needed */
@@ -734,7 +733,11 @@ class MailCore extends ObjectModel
         $smtpLogin,
         $smtpPassword,
         $smtpPort,
-        $smtpEncryption
+        $smtpEncryption,
+        bool $dkimEnable = false,
+        string $dkimKey = '',
+        string $dkimDomain = '',
+        string $dkimSelector = ''
     ) {
         $result = false;
 
@@ -763,6 +766,20 @@ class MailCore extends ObjectModel
 
             $swift = new Swift_Mailer($connection);
             $message = new Swift_Message();
+
+            /* Create new message and DKIM sign it, if enabled and all data for signature are provided */
+            if ($dkimEnable === true
+                && !empty($dkimKey)
+                && !empty($dkimDomain)
+                && !empty($dkimSelector)
+            ) {
+                $signer = new Swift_Signers_DKIMSigner(
+                    $dkimKey,
+                    $dkimDomain,
+                    $dkimSelector
+                );
+                $message->attachSigner($signer);
+            }
 
             $message
                 ->setFrom($from)

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -751,6 +751,18 @@ Country</value>
   <configuration id="PS_MAIL_COLOR" name="PS_MAIL_COLOR">
     <value>#db3484</value>
   </configuration>
+  <configuration id="PS_MAIL_DKIM_ENABLE" name="PS_MAIL_DKIM_ENABLE">
+    <value>0</value>
+  </configuration>
+  <configuration id="PS_MAIL_DKIM_DOMAIN" name="PS_MAIL_DKIM_DOMAIN">
+    <value/>
+  </configuration>
+  <configuration id="PS_MAIL_DKIM_SELECTOR" name="PS_MAIL_DKIM_SELECTOR">
+    <value/>
+  </configuration>
+  <configuration id="PS_MAIL_DKIM_KEY" name="PS_MAIL_DKIM_KEY">
+    <value/>
+  </configuration>
   <configuration id="NW_SALT" name="NW_SALT">
     <value>nK4KJP7jOsnzWMpo</value>
   </configuration>

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -29,7 +29,11 @@ ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAUL
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
     ('PS_COOKIE_SAMESITE', 'Lax', NOW(), NOW()),
     ('PS_SHOW_LABEL_OOS_LISTING_PAGES', '1', NOW(), NOW()),
-    ('ADDONS_API_MODULE_CHANNEL', 'stable', NOW(), NOW())
+    ('ADDONS_API_MODULE_CHANNEL', 'stable', NOW(), NOW()),
+    ('PS_MAIL_DKIM_ENABLE', '0', NOW(), NOW()),
+    ('PS_MAIL_DKIM_DOMAIN', '', NOW(), NOW()),
+    ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
+    ('PS_MAIL_DKIM_KEY', '', NOW(), NOW())
 ;
 
 ALTER TABLE `PREFIX_hook` ADD `active` TINYINT(1) UNSIGNED DEFAULT 1 NOT NULL AFTER `description`;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -29,11 +29,7 @@ ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAUL
 INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
     ('PS_COOKIE_SAMESITE', 'Lax', NOW(), NOW()),
     ('PS_SHOW_LABEL_OOS_LISTING_PAGES', '1', NOW(), NOW()),
-    ('ADDONS_API_MODULE_CHANNEL', 'stable', NOW(), NOW()),
-    ('PS_MAIL_DKIM_ENABLE', '0', NOW(), NOW()),
-    ('PS_MAIL_DKIM_DOMAIN', '', NOW(), NOW()),
-    ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
-    ('PS_MAIL_DKIM_KEY', '', NOW(), NOW())
+    ('ADDONS_API_MODULE_CHANNEL', 'stable', NOW(), NOW())
 ;
 
 ALTER TABLE `PREFIX_hook` ADD `active` TINYINT(1) UNSIGNED DEFAULT 1 NOT NULL AFTER `description`;

--- a/install-dev/upgrade/sql/1.7.9.0.sql
+++ b/install-dev/upgrade/sql/1.7.9.0.sql
@@ -1,0 +1,9 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VALUES
+    ('PS_MAIL_DKIM_ENABLE', '0', NOW(), NOW()),
+    ('PS_MAIL_DKIM_DOMAIN', '', NOW(), NOW()),
+    ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
+    ('PS_MAIL_DKIM_KEY', '', NOW(), NOW())
+;

--- a/src/Adapter/Email/EmailConfigurationTester.php
+++ b/src/Adapter/Email/EmailConfigurationTester.php
@@ -98,7 +98,11 @@ final class EmailConfigurationTester implements EmailConfigurationTesterInterfac
             Tools::htmlentitiesUTF8($config['smtp_username']),
             $password,
             Tools::htmlentitiesUTF8($config['smtp_port']),
-            Tools::htmlentitiesUTF8($config['smtp_encryption'])
+            Tools::htmlentitiesUTF8($config['smtp_encryption']),
+            (bool) $config['dkim_enable'],
+            (string) $config['dkim_key'],
+            (string) $config['dkim_domain'],
+            (string) $config['dkim_selector']
         );
 
         $errors = [];

--- a/src/Core/Email/EmailDataConfigurator.php
+++ b/src/Core/Email/EmailDataConfigurator.php
@@ -65,6 +65,12 @@ final class EmailDataConfigurator implements DataConfigurationInterface
                 'encryption' => $this->configuration->get('PS_MAIL_SMTP_ENCRYPTION'),
                 'port' => $this->configuration->get('PS_MAIL_SMTP_PORT'),
             ],
+            'dkim_enable' => (bool) $this->configuration->get('PS_MAIL_DKIM_ENABLE'),
+            'dkim_config' => [
+                'domain' => (string) $this->configuration->get('PS_MAIL_DKIM_DOMAIN'),
+                'selector' => (string) $this->configuration->get('PS_MAIL_DKIM_SELECTOR'),
+                'key' => (string) $this->configuration->get('PS_MAIL_DKIM_KEY'),
+            ],
         ];
     }
 
@@ -78,7 +84,10 @@ final class EmailDataConfigurator implements DataConfigurationInterface
             $this->configuration->set('PS_MAIL_METHOD', $config['mail_method']);
             $this->configuration->set('PS_MAIL_TYPE', $config['mail_type']);
             $this->configuration->set('PS_LOG_EMAILS', $config['log_emails']);
-
+            $this->configuration->set('PS_MAIL_DKIM_ENABLE', $config['dkim_enable']);
+            $this->configuration->set('PS_MAIL_DKIM_DOMAIN', $config['dkim_config']['domain']);
+            $this->configuration->set('PS_MAIL_DKIM_SELECTOR', $config['dkim_config']['selector']);
+            $this->configuration->set('PS_MAIL_DKIM_KEY', $config['dkim_config']['key']);
             $this->configuration->set('PS_MAIL_DOMAIN', $config['smtp_config']['domain']);
             $this->configuration->set('PS_MAIL_SERVER', $config['smtp_config']['server']);
             $this->configuration->set('PS_MAIL_USER', $config['smtp_config']['username']);
@@ -104,6 +113,10 @@ final class EmailDataConfigurator implements DataConfigurationInterface
             $config['mail_method'],
             $config['mail_type'],
             $config['log_emails'],
+            $config['dkim_enable'],
+            $config['dkim_config']['domain'],
+            $config['dkim_config']['selector'],
+            $config['dkim_config']['key'],
             $config['smtp_config']['domain'],
             $config['smtp_config']['server'],
             $config['smtp_config']['username'],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/DkimConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/DkimConfigurationType.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email;
+
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class DkimConfigurationType build form for DKIM data configuration.
+ */
+class DkimConfigurationType extends TranslatorAwareType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('domain', TextType::class, [
+                'label' => $this->trans('DKIM domain', 'Admin.Advparameters.Feature'),
+                'required' => false,
+                'empty_data' => '',
+            ])
+            ->add('selector', TextType::class, [
+                'label' => $this->trans('DKIM selector', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('A DKIM selector usually looks like 12345.domain. It must match the name of your DNS record.', 'Admin.Advparameters.Help'),
+                'required' => false,
+                'empty_data' => '',
+            ])
+            ->add('key', TextareaType::class, [
+                'label' => $this->trans('DKIM private key', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('The private key starts with -----BEGIN RSA PRIVATE KEY-----.', 'Admin.Advparameters.Help'),
+                'required' => false,
+                'empty_data' => '',
+                'attr' => [
+                    'rows' => 10,
+                ],
+            ]);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -107,7 +107,7 @@ class EmailConfigurationType extends TranslatorAwareType
                     'Enabled' => true,
                 ],
                 'label' => $this->trans('DKIM signing', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('When enabling DKIM, fill the data below and properly test it afterwards. If no email is sent, check logs.', 'Admin.Advparameters.Help'),
+                'help' => $this->trans('Enable DKIM, fill in the fields and give it a try. If no email is sent, check logs.', 'Admin.Advparameters.Help'),
             ])
             ->add('smtp_config', SmtpConfigurationType::class)
             ->add('dkim_config', DkimConfigurationType::class);

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -100,6 +100,16 @@ class EmailConfigurationType extends TranslatorAwareType
             ->add('log_emails', SwitchType::class, [
                 'label' => $this->trans('Log Emails', 'Admin.Advparameters.Feature'),
             ])
-            ->add('smtp_config', SmtpConfigurationType::class);
+            ->add('dkim_enable', SwitchType::class, [
+                'attr' => ['class' => 'js-dkim-enable'],
+                'choices' => [
+                    'Disabled' => false,
+                    'Enabled' => true,
+                ],
+                'label' => $this->trans('DKIM signing', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('When enabling DKIM, fill the data below and properly test it afterwards. If no email is sent, check logs.', 'Admin.Advparameters.Help'),
+            ])
+            ->add('smtp_config', SmtpConfigurationType::class)
+            ->add('dkim_config', DkimConfigurationType::class);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/TestEmailSendingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/TestEmailSendingType.php
@@ -50,6 +50,10 @@ class TestEmailSendingType extends TranslatorAwareType
             ->add('smtp_username', HiddenType::class)
             ->add('smtp_password', HiddenType::class)
             ->add('smtp_port', HiddenType::class)
-            ->add('smtp_encryption', HiddenType::class);
+            ->add('smtp_encryption', HiddenType::class)
+            ->add('dkim_enable', HiddenType::class)
+            ->add('dkim_key', HiddenType::class)
+            ->add('dkim_domain', HiddenType::class)
+            ->add('dkim_selector', HiddenType::class);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -555,6 +555,13 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.email.dkim_configuration:
+        class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\DkimConfigurationType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.email.test_email_sending:
         class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\TestEmailSendingType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
@@ -38,6 +38,19 @@
           <div class="js-smtp-configuration{% if emailConfigurationForm.mail_method.vars.value != smtpMailMethod %} d-none{% endif %}">
             {{ form_widget(emailConfigurationForm.smtp_config) }}
           </div>
+          {{ form_row(emailConfigurationForm.mail_type) }}
+          {{ form_row(emailConfigurationForm.log_emails) }}
+          <div class="alert alert-info" role="alert">
+            <p class="alert-text">
+              {{ 'Fill in the fields below to set up DKIM signing of outgoing emails. This will reduce the likelihood of your emails being marked as spam. 
+              You can get the data below from your server administrator or generate it yourself by using one of the freely available tools, such as dkimcore.org. 
+              Also, make sure that your server is registered as an authorized sender in your SPF record. '|trans({}, 'Admin.Advparameters.Help') }}
+            </p>
+          </div>
+          {{ form_row(emailConfigurationForm.dkim_enable) }}
+          <div class="js-dkim-configuration{% if emailConfigurationForm.dkim_enable.vars.value == 0 %} d-none{% endif %}">
+            {{ form_widget(emailConfigurationForm.dkim_config) }}
+          </div>
           {{ form_rest(emailConfigurationForm) }}
         </div>
       </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows to enable DKIM signing all emails. This will provide much higher authority of the messages and less chance of emails ending up in SPAM folder.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23396
| How to test?      | See below
| Possible impacts? | None

### How to test
* Generate DKIM key for your domain. You can do it easily here: https://dkimcore.org/tools/. 
* Go to Prestashop email configuration, enable DKIM and fill the required information:
  * your selector - something like **your.selector**
  * your domain = **yourdomain.com**
  * your private key = looks like **-----BEGIN RSA PRIVATE KEY-----your private key-----END RSA PRIVATE KEY-----**
* Add your public key as a TXT record to your domain. Record name is the selector - **your.selector**, the value looks like this - **v=DKIM1;t=s;p=MIGfMA0GCSqGXXXXxxxxxxx....**
* Try to send an email
* In any email client that allows to check message source code, check for DKIM signature pass.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23413)
<!-- Reviewable:end -->
