### PR TITLE
Remove useless code since migration to BO new-theme

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1567,25 +1567,6 @@ function checkLangPack(token){
 
 function redirect(new_page) { window.location = new_page; }
 
-function saveCustomerNote() {
-  var $customerNoteForm = $('#customer_note');
-  var noteContent = $('#noteContent').val();
-
-  $.ajax({
-    type: "POST",
-    url: $customerNoteForm.attr('action'),
-    data: {
-      'private_note': {
-        'note': noteContent
-      }
-    },
-    async : true,
-    success: function(r) {
-      showSuccessMessage(r.message);
-    }
-  });
-}
-
 function isCleanHtml(content)
 {
   var events = 'onmousedown|onmousemove|onmmouseup|onmouseover|onmouseout|onload|onunload|onfocus|onblur|onchange';

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -311,14 +311,6 @@ class CustomerController extends AbstractAdminController
                     (int) $customerId,
                     $data['note']
                 ));
-
-                if ($request->isXmlHttpRequest()) {
-                    return $this->json([
-                        'success' => true,
-                        'message' => $this->trans('Successful update.', 'Admin.Notifications.Success'),
-                    ]);
-                }
-
                 $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
             } catch (CustomerException $e) {
                 $this->addFlash(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customer Note used to be save using AJAX from the view order page. But since we moved it to BO new-theme it's now useless. `saveCustomerNote` from `admin.js` is no more called nowhere, so it's handling in `CustomerController` is now useless too.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Check if all private note are still working inside the BO
| Possible impacts? | Check if js function `saveCustomerNote` is called somewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23579)
<!-- Reviewable:end -->
