### PR TITLE
Enable mysql extension for Integration GA - fixing CI for Integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
+                    extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, mysql
             -   name: Setup MySQL
                 uses: mirromutth/mysql-action@v1.1
                 with:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Enable mysql extension for integration tests
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should be green for integration tests run by GitHub
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23488)
<!-- Reviewable:end -->
