### PR TITLE
Fix shadow of right sidebar on responsive

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
@@ -9,7 +9,10 @@
   padding: 0 3em 0 0;
   overflow: auto;
   background: #fff;
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+
+  &.sidebar-open {
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+  }
 
   .quicknav-container {
     height: 100%;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is a visible shadow when right sidebar is closed on the backoffice on mobile
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on the bo on a migrated page, on mobile mode, the box shadow shouldn't be visible
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

![image](https://user-images.githubusercontent.com/14963751/110771607-fb512a00-825a-11eb-97f8-cf0394a399f9.png)

Box shadow on the right of the screen is wrong


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23607)
<!-- Reviewable:end -->
