### PR TITLE
Fix "Trying to access array offset on value of type ..." error for legacy creation forms

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -104,7 +104,11 @@
 									<div class="form-group">
 									{/if}
 									{foreach $languages as $language}
-										{assign var='value_text' value=$fields_value[$input.name][$language.id_lang]}
+                    {if is_array($fields_value[$input.name]) AND isset($fields_value[$input.name][$language.id_lang])}
+                      {assign var='value_text' value=$fields_value[$input.name][$language.id_lang]}
+                    {else}
+                      {assign var='value_text' value=''}
+                    {/if}
 										{if $languages|count > 1}
 										<div class="translatable-field lang-{$language.id_lang}" {if $language.id_lang != $defaultFormLanguage}style="display:none"{/if}>
 											<div class="col-lg-9">

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -104,7 +104,7 @@
 									<div class="form-group">
 									{/if}
 									{foreach $languages as $language}
-                    {if is_array($fields_value[$input.name]) AND isset($fields_value[$input.name][$language.id_lang])}
+                    {if isset($fields_value[$input.name][$language.id_lang])}
                       {assign var='value_text' value=$fields_value[$input.name][$language.id_lang]}
                     {else}
                       {assign var='value_text' value=''}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In PHP 7.4, in legacy creation forms where is language fields, some controllers don't give an array as a value, but something else instead and this causes "Trying to access array offset on the value of type ..." if this try to access value as an array using language ID. Added `is_array` check for value and also `isset` check does language value exist.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23428.
| How to test?      | Try to reproduce errors/warnings that are shown inside linked issue (carrier and order return states).
| Possible impacts? | Shouldn't give any impact, just bugfix.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23630)
<!-- Reviewable:end -->
