### PR TITLE
Fixed save of translation message

### DIFF
--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -263,7 +263,7 @@ class TranslationService
         if (empty($theme)) {
             $theme = null;
         }
-        
+
         $translation = null;
 
         try {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Before the changes that i've done, the select query uses the **equal** comparison operator to find the row, i changed it with the **like** one. The equal comparison returns the values without checking the space after the last character so if you have a key named "first name " (notice the space after "name") and it searchs for "first name", it updates "first name".
| Type?             | bug fix
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23437.
| How to test?      | In the issue there are the instructions.
| Possible impacts? | Nope.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23443)
<!-- Reviewable:end -->
