### PR TITLE
Set module instance in Module Adapter

### DIFF
--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -179,6 +179,9 @@ class Module implements ModuleInterface
         // Unfortunately, we can sometime have an array, and sometimes an object.
         // This is the first place where this value *always* exists
         $this->attributes->set('price', (array) $this->attributes->get('price'));
+
+        // Set module instance
+        $this->instance = $this->getInstance();
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This change fixes minor code issues I found while working on another bug. Module instance in Module Adapter is always null.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | See description below 👇🏿
| Possible impacts? | N/A

## How to test

1 - Edit /[src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig](https://github.com/PrestaShop/PrestaShop/blob/develop/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig)

2 - Dump modules var : `{{ dump(modules) }}`

## Before 


❌ - See module instance is null

![image](https://user-images.githubusercontent.com/16455155/110252092-fe5ec880-7f83-11eb-826f-6797af228bee.png)


## After

✔️ - See you can access module instance properties

![image](https://user-images.githubusercontent.com/16455155/110252136-38c86580-7f84-11eb-807a-b1bc264ab59e.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23553)
<!-- Reviewable:end -->
