### PR TITLE
Fix module page responsive bug on modal nav, close icon and icon height

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -73,6 +73,8 @@
 }
 
 .module-menu-readmore {
+  width: calc(100% + 2.8rem);
+  margin: 0 -1.4rem;
   margin-top: 2px;
 }
 
@@ -115,8 +117,13 @@
 
         img {
           width: 40px;
+          height: 40px;
           margin-right: 1rem;
         }
+      }
+
+      button.close {
+        padding: 0 1rem;
       }
     }
 

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -127,8 +127,12 @@
       }
     }
 
-    .tab-content {
+    .module-readmore-tab-content {
       padding: 0;
+    }
+
+    .tab-content {
+      padding: 5px 15px 35px;
     }
 
     .navbar {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There was some visual bug on module page modal on mobile such as nav pills, cross position and image height
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23598.
| How to test?      | Go on module catalog page, responsive mode, open a modal by clicking on "read more" and see if everything is fixed


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23599)
<!-- Reviewable:end -->
