### PR TITLE
[POC] Add HOC to send event on every method calls of a JS Object

### DIFF
--- a/admin-dev/themes/new-theme/js/components/event-hoc.js
+++ b/admin-dev/themes/new-theme/js/components/event-hoc.js
@@ -25,25 +25,26 @@
 
 import EventEmitterClass from 'events';
 
-function overloadProperties(obj, afterFn) {
-  Object.getOwnPropertyNames(obj).forEach((propName) => {
+function overloadProperties(obj, ignoreList, afterFn) {
+  console.log(Object.getOwnPropertyNames(obj));
+  Object.getOwnPropertyNames(obj).forEach(propName => {
     const prop = obj[propName];
 
-    if (Object.prototype.toString.call(prop) === '[object Function]') {
-      obj[propName] = (function (fnName) {
-        return function (...args) {
+    if (Object.prototype.toString.call(prop) === '[object Function]' && !ignoreList.includes(propName)) {
+      obj[propName] = (function(fnName) {
+        return function(...args) {
           prop.apply(this, args);
           afterFn.call(this, fnName, args);
         };
-      }(propName));
+      })(propName);
     }
   });
 }
 
-export default function EventHOC(Component) {
+export default function EventHOC(Component, ignoreList = []) {
   const EventEmitter = new EventEmitterClass();
 
-  overloadProperties(Component.prototype, (fnName, args) => {
+  overloadProperties(Component.prototype, ignoreList, (fnName, args) => {
     console.log(`${Component.name}.${fnName}`, args);
     EventEmitter.emit(`${Component.name}.${fnName}`, args);
   });

--- a/admin-dev/themes/new-theme/js/components/event-hoc.js
+++ b/admin-dev/themes/new-theme/js/components/event-hoc.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import EventEmitterClass from 'events';
+
+function overloadProperties(obj, afterFn) {
+  Object.getOwnPropertyNames(obj).forEach((propName) => {
+    const prop = obj[propName];
+
+    if (Object.prototype.toString.call(prop) === '[object Function]') {
+      obj[propName] = (function (fnName) {
+        return function (...args) {
+          prop.apply(this, args);
+          afterFn.call(this, fnName, args);
+        };
+      }(propName));
+    }
+  });
+}
+
+export default function EventHOC(Component) {
+  const EventEmitter = new EventEmitterClass();
+
+  overloadProperties(Component.prototype, (fnName, args) => {
+    console.log(`${Component.name}.${fnName}`, args);
+    EventEmitter.emit(`${Component.name}.${fnName}`, args);
+  });
+
+  return Component;
+}

--- a/admin-dev/themes/new-theme/js/pages/product/edit/customizations-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/customizations-manager.js
@@ -44,7 +44,7 @@ class CustomizationsManager {
     this.$customizationsContainer.on('click', ProductMap.customizations.addCustomizationBtn, () => {
       this.addCustomizationField();
     });
-    this.$customizationsContainer.on('click', ProductMap.customizations.removeCustomizationBtn, e => {
+    this.$customizationsContainer.on('click', ProductMap.customizations.removeCustomizationBtn, (e) => {
       this.removeCustomizationField(e);
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/customizations-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/customizations-manager.js
@@ -44,7 +44,7 @@ class CustomizationsManager {
     this.$customizationsContainer.on('click', ProductMap.customizations.addCustomizationBtn, () => {
       this.addCustomizationField();
     });
-    this.$customizationsContainer.on('click', ProductMap.customizations.removeCustomizationBtn, (e) => {
+    this.$customizationsContainer.on('click', ProductMap.customizations.removeCustomizationBtn, e => {
       this.removeCustomizationField(e);
     });
   }
@@ -69,4 +69,4 @@ class CustomizationsManager {
   }
 }
 
-export default EventHOC(CustomizationsManager);
+export default EventHOC(CustomizationsManager, ['getIndex']);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/customizations-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/customizations-manager.js
@@ -25,10 +25,11 @@
 
 import ProductMap from '@pages/product/product-map';
 import ProductEventMap from '@pages/product/product-event-map';
+import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
-export default class CustomizationsManager {
+class CustomizationsManager {
   constructor() {
     this.$customizationsContainer = $(ProductMap.customizations.customizationsContainer);
     this.$customizationFieldsList = $(ProductMap.customizations.customizationFieldsList);
@@ -57,7 +58,9 @@ export default class CustomizationsManager {
   }
 
   removeCustomizationField(event) {
-    $(event.currentTarget).closest(ProductMap.customizations.customizationFieldRow).remove();
+    $(event.currentTarget)
+      .closest(ProductMap.customizations.customizationFieldRow)
+      .remove();
     this.eventEmitter.emit(ProductEventMap.customizations.rowRemoved);
   }
 
@@ -65,3 +68,5 @@ export default class CustomizationsManager {
     return this.$customizationFieldsList.find(ProductMap.customizations.customizationFieldRow).length;
   }
 }
+
+export default EventHOC(CustomizationsManager);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
@@ -27,10 +27,11 @@ import ProductMap from '@pages/product/product-map';
 import Router from '@components/router';
 import ConfirmModal from '@components/modal';
 import ProductEventMap from '@pages/product/product-event-map';
+import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
-export default class FeatureValuesManager {
+export class FeatureValuesManager {
   /**
    * @param eventEmitter {EventEmitter}
    */
@@ -59,7 +60,7 @@ export default class FeatureValuesManager {
   }
 
   watchDeleteButtons() {
-    $(this.$collectionContainer).on('click', ProductMap.featureValues.deleteFeatureValue, (event) => {
+    $(this.$collectionContainer).on('click', ProductMap.featureValues.deleteFeatureValue, event => {
       const $deleteButton = $(event.currentTarget);
       const $collectionRow = $deleteButton.closest(ProductMap.featureValues.collectionRow);
       const modal = new ConfirmModal(
@@ -68,19 +69,19 @@ export default class FeatureValuesManager {
           confirmTitle: $deleteButton.data('modal-title'),
           confirmMessage: $deleteButton.data('modal-message'),
           confirmButtonLabel: $deleteButton.data('modal-apply'),
-          closeButtonLabel: $deleteButton.data('modal-cancel'),
+          closeButtonLabel: $deleteButton.data('modal-cancel')
         },
         () => {
           $collectionRow.remove();
           this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState);
-        },
+        }
       );
       modal.show();
     });
   }
 
   watchCustomInputs() {
-    $(this.$collectionContainer).on('keyup change', ProductMap.featureValues.customValueInput, (event) => {
+    $(this.$collectionContainer).on('keyup change', ProductMap.featureValues.customValueInput, event => {
       const $changedInput = $(event.target);
       const $collectionRow = $changedInput.closest(ProductMap.featureValues.collectionRow);
 
@@ -103,7 +104,7 @@ export default class FeatureValuesManager {
   }
 
   watchFeatureSelectors() {
-    $(this.$collectionContainer).on('change', ProductMap.featureValues.featureSelect, (event) => {
+    $(this.$collectionContainer).on('change', ProductMap.featureValues.featureSelect, event => {
       const $selector = $(event.target);
       const idFeature = $selector.val();
       const $collectionRow = $selector.closest(ProductMap.featureValues.collectionRow);
@@ -116,22 +117,28 @@ export default class FeatureValuesManager {
       $featureValueSelector.val('');
       $customFeatureIdInput.val('');
 
-      $.get(this.router.generate('admin_feature_get_feature_values', {idFeature}))
-        .then((featureValuesData) => {
-          $featureValueSelector.prop('disabled', featureValuesData.length === 0);
-          $featureValueSelector.empty();
-          $.each(featureValuesData, (index, featureValue) => {
-            // The placeholder shouldn't be posted.
-            if (featureValue.id === '0') {
-              featureValue.id = '';
-            }
+      $.get(
+        this.router.generate('admin_feature_get_feature_values', {
+          idFeature
+        })
+      ).then(featureValuesData => {
+        $featureValueSelector.prop('disabled', featureValuesData.length === 0);
+        $featureValueSelector.empty();
+        $.each(featureValuesData, (index, featureValue) => {
+          // The placeholder shouldn't be posted.
+          if (featureValue.id === '0') {
+            featureValue.id = '';
+          }
 
-            $featureValueSelector
-              .append($('<option></option>')
-                .attr('value', featureValue.id)
-                .text(featureValue.value));
-          });
+          $featureValueSelector.append(
+            $('<option></option>')
+              .attr('value', featureValue.id)
+              .text(featureValue.value)
+          );
         });
+      });
     });
   }
 }
+
+export default EventHOC(FeatureValuesManager);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/feature-values-manager.js
@@ -31,7 +31,7 @@ import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
-export class FeatureValuesManager {
+class FeatureValuesManager {
   /**
    * @param eventEmitter {EventEmitter}
    */
@@ -60,7 +60,7 @@ export class FeatureValuesManager {
   }
 
   watchDeleteButtons() {
-    $(this.$collectionContainer).on('click', ProductMap.featureValues.deleteFeatureValue, event => {
+    $(this.$collectionContainer).on('click', ProductMap.featureValues.deleteFeatureValue, (event) => {
       const $deleteButton = $(event.currentTarget);
       const $collectionRow = $deleteButton.closest(ProductMap.featureValues.collectionRow);
       const modal = new ConfirmModal(
@@ -69,19 +69,19 @@ export class FeatureValuesManager {
           confirmTitle: $deleteButton.data('modal-title'),
           confirmMessage: $deleteButton.data('modal-message'),
           confirmButtonLabel: $deleteButton.data('modal-apply'),
-          closeButtonLabel: $deleteButton.data('modal-cancel')
+          closeButtonLabel: $deleteButton.data('modal-cancel'),
         },
         () => {
           $collectionRow.remove();
           this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState);
-        }
+        },
       );
       modal.show();
     });
   }
 
   watchCustomInputs() {
-    $(this.$collectionContainer).on('keyup change', ProductMap.featureValues.customValueInput, event => {
+    $(this.$collectionContainer).on('keyup change', ProductMap.featureValues.customValueInput, (event) => {
       const $changedInput = $(event.target);
       const $collectionRow = $changedInput.closest(ProductMap.featureValues.collectionRow);
 
@@ -104,7 +104,7 @@ export class FeatureValuesManager {
   }
 
   watchFeatureSelectors() {
-    $(this.$collectionContainer).on('change', ProductMap.featureValues.featureSelect, event => {
+    $(this.$collectionContainer).on('change', ProductMap.featureValues.featureSelect, (event) => {
       const $selector = $(event.target);
       const idFeature = $selector.val();
       const $collectionRow = $selector.closest(ProductMap.featureValues.collectionRow);
@@ -119,9 +119,9 @@ export class FeatureValuesManager {
 
       $.get(
         this.router.generate('admin_feature_get_feature_values', {
-          idFeature
-        })
-      ).then(featureValuesData => {
+          idFeature,
+        }),
+      ).then((featureValuesData) => {
         $featureValueSelector.prop('disabled', featureValuesData.length === 0);
         $featureValueSelector.empty();
         $.each(featureValuesData, (index, featureValue) => {
@@ -133,7 +133,7 @@ export class FeatureValuesManager {
           $featureValueSelector.append(
             $('<option></option>')
               .attr('value', featureValue.id)
-              .text(featureValue.value)
+              .text(featureValue.value),
           );
         });
       });

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.js
@@ -25,6 +25,7 @@
 
 import _ from 'lodash';
 import ProductEventMap from '@pages/product/product-event-map';
+import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
@@ -38,7 +39,7 @@ const {$} = window;
  * It also disabled the submit button as long as no data has been
  * modified by the user.
  */
-export default class ProductPartialUpdater {
+export class ProductPartialUpdater {
   /**
    * @param eventEmitter {EventEmitter}
    * @param $productForm {jQuery}
@@ -78,7 +79,7 @@ export default class ProductPartialUpdater {
    * Rich editors apply a layer over initial textarea fields therefore they need to be watched differently.
    */
   initFormattedTextarea() {
-    this.eventEmitter.on('tinymceEditorSetup', (event) => {
+    this.eventEmitter.on('tinymceEditorSetup', event => {
       event.editor.on('change', () => this.updateSubmitButtonState());
     });
   }
@@ -138,9 +139,9 @@ export default class ProductPartialUpdater {
     const $updatedForm = this.$productForm.clone();
     $updatedForm.empty();
     $updatedForm.prop('class', '');
-    Object.keys(updatedData).forEach((fieldName) => {
+    Object.keys(updatedData).forEach(fieldName => {
       if (Array.isArray(updatedData[fieldName])) {
-        updatedData[fieldName].forEach((value) => {
+        updatedData[fieldName].forEach(value => {
           this.appendInputToForm($updatedForm, fieldName, value);
         });
       } else {
@@ -171,7 +172,7 @@ export default class ProductPartialUpdater {
     const currentData = this.getFormDataAsObject();
     // Loop through current form data and remove the one that did not change
     // This way only updated AND new values remain
-    Object.keys(this.initialData).forEach((fieldName) => {
+    Object.keys(this.initialData).forEach(fieldName => {
       const fieldValue = this.initialData[fieldName];
 
       // Field is absent in the new data (it was not in the initial) we force it to empty string (not null
@@ -194,9 +195,9 @@ export default class ProductPartialUpdater {
       // We need the form CSRF token
       'product[_token]',
       // If method is not POST or GET a hidden type input is used to simulate it (like PATCH)
-      '_method',
+      '_method'
     ];
-    permanentParameters.forEach((permanentParameter) => {
+    permanentParameters.forEach(permanentParameter => {
       if (Object.prototype.hasOwnProperty.call(this.initialData, permanentParameter)) {
         currentData[permanentParameter] = this.initialData[permanentParameter];
       }
@@ -214,7 +215,7 @@ export default class ProductPartialUpdater {
     const formArray = this.$productForm.serializeArray();
     const serializedForm = {};
 
-    formArray.forEach((formField) => {
+    formArray.forEach(formField => {
       let {value} = formField;
 
       // Input names can be identical when expressing array of values for same field (like multiselect checkboxes)
@@ -244,10 +245,14 @@ export default class ProductPartialUpdater {
    * @private
    */
   appendInputToForm($form, name, value) {
-    $('<input>').attr({
-      name,
-      type: 'hidden',
-      value,
-    }).appendTo($form);
+    $('<input>')
+      .attr({
+        name,
+        type: 'hidden',
+        value
+      })
+      .appendTo($form);
   }
 }
+
+export default EventHOC(ProductPartialUpdater);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.js
@@ -39,7 +39,7 @@ const {$} = window;
  * It also disabled the submit button as long as no data has been
  * modified by the user.
  */
-export class ProductPartialUpdater {
+class ProductPartialUpdater {
   /**
    * @param eventEmitter {EventEmitter}
    * @param $productForm {jQuery}
@@ -79,7 +79,7 @@ export class ProductPartialUpdater {
    * Rich editors apply a layer over initial textarea fields therefore they need to be watched differently.
    */
   initFormattedTextarea() {
-    this.eventEmitter.on('tinymceEditorSetup', event => {
+    this.eventEmitter.on('tinymceEditorSetup', (event) => {
       event.editor.on('change', () => this.updateSubmitButtonState());
     });
   }
@@ -139,9 +139,9 @@ export class ProductPartialUpdater {
     const $updatedForm = this.$productForm.clone();
     $updatedForm.empty();
     $updatedForm.prop('class', '');
-    Object.keys(updatedData).forEach(fieldName => {
+    Object.keys(updatedData).forEach((fieldName) => {
       if (Array.isArray(updatedData[fieldName])) {
-        updatedData[fieldName].forEach(value => {
+        updatedData[fieldName].forEach((value) => {
           this.appendInputToForm($updatedForm, fieldName, value);
         });
       } else {
@@ -172,7 +172,7 @@ export class ProductPartialUpdater {
     const currentData = this.getFormDataAsObject();
     // Loop through current form data and remove the one that did not change
     // This way only updated AND new values remain
-    Object.keys(this.initialData).forEach(fieldName => {
+    Object.keys(this.initialData).forEach((fieldName) => {
       const fieldValue = this.initialData[fieldName];
 
       // Field is absent in the new data (it was not in the initial) we force it to empty string (not null
@@ -195,9 +195,9 @@ export class ProductPartialUpdater {
       // We need the form CSRF token
       'product[_token]',
       // If method is not POST or GET a hidden type input is used to simulate it (like PATCH)
-      '_method'
+      '_method',
     ];
-    permanentParameters.forEach(permanentParameter => {
+    permanentParameters.forEach((permanentParameter) => {
       if (Object.prototype.hasOwnProperty.call(this.initialData, permanentParameter)) {
         currentData[permanentParameter] = this.initialData[permanentParameter];
       }
@@ -215,7 +215,7 @@ export class ProductPartialUpdater {
     const formArray = this.$productForm.serializeArray();
     const serializedForm = {};
 
-    formArray.forEach(formField => {
+    formArray.forEach((formField) => {
       let {value} = formField;
 
       // Input names can be identical when expressing array of values for same field (like multiselect checkboxes)
@@ -249,7 +249,7 @@ export class ProductPartialUpdater {
       .attr({
         name,
         type: 'hidden',
-        value
+        value,
       })
       .appendTo($form);
   }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-suppliers-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-suppliers-manager.js
@@ -24,10 +24,11 @@
  */
 
 import ProductMap from '@pages/product/product-map';
+import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
-export default class ProductSuppliersManager {
+export class ProductSuppliersManager {
   constructor() {
     this.$productSuppliersCollection = $(ProductMap.suppliers.productSuppliersCollection);
     this.$supplierIdsGroup = $(ProductMap.suppliers.supplierIdsInput).closest('.form-group');
@@ -52,13 +53,13 @@ export default class ProductSuppliersManager {
       this.memorizeCurrentSuppliers();
     });
 
-    this.$supplierIdsGroup.on('change', 'input', (e) => {
+    this.$supplierIdsGroup.on('change', 'input', e => {
       const input = e.currentTarget;
 
       if (input.checked) {
         this.addSupplier({
           id: input.value,
-          name: input.dataset.label,
+          name: input.dataset.label
         });
       } else {
         this.removeSupplier(input.value);
@@ -101,7 +102,7 @@ export default class ProductSuppliersManager {
 
     // Custom incremental index since this.suppliers uses the supplierId as key
     let supplierIndex = 0;
-    this.suppliers.forEach((supplier) => {
+    this.suppliers.forEach(supplier => {
       if (supplier.removed) {
         return;
       }
@@ -126,7 +127,7 @@ export default class ProductSuppliersManager {
     this.$supplierIdsGroup.find('input:checked').each((index, input) => {
       selectedSuppliers.push({
         name: input.dataset.label,
-        id: input.value,
+        id: input.value
       });
     });
 
@@ -144,7 +145,7 @@ export default class ProductSuppliersManager {
     }
 
     this.showDefaultSuppliers();
-    const selectedSupplierIds = suppliers.map((supplier) => supplier.id);
+    const selectedSupplierIds = suppliers.map(supplier => supplier.id);
 
     this.$defaultSupplierGroup.find('input').each((key, input) => {
       const isValid = selectedSupplierIds.includes(input.value);
@@ -195,7 +196,7 @@ export default class ProductSuppliersManager {
         reference: $(ProductMap.suppliers.productSupplierRow.referenceInput(index)).val(),
         price: $(ProductMap.suppliers.productSupplierRow.priceInput(index)).val(),
         currencyId: $(ProductMap.suppliers.productSupplierRow.currencyIdInput(index)).val(),
-        removed: false,
+        removed: false
       };
     });
   }
@@ -207,18 +208,17 @@ export default class ProductSuppliersManager {
    * @returns {{reference, removed: boolean, price, currencyId, productSupplierId}}
    */
   collectDefaultDataForSupplier() {
-    const rowPrototype = new DOMParser().parseFromString(
-      this.prototypeTemplate,
-      'text/html',
-    );
+    const rowPrototype = new DOMParser().parseFromString(this.prototypeTemplate, 'text/html');
 
     return {
       removed: false,
-      productSupplierId:
-        this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.productSupplierIdInput, rowPrototype),
+      productSupplierId: this.collectDataFromRow(
+        ProductMap.suppliers.productSupplierRow.productSupplierIdInput,
+        rowPrototype
+      ),
       reference: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.referenceInput, rowPrototype),
       price: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.priceInput, rowPrototype),
-      currencyId: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.currencyIdInput, rowPrototype),
+      currencyId: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.currencyIdInput, rowPrototype)
     };
   }
 
@@ -232,3 +232,5 @@ export default class ProductSuppliersManager {
     return rowPrototype.querySelector(selectorGenerator(this.prototypeName)).value;
   }
 }
+
+export default EventHOC(ProductSuppliersManager);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-suppliers-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-suppliers-manager.js
@@ -28,7 +28,7 @@ import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
-export class ProductSuppliersManager {
+class ProductSuppliersManager {
   constructor() {
     this.$productSuppliersCollection = $(ProductMap.suppliers.productSuppliersCollection);
     this.$supplierIdsGroup = $(ProductMap.suppliers.supplierIdsInput).closest('.form-group');
@@ -53,13 +53,13 @@ export class ProductSuppliersManager {
       this.memorizeCurrentSuppliers();
     });
 
-    this.$supplierIdsGroup.on('change', 'input', e => {
+    this.$supplierIdsGroup.on('change', 'input', (e) => {
       const input = e.currentTarget;
 
       if (input.checked) {
         this.addSupplier({
           id: input.value,
-          name: input.dataset.label
+          name: input.dataset.label,
         });
       } else {
         this.removeSupplier(input.value);
@@ -102,7 +102,7 @@ export class ProductSuppliersManager {
 
     // Custom incremental index since this.suppliers uses the supplierId as key
     let supplierIndex = 0;
-    this.suppliers.forEach(supplier => {
+    this.suppliers.forEach((supplier) => {
       if (supplier.removed) {
         return;
       }
@@ -127,7 +127,7 @@ export class ProductSuppliersManager {
     this.$supplierIdsGroup.find('input:checked').each((index, input) => {
       selectedSuppliers.push({
         name: input.dataset.label,
-        id: input.value
+        id: input.value,
       });
     });
 
@@ -145,7 +145,7 @@ export class ProductSuppliersManager {
     }
 
     this.showDefaultSuppliers();
-    const selectedSupplierIds = suppliers.map(supplier => supplier.id);
+    const selectedSupplierIds = suppliers.map((supplier) => supplier.id);
 
     this.$defaultSupplierGroup.find('input').each((key, input) => {
       const isValid = selectedSupplierIds.includes(input.value);
@@ -196,7 +196,7 @@ export class ProductSuppliersManager {
         reference: $(ProductMap.suppliers.productSupplierRow.referenceInput(index)).val(),
         price: $(ProductMap.suppliers.productSupplierRow.priceInput(index)).val(),
         currencyId: $(ProductMap.suppliers.productSupplierRow.currencyIdInput(index)).val(),
-        removed: false
+        removed: false,
       };
     });
   }
@@ -214,11 +214,11 @@ export class ProductSuppliersManager {
       removed: false,
       productSupplierId: this.collectDataFromRow(
         ProductMap.suppliers.productSupplierRow.productSupplierIdInput,
-        rowPrototype
+        rowPrototype,
       ),
       reference: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.referenceInput, rowPrototype),
       price: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.priceInput, rowPrototype),
-      currencyId: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.currencyIdInput, rowPrototype)
+      currencyId: this.collectDataFromRow(ProductMap.suppliers.productSupplierRow.currencyIdInput, rowPrototype),
     };
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/edit/redirect-option-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/redirect-option-manager.js
@@ -37,7 +37,7 @@ const {$} = window;
  * When the type is changed the component automatically updates the labels, remote search urls
  * and values of the target.
  */
-export class RedirectOptionManager {
+class RedirectOptionManager {
   constructor($redirectTypeInput, $redirectTargetInput) {
     this.$redirectTypeInput = $redirectTypeInput;
     this.$redirectTargetInput = $redirectTargetInput;

--- a/admin-dev/themes/new-theme/js/pages/product/edit/redirect-option-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/redirect-option-manager.js
@@ -24,6 +24,7 @@
  */
 
 import EntitySearchInput from '@components/entity-search-input';
+import EventHOC from '@components/event-hoc';
 
 const {$} = window;
 
@@ -36,7 +37,7 @@ const {$} = window;
  * When the type is changed the component automatically updates the labels, remote search urls
  * and values of the target.
  */
-export default class RedirectOptionManager {
+export class RedirectOptionManager {
   constructor($redirectTypeInput, $redirectTargetInput) {
     this.$redirectTypeInput = $redirectTypeInput;
     this.$redirectTargetInput = $redirectTargetInput;
@@ -92,3 +93,5 @@ export default class RedirectOptionManager {
     this.entitySearchInput = new EntitySearchInput(this.$redirectTargetInput);
   }
 }
+
+export default EventHOC(RedirectOptionManager);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We've no way of sending events without duplicating code like EventEmitter.emit, We could create an HOC that we invoke on export in order to log method calls, it could also contain an ignore parameter in order to ignore some methods
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Should be tested by a dev => Try to catch an event like `CustomizationsManager.addCustomizationField`
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23531)
<!-- Reviewable:end -->
