### PR TITLE
FO: Fix OrderInvoice base tax Calculation

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -442,11 +442,11 @@ class OrderInvoiceCore extends ObjectModel
             foreach ($shipping_breakdown as &$row) {
                 if (Configuration::get('PS_ATCP_SHIPWRAP')) {
                     $row['total_tax_excl'] = Tools::ps_round($row['total_amount'] / $row['rate'] * 100, Context::getContext()->getComputingPrecision(), $this->getOrder()->round_mode);
-                    $sum_of_tax_bases += $row['total_tax_excl'];
                 } else {
                     $row['total_tax_excl'] = $this->total_shipping_tax_excl;
                 }
 
+                $sum_of_tax_bases += $row['total_tax_excl'];
                 $row['total_amount'] = Tools::ps_round($row['total_amount'], Context::getContext()->getComputingPrecision(), $this->getOrder()->round_mode);
                 $sum_of_split_taxes += $row['total_amount'];
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix `$sum_of_tax_bases`, depending on the configuration the sum is skipped causing `$shipping_breakdown['total_tax_excl']`, and then `$delta_base`, to be incorrect
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | The shipping tax breakdown tax excl. value should be wrong on the invoice depending on configuration
| Possible impacts? | Change amount of shipping tax in details table on invoices


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23478)
<!-- Reviewable:end -->
