### PR TITLE
Remove bad template inclusion for Adv Stock in product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -151,10 +151,7 @@
 </div>
 
 <div class="col-md-12">
-  <div id="warehouse_combination_collection" class="col-md-12 form-group" data-url="{{ path('admin_warehouse_refresh_product_warehouse_combination_form') }}">
-    {% if asm_globally_activated and isNotVirtual and isChecked %}
-      {{ include('@PrestaShop/Admin:Product/ProductPage/Forms/form_warehouse_combination.html.twig', { 'warehouses': warehouses, 'form': form }) }}
-    {% endif %}
+  <div id="warehouse_combination_collection" class="col-md-12 form-group">
   </div>
 </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Following the comment https://github.com/PrestaShop/PrestaShop/issues/16695#issuecomment-791514517 and agreed with PM https://github.com/PrestaShop/PrestaShop/pull/23587#issuecomment-811902213 I remove the bad form `form_warehouse_combination.html` that was not expected to work.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/16695
| How to test?      | See below
| Possible impacts? | Only the Product page template is modified, removing the bad form

## How to test?

In PS 1.7, Advanced Stock Management option cannot be used anymore. **However** people upgrading from PS 1.6 to PS 1.7 might have turned this option on before upgrading.

To simulate "I have a shop with Advanced Stock Management enabled" you must do
- Open MySQL database
- Look in table ps_configuration
- modify PS_ADVANCED_STOCK_MANAGEMENT value to 1

Then open a Product BO page, any product that already exists.

[Enable stock management](https://github.com/PrestaShop/PrestaShop/issues/16695#issuecomment-791514517) for this product.

Refresh. Page crashes.

**These are the steps also described in the issue https://github.com/PrestaShop/PrestaShop/issues/16695**

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23587)
<!-- Reviewable:end -->
