### PR TITLE
[POC] Split services from principal logic of JS files

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
@@ -24,9 +24,9 @@
  */
 
 import ProductMap from '@pages/product/product-map';
-import Router from '@components/router';
 import ConfirmModal from '@components/modal';
 import ProductEventMap from '@pages/product/product-event-map';
+import {getFeatureValues} from '@pages/product/edit/services/feature';
 
 const {$} = window;
 
@@ -35,7 +35,6 @@ export default class FeatureValuesManager {
    * @param eventEmitter {EventEmitter}
    */
   constructor(eventEmitter) {
-    this.router = new Router();
     this.eventEmitter = eventEmitter;
     this.$collectionContainer = $(ProductMap.featureValues.collectionContainer);
     this.$collectionRowsContainer = $(ProductMap.featureValues.collectionRowsContainer);
@@ -103,7 +102,7 @@ export default class FeatureValuesManager {
   }
 
   watchFeatureSelectors() {
-    $(this.$collectionContainer).on('change', ProductMap.featureValues.featureSelect, (event) => {
+    $(this.$collectionContainer).on('change', ProductMap.featureValues.featureSelect, async (event) => {
       const $selector = $(event.target);
       const idFeature = $selector.val();
       const $collectionRow = $selector.closest(ProductMap.featureValues.collectionRow);
@@ -116,22 +115,23 @@ export default class FeatureValuesManager {
       $featureValueSelector.val('');
       $customFeatureIdInput.val('');
 
-      $.get(this.router.generate('admin_feature_get_feature_values', {idFeature}))
-        .then((featureValuesData) => {
-          $featureValueSelector.prop('disabled', featureValuesData.length === 0);
-          $featureValueSelector.empty();
-          $.each(featureValuesData, (index, featureValue) => {
-            // The placeholder shouldn't be posted.
-            if (featureValue.id === '0') {
-              featureValue.id = '';
-            }
+      const featureValuesData = await getFeatureValues(idFeature);
+      console.log(featureValuesData);
 
-            $featureValueSelector
-              .append($('<option></option>')
-                .attr('value', featureValue.id)
-                .text(featureValue.value));
-          });
-        });
+      $featureValueSelector.prop('disabled', featureValuesData.length === 0);
+      $featureValueSelector.empty();
+      $.each(featureValuesData, (index, featureValue) => {
+        // The placeholder shouldn't be posted.
+        if (featureValue.id === '0') {
+          featureValue.id = '';
+        }
+
+        $featureValueSelector.append(
+          $('<option></option>')
+            .attr('value', featureValue.id)
+            .text(featureValue.value),
+        );
+      });
     });
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
@@ -116,7 +116,6 @@ export default class FeatureValuesManager {
       $customFeatureIdInput.val('');
 
       const featureValuesData = await getFeatureValues(idFeature);
-      console.log(featureValuesData);
 
       $featureValueSelector.prop('disabled', featureValuesData.length === 0);
       $featureValueSelector.empty();

--- a/admin-dev/themes/new-theme/js/pages/product/edit/services/feature.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/services/feature.js
@@ -1,0 +1,13 @@
+import Router from '@components/router';
+
+const {$} = window;
+
+export function getFeatureValues(idFeature) {
+  const router = new Router();
+
+  return $.get(router.generate('admin_feature_get_feature_values', {idFeature}));
+}
+
+export default {
+  getFeatureValues,
+};


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | HTTP Request shouldn't be inside code logics, it's way clearer to have these outside, inside a services folders and usable by any files (we could also export these to a global object, to make it usable by modules)
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check on the edit product page if features works as expected


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23520)
<!-- Reviewable:end -->
