### PR TITLE
Improve accessibility of classic theme forms by adding for and ids

### DIFF
--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -99,7 +99,7 @@
         {/if}
 
         <div class="form-group row">
-          <label class="col-md-3 form-control-label" for="message">{l s='Message' d='Shop.Forms.Labels'}</label>
+          <label class="col-md-3 form-control-label" for="contactform-message">{l s='Message' d='Shop.Forms.Labels'}</label>
           <div class="col-md-9">
             <textarea
               id="contactform-message"

--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -56,9 +56,10 @@
         </div>
 
         <div class="form-group row">
-          <label class="col-md-3 form-control-label">{l s='Email address' d='Shop.Forms.Labels'}</label>
+          <label class="col-md-3 form-control-label" for="email">{l s='Email address' d='Shop.Forms.Labels'}</label>
           <div class="col-md-6">
             <input
+              id="email"
               class="form-control"
               name="from"
               type="email"
@@ -70,9 +71,9 @@
 
         {if $contact.orders}
           <div class="form-group row">
-            <label class="col-md-3 form-control-label">{l s='Order reference' d='Shop.Forms.Labels'}</label>
+            <label class="col-md-3 form-control-label" for="id-order">{l s='Order reference' d='Shop.Forms.Labels'}</label>
             <div class="col-md-6">
-              <select name="id_order" class="form-control form-control-select">
+              <select id="id-order" name="id_order" class="form-control form-control-select">
                 <option value="">{l s='Select reference' d='Shop.Forms.Help'}</option>
                 {foreach from=$contact.orders item=order}
                   <option value="{$order.id_order}">{$order.reference}</option>
@@ -87,9 +88,9 @@
 
         {if $contact.allow_file_upload}
           <div class="form-group row">
-            <label class="col-md-3 form-control-label">{l s='Attachment' d='Shop.Forms.Labels'}</label>
+            <label class="col-md-3 form-control-label" for="file-upload">{l s='Attachment' d='Shop.Forms.Labels'}</label>
             <div class="col-md-6">
-              <input type="file" name="fileUpload" class="filestyle" data-buttonText="{l s='Choose file' d='Shop.Theme.Actions'}">
+              <input id="file-upload" type="file" name="fileUpload" class="filestyle" data-buttonText="{l s='Choose file' d='Shop.Theme.Actions'}">
             </div>
             <span class="col-md-3 form-control-comment">
               {l s='optional' d='Shop.Forms.Help'}
@@ -98,9 +99,10 @@
         {/if}
 
         <div class="form-group row">
-          <label class="col-md-3 form-control-label">{l s='Message' d='Shop.Forms.Labels'}</label>
+          <label class="col-md-3 form-control-label" for="message">{l s='Message' d='Shop.Forms.Labels'}</label>
           <div class="col-md-9">
             <textarea
+              id="message"
               class="form-control"
               name="message"
               placeholder="{l s='How can we help?' d='Shop.Forms.Help'}"

--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -24,7 +24,6 @@
  *}
 <section class="contact-form">
   <form action="{$urls.pages.contact}" method="post" {if $contact.allow_file_upload}enctype="multipart/form-data"{/if}>
-
     {if $notifications}
       <div class="col-xs-12 alert {if $notifications.nw_error}alert-danger{else}alert-success{/if}">
         <ul>
@@ -45,9 +44,9 @@
         </div>
 
         <div class="form-group row">
-          <label class="col-md-3 form-control-label">{l s='Subject' d='Shop.Forms.Labels'}</label>
+          <label class="col-md-3 form-control-label" for="id_contact">{l s='Subject' d='Shop.Forms.Labels'}</label>
           <div class="col-md-6">
-            <select name="id_contact" class="form-control form-control-select">
+            <select name="id_contact" id="id_contact" class="form-control form-control-select">
               {foreach from=$contact.contacts item=contact_elt}
                 <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
               {/foreach}

--- a/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
+++ b/themes/classic/modules/contactform/views/templates/widget/contactform.tpl
@@ -102,7 +102,7 @@
           <label class="col-md-3 form-control-label" for="message">{l s='Message' d='Shop.Forms.Labels'}</label>
           <div class="col-md-9">
             <textarea
-              id="message"
+              id="contactform-message"
               class="form-control"
               name="message"
               placeholder="{l s='How can we help?' d='Shop.Forms.Help'}"

--- a/themes/classic/modules/ps_shoppingcart/ps_shoppingcart.tpl
+++ b/themes/classic/modules/ps_shoppingcart/ps_shoppingcart.tpl
@@ -26,9 +26,9 @@
   <div class="blockcart cart-preview {if $cart.products_count > 0}active{else}inactive{/if}" data-refresh-url="{$refresh_url}">
     <div class="header">
       {if $cart.products_count > 0}
-        <a rel="nofollow" href="{$cart_url}">
+        <a rel="nofollow" aria-label="{l s='Shopping cart link containing %nbProducts% product(s)' sprintf=['%nbProducts%' => $cart.products_count] d='Shop.Theme.Checkout'}" href="{$cart_url}">
       {/if}
-        <i class="material-icons shopping-cart">shopping_cart</i>
+        <i class="material-icons shopping-cart" aria-hidden="true">shopping_cart</i>
         <span class="hidden-sm-down">{l s='Cart' d='Shop.Theme.Checkout'}</span>
         <span class="cart-products-count">({$cart.products_count})</span>
       {if $cart.products_count > 0}

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -140,7 +140,7 @@
               class="form-control js-child-focus js-visible-password"
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
-              aria-label="{l s='Password input with at least 5 characters long' d='Shop.Forms.Help'}"
+              aria-label="{l s='Password input of at least 5 characters long' d='Shop.Forms.Help'}"
               type="password"
               {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
               value=""

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -69,10 +69,11 @@
 
         {block name='form_field_item_radio'}
           {foreach from=$field.availableValues item="label" key="value"}
-            <label class="radio-inline">
+            <label class="radio-inline" for="field-{$field.name}-{$value}">
               <span class="custom-radio">
                 <input
                   name="{$field.name}"
+                  id="field-{$field.name}-{$value}"
                   type="radio"
                   value="{$value}"
                   {if $field.required}required{/if}
@@ -139,6 +140,7 @@
               class="form-control js-child-focus js-visible-password"
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
+              aria-label="{l s='Password input with at least 5 characters long' d='Shop.Forms.Help'}"
               type="password"
               {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
               value=""

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -31,7 +31,7 @@
 {else}
 
   <div class="form-group row {if !empty($field.errors)}has-error{/if}">
-    <label class="col-md-3 form-control-label{if $field.required} required{/if}">
+    <label class="col-md-3 form-control-label{if $field.required} required{/if}" for="{$field.name}">
       {if $field.type !== 'checkbox'}
         {$field.label}
       {/if}
@@ -41,7 +41,7 @@
       {if $field.type === 'select'}
 
         {block name='form_field_item_select'}
-          <select class="form-control form-control-select" name="{$field.name}" {if $field.required}required{/if}>
+          <select id="{$field.name}" class="form-control form-control-select" name="{$field.name}" {if $field.required}required{/if}>
             <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
             {foreach from=$field.availableValues item="label" key="value"}
               <option value="{$value}" {if $value eq $field.value} selected {/if}>{$label}</option>
@@ -53,9 +53,10 @@
 
         {block name='form_field_item_country'}
           <select
-          class="form-control form-control-select js-country"
-          name="{$field.name}"
-          {if $field.required}required{/if}
+            id="{$field.name}"
+            class="form-control form-control-select js-country"
+            name="{$field.name}"
+            {if $field.required}required{/if}
           >
             <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
             {foreach from=$field.availableValues item="label" key="value"}
@@ -68,9 +69,10 @@
 
         {block name='form_field_item_radio'}
           {foreach from=$field.availableValues item="label" key="value"}
-            <label class="radio-inline">
+            <label class="radio-inline" for="{$field.name}">
               <span class="custom-radio">
                 <input
+                  id="{$field.name}"
                   name="{$field.name}"
                   type="radio"
                   value="{$value}"
@@ -88,8 +90,8 @@
 
         {block name='form_field_item_checkbox'}
           <span class="custom-checkbox">
-            <label>
-              <input name="{$field.name}" type="checkbox" value="1" {if $field.value}checked="checked"{/if} {if $field.required}required{/if}>
+            <label for="{$field.name}">
+              <input id="{$field.name}" name="{$field.name}" type="checkbox" value="1" {if $field.value}checked="checked"{/if} {if $field.required}required{/if}>
               <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
               {$field.label nofilter}
             </label>
@@ -99,7 +101,7 @@
       {elseif $field.type === 'date'}
 
         {block name='form_field_item_date'}
-          <input name="{$field.name}" class="form-control" type="date" value="{$field.value}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}" aria-label="{$field.availableValues.placeholder}"{/if}>
+          <input id="{$field.name}" name="{$field.name}" class="form-control" type="date" value="{$field.value}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}"{/if}>
           {if isset($field.availableValues.comment)}
             <span class="form-control-comment">
               {$field.availableValues.comment}
@@ -134,9 +136,11 @@
         {block name='form_field_item_password'}
           <div class="input-group js-parent-focus">
             <input
+              id="{$field.name}"
               class="form-control js-child-focus js-visible-password"
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
+              id="{$field.name}"
               type="password"
               {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
               value=""
@@ -161,6 +165,7 @@
 
         {block name='form_field_item_other'}
           <input
+            id="{$field.name}"
             class="form-control"
             name="{$field.name}"
             type="{$field.type}"
@@ -169,7 +174,6 @@
             {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
             {if $field.maxLength}maxlength="{$field.maxLength}"{/if}
             {if $field.required}required{/if}
-            aria-label="{$field.name}"
           >
           {if isset($field.availableValues.comment)}
             <span class="form-control-comment">

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -53,7 +53,7 @@
 
         {block name='form_field_item_country'}
           <select
-            id="{$field.name}"
+            id="field-{$field.name}"
             class="form-control form-control-select js-country"
             name="{$field.name}"
             {if $field.required}required{/if}

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -31,7 +31,7 @@
 {else}
 
   <div class="form-group row {if !empty($field.errors)}has-error{/if}">
-    <label class="col-md-3 form-control-label{if $field.required} required{/if}" for="{$field.name}">
+    <label class="col-md-3 form-control-label{if $field.required} required{/if}" for="field-{$field.name}">
       {if $field.type !== 'checkbox'}
         {$field.label}
       {/if}
@@ -41,7 +41,7 @@
       {if $field.type === 'select'}
 
         {block name='form_field_item_select'}
-          <select id="{$field.name}" class="form-control form-control-select" name="{$field.name}" {if $field.required}required{/if}>
+          <select id="field-{$field.name}" class="form-control form-control-select" name="{$field.name}" {if $field.required}required{/if}>
             <option value disabled selected>{l s='Please choose' d='Shop.Forms.Labels'}</option>
             {foreach from=$field.availableValues item="label" key="value"}
               <option value="{$value}" {if $value eq $field.value} selected {/if}>{$label}</option>
@@ -100,7 +100,7 @@
       {elseif $field.type === 'date'}
 
         {block name='form_field_item_date'}
-          <input id="{$field.name}" name="{$field.name}" class="form-control" type="date" value="{$field.value}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}"{/if}>
+          <input id="field-{$field.name}" name="{$field.name}" class="form-control" type="date" value="{$field.value}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}"{/if}>
           {if isset($field.availableValues.comment)}
             <span class="form-control-comment">
               {$field.availableValues.comment}
@@ -135,7 +135,7 @@
         {block name='form_field_item_password'}
           <div class="input-group js-parent-focus">
             <input
-              id="{$field.name}"
+              id="field-{$field.name}"
               class="form-control js-child-focus js-visible-password"
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
@@ -163,7 +163,7 @@
 
         {block name='form_field_item_other'}
           <input
-            id="{$field.name}"
+            id="field-{$field.name}"
             class="form-control"
             name="{$field.name}"
             type="{$field.type}"

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -58,7 +58,7 @@
             name="{$field.name}"
             {if $field.required}required{/if}
           >
-            <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
+            <option value disabled selected>{l s='Please choose' d='Shop.Forms.Labels'}</option>
             {foreach from=$field.availableValues item="label" key="value"}
               <option value="{$value}" {if $value eq $field.value} selected {/if}>{$label}</option>
             {/foreach}

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -69,10 +69,9 @@
 
         {block name='form_field_item_radio'}
           {foreach from=$field.availableValues item="label" key="value"}
-            <label class="radio-inline" for="{$field.name}">
+            <label class="radio-inline">
               <span class="custom-radio">
                 <input
-                  id="{$field.name}"
                   name="{$field.name}"
                   type="radio"
                   value="{$value}"
@@ -90,8 +89,8 @@
 
         {block name='form_field_item_checkbox'}
           <span class="custom-checkbox">
-            <label for="{$field.name}">
-              <input id="{$field.name}" name="{$field.name}" type="checkbox" value="1" {if $field.value}checked="checked"{/if} {if $field.required}required{/if}>
+            <label>
+              <input name="{$field.name}" type="checkbox" value="1" {if $field.value}checked="checked"{/if} {if $field.required}required{/if}>
               <span><i class="material-icons rtl-no-flip checkbox-checked">&#xE5CA;</i></span>
               {$field.label nofilter}
             </label>
@@ -140,7 +139,6 @@
               class="form-control js-child-focus js-visible-password"
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
-              id="{$field.name}"
               type="password"
               {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
               value=""

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -42,7 +42,7 @@
 
         {block name='form_field_item_select'}
           <select id="{$field.name}" class="form-control form-control-select" name="{$field.name}" {if $field.required}required{/if}>
-            <option value disabled selected>{l s='-- please choose --' d='Shop.Forms.Labels'}</option>
+            <option value disabled selected>{l s='Please choose' d='Shop.Forms.Labels'}</option>
             {foreach from=$field.availableValues item="label" key="value"}
               <option value="{$value}" {if $value eq $field.value} selected {/if}>{$label}</option>
             {/foreach}

--- a/themes/classic/templates/_partials/form-fields.tpl
+++ b/themes/classic/templates/_partials/form-fields.tpl
@@ -140,7 +140,7 @@
               class="form-control js-child-focus js-visible-password"
               name="{$field.name}"
               title="{l s='At least 5 characters long' d='Shop.Forms.Help'}"
-              aria-label="{l s='Password input of at least 5 characters long' d='Shop.Forms.Help'}"
+              aria-label="{l s='Password input of at least 5 characters' d='Shop.Forms.Help'}"
               type="password"
               {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
               value=""

--- a/themes/classic/templates/catalog/_partials/product-customization.tpl
+++ b/themes/classic/templates/catalog/_partials/product-customization.tpl
@@ -33,9 +33,9 @@
           <ul class="clearfix">
             {foreach from=$customizations.fields item="field"}
               <li class="product-customization-item">
-                <label> {$field.label}</label>
+                <label for="field-{$field.input_name}">{$field.label}</label>
                 {if $field.type == 'text'}
-                  <textarea placeholder="{l s='Your message here' d='Shop.Forms.Help'}" class="product-message" maxlength="250" {if $field.required} required {/if} name="{$field.input_name}"></textarea>
+                  <textarea placeholder="{l s='Your message here' d='Shop.Forms.Help'}" class="product-message" maxlength="250" {if $field.required} required {/if} name="{$field.input_name}" id="field-{$field.input_name}"></textarea>
                   <small class="float-xs-right">{l s='250 char. max' d='Shop.Forms.Help'}</small>
                   {if $field.text !== ''}
                       <h6 class="customization-message">{l s='Your customization:' d='Shop.Theme.Catalog'}
@@ -50,7 +50,7 @@
                   {/if}
                   <span class="custom-file">
                     <span class="js-file-name">{l s='No selected file' d='Shop.Forms.Help'}</span>
-                    <input class="file-input js-file-input" {if $field.required} required {/if} type="file" name="{$field.input_name}">
+                    <input class="file-input js-file-input" {if $field.required} required {/if} type="file" name="{$field.input_name}" id="field-{$field.input_name}">
                     <button class="btn btn-primary">{l s='Choose file' d='Shop.Theme.Actions'}</button>
                   </span>
                   <small class="float-xs-right">{l s='.png .jpg .gif' d='Shop.Forms.Help'}</small>

--- a/themes/classic/templates/catalog/_partials/sort-orders.tpl
+++ b/themes/classic/templates/catalog/_partials/sort-orders.tpl
@@ -29,7 +29,7 @@
     class="btn-unstyle select-title"
     rel="nofollow"
     data-toggle="dropdown"
-    aria-label="{l s='Sort by select' d='Shop.Theme.Global'}"
+    aria-label="{l s='Sort by selection' d='Shop.Theme.Global'}"
     aria-haspopup="true"
     aria-expanded="false">
     {if $listing.sort_selected}{$listing.sort_selected}{else}{l s='Select' d='Shop.Theme.Actions'}{/if}

--- a/themes/classic/templates/catalog/_partials/sort-orders.tpl
+++ b/themes/classic/templates/catalog/_partials/sort-orders.tpl
@@ -29,6 +29,7 @@
     class="btn-unstyle select-title"
     rel="nofollow"
     data-toggle="dropdown"
+    aria-label="{l s='Sort by select' d='Shop.Theme.Global'}"
     aria-haspopup="true"
     aria-expanded="false">
     {if $listing.sort_selected}{$listing.sort_selected}{else}{l s='Select' d='Shop.Theme.Actions'}{/if}

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -136,7 +136,7 @@
                 pattern="[0-9]*"
                 value="{$product.quantity}"
                 name="product-quantity-spin"
-                aria-label="{$product.name} {l s='product quantity field' d='Shop.Theme.Checkout'}"
+                aria-label="{l s='%productName% product quantity field' sprintf=['%productName%' => $product.name] d='Shop.Theme.Checkout'}"
               />
             {/if}
           </div>

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -136,6 +136,7 @@
                 pattern="[0-9]*"
                 value="{$product.quantity}"
                 name="product-quantity-spin"
+                aria-label="{$product.name} {l s='product quantity field' d='Shop.Theme.Checkout'}"
               />
             {/if}
           </div>

--- a/themes/classic/templates/customer/_partials/customer-form.tpl
+++ b/themes/classic/templates/customer/_partials/customer-form.tpl
@@ -28,7 +28,7 @@
   {/block}
 
 <form action="{block name='customer_form_actionurl'}{$action}{/block}" id="customer-form" class="js-customer-form" method="post">
-  <section>
+  <div>
     {block "form_fields"}
       {foreach from=$formFields item="field"}
         {block "form_field"}
@@ -37,7 +37,7 @@
       {/foreach}
       {$hook_create_account_form nofilter}
     {/block}
-  </section>
+  </div>
 
   {block name='customer_form_footer'}
     <footer class="form-footer clearfix">

--- a/themes/classic/templates/customer/_partials/login-form.tpl
+++ b/themes/classic/templates/customer/_partials/login-form.tpl
@@ -30,7 +30,7 @@
 
   <form id="login-form" action="{block name='login_form_actionurl'}{$action}{/block}" method="post">
 
-    <section>
+    <div>
       {block name='login_form_fields'}
         {foreach from=$formFields item="field"}
           {block name='form_field'}
@@ -43,7 +43,7 @@
           {l s='Forgot your password?' d='Shop.Theme.Customeraccount'}
         </a>
       </div>
-    </section>
+    </div>
 
     {block name='login_form_footer'}
       <footer class="form-footer text-sm-center clearfix">

--- a/themes/classic/templates/index.tpl
+++ b/themes/classic/templates/index.tpl
@@ -25,7 +25,7 @@
 {extends file='page.tpl'}
 
     {block name='page_content_container'}
-      <div id="content" class="page-home">
+      <section id="content" class="page-home">
         {block name='page_content_top'}{/block}
 
         {block name='page_content'}
@@ -33,5 +33,5 @@
             {$HOOK_HOME nofilter}
           {/block}
         {/block}
-      </div>
+      </section>
     {/block}

--- a/themes/classic/templates/index.tpl
+++ b/themes/classic/templates/index.tpl
@@ -25,7 +25,7 @@
 {extends file='page.tpl'}
 
     {block name='page_content_container'}
-      <section id="content" class="page-home">
+      <div id="content" class="page-home">
         {block name='page_content_top'}{/block}
 
         {block name='page_content'}
@@ -33,5 +33,5 @@
             {$HOOK_HOME nofilter}
           {/block}
         {/block}
-      </section>
+      </div>
     {/block}

--- a/themes/classic/templates/page.tpl
+++ b/themes/classic/templates/page.tpl
@@ -37,12 +37,12 @@
     {/block}
 
     {block name='page_content_container'}
-      <section id="content" class="page-content card card-block">
+      <div id="content" class="page-content card card-block">
         {block name='page_content_top'}{/block}
         {block name='page_content'}
           <!-- Page content -->
         {/block}
-      </section>
+      </div>
     {/block}
 
     {block name='page_footer_container'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Prefer using for and ids on form fields, it's better for screen readers
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23444.
| How to test?      | You should inspect register, login, checkout, contact forms and see if every labels got a for attribute and the id exist and is not duplicated
| Possible impacts? | Screen reader use


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23480)
<!-- Reviewable:end -->
