### PR TITLE
Fix logout and hover colors on profile pan responsive

### DIFF
--- a/admin-dev/themes/default/scss/partials/_header.scss
+++ b/admin-dev/themes/default/scss/partials/_header.scss
@@ -443,6 +443,11 @@ $search-border-color: #bbcdd2;
             a {
               color: #6c868e;
 
+              &:hover {
+                color: #25b9d7;
+                background-color: inherit;
+              }
+
               @include media-breakpoint-down(sm) {
                 display: flex;
                 align-items: center;
@@ -452,11 +457,11 @@ $search-border-color: #bbcdd2;
                 i {
                   color: $brand-danger;
                 }
-              }
 
-              &:hover {
-                color: #25b9d7;
-                background-color: inherit;
+                &:hover {
+                  color: #fff;
+                  background-color: #f54c3e;
+                }
               }
             }
           }

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -362,7 +362,7 @@
               </span>
             </li>
             <li class="text-left text-nowrap username" data-mobile="true" data-from="employee_links" data-target="menu">{l s='Welcome back %name%' sprintf=['%name%' => $employee->firstname] d='Admin.Navigation.Header'}</li>
-            <li class="employee-wrapper-profile"><a class="admin-link" href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}"><i class="material-icons">settings</i> {l s='Your profile' d='Admin.Navigation.Header'}</a></li>
+            <li class="employee-wrapper-profile"><a class="admin-link" href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}"><i class="material-icons">edit</i> {l s='Your profile' d='Admin.Navigation.Header'}</a></li>
             <li class="divider"></li>
             <li><a href="{l s='https://www.prestashop.com/en/resources/documentations?utm_source=back-office&utm_medium=profile&utm_campaign=resources-en&utm_content=download17
 ' d='Admin.Navigation.Header'}" target="_blank"><i class="material-icons">book</i> {l s='Resources' d='Admin.Navigation.Header'}</a></li>

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -403,7 +403,6 @@ $header-text-color: #4e6167 !default;
       }
     }
 
-
     &.gamification-component {
       @include media-breakpoint-down("sm") {
         // stylelint-disable-next-line
@@ -876,12 +875,12 @@ $header-text-color: #4e6167 !default;
         &:hover,
         &:focus {
           // stylelint-disable-next-line
-          background-color: #f4fcfd !important;
+          background-color: $primary !important;
 
           &,
           i {
             // stylelint-disable-next-line
-            color: $primary !important;
+            color: #fff !important;
           }
         }
 
@@ -890,15 +889,27 @@ $header-text-color: #4e6167 !default;
         }
       }
 
-      .employee-link {
-        &#header_logout {
-          padding: 0.5rem 0;
-          margin: 0;
+      #header_logout {
+        padding: 0.5rem 0;
+        // stylelint-disable-next-line
+        margin: 10px -1.25rem !important;
+
+        &:hover,
+        &:active,
+        &:focus {
+          // stylelint-disable-next-line
+          background-color: $danger !important;
 
           &,
           i {
-            color: $danger;
+            // stylelint-disable-next-line
+            color: #fff !important;
           }
+        }
+
+        &,
+        i {
+          color: $danger;
         }
       }
     }

--- a/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
@@ -33,7 +33,7 @@
       <span class="employee-avatar"><img class="avatar rounded-circle" src="{$employee->getImage()}" /></span>
       <span class="employee_profile">{l s='Welcome back %name%' sprintf=['%name%' => $employee->firstname] d='Admin.Navigation.Header'}</span>
       <a class="dropdown-item employee-link profile-link" href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}">
-      <i class="material-icons">settings</i>
+      <i class="material-icons">edit</i>
       <span>{l s='Your profile' d='Admin.Navigation.Header'}</span>
     </a>
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Profile pan needed some adjustements on colors on mobile, normal item need to have a background using primary colors and signout needs a background with red color
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23102.
| How to test?      | Go on legacy page AND migrated page and check Profile pan colors on mobile (see issues contains screens)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23568)
<!-- Reviewable:end -->
