### PR TITLE
Limit mail sender name to 22 chars

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -596,7 +596,7 @@ class MailCore extends ObjectModel
                 }
             }
             /* Send mail */
-            $message->setFrom([$from => $fromName]);
+            $message->setFrom([$from => Tools::substr($fromName, 0, 22)]);
 
             // Hook to alter Swift Message before sending mail
             Hook::exec('actionMailAlterMessageBeforeSend', [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Email cannot be sent when `$fromName` is greater than 22 characters. I limit the field to 22 chars max.<br/><br/>Thansk Antonio Gomariz Martínez
| Type?             | bug fix
| Category?      |  BO
| BC breaks?    |    no
| Deprecations?     |no
| Fixed ticket?      |Fixes #23418.
| How to test?     |Write Shop name width greater 22 charters. Example: "Rincón Home, mobiliario para el hogar y oficina al mejor precio". Attempt to send email, it fails. With this PR it works.
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---

<!-- Reviewable:end -->
