### PR TITLE
Remove unused bootstrap classes causing side effects on nav

### DIFF
--- a/admin-dev/themes/default/template/nav.tpl
+++ b/admin-dev/themes/default/template/nav.tpl
@@ -1,4 +1,4 @@
-<nav class="nav-bar d-none d-md-block" role="navigation" id="nav-sidebar">
+<nav class="nav-bar" role="navigation" id="nav-sidebar">
 	<span class="menu-collapse" data-toggle-url="{$toggle_navigation_url}">
 		<i class="material-icons">chevron_left</i>
 		<i class="material-icons">chevron_left</i>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Some bootstrap classes on nav on default theme in the BO was causing side effects if something else add some styles to .d-none and .d-md-block classes
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23576.
| How to test?      | Go on the dashboad, try to add some styles to .d-none class such as `display: none;` in your console, the navbar shouldnt get these styles as the class is not there anymore, you can also just inspect the .nav-bar component and see if it contain .d-none and .d-md-block, it shouldnt contain it!
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23583)
<!-- Reviewable:end -->
