### PR TITLE
Fix getCatalogueFromPaths type error on $paths

### DIFF
--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -268,7 +268,7 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
     public function getCatalogueFromPaths($paths, $locale, $pattern = null)
     {
         if (!is_array($paths)) {
-            $paths = array($paths);
+            $paths = [$paths];
         }
         
         return (new TranslationFinder())->getCatalogueFromPaths($paths, $locale, $pattern);

--- a/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/AbstractProvider.php
@@ -267,6 +267,10 @@ abstract class AbstractProvider implements ProviderInterface, XliffCatalogueInte
      */
     public function getCatalogueFromPaths($paths, $locale, $pattern = null)
     {
+        if (!is_array($paths)) {
+            $paths = array($paths);
+        }
+        
         return (new TranslationFinder())->getCatalogueFromPaths($paths, $locale, $pattern);
     }
 


### PR DESCRIPTION
getCatalogueFromPaths methods $paths parameter typecast as array, but $paths parameter can be set as string on singularity

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | getCatalogueFromPaths methods $paths parameter typecast as array, but $paths parameter can be set as string on singularity
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | For testing, export theme language from backoffice
| Possible impacts? | Fixing type error


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23518)
<!-- Reviewable:end -->
