### PR TITLE
Fix shadow of right sidebar on responsive

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -33,7 +33,7 @@ const bourbon = require('bourbon');
 
 module.exports = {
   externals: {
-    jquery: 'jQuery',
+    jquery: 'jQuery'
   },
   entry: {
     address: './js/pages/address',
@@ -109,7 +109,7 @@ module.exports = {
     orders: './scss/pages/orders/orders.scss',
     product: './scss/pages/product/product_page.scss',
     product_catalog: './scss/pages/product/products_catalog.scss',
-    stock_page: './scss/pages/stock/stock_page.scss',
+    stock_page: './scss/pages/stock/stock_page.scss'
   },
   output: {
     path: path.resolve(__dirname, '../public'),
@@ -118,7 +118,7 @@ module.exports = {
     library: '[name]',
 
     sourceMapFilename: '[name].[hash:8].map',
-    chunkFilename: '[id].[hash:8].js',
+    chunkFilename: '[id].[hash:8].js'
   },
   resolve: {
     extensions: ['.js', '.vue', '.json'],
@@ -130,8 +130,8 @@ module.exports = {
       '@components': path.resolve(__dirname, '../js/components'),
       '@scss': path.resolve(__dirname, '../scss'),
       '@node_modules': path.resolve(__dirname, '../node_modules'),
-      '@vue': path.resolve(__dirname, '../js/vue'),
-    },
+      '@vue': path.resolve(__dirname, '../js/vue')
+    }
   },
   module: {
     rules: [
@@ -143,68 +143,68 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               presets: [['env', {useBuiltIns: 'usage', modules: false}]],
-              plugins: ['transform-object-rest-spread', 'transform-runtime'],
-            },
-          },
-        ],
+              plugins: ['transform-object-rest-spread', 'transform-runtime']
+            }
+          }
+        ]
       },
       {
         test: /jquery-ui\.js/,
-        use: 'imports-loader?define=>false&this=>window',
+        use: 'imports-loader?define=>false&this=>window'
       },
       {
         test: /jquery\.magnific-popup\.js/,
-        use: 'imports-loader?define=>false&exports=>false&this=>window',
+        use: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bloodhound\.min\.js/,
         use: [
           {
             loader: 'expose-loader',
-            query: 'Bloodhound',
-          },
-        ],
+            query: 'Bloodhound'
+          }
+        ]
       },
       {
         test: /dropzone\/dist\/dropzone\.js/,
-        loader: 'imports-loader?this=>window&module=>null',
+        loader: 'imports-loader?this=>window&module=>null'
       },
       {
         test: require.resolve('moment'),
-        loader: 'imports-loader?define=>false&this=>window',
+        loader: 'imports-loader?define=>false&this=>window'
       },
       {
         test: /typeahead\.jquery\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bootstrap-tokenfield\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bootstrap-datetimepicker\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /bootstrap-colorpicker\.js/,
-        loader: 'imports-loader?define=>false&exports=>false&this=>window',
+        loader: 'imports-loader?define=>false&exports=>false&this=>window'
       },
       {
         test: /jwerty\/jwerty\.js/,
-        loader: 'imports-loader?this=>window&module=>false',
+        loader: 'imports-loader?this=>window&module=>false'
       },
       {
         test: /\.vue$/,
-        loader: 'vue-loader',
+        loader: 'vue-loader'
       },
       {
         test: /\.css$/,
         use: [
           {
-            loader: MiniCssExtractPlugin.loader,
+            loader: MiniCssExtractPlugin.loader
           },
-          'css-loader',
-        ],
+          'css-loader'
+        ]
       },
       {
         test: /\.scss$/,
@@ -215,50 +215,50 @@ module.exports = {
           {
             loader: 'css-loader',
             options: {
-              sourceMap: true,
-            },
+              sourceMap: true
+            }
           },
           {
             loader: 'postcss-loader',
             options: {
-              sourceMap: true,
-            },
+              sourceMap: true
+            }
           },
           {
             loader: 'sass-loader',
             options: {
               sourceMap: true,
               sassOptions: {
-                includePaths: [bourbon.includePaths],
-              },
-            },
-          },
-        ],
+                includePaths: [bourbon.includePaths]
+              }
+            }
+          }
+        ]
       },
       {
         test: /\.scss$/,
         include: /js/,
-        use: ['vue-style-loader', 'css-loader', 'sass-loader'],
+        use: ['vue-style-loader', 'css-loader', 'sass-loader']
       },
       // FILES
       {
         test: /.(jpg|png|woff2?|eot|otf|ttf|svg|gif)$/,
-        loader: 'file-loader?name=[hash].[ext]',
-      },
-    ],
+        loader: 'file-loader?name=[hash].[ext]'
+      }
+    ]
   },
   plugins: [
     new FixStyleOnlyEntriesPlugin(),
     new CleanWebpackPlugin({
-      cleanOnceBeforeBuildPatterns: ['!theme.rtlfix'],
+      cleanOnceBeforeBuildPatterns: ['!theme.rtlfix']
     }),
     new MiniCssExtractPlugin({filename: '[name].css'}),
     new webpack.ProvidePlugin({
       moment: 'moment', // needed for bootstrap datetime picker
       $: 'jquery', // needed for jquery-ui
-      jQuery: 'jquery',
+      jQuery: 'jquery'
     }),
     new CopyPlugin([{from: 'static'}]),
-    new VueLoaderPlugin(),
-  ],
+    new VueLoaderPlugin()
+  ]
 };

--- a/admin-dev/themes/new-theme/js/components/translations.js
+++ b/admin-dev/themes/new-theme/js/components/translations.js
@@ -1,0 +1,10 @@
+export default async function getTranslations() {
+  try {
+    const response = await fetch(window.data.translationUrl);
+    const datas = response.json();
+
+    return datas;
+  } catch (error) {
+    return error;
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -1,0 +1,53 @@
+<!--**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *-->
+<template>
+  <div class="dropzone">
+
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'Dropzone',
+    computed: {
+    },
+    mounted() {
+    },
+    methods: {
+    },
+    data() {
+      return {
+        
+      }
+    },
+    components: {
+    },
+  };
+</script>
+
+<style lang="scss" type="text/scss">
+  @import '~@scss/config/_settings.scss';
+
+</style>

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/index.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+import Vue from 'vue';
+import Dropzone from './Dropzone.vue';
+
+new Vue({
+  el: '.dropzone',
+  template: '<dropzone />',
+  components: {Dropzone}
+});

--- a/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
@@ -9,7 +9,10 @@
   padding: 0 3em 0 0;
   overflow: auto;
   background: #fff;
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+
+  &.sidebar-open {
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+  }
 
   .quicknav-container {
     height: 100%;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is a visible shadow when right sidebar is closed on the backoffice on mobile
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on the bo on a migrated page, on mobile mode, the box shadow shouldn't be visible
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

![image](https://user-images.githubusercontent.com/14963751/110771607-fb512a00-825a-11eb-97f8-cf0394a399f9.png)

Box shadow on the right of the screen is wrong


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23607)
<!-- Reviewable:end -->
