### PR TITLE
Fix visibility of const OutstandingGridDefinitionFactory::GRID_ID

### DIFF
--- a/src/Core/Grid/Definition/Factory/OutstandingGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/OutstandingGridDefinitionFactory.php
@@ -49,7 +49,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
  */
 final class OutstandingGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
-    const GRID_ID = 'outstanding';
+    public const GRID_ID = 'outstanding';
 
     /**
      * @var ConfigurationInterface


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix missing visibility of const OutstandingGridDefinitionFactory::GRID_ID. Such issues will soon be reported automatically by phpstan when we use https://github.com/PrestaShop/phpstan-prestashop v1.1
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should be happy
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23510)
<!-- Reviewable:end -->
