### PR TITLE
Fix, hide desactivated  categories in breadcrumbs

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1210,18 +1210,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function getBreadcrumbLinks()
     {
-        $breadcrumb = parent::getBreadcrumbLinks();
-
+        $breadcrumb = ProductPresentingFrontControllerCore::getBreadcrumbLinks();
+        
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {
             if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
-                $breadcrumb['links'][] = $this->getCategoryPath($category);
+                $breadcrumb['links'][] =  [
+                        'title' => $category->name,
+                        'url' => $this->context->link->getCategoryLink($category),
+                    ];
             }
-        }
-
-        if (!$categoryDefault->is_root_category) {
-            $breadcrumb['links'][] = $this->getCategoryPath($categoryDefault);
         }
 
         $breadcrumb['links'][] = [

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1211,15 +1211,15 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function getBreadcrumbLinks()
     {
         $breadcrumb = parent::getBreadcrumbLinks();
-        
+
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {
             if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
-                $breadcrumb['links'][] =  [
+                $breadcrumb['links'][] = [
                         'title' => $category->name,
                         'url' => $this->context->link->getCategoryLink($category),
-                    ];
+                ];
             }
         }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1217,8 +1217,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         foreach ($categoryDefault->getAllParents() as $category) {
             if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
                 $breadcrumb['links'][] = [
-                        'title' => $category->name,
-                        'url' => $this->context->link->getCategoryLink($category),
+                    'title' => $category->name,
+                    'url' => $this->context->link->getCategoryLink($category),
                 ];
             }
         }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1210,7 +1210,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     public function getBreadcrumbLinks()
     {
-        $breadcrumb = ProductPresentingFrontControllerCore::getBreadcrumbLinks();
+        $breadcrumb = parent::getBreadcrumbLinks();
         
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1215,7 +1215,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {
-            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {) {
+            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
                 $breadcrumb['links'][] = $this->getCategoryPath($category);
             }
         }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1222,6 +1222,13 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 ];
             }
         }
+        
+        if ($categoryDefault->id_parent != 0 && !$categoryDefault->is_root_category && $categoryDefault->active ) {
+            $breadcrumb['links'][] =  [
+                'title' => $categoryDefault->name,
+                'url' => $this->context->link->getCategoryLink($categoryDefault),
+            ];
+        }
 
         $breadcrumb['links'][] = [
             'title' => $this->product->name,

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1223,8 +1223,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
         }
         
-        if ($categoryDefault->id_parent != 0 && !$categoryDefault->is_root_category && $categoryDefault->active ) {
-            $breadcrumb['links'][] =  [
+        if ($categoryDefault->id_parent != 0 && !$categoryDefault->is_root_category && $categoryDefault->active) {
+            $breadcrumb['links'][] = [
                 'title' => $categoryDefault->name,
                 'url' => $this->context->link->getCategoryLink($categoryDefault),
             ];

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1222,7 +1222,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 ];
             }
         }
-        
+
         if ($categoryDefault->id_parent != 0 && !$categoryDefault->is_root_category && $categoryDefault->active) {
             $breadcrumb['links'][] = [
                 'title' => $categoryDefault->name,

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1215,7 +1215,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
 
         foreach ($categoryDefault->getAllParents() as $category) {
-            if ($category->id_parent != 0 && !$category->is_root_category) {
+            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {) {
                 $breadcrumb['links'][] = $this->getCategoryPath($category);
             }
         }

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -238,8 +238,8 @@ class CategoryControllerCore extends ProductListingFrontController
             }
         }
 
-        if ($this->category->id_parent != 0 && !$this->category->is_root_category && $category->active ) {
-            $breadcrumb['links'][] =  [
+        if ($this->category->id_parent != 0 && !$this->category->is_root_category && $category->active) {
+            $breadcrumb['links'][] = [
                 'title' => $this->category->name,
                 'url' => $this->context->link->getCategoryLink($this->category),
             ];

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -226,11 +226,11 @@ class CategoryControllerCore extends ProductListingFrontController
 
     public function getBreadcrumbLinks()
     {
-  
-        $breadcrumb = parent::getBreadcrumbLinks();     
-        
-        foreach ($this->category->getAllParents() as $category) {           
-            if ($category->id_parent != 0 && !$category->is_root_category && $category->active  ) {
+
+        $breadcrumb = parent::getBreadcrumbLinks();
+
+        foreach ($this->category->getAllParents() as $category) {
+            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
                 $breadcrumb['links'][] = [
                     'title' => $category->name,
                     'url' => $this->context->link->getCategoryLink($category),
@@ -244,7 +244,7 @@ class CategoryControllerCore extends ProductListingFrontController
                 'url' => $this->context->link->getCategoryLink($this->category),
             ];
         }
-       
+
         return $breadcrumb;
     }
 

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -229,9 +229,7 @@ class CategoryControllerCore extends ProductListingFrontController
         $breadcrumb = parent::getBreadcrumbLinks();
 
         foreach ($this->category->getAllParents() as $category) {
-            if ($category->id_parent != 0 
-                && !$category->is_root_category
-                && $category->active) {
+            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
                 $breadcrumb['links'][] = $this->getCategoryPath($category);
             }
         }

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -227,7 +227,7 @@ class CategoryControllerCore extends ProductListingFrontController
     public function getBreadcrumbLinks()
     {
   
-        $breadcrumb = ProductListingFrontController::getBreadcrumbLinks();     
+        $breadcrumb = parent::getBreadcrumbLinks();     
         
         foreach ($this->category->getAllParents() as $category) {           
             if ($category->id_parent != 0 && !$category->is_root_category && $category->active  ) {

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -226,7 +226,6 @@ class CategoryControllerCore extends ProductListingFrontController
 
     public function getBreadcrumbLinks()
     {
-
         $breadcrumb = parent::getBreadcrumbLinks();
 
         foreach ($this->category->getAllParents() as $category) {

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -229,7 +229,9 @@ class CategoryControllerCore extends ProductListingFrontController
         $breadcrumb = parent::getBreadcrumbLinks();
 
         foreach ($this->category->getAllParents() as $category) {
-            if ($category->id_parent != 0 && !$category->is_root_category) {
+            if ($category->id_parent != 0 
+                && !$category->is_root_category
+                && $category->active) {
                 $breadcrumb['links'][] = $this->getCategoryPath($category);
             }
         }

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -226,18 +226,25 @@ class CategoryControllerCore extends ProductListingFrontController
 
     public function getBreadcrumbLinks()
     {
-        $breadcrumb = parent::getBreadcrumbLinks();
-
-        foreach ($this->category->getAllParents() as $category) {
-            if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
-                $breadcrumb['links'][] = $this->getCategoryPath($category);
+  
+        $breadcrumb = ProductListingFrontController::getBreadcrumbLinks();     
+        
+        foreach ($this->category->getAllParents() as $category) {           
+            if ($category->id_parent != 0 && !$category->is_root_category && $category->active  ) {
+                $breadcrumb['links'][] = [
+                    'title' => $category->name,
+                    'url' => $this->context->link->getCategoryLink($category),
+                ];
             }
         }
 
-        if ($this->category->id_parent != 0 && !$this->category->is_root_category) {
-            $breadcrumb['links'][] = $this->getCategoryPath($this->category);
+        if ($this->category->id_parent != 0 && !$this->category->is_root_category && $category->active ) {
+            $breadcrumb['links'][] =  [
+                'title' => $this->category->name,
+                'url' => $this->context->link->getCategoryLink($this->category),
+            ];
         }
-
+       
         return $breadcrumb;
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  develop 
| Description?      |  The bug: when desactivate a categorie she still showing in breadcrumb. This PR fix it 
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     |  Fixes #23530
| How to test?      |  on a page of product with a categories path, deactivate one category. She must not appear in breadcrumb  
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23528)
<!-- Reviewable:end -->
