### PR TITLE
FIX bug get Fields (show_condition)

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -717,7 +717,7 @@ class ProductCore extends ObjectModel
             $this->price = Product::getPriceStatic((int) $this->id, false, null, 6, null, false, true, 1, false, null, null, null, $this->specificPrice);
             $this->unit_price = ($this->unit_price_ratio != 0 ? $this->price / $this->unit_price_ratio : 0);
             $this->tags = Tag::getProductTags((int) $this->id);
-
+            $this->show_condition = $this->getShowCondition($id_product); //Temporary Solution to be removed later
             $this->loadStockData();
         }
 
@@ -726,6 +726,16 @@ class ProductCore extends ObjectModel
         }
     }
 
+    /**
+     * Temporary Solution to be removed later
+     * 
+     */
+    public function getShowCondition($id_product) {
+        $sql = 'SELECT `show_condition`
+        FROM `' . _DB_PREFIX_ . 'product`
+        WHERE `id_product` = ' . (int) $id_product;
+        return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
     /**
      * @see ObjectModel::getFieldsShop()
      *


### PR DESCRIPTION
some attributes return the default declared value. For example show_condition return 0 always
#23628

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | some attributes return the default declared value. For example show_condition return 0 always
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #23628
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23629)
<!-- Reviewable:end -->
