### PR TITLE
Update phpstan-prestashop to 1.1.1, restore the usage of the extension

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9697,16 +9697,16 @@
         },
         {
             "name": "prestashop/phpstan-prestashop",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/phpstan-prestashop.git",
-                "reference": "e68212a2d5a2ad9e53f66960dae07f7a83b8f8c4"
+                "reference": "8935c0702980ed05ff9faf2f646d1df5be9effef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/phpstan-prestashop/zipball/e68212a2d5a2ad9e53f66960dae07f7a83b8f8c4",
-                "reference": "e68212a2d5a2ad9e53f66960dae07f7a83b8f8c4",
+                "url": "https://api.github.com/repos/PrestaShop/phpstan-prestashop/zipball/8935c0702980ed05ff9faf2f646d1df5be9effef",
+                "reference": "8935c0702980ed05ff9faf2f646d1df5be9effef",
                 "shasum": ""
             },
             "require": {
@@ -9714,6 +9714,7 @@
                 "phpstan/phpstan": "^0.12.48"
             },
             "require-dev": {
+                "nikic/php-parser": "^4.10",
                 "phpstan/phpstan-phpunit": "^0.12.16",
                 "phpstan/phpstan-strict-rules": "^0.12.5",
                 "phpunit/phpunit": "^7.5.20",
@@ -9749,9 +9750,9 @@
             "description": "PrestaShop extension for PHPStan",
             "support": {
                 "issues": "https://github.com/PrestaShop/phpstan-prestashop/issues",
-                "source": "https://github.com/PrestaShop/phpstan-prestashop/tree/1.1.0"
+                "source": "https://github.com/PrestaShop/phpstan-prestashop/tree/1.1.1"
             },
-            "time": "2021-03-04T09:09:27+00:00"
+            "time": "2021-03-09T21:54:31+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,8 @@ parameters:
 		- OrderInvoice
 		- Product
 
+includes:
+    - vendor/prestashop/phpstan-prestashop/extension.neon
 
 services:
   strictTypesForNewClassesRuleConfigurationFileLoader:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | phpstan-prestashop usage [was disabled](https://github.com/PrestaShop/PrestaShop/pull/23539) because of an issue in 1.1.0 . This PR updates the extension to 1.1.1 which contains the bugfixes to patch the situation.
| Type?             | new feature
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | PHPStan should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23590)
<!-- Reviewable:end -->
