### PR TITLE
Problem with PHP7.4 with Customer::getCurrentCountry and Tab management

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1149,7 +1149,7 @@ class CustomerCore extends ObjectModel
         }
         $ids = Address::getCountryAndState($idAddress);
 
-        return (int) ($ids['id_country'] ? $ids['id_country'] : Configuration::get('PS_COUNTRY_DEFAULT'));
+        return (int) ($ids['id_country'] ?? Configuration::get('PS_COUNTRY_DEFAULT'));
     }
 
     /**

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -628,7 +628,7 @@ class TabCore extends ObjectModel
     {
         $adminTab = Tab::getTab((int) Context::getContext()->language->id, $idTab);
         $tabs[] = $adminTab;
-        if ($adminTab['id_parent'] > 0) {
+        if (!empty($adminTab['id_parent'])) {
             $tabs = Tab::recursiveTab($adminTab['id_parent'], $tabs);
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -659,7 +659,7 @@ class AdminControllerCore extends Controller
         ]);
 
         /* BEGIN - Backward compatibility < 1.6.0.3 */
-        $this->breadcrumbs[] = $tabs[0]['name'];
+        $this->breadcrumbs[] = $tabs[0]['name'] ?? '';
         $navigation_pipe = (Configuration::get('PS_NAVIGATION_PIPE') ? Configuration::get('PS_NAVIGATION_PIPE') : '>');
         $this->context->smarty->assign('navigationPipe', $navigation_pipe);
         /* END - Backward compatibility < 1.6.0.3 */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since PHP7.4, a boolean can not be used as array, which is totally logic, but because tests on key existence were never used, we have a lot of boolean that are treated as array -_-.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23523
| How to test?      | Create a new shop in multistore in BO and go to product details after being login in FO.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23525)
<!-- Reviewable:end -->
