### PR TITLE
Fix renderStock signature changed on 1.7.7 on create order page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
@@ -64,10 +64,8 @@ export default class ProductManager {
    * @private
    */
   initListeners() {
-    $(createOrderMap.productSelect).on('change', (e) => this.initProductSelect(e),
-    );
-    $(createOrderMap.combinationsSelect).on('change', (e) => this.initCombinationSelect(e),
-    );
+    $(createOrderMap.productSelect).on('change', (e) => this.initProductSelect(e));
+    $(createOrderMap.combinationsSelect).on('change', (e) => this.initCombinationSelect(e));
 
     this.onProductSearch();
     this.onAddProductToCart();
@@ -216,19 +214,11 @@ export default class ProductManager {
       search_phrase: searchPhrase,
     };
 
-    if (
-      $(createOrderMap.cartCurrencySelect).data('selectedCurrencyId')
-      !== undefined
-    ) {
-      params.currency_id = $(createOrderMap.cartCurrencySelect).data(
-        'selectedCurrencyId',
-      );
+    if ($(createOrderMap.cartCurrencySelect).data('selectedCurrencyId') !== undefined) {
+      params.currency_id = $(createOrderMap.cartCurrencySelect).data('selectedCurrencyId');
     }
 
-    const $searchRequest = $.get(
-      this.router.generate('admin_orders_products_search'),
-      params,
-    );
+    const $searchRequest = $.get(this.router.generate('admin_orders_products_search'), params);
     this.activeSearchRequest = $searchRequest;
 
     $searchRequest
@@ -267,9 +257,7 @@ export default class ProductManager {
   selectProduct(productId) {
     this.unsetCombination();
 
-    const selectedProduct = Object.values(this.products).find(
-      (product) => product.productId === productId,
-    );
+    const selectedProduct = Object.values(this.products).find((product) => product.productId === productId);
 
     if (selectedProduct) {
       this.selectedProduct = selectedProduct;
@@ -331,12 +319,8 @@ export default class ProductManager {
    * @private
    */
   getProductData() {
-    const $fileInputs = $(createOrderMap.productCustomizationContainer).find(
-      'input[type="file"]',
-    );
-    const formData = new FormData(
-      document.querySelector(createOrderMap.productAddForm),
-    );
+    const $fileInputs = $(createOrderMap.productCustomizationContainer).find('input[type="file"]');
+    const formData = new FormData(document.querySelector(createOrderMap.productAddForm));
     const fileSizes = {};
 
     // adds key value pairs {input name: file size} of each file in separate object
@@ -403,6 +387,7 @@ export default class ProductManager {
 
     for (let i = 0; i < productKeys.length; i += 1) {
       if (productValues[i].productId === productId) {
+        const $template = this.productRenderer.cloneProductTemplate(productValues[i]);
         // Update the stock value  in products object
         productValues[i].stock += qty;
 
@@ -414,9 +399,19 @@ export default class ProductManager {
         // Render the new stock value
         if (this.selectedProduct.productId === productId) {
           if (this.selectedProduct.combinations.length === 0) {
-            this.productRenderer.renderStock(productValues[i].stock);
+            this.productRenderer.renderStock(
+              $template.find(createOrderMap.listedProductQtyStock),
+              $template.find(createOrderMap.listedProductQtyInput),
+              productValues[i].stock,
+              productValues[i].availableOutOfStock || productValues[i].availableStock <= 0,
+            );
           } else if (attributeId && Number(this.selectedCombinationId) === Number(attributeId)) {
-            this.productRenderer.renderStock(productValues[i].combinations[attributeId].stock);
+            this.productRenderer.renderStock(
+              $template.find(createOrderMap.listedProductQtyStock),
+              $template.find(createOrderMap.listedProductQtyInput),
+              productValues[i].combinations[attributeId].stock,
+              productValues[i].availableOutOfStock || productValues[i].availableStock <= 0,
+            );
           }
         }
         break;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | renderStock method signature changed on 1.7.7 but it has been used inside a new method on develop causing a bug when creating an order
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23397.
| How to test?      | Go on create order page, and try to create an order, add product, it should work as expected


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23499)
<!-- Reviewable:end -->
