### PR TITLE
Fix payment module list responsive in the BO

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_payment.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_payment.scss
@@ -39,5 +39,59 @@
         }
       }
     }
+
+    .tab-content {
+      @include media-breakpoint-down(sm) {
+        padding: 0 0.5rem;
+      }
+    }
+
+    .tab-pane {
+      @include media-breakpoint-down(sm) {
+        .table {
+          tr {
+            position: relative;
+            display: flex;
+            flex-wrap: wrap;
+            width: 100%;
+            min-width: 12rem;
+            padding: 1rem 0;
+            padding-left: 4.375rem;
+
+            &:not(:last-child) {
+              border-bottom: 1px solid $gray-light;
+            }
+
+            td {
+              padding: 0;
+              border: none;
+
+              &:first-child {
+                position: absolute;
+                left: 0;
+              }
+
+              &:last-child {
+                .btn-group {
+                  margin-top: 0;
+                }
+              }
+            }
+
+            .module_name {
+              .text-muted {
+                display: block;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .alert-block {
+    @include media-breakpoint-down(sm) {
+      padding: 0;
+    }
   }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -29,7 +29,7 @@
   <div class="container">
 
     {% if paymentModules|length < 2 %}
-      <div class="card-block row">
+      <div class="card-block row alert-block">
         <div class="card-text">
           <div class="row">
             <div class="col-sm">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Payment module list was unreadable on mobile
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22801.
| How to test?      | Go on payment list on the BO, see on responsive if it looks almost like Scott screens in comments of the issue


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23483)
<!-- Reviewable:end -->
