### PR TITLE
Product shortcuts

### DIFF
--- a/admin-dev/themes/new-theme/js/components/navbar-handler.js
+++ b/admin-dev/themes/new-theme/js/components/navbar-handler.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+/**
+ * This component watches a navigation bar and is able to link it alternative links, and automatic switch
+ * on page load.
+ *
+ * You can add button with class tab-link when they are clicked the tab target is fetched
+ * from the button's data property targetTab (so data-target-tab), it then search for a tab
+ * which targets matches in the navbar and simulates a click on it.
+ *
+ * Alternatively it also checks on page load if a hash matches a tab and activates it if one is found,
+ * and of course the hash is kept in sync when the navbar or alternative links are used.
+ */
+export default class NavbarHandler {
+  constructor($navigationContainer) {
+    this.$navigationContainer = $navigationContainer;
+
+    this.watchNavbar();
+    this.watchTabLinks();
+    this.switchOnPageLoad();
+  }
+
+  switchToTab(target) {
+    if (!target) {
+      return;
+    }
+
+    const matchingTabs = $(`[href="${target}"]`, this.$navigationContainer);
+
+    if (matchingTabs.length <= 0) {
+      return;
+    }
+
+    const tabLink = matchingTabs.first();
+    tabLink.click();
+    this.updateBrowserHash(target);
+  }
+
+  updateBrowserHash(target) {
+    if (window.history.pushState) {
+      window.history.pushState(null, null, target);
+    } else {
+      window.location.hash = target;
+    }
+  }
+
+  watchNavbar() {
+    $(this.$navigationContainer).on('shown.bs.tab', (event) => {
+      if (event.target.hash) {
+        this.updateBrowserHash(event.target.hash);
+      }
+    });
+  }
+
+  watchTabLinks() {
+    $('.tab-link').click((event) => {
+      const target = $(event.target).data('targetTab');
+
+      if (!target) {
+        return;
+      }
+
+      this.switchToTab(`#${target}`);
+    });
+  }
+
+  switchOnPageLoad() {
+    const {hash} = document.location;
+    this.switchToTab(hash);
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.js
@@ -30,6 +30,7 @@ import FeatureValuesManager from '@pages/product/edit/feature-values-manager';
 import CustomizationsManager from '@pages/product/edit/customizations-manager';
 import ProductMap from '@pages/product/product-map';
 import ProductPartialUpdater from '@pages/product/edit/product-partial-updater';
+import NavbarHandler from '@components/navbar-handler';
 
 const {$} = window;
 
@@ -61,6 +62,8 @@ $(() => {
     },
     $('#product_preview').data('seo-url'),
   );
+
+  new NavbarHandler(ProductMap.navigationBar);
 
   // Init the product/category search field for redirection target
   const $redirectTypeInput = $(ProductMap.redirectOption.typeInput);

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.js
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.js
@@ -29,6 +29,7 @@ const productSupplierInputId = (supplierIndex, inputName) => `${productSuppliers
 export default {
   productForm: 'form[name=product]',
   productFormSubmitButton: 'button[name="product[save]"]',
+  navigationBar: '#form-nav',
   suppliers: {
     productSuppliersCollection: `${productSuppliersId}`,
     supplierIdsInput: '#product_suppliers_supplier_ids',

--- a/src/Adapter/Form/ChoiceProvider/TaxRuleGroupChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/TaxRuleGroupChoiceProvider.php
@@ -55,6 +55,11 @@ final class TaxRuleGroupChoiceProvider implements FormChoiceProviderInterface, F
     {
         $attrs = [];
         foreach ($this->getRules() as $rule) {
+            // Keep first one found
+            if (!empty($attrs[$rule['name']]['data-tax-rate'])) {
+                continue;
+            }
+
             $attrs[$rule['name']] = [
                 'data-tax-rate' => !empty($rule['rate']) ? $rule['rate'] : null,
             ];

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -355,8 +355,6 @@ final class GetProductForEditingHandler extends AbstractProductHandler implement
         $stockAvailable = $this->stockAvailableRepository->getForProduct(new ProductId($product->id));
 
         return new ProductStockInformation(
-            (bool) $product->advanced_stock_management,
-            (bool) $stockAvailable->depends_on_stock,
             (int) $product->pack_stock_type,
             (int) $stockAvailable->out_of_stock,
             (int) $stockAvailable->quantity,

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -31,9 +31,11 @@ namespace PrestaShop\PrestaShop\Adapter\Product\QueryHandler;
 use Customization;
 use DateTime;
 use Pack;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
 use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Repository\VirtualProductFileRepository;
+use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductCustomizabilitySettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
@@ -53,6 +55,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\QueryResult\VirtualProductFileForEditing;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractorException;
@@ -80,18 +83,34 @@ final class GetProductForEditingHandler extends AbstractProductHandler implement
     private $virtualProductFileRepository;
 
     /**
+     * @var TaxRulesGroupRepository
+     */
+    private $taxRulesGroupRepository;
+
+    /**
+     * @var int
+     */
+    private $countryId;
+
+    /**
      * @param NumberExtractor $numberExtractor
      * @param StockAvailableRepository $stockAvailableRepository
      * @param VirtualProductFileRepository $virtualProductFileRepository
+     * @param TaxRulesGroupRepository $taxRulesGroupRepository
+     * @param int $countryId
      */
     public function __construct(
         NumberExtractor $numberExtractor,
         StockAvailableRepository $stockAvailableRepository,
-        VirtualProductFileRepository $virtualProductFileRepository
+        VirtualProductFileRepository $virtualProductFileRepository,
+        TaxRulesGroupRepository $taxRulesGroupRepository,
+        int $countryId
     ) {
         $this->numberExtractor = $numberExtractor;
         $this->stockAvailableRepository = $stockAvailableRepository;
         $this->virtualProductFileRepository = $virtualProductFileRepository;
+        $this->taxRulesGroupRepository = $taxRulesGroupRepository;
+        $this->countryId = $countryId;
     }
 
     /**
@@ -153,8 +172,15 @@ final class GetProductForEditingHandler extends AbstractProductHandler implement
      */
     private function getPricesInformation(Product $product): ProductPricesInformation
     {
+        $priceTaxExcluded = $this->numberExtractor->extract($product, 'price');
+        $taxRulesGroup = $this->taxRulesGroupRepository->getTaxRulesGroupDetails(new TaxRulesGroupId((int) $product->id_tax_rules_group));
+        $countryTaxRate = $taxRulesGroup['rates_by_country'][$this->countryId] ?? 0;
+        $taxRatio = new DecimalNumber((string) (1 + ($countryTaxRate / 100)));
+        $priceTaxIncluded = $priceTaxExcluded->times($taxRatio);
+
         return new ProductPricesInformation(
-            $this->numberExtractor->extract($product, 'price'),
+            $priceTaxExcluded,
+            $priceTaxIncluded,
             $this->numberExtractor->extract($product, 'ecotax'),
             (int) $product->id_tax_rules_group,
             (bool) $product->on_sale,

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -174,7 +174,12 @@ final class GetProductForEditingHandler extends AbstractProductHandler implement
     {
         $priceTaxExcluded = $this->numberExtractor->extract($product, 'price');
         $taxRulesGroup = $this->taxRulesGroupRepository->getTaxRulesGroupDetails(new TaxRulesGroupId((int) $product->id_tax_rules_group));
-        $countryTaxRate = $taxRulesGroup['rates_by_country'][$this->countryId] ?? 0;
+        if (!empty($taxRulesGroup['rates'])) {
+            // Use the tax rate associated to context country, or the first one as fallback
+            $countryTaxRate = $taxRulesGroup['rates'][$this->countryId] ?? reset($taxRulesGroup['rates']);
+        } else {
+            $countryTaxRate = 0;
+        }
         $taxRatio = new DecimalNumber((string) (1 + ($countryTaxRate / 100)));
         $priceTaxIncluded = $priceTaxExcluded->times($taxRatio);
 

--- a/src/Core/Domain/Product/QueryResult/ProductPricesInformation.php
+++ b/src/Core/Domain/Product/QueryResult/ProductPricesInformation.php
@@ -43,6 +43,11 @@ class ProductPricesInformation
     /**
      * @var DecimalNumber
      */
+    private $priceTaxIncluded;
+
+    /**
+     * @var DecimalNumber
+     */
     private $ecotax;
 
     /**
@@ -77,6 +82,7 @@ class ProductPricesInformation
 
     /**
      * @param DecimalNumber $price
+     * @param DecimalNumber $priceTaxIncluded
      * @param DecimalNumber $ecotax
      * @param int $taxRulesGroupId
      * @param bool $onSale
@@ -87,6 +93,7 @@ class ProductPricesInformation
      */
     public function __construct(
         DecimalNumber $price,
+        DecimalNumber $priceTaxIncluded,
         DecimalNumber $ecotax,
         int $taxRulesGroupId,
         bool $onSale,
@@ -96,6 +103,7 @@ class ProductPricesInformation
         DecimalNumber $unitPriceRatio
     ) {
         $this->price = $price;
+        $this->priceTaxIncluded = $priceTaxIncluded;
         $this->ecotax = $ecotax;
         $this->taxRulesGroupId = $taxRulesGroupId;
         $this->onSale = $onSale;
@@ -111,6 +119,14 @@ class ProductPricesInformation
     public function getPrice(): DecimalNumber
     {
         return $this->price;
+    }
+
+    /**
+     * @return DecimalNumber
+     */
+    public function getPriceTaxIncluded(): DecimalNumber
+    {
+        return $this->priceTaxIncluded;
     }
 
     /**

--- a/src/Core/Domain/Product/QueryResult/ProductStockInformation.php
+++ b/src/Core/Domain/Product/QueryResult/ProductStockInformation.php
@@ -96,8 +96,6 @@ class ProductStockInformation
     private $availableDate;
 
     /**
-     * @param bool $useAdvancedStockManagement
-     * @param bool $dependsOnStock
      * @param int $packStockType
      * @param int $outOfStockType
      * @param int $quantity
@@ -110,8 +108,6 @@ class ProductStockInformation
      * @param DateTimeInterface|null $availableDate
      */
     public function __construct(
-        bool $useAdvancedStockManagement,
-        bool $dependsOnStock,
         int $packStockType,
         int $outOfStockType,
         int $quantity,
@@ -123,8 +119,6 @@ class ProductStockInformation
         string $location,
         ?DateTimeInterface $availableDate
     ) {
-        $this->useAdvancedStockManagement = $useAdvancedStockManagement;
-        $this->dependsOnStock = $dependsOnStock;
         $this->packStockType = $packStockType;
         $this->outOfStockType = $outOfStockType;
         $this->quantity = $quantity;

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -52,12 +52,28 @@ final class ProductFormDataProvider implements FormDataProviderInterface
     private $queryBus;
 
     /**
+     * @var bool
+     */
+    private $defaultProductActivation;
+
+    /**
+     * @var int
+     */
+    private $mostUsedTaxRulesGroupId;
+
+    /**
      * @param CommandBusInterface $queryBus
+     * @param bool $defaultProductActivation
+     * @param int $mostUsedTaxRulesGroupId
      */
     public function __construct(
-        CommandBusInterface $queryBus
+        CommandBusInterface $queryBus,
+        bool $defaultProductActivation,
+        int $mostUsedTaxRulesGroupId
     ) {
         $this->queryBus = $queryBus;
+        $this->defaultProductActivation = $defaultProductActivation;
+        $this->mostUsedTaxRulesGroupId = $mostUsedTaxRulesGroupId;
     }
 
     /**
@@ -97,6 +113,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
             'price' => [
                 'price_tax_excluded' => 0,
                 'price_tax_included' => 0,
+                'tax_rules_group_id' => $this->mostUsedTaxRulesGroupId,
                 'wholesale_price' => 0,
                 'unit_price' => 0,
             ],
@@ -106,6 +123,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
                 'depth' => 0,
                 'weight' => 0,
             ],
+            'activate' => $this->defaultProductActivation,
         ];
     }
 
@@ -209,8 +227,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
     {
         return [
             'price_tax_excluded' => (float) (string) $productForEditing->getPricesInformation()->getPrice(),
-            // @todo: we don't have the price tax included for now This should be computed by GetProductForEditing
-            'price_tax_included' => (float) (string) $productForEditing->getPricesInformation()->getPrice(),
+            'price_tax_included' => (float) (string) $productForEditing->getPricesInformation()->getPriceTaxIncluded(),
             'ecotax' => (float) (string) $productForEditing->getPricesInformation()->getEcotax(),
             'tax_rules_group_id' => $productForEditing->getPricesInformation()->getTaxRulesGroupId(),
             'on_sale' => $productForEditing->getPricesInformation()->isOnSale(),

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -142,6 +142,9 @@ final class ProductFormDataProvider implements FormDataProviderInterface
                 'price_tax_included' => $productData['price']['price_tax_included'],
                 'tax_rules_group_id' => $productData['price']['tax_rules_group_id'],
             ],
+            'stock' => [
+                'quantity' => $productData['stock']['quantity'],
+            ],
         ];
 
         return $productData;

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -68,7 +68,7 @@ final class ProductFormDataProvider implements FormDataProviderInterface
         /** @var ProductForEditing $productForEditing */
         $productForEditing = $this->queryBus->handle(new GetProductForEditing((int) $id));
 
-        return [
+        $productData = [
             'id' => $id,
             'basic' => $this->extractBasicData($productForEditing),
             'features' => $this->extractFeatureValues((int) $id),
@@ -81,6 +81,8 @@ final class ProductFormDataProvider implements FormDataProviderInterface
             'suppliers' => $this->extractSuppliersData($productForEditing),
             'customizations' => $this->extractCustomizationsData($productForEditing),
         ];
+
+        return $this->addShortcutData($productData);
     }
 
     /**
@@ -105,6 +107,26 @@ final class ProductFormDataProvider implements FormDataProviderInterface
                 'weight' => 0,
             ],
         ];
+    }
+
+    /**
+     * Returned product data with shortcut data that is picked from existing data.
+     *
+     * @param array $productData
+     *
+     * @return array
+     */
+    private function addShortcutData(array $productData): array
+    {
+        $productData['shortcuts'] = [
+            'price' => [
+                'price_tax_excluded' => $productData['price']['price_tax_excluded'],
+                'price_tax_included' => $productData['price']['price_tax_included'],
+                'tax_rules_group_id' => $productData['price']['tax_rules_group_id'],
+            ],
+        ];
+
+        return $productData;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -84,7 +84,6 @@ class EmailConfigurationType extends TranslatorAwareType
                     'class' => 'js-email-method',
                     'data-smtp-mail-method' => MailOption::METHOD_SMTP,
                 ],
-                'label' => false,
                 'expanded' => true,
                 'multiple' => false,
                 'choices' => $this->mailMethodChoiceProvider->getChoices(),
@@ -92,7 +91,6 @@ class EmailConfigurationType extends TranslatorAwareType
             ->add('mail_type', ChoiceType::class, [
                 'expanded' => true,
                 'multiple' => false,
-                'label' => false,
                 'choices' => [
                     $this->trans('Send email in HTML format', 'Admin.Advparameters.Feature') => MailOption::TYPE_HTML,
                     $this->trans('Send email in text format', 'Admin.Advparameters.Feature') => MailOption::TYPE_TXT,
@@ -102,8 +100,6 @@ class EmailConfigurationType extends TranslatorAwareType
             ->add('log_emails', SwitchType::class, [
                 'label' => $this->trans('Log Emails', 'Admin.Advparameters.Feature'),
             ])
-            ->add('smtp_config', SmtpConfigurationType::class, [
-                'label' => false,
-            ]);
+            ->add('smtp_config', SmtpConfigurationType::class);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicInformationType.php
@@ -76,17 +76,25 @@ class BasicInformationType extends TranslatorAwareType
                 ],
             ])
             ->add('description_short', TranslatableType::class, [
+                'required' => false,
                 'label' => $this->trans('Summary', 'Admin.Global'),
                 'type' => FormattedTextareaType::class,
                 'options' => [
                     'attr' => [
-                        'class' => 'serp-default-description',
+                        'class' => 'serp-default-description h2',
                     ],
+                ],
+                'label_attr' => [
+                    'title' => 'h2',
                 ],
             ])
             ->add('description', TranslatableType::class, [
+                'required' => false,
                 'label' => $this->trans('Description', 'Admin.Global'),
                 'type' => FormattedTextareaType::class,
+                'label_attr' => [
+                    'title' => 'h2',
+                ],
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/CustomizationFieldType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/CustomizationFieldType.php
@@ -83,7 +83,6 @@ class CustomizationFieldType extends TranslatorAwareType
                 'label' => $this->trans('Required', 'Admin.Global'),
             ])
             ->add('remove', IconButtonType::class, [
-                'label' => false,
                 'icon' => 'delete',
                 'attr' => [
                     'class' => 'text-secondary remove-customization-btn',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FeatureValueType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FeatureValueType.php
@@ -107,7 +107,6 @@ class FeatureValueType extends TranslatorAwareType
                 ],
             ])
             ->add('delete', IconButtonType::class, [
-                'label' => false,
                 'icon' => 'delete',
                 'attr' => [
                     'class' => 'tooltip-link delete-feature-value pl-0 pr-0',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -80,6 +80,7 @@ class ProductType extends TranslatorAwareType
             ->add('seo', SEOType::class)
             ->add('redirect_option', RedirectOptionType::class)
             ->add('suppliers', SuppliersType::class)
+            ->add('shortcuts', ShortcutsType::class)
             ->add('save', SubmitType::class, [
                 'label' => $this->trans('Save', 'Admin.Actions'),
                 'attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/PriceShortcutType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/PriceShortcutType.php
@@ -26,23 +26,17 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\Form\Admin\Sell\Product;
+namespace PrestaShopBundle\Form\Admin\Sell\Product\Shortcut;
 
 use Currency;
-use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
-/**
- * Form type containing price fields for Pricing tab
- */
-class PriceType extends TranslatorAwareType
+class PriceShortcutType extends ShortcutType
 {
     /**
      * @var array
@@ -86,7 +80,6 @@ class PriceType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            // @todo we should have DecimalType and MoneyDecimalType it was moved in a separate PR #22162
             ->add('price_tax_excluded', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Retail price (tax excl.)', 'Admin.Catalog.Feature'),
@@ -117,29 +110,8 @@ class PriceType extends TranslatorAwareType
                 ],
                 'label' => $this->trans('Tax rule', 'Admin.Catalog.Feature'),
             ])
-            ->add('on_sale', CheckboxType::class, [
-                'required' => false,
-                'label' => $this->trans(
-                    'Display the "On sale!" flag on the product page, and on product listings.',
-                    'Admin.Catalog.Feature'
-                ),
-            ])
-            ->add('wholesale_price', MoneyType::class, [
-                'required' => false,
-                'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
-                'currency' => $this->defaultCurrency->iso_code,
-            ])
-            ->add('unit_price', MoneyType::class, [
-                'required' => false,
-                'label' => $this->trans('Retail price per unit (tax excl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
-                'currency' => $this->defaultCurrency->iso_code,
-            ])
-            ->add('unity', TextType::class, [
-                'required' => false,
-                'attr' => ['placeholder' => $this->trans('Per kilo, per litre', 'Admin.Catalog.Help')],
-            ])
         ;
+
+        parent::buildForm($builder, $options);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/PriceShortcutType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/PriceShortcutType.php
@@ -112,6 +112,7 @@ class PriceShortcutType extends ShortcutType
             ])
         ;
 
+        // Call parent build to add potential target tab button
         parent::buildForm($builder, $options);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/ShortcutType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/ShortcutType.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product\Shortcut;
+
+use PrestaShopBundle\Form\Admin\Type\IconButtonType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * This base type for shortcut type is used to override the block prefix (which is useful
+ * for the form theme rendering) and offer additional options used for rendering as well.
+ */
+class ShortcutType extends TranslatorAwareType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+        if (empty($options['target_tab']) || empty($options['target_tab_name'])) {
+            return;
+        }
+
+        $builder->add('tab_button', IconButtonType::class, [
+            'label' => $options['target_tab_name'],
+            'icon' => 'open_in_new',
+            'attr' => [
+                'class' => 'btn btn-link px-0',
+                'href' => '#' . $options['target_tab'],
+            ],
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'target_tab' => null,
+            'target_tab_name' => null,
+        ]);
+        $resolver->setAllowedTypes('target_tab', ['string', 'null']);
+        $resolver->setAllowedTypes('target_tab_name', ['string', 'null']);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        parent::buildView($view, $form, $options);
+        $view->vars['target_tab'] = $options['target_tab'];
+        $view->vars['target_tab_name'] = $options['target_tab_name'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'shortcut';
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/ShortcutType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/ShortcutType.php
@@ -51,14 +51,16 @@ class ShortcutType extends TranslatorAwareType
             return;
         }
 
-        $builder->add('tab_button', IconButtonType::class, [
+        $options = [
             'label' => $options['target_tab_name'],
             'icon' => 'open_in_new',
             'attr' => [
-                'class' => 'btn btn-link px-0',
-                'href' => '#' . $options['target_tab'],
+                'class' => 'btn btn-link px-0 tab-link',
+                'data-target-tab' => $options['target_tab'],
             ],
-        ]);
+        ];
+
+        $builder->add('tab_button', IconButtonType::class, $options);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/StockShortcutType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/StockShortcutType.php
@@ -43,7 +43,7 @@ class StockShortcutType extends ShortcutType
         $builder
             ->add('quantity', NumberType::class, [
                 'required' => false,
-                'label' => null,
+                'label' => false,
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'numeric']),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/StockShortcutType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shortcut/StockShortcutType.php
@@ -26,14 +26,14 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\Form\Admin\Sell\Product;
+namespace PrestaShopBundle\Form\Admin\Sell\Product\Shortcut;
 
-use PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\PriceShortcutType;
-use PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\StockShortcutType;
-use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
 
-class ShortcutsType extends TranslatorAwareType
+class StockShortcutType extends ShortcutType
 {
     /**
      * {@inheritDoc}
@@ -41,18 +41,17 @@ class ShortcutsType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('stock', StockShortcutType::class, [
-                'label' => $this->trans('Quantity', 'Admin.Catalog.Feature'),
-                'help' => $this->trans('How many products should be available for sale?', 'Admin.Catalog.Help'),
-                'target_tab' => 'stock-tab',
-                'target_tab_name' => $this->trans('Quantity', 'Admin.Catalog.Feature'),
-            ])
-            ->add('price', PriceShortcutType::class, [
-                'label' => $this->trans('Price', 'Admin.Global'),
-                'help' => $this->trans('This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.', 'Admin.Catalog.Help'),
-                'target_tab' => 'pricing-tab',
-                'target_tab_name' => $this->trans('Pricing', 'Admin.Catalog.Feature'),
+            ->add('quantity', NumberType::class, [
+                'required' => false,
+                'label' => null,
+                'constraints' => [
+                    new NotBlank(),
+                    new Type(['type' => 'numeric']),
+                ],
             ])
         ;
+
+        // Call parent build to add potential target tab button
+        parent::buildForm($builder, $options);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ShortcutsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ShortcutsType.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product;
+
+use PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\PriceShortcutType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ShortcutsType extends TranslatorAwareType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('price', PriceShortcutType::class, [
+                'label' => $this->trans('Price', 'Admin.Global'),
+                'help' => $this->trans('This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select.', 'Admin.Catalog.Help'),
+                'target_tab' => 'pricing-tab',
+                'target_tab_name' => $this->trans('Pricing', 'Admin.Catalog.Feature'),
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
@@ -73,6 +73,7 @@ class StockType extends TranslatorAwareType
     {
         $builder
             ->add('quantity', NumberType::class, [
+                'required' => false,
                 'label' => $this->trans('Quantity', 'Admin.Catalog.Feature'),
                 'constraints' => [
                     new NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SuppliersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SuppliersType.php
@@ -88,7 +88,6 @@ class SuppliersType extends TranslatorAwareType
                 ],
             ])
             ->add('product_suppliers', CollectionType::class, [
-                'label' => false,
                 'entry_type' => ProductSupplierType::class,
                 'allow_add' => true,
                 'allow_delete' => true,

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -75,6 +75,8 @@ services:
             - '@prestashop.core.util.number.number_extractor'
             - '@prestashop.adapter.product.stock.repository.stock_available_repository'
             - '@prestashop.adapter.product.virtual_product.repository.virtual_product_file_repository'
+            - '@prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository'
+            - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_COUNTRY_DEFAULT')"
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing

--- a/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
@@ -34,3 +34,6 @@ services:
 
   prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository:
     class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository'
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1289,6 +1289,13 @@ services:
         tags:
             - { name: form.type }
 
+    form.type.sell.product.shortcut.stock_shortcut_type:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\StockShortcutType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
     form.type.sell.product.shipping_type:
         class: 'PrestaShopBundle\Form\Admin\Sell\Product\ShippingType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1271,6 +1271,24 @@ services:
       tags:
           - { name: form.type }
 
+    form.type.sell.product.shortcuts_type:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\ShortcutsType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        tags:
+            - { name: form.type }
+
+    form.type.sell.product.shortcut.price_shortcut_type:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\PriceShortcutType'
+        parent: 'form.type.translatable.aware'
+        public: true
+        arguments:
+            - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider").getChoices()'
+            - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider").getChoicesAttributes()'
+            - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency()'
+        tags:
+            - { name: form.type }
+
     form.type.sell.product.shipping_type:
         class: 'PrestaShopBundle\Form\Admin\Sell\Product\ShippingType'
         parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -153,3 +153,5 @@ services:
       class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ProductFormDataProvider'
       arguments:
           - '@prestashop.core.query_bus'
+          - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_PRODUCT_ACTIVATION_DEFAULT")'
+          - '@=service("prestashop.adapter.data_provider.tax").getIdTaxRulesGroupMostUsed()'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/features_form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/features_form_theme.html.twig
@@ -32,7 +32,7 @@
 
 {%- block feature_value_row -%}
   <div class="form-group row product-feature">
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-lg-12 col-xl-3">
       <fieldset class="form-group mb-0">
         <label class="form-control-label">{{ form.feature_id.vars.label }}</label>
         {{ form_widget(form.feature_id) }}
@@ -46,7 +46,7 @@
         {{ form_errors(form.feature_value_id) }}
       </fieldset>
     </div>
-    <div class="col-lg-11 col-xl-3">
+    <div class="col-lg-11 col-xl-4">
       <fieldset class="form-group mb-0">
         <label class="form-control-label">{{ form.custom_value.vars.label }}</label>
         {{ form_widget(form.custom_value_id) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/shortcut_tab_button_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/shortcut_tab_button_theme.html.twig
@@ -23,34 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{%- block shortcuts_row -%}
-  {% for child in form.children %}
-    <div class="{{ block('form_row_class') }} mb-3">
-      <div class="{{ block('form_group_class') }}">
-        {{ form_widget(child) }}
-      </div>
-    </div>
-  {% endfor %}
-{%- endblock %}
-
-{%- block shortcut_widget -%}
-  {#  Shortcut form type may add an automatically added tab_button which needs a special theme#}
-  {% for child in form.children %}
-    {% if child.vars.name == 'tab_button' %}
-      {% form_theme child '@PrestaShop/Admin/Sell/Catalog/Product/Form/shortcut_tab_button_theme.html.twig' %}
-    {% endif %}
-  {% endfor %}
-  <h2>
-    {{ form.vars.label }}
-    {{- block('form_help') -}}
-  </h2>
-
-  {{- block('form_widget_compound') -}}
-  {{ form_errors(form) }}
-{%- endblock %}
-
-{%- block form_help -%}
-  {% if help %}
-    <span class="help-box" data-toggle="popover" data-content="{{ help }}" data-original-title="" title=""></span>
-  {% endif %}
+{%- block icon_button_row -%}
+  <div class="col-md-12">
+      <span class="small font-secondary">
+        {{ 'Advanced settings in'|trans({}, 'Admin.Catalog.Help') }}
+        {{ form_widget(form) }}
+      </span>
+  </div>
 {%- endblock -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/shortcuts_form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/shortcuts_form_theme.html.twig
@@ -1,0 +1,59 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{%- block shortcuts_row -%}
+  {% for child in form.children %}
+    <div class="{{ block('form_row_class') }} mb-3">
+      <div class="{{ block('form_group_class') }}">
+        {{ form_widget(child) }}
+      </div>
+    </div>
+  {% endfor %}
+{%- endblock %}
+
+{%- block shortcut_widget -%}
+  <h2>
+    {{ form.vars.label }}
+    {{- block('form_help') -}}
+  </h2>
+
+  {{- block('form_widget_compound') -}}
+  {{ form_errors(form) }}
+{%- endblock %}
+
+{%- block icon_button_row -%}
+  <div class="col-md-12">
+      <span class="small font-secondary">
+        {{ 'Advanced settings in'|trans({}, 'Admin.Catalog.Help') }}
+        {{ form_widget(form) }}
+      </span>
+  </div>
+{%- endblock -%}
+
+{%- block form_help -%}
+  {% if help %}
+    <span class="help-box" data-toggle="popover" data-content="{{ help }}" data-original-title="" title=""></span>
+  {% endif %}
+{%- endblock -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/basic.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/basic.html.twig
@@ -28,7 +28,7 @@
 <div role="tabpanel" class="form-contenttab tab-pane container-fluid active" id="basic-tab">
   <div class="row">
     <div class="col-md-9 left-column">
-      {{ form_row(productForm.basic) }}
+      {{ form_widget(productForm.basic) }}
 
       {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/features.html.twig', {
         'productForm': productForm,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/basic.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/basic.html.twig
@@ -1,0 +1,41 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% form_theme productForm.shortcuts '@PrestaShop/Admin/Sell/Catalog/Product/Form/shortcuts_form_theme.html.twig' %}
+
+<div role="tabpanel" class="form-contenttab tab-pane container-fluid active" id="basic-tab">
+  <div class="row">
+    <div class="col-md-9 left-column">
+      {{ form_row(productForm.basic) }}
+
+      {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/features.html.twig', {
+        'productForm': productForm,
+      }) }}
+    </div>
+    <div class="col-md-3 right-column">
+      {{ form_row(productForm.shortcuts) }}
+    </div>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -53,13 +53,9 @@
 
     <div id="form_content" class="tab-content">
       {% block product_tab_basic %}
-        <div role="tabpanel" class="form-contenttab tab-pane container-fluid active" id="basic-tab">
-          {{ form_widget(productForm.basic) }}
-
-          {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/features.html.twig', {
-            'productForm': productForm,
-          }) }}
-        </div>
+        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/basic.html.twig', {
+          'productForm': productForm,
+        }) }}
       {% endblock %}
 
       {% block product_tab_stock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -36,7 +36,9 @@
 
 {% block form_label -%}
   {% spaceless %}
-    {% if label is same as(false) %}
+    {% if label is same as(null) or label_attr.title is defined %}
+      {# nothing #}
+    {% elseif label is same as(false) %}
       <div class="{{ block('form_label_class') }}"></div>
     {% else %}
       {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ block('form_label_class'))|trim}) %}
@@ -53,6 +55,12 @@
 
 {% block form_row -%}
   {% spaceless %}
+    {% if label_attr.title is defined %}
+      <{{ label_attr.title }}{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+      {{ label|raw }}
+      </{{ label_attr.title }}>
+    {% endif %}
+
     {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
     {% set multistoreCheckboxName = multistore_field_prefix ~ form.vars.name %}
     {% set disabledField = false %}
@@ -71,7 +79,6 @@
         {{ form_errors(form, {'attr': {'fieldError': true}}) }}
       </div>
     </div>
-
   {% endspaceless %}
 {%- endblock form_row %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -36,10 +36,10 @@
 
 {% block form_label -%}
   {% spaceless %}
-    {% if label is same as(null) or label_attr.title is defined %}
-      {# nothing #}
-    {% elseif label is same as(false) %}
+    {% if label is same as(null) %}
       <div class="{{ block('form_label_class') }}"></div>
+    {% elseif label is same as(false) %}
+      {# Use false as label is you don't want an empty column #}
     {% else %}
       {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ block('form_label_class'))|trim}) %}
       {{- parent() -}}
@@ -73,7 +73,10 @@
         {{ form_errors(attribute(form.parent, multistoreCheckboxName)) }}
         {{ form_widget(attribute(form.parent, multistoreCheckboxName)) }}
       {% endif %}
-      {{ form_label(form) }}
+
+      {% if label_attr.title is not defined %}
+        {{ form_label(form) }}
+      {% endif %}
       <div class="{{ block('form_group_class') }}{% if disabledField %} disabled{% endif %}">
         {{ form_widget(form) }}
         {{ form_errors(form, {'attr': {'fieldError': true}}) }}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
@@ -188,6 +188,7 @@ class UpdatePricesFeatureContext extends AbstractProductFeatureContext
     {
         $numberPriceFields = [
             'price',
+            'price_tax_included',
             'ecotax',
             'wholesale_price',
             'unit_price',

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -9,80 +9,85 @@ Feature: Update product price fields from Back Office (BO).
       | name[en-US] | magic staff |
       | is_virtual  | false       |
     And product product1 should have following prices information:
-      | price            | 0     |
-      | ecotax           | 0     |
-      | tax rules group  |       |
-      | on_sale          | false |
-      | wholesale_price  | 0     |
-      | unit_price       | 0     |
-      | unity            |       |
-      | unit_price_ratio | 0     |
+      | price              | 0     |
+      | price_tax_included | 0     |
+      | ecotax             | 0     |
+      | tax rules group    |       |
+      | on_sale            | false |
+      | wholesale_price    | 0     |
+      | unit_price         | 0     |
+      | unity              |       |
+      | unit_price_ratio   | 0     |
 
   Scenario: I update product prices
     And tax rules group named "US-AL Rate (4%)" exists
     When I update product "product1" prices with following information:
-      | price           | 100.99          |
-      | ecotax          | 0               |
-      | tax rules group | US-AL Rate (4%) |
-      | on_sale         | true            |
-      | wholesale_price | 70              |
-      | unit_price      | 900             |
-      | unity           | bag of ten      |
+      | price              | 100.99          |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
+      | unit_price         | 900             |
+      | unity              | bag of ten      |
     Then product product1 should have following prices information:
-      | price            | 100.99          |
-      | ecotax           | 0               |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | true            |
-      | wholesale_price  | 70              |
+      | price              | 100.99          |
+      | price_tax_included | 105.0296        |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
 #      #todo: rounding issue. #19620
 #      #| unit_price         | 900         |
-      | unity            | bag of ten      |
-      | unit_price_ratio | 0.112211        |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 0.112211        |
 
   Scenario: I partially update product prices, providing only those values which I want to update
     Given I update product "product1" prices with following information:
-      | price           | 100.99          |
-      | ecotax          | 0               |
-      | tax rules group | US-AL Rate (4%) |
-      | on_sale         | true            |
-      | wholesale_price | 70              |
-      | unit_price      | 900             |
-      | unity           | bag of ten      |
+      | price              | 100.99          |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
+      | unit_price         | 900             |
+      | unity              | bag of ten      |
     Given product product1 should have following prices information:
-      | price            | 100.99          |
-      | ecotax           | 0               |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | true            |
-      | wholesale_price  | 70              |
+      | price              | 100.99          |
+      | price_tax_included | 105.0296        |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
 #      #todo: rounding issue. #19620
 #      #| unit_price         | 900         |
-      | unity            | bag of ten      |
-      | unit_price_ratio | 0.112211        |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 0.112211        |
     When I update product "product1" prices with following information:
       | price | 200 |
     Then product product1 should have following prices information:
-      | price            | 200             |
-      | ecotax           | 0               |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | true            |
-      | wholesale_price  | 70              |
+      | price              | 200             |
+      | price_tax_included | 208             |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
 #        #todo: rounding issue. #19620
 #        #| unit_price         | 900         |
-      | unity            | bag of ten      |
-      | unit_price_ratio | 0.222222        |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 0.222222        |
     When I update product "product1" prices with following information:
       | ecotax  | 5.5   |
       | on_sale | false |
     Then product product1 should have following prices information:
-      | price            | 200             |
-      | ecotax           | 5.5             |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | false           |
-      | wholesale_price  | 70              |
+      | price              | 200             |
+      | price_tax_included | 208             |
+      | ecotax             | 5.5             |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | false           |
+      | wholesale_price    | 70              |
 #        #todo: rounding issue. #19620
 #        #| unit_price         | 900         |
-      | unity            | bag of ten      |
-      | unit_price_ratio | 0.222222        |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 0.222222        |
 
   Scenario: I update product prices with negative values
     Given I update product "product1" prices with following information:
@@ -94,14 +99,15 @@ Feature: Update product price fields from Back Office (BO).
       | unit_price      | 500             |
       | unity           | bag of ten      |
     And product product1 should have following prices information:
-      | price            | 50              |
-      | ecotax           | 3               |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | true            |
-      | wholesale_price  | 10              |
-      | unit_price       | 500             |
-      | unity            | bag of ten      |
-      | unit_price_ratio | 0.1             |
+      | price              | 50              |
+      | price_tax_included | 52              |
+      | ecotax             | 3               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 10              |
+      | unit_price         | 500             |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 0.1             |
     When I update product "product1" prices with following information:
       | price | -20 |
     Then I should get error that product "price" is invalid
@@ -115,14 +121,15 @@ Feature: Update product price fields from Back Office (BO).
       | unit_price | -300 |
     Then I should get error that product "unit_price" is invalid
     And product product1 should have following prices information:
-      | price            | 50              |
-      | ecotax           | 3               |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | true            |
-      | wholesale_price  | 10              |
-      | unit_price       | 500             |
-      | unity            | bag of ten      |
-      | unit_price_ratio | 0.1             |
+      | price              | 50              |
+      | price_tax_included | 52              |
+      | ecotax             | 3               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 10              |
+      | unit_price         | 500             |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 0.1             |
 
   Scenario: I update product unit price when product price is 0
     When I update product "product1" prices with following information:
@@ -131,30 +138,53 @@ Feature: Update product price fields from Back Office (BO).
       | price      | 0 |
       | unit_price | 0 |
     And product product1 should have following prices information:
-      | price            | 0     |
-      | ecotax           | 0     |
-      | tax rules group  |       |
-      | on_sale          | false |
-      | wholesale_price  | 0     |
-      | unit_price       | 0     |
-      | unity            |       |
-      | unit_price_ratio | 0     |
+      | price              | 0     |
+      | price_tax_included | 0     |
+      | ecotax             | 0     |
+      | tax rules group    |       |
+      | on_sale            | false |
+      | wholesale_price    | 0     |
+      | unit_price         | 0     |
+      | unity              |       |
+      | unit_price_ratio   | 0     |
 
   Scenario: I update product unit price along with product price
     When I update product "product1" prices with following information:
       | price      | 20  |
       | unit_price | 500 |
     Then product product1 should have following prices information:
-      | price            | 20   |
-      | unit_price       | 500  |
-      | unit_price_ratio | 0.04 |
+      | price              | 20   |
+      | price_tax_included | 20   |
+      | unit_price         | 500  |
+      | unit_price_ratio   | 0.04 |
     When I update product "product1" prices with following information:
       | price      | 0   |
       | unit_price | 500 |
     Then product product1 should have following prices information:
-      | price            | 0 |
-      | unit_price       | 0 |
-      | unit_price_ratio | 0 |
+      | price              | 0 |
+      | price_tax_included | 0 |
+      | unit_price         | 0 |
+      | unit_price_ratio   | 0 |
+
+  Scenario: I update product tax the price tax included is impacted
+    When I update product "product1" prices with following information:
+      | price      | 20  |
+    Then product product1 should have following prices information:
+      | price              | 20 |
+      | price_tax_included | 20 |
+      | tax rules group    |    |
+    When I update product "product1" prices with following information:
+      | tax rules group | US-AL Rate (4%) |
+    Then product product1 should have following prices information:
+      | price              | 20              |
+      | price_tax_included | 20.80           |
+      | tax rules group    | US-AL Rate (4%) |
+    When I update product "product1" prices with following information:
+      | tax rules group | US-FL Rate (6%) |
+    Then product product1 should have following prices information:
+      | price              | 20              |
+      | price_tax_included | 21.20           |
+      | tax rules group    | US-FL Rate (6%) |
 
   Scenario: I update product prices providing non-existing tax rules group
     Given I update product "product1" prices with following information:

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -783,6 +783,13 @@ class ProductFormDataProviderTest extends TestCase
             'suppliers' => [],
             'features' => [],
             'customizations' => [],
+            'shortcuts' => [
+                'price' => [
+                    'price_tax_excluded' => 19.86,
+                    'price_tax_included' => 19.86,
+                    'tax_rules_group_id' => 1,
+                ],
+            ],
         ];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -74,7 +74,7 @@ class ProductFormDataProviderTest extends TestCase
     public function testGetDefaultData()
     {
         $queryBusMock = $this->createMock(CommandBusInterface::class);
-        $provider = new ProductFormDataProvider($queryBusMock);
+        $provider = new ProductFormDataProvider($queryBusMock, false, 42);
 
         $expectedDefaultData = [
             'basic' => [
@@ -83,6 +83,7 @@ class ProductFormDataProviderTest extends TestCase
             'price' => [
                 'price_tax_excluded' => 0,
                 'price_tax_included' => 0,
+                'tax_rules_group_id' => 42,
                 'wholesale_price' => 0,
                 'unit_price' => 0,
             ],
@@ -92,6 +93,32 @@ class ProductFormDataProviderTest extends TestCase
                 'depth' => 0,
                 'weight' => 0,
             ],
+            'activate' => false,
+        ];
+
+        $defaultData = $provider->getDefaultData();
+        $this->assertEquals($expectedDefaultData, $defaultData);
+
+        $provider = new ProductFormDataProvider($queryBusMock, true, 42);
+
+        $expectedDefaultData = [
+            'basic' => [
+                'type' => ProductType::TYPE_STANDARD,
+            ],
+            'price' => [
+                'price_tax_excluded' => 0,
+                'price_tax_included' => 0,
+                'tax_rules_group_id' => 42,
+                'wholesale_price' => 0,
+                'unit_price' => 0,
+            ],
+            'shipping' => [
+                'width' => 0,
+                'height' => 0,
+                'depth' => 0,
+                'weight' => 0,
+            ],
+            'activate' => true,
         ];
 
         $defaultData = $provider->getDefaultData();
@@ -107,7 +134,7 @@ class ProductFormDataProviderTest extends TestCase
     public function testGetData(array $productData, array $expectedData)
     {
         $queryBusMock = $this->createQueryBusMock($productData);
-        $provider = new ProductFormDataProvider($queryBusMock);
+        $provider = new ProductFormDataProvider($queryBusMock, false, 42);
 
         $formData = $provider->getData(static::PRODUCT_ID);
         $this->assertEquals($expectedData, $formData);
@@ -623,6 +650,7 @@ class ProductFormDataProviderTest extends TestCase
     {
         return new ProductPricesInformation(
             $product['price'] ?? new DecimalNumber('19.86'),
+            $product['price_tax_included'] ?? new DecimalNumber('23.832'),
             $product['ecotax'] ?? new DecimalNumber('19.86'),
             $product['id_tax_rules_group'] ?? 1,
             $product['on_sale'] ?? false,
@@ -737,7 +765,7 @@ class ProductFormDataProviderTest extends TestCase
             ],
             'price' => [
                 'price_tax_excluded' => 19.86,
-                'price_tax_included' => 19.86,
+                'price_tax_included' => 23.832,
                 'ecotax' => 19.86,
                 'tax_rules_group_id' => 1,
                 'on_sale' => false,
@@ -786,7 +814,7 @@ class ProductFormDataProviderTest extends TestCase
             'shortcuts' => [
                 'price' => [
                     'price_tax_excluded' => 19.86,
-                    'price_tax_included' => 19.86,
+                    'price_tax_included' => 23.832,
                     'tax_rules_group_id' => 1,
                 ],
             ],

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
 
+use DateTime;
 use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -149,6 +150,8 @@ class ProductFormDataProviderTest extends TestCase
             $this->getDatasetsForProductSuppliers(),
             $this->getDataSetsForFeatures(),
             $this->getDatasetsForCustomizations(),
+            $this->getDatasetsForPrices(),
+            $this->getDatasetsForStock(),
         ];
 
         foreach ($datasetsByType as $datasetByType) {
@@ -217,6 +220,110 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData['basic']['type'] = ProductType::TYPE_COMBINATION;
         $expectedOutputData['basic']['description'] = $localizedValues;
         $expectedOutputData['basic']['description_short'] = $localizedValues;
+
+        $datasets[] = [
+            $productData,
+            $expectedOutputData,
+        ];
+
+        return $datasets;
+    }
+
+    /**
+     * @return array
+     */
+    private function getDatasetsForPrices(): array
+    {
+        $datasets = [];
+
+        $expectedOutputData = $this->getDefaultOutputData();
+        $productData = [];
+
+        $datasets[] = [
+            $productData,
+            $expectedOutputData,
+        ];
+
+        $expectedOutputData = $this->getDefaultOutputData();
+        $productData = [
+            'price_tax_excluded' => new DecimalNumber('42.00'),
+            'price_tax_included' => new DecimalNumber('50.40'),
+            'ecotax' => new DecimalNumber('69.51'),
+            'tax_rules_group_id' => 49,
+            'on_sale' => true,
+            'wholesale_price' => new DecimalNumber('66.56'),
+            'unit_price' => new DecimalNumber('6.656'),
+            'unity' => 'candies',
+            'unit_price_ratio' => new DecimalNumber('5'),
+        ];
+        $expectedOutputData['price']['price_tax_excluded'] = 42.00;
+        $expectedOutputData['price']['price_tax_included'] = 50.40;
+        $expectedOutputData['price']['ecotax'] = 69.51;
+        $expectedOutputData['price']['tax_rules_group_id'] = 49;
+        $expectedOutputData['price']['on_sale'] = true;
+        $expectedOutputData['price']['wholesale_price'] = 66.56;
+        $expectedOutputData['price']['unit_price'] = 6.656;
+        $expectedOutputData['price']['unity'] = 'candies';
+
+        // Not handled yet
+        // $expectedOutputData['price']['unit_price_ratio'] = 5;
+
+        $expectedOutputData['shortcuts']['price']['price_tax_excluded'] = 42.00;
+        $expectedOutputData['shortcuts']['price']['price_tax_included'] = 50.40;
+        $expectedOutputData['shortcuts']['price']['tax_rules_group_id'] = 49;
+
+        $datasets[] = [
+            $productData,
+            $expectedOutputData,
+        ];
+
+        return $datasets;
+    }
+
+    /**
+     * @return array
+     */
+    private function getDatasetsForStock(): array
+    {
+        $datasets = [];
+
+        $expectedOutputData = $this->getDefaultOutputData();
+        $productData = [];
+
+        $datasets[] = [
+            $productData,
+            $expectedOutputData,
+        ];
+
+        $localizedValues = [
+            1 => 'english',
+            2 => 'french',
+        ];
+        $expectedOutputData = $this->getDefaultOutputData();
+        $productData = [
+            'pack_stock_type' => PackStockType::STOCK_TYPE_PACK_ONLY,
+            'out_of_stock' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+            'quantity' => 42,
+            'minimal_quantity' => 7,
+            'low_stock_threshold' => 5,
+            'low_stock_alert' => true,
+            'available_now' => $localizedValues,
+            'available_later' => $localizedValues,
+            'location' => 'top shelf',
+            'available_date' => new DateTime('1969/07/20'),
+        ];
+        $expectedOutputData['stock']['pack_stock_type'] = PackStockType::STOCK_TYPE_PACK_ONLY;
+        $expectedOutputData['stock']['out_of_stock_type'] = OutOfStockType::OUT_OF_STOCK_AVAILABLE;
+        $expectedOutputData['stock']['quantity'] = 42;
+        $expectedOutputData['stock']['minimal_quantity'] = 7;
+        $expectedOutputData['stock']['low_stock_threshold'] = 5;
+        $expectedOutputData['stock']['low_stock_alert'] = true;
+        $expectedOutputData['stock']['available_now_label'] = $localizedValues;
+        $expectedOutputData['stock']['available_later_label'] = $localizedValues;
+        $expectedOutputData['stock']['stock_location'] = 'top shelf';
+        $expectedOutputData['stock']['available_date'] = '1969-07-20';
+
+        $expectedOutputData['shortcuts']['stock']['quantity'] = 42;
 
         $datasets[] = [
             $productData,
@@ -555,8 +662,6 @@ class ProductFormDataProviderTest extends TestCase
     private function createProductStockInformation(array $product): ProductStockInformation
     {
         return new ProductStockInformation(
-            $product['advanced_stock_management'] ?? false,
-            $product['depends_on_stock'] ?? false,
             $product['pack_stock_type'] ?? PackStockType::STOCK_TYPE_DEFAULT,
             $product['out_of_stock'] ?? OutOfStockType::OUT_OF_STOCK_DEFAULT,
             $product['quantity'] ?? static::DEFAULT_QUANTITY,
@@ -649,10 +754,10 @@ class ProductFormDataProviderTest extends TestCase
     private function createPricesInformation(array $product): ProductPricesInformation
     {
         return new ProductPricesInformation(
-            $product['price'] ?? new DecimalNumber('19.86'),
+            $product['price_tax_excluded'] ?? new DecimalNumber('19.86'),
             $product['price_tax_included'] ?? new DecimalNumber('23.832'),
             $product['ecotax'] ?? new DecimalNumber('19.86'),
-            $product['id_tax_rules_group'] ?? 1,
+            $product['tax_rules_group_id'] ?? 1,
             $product['on_sale'] ?? false,
             $product['wholesale_price'] ?? new DecimalNumber('19.86'),
             $product['unit_price'] ?? new DecimalNumber('19.86'),
@@ -816,6 +921,9 @@ class ProductFormDataProviderTest extends TestCase
                     'price_tax_excluded' => 19.86,
                     'price_tax_included' => 23.832,
                     'tax_rules_group_id' => 1,
+                ],
+                'stock' => [
+                    'quantity' => static::DEFAULT_QUANTITY,
                 ],
             ],
         ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In this PR we add some of the shortcuts fields in the Product form 
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23602)
<!-- Reviewable:end -->


# PR changes

The PR includes a few little modifications that were needed for the correct integration of "Shortcuts" feature, here are a few new features:

## ShortcutType

This is a new base type to use in forms, it's a simple Form container for extra shortcut (it needs to be extended) that are then added in the `ShortcutsType`. Then the page theme automatically display them appropriately thanks to a dedicated form theme.

Besides the automatic theme that `ShortcutType` provides you can also define a link to an alternative Tab in the page (since shortcut are related to existing inputs in other tabs), it is configurable (but not required) thanks to the `target_tab` and `target_tab_name` options.

```php
$builder
            ->add('stock', StockShortcutType::class, [
                'label' => $this->trans('Quantity', 'Admin.Catalog.Feature'),
                'help' => $this->trans('How many products should be available for sale?', 'Admin.Catalog.Help'),
                'target_tab' => 'stock-tab',
                'target_tab_name' => $this->trans('Quantity', 'Admin.Catalog.Feature'),
            ])
;
```

Which will result in automatically adding a button to the `ShortcutType` children which will be displayed after the other inputs:

![Capture d’écran 2021-02-26 à 19 42 38](https://user-images.githubusercontent.com/13801017/109341520-d1673300-786a-11eb-8e51-6f78386f3695.png)

## Other changes

### Tab switching component

To handle the shortcut links a small component was required so that a click on the button activates the appropriate tab. This is handled by the `NavbarHandler` component which can, potentially, be reused in other pages since it only requires the navigation div as an input.

It also handles the automatic update of a hashtag in the browser address which allows to automatically display the previous tab when the form is submitted.

### Improved form data

The `GetProductForEditing` query now returns the price with tax included, it is computed based on the price tax excluded and the assigned Tax rules group (of course the form provider was adapted to handle this so now the form is correctly pre-filled).

To handle the shortcuts data a sub array is also built for the new FormTypes, it simply copies the already present data in the right place to match the form structure.

### Prestashop UI theme

A small improvement was added in the `prestashop_ui_kit.html.twig` theme:

- **label**: we had the possibility to put an empty label but there was always an empty div that was inserted to keep the "left column" present and avoid creating an offset a the fields list. But sometimes (like for shortcut) we want to get rid of this extra div so now using `'label' => false,` will remove this div (the previous behaviour with empty dic is still possible with `'label' => null,` which is the default value when no label is set)
- **title label** some field required a header `h2` instead of a small label it is now configurable in the form by setting this option `['label_attr' => ['title' => 'h2']]` (the value is used to create the header tag, so any `h*` is usable, or even other tags)