### PR TITLE
Clean all dependencies between PrestaShopBundle and Core

### DIFF
--- a/src/Core/Language/LanguageRepositoryInterface.php
+++ b/src/Core/Language/LanguageRepositoryInterface.php
@@ -26,11 +26,13 @@
 
 namespace PrestaShop\PrestaShop\Core\Language;
 
+use Doctrine\Persistence\ObjectRepository;
+
 /**
  * Interface LanguageRepositoryInterface allows to fetch a LanguageInterface
  * via different methods.
  */
-interface LanguageRepositoryInterface
+interface LanguageRepositoryInterface extends ObjectRepository
 {
     /**
      * Returns a LanguageInterface whose locale matches the provided one.

--- a/src/Core/Translation/Exception/InvalidLegacyTranslationKeyException.php
+++ b/src/Core/Translation/Exception/InvalidLegacyTranslationKeyException.php
@@ -28,30 +28,25 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Exception;
 
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use Throwable;
+
 /**
  * Thrown when an invalid key is found in a legacy translation file
  */
-class InvalidLegacyTranslationKeyException extends \Exception
+class InvalidLegacyTranslationKeyException extends CoreException
 {
     /**
      * @var string The invalid key
      */
-    private $key = '';
+    private $key;
 
-    /**
-     * @param string $missingElement The missing element
-     * @param string $key The offending key
-     *
-     * @return InvalidLegacyTranslationKeyException
-     */
-    public static function missingElementFromKey(string $missingElement, string $key): self
+    public function __construct(string $missingElement, string $key, $code = 0, Throwable $previous = null)
     {
-        $instance = new self(
-            sprintf('Invalid key in legacy translation file: "%s" (missing %s)', $key, $missingElement)
-        );
-        $instance->setKey($key);
+        $message = sprintf('Invalid key in legacy translation file: "%s" (missing %s)', $key, $missingElement);
+        $this->key = $key;
 
-        return $instance;
+        parent::__construct($message, $code, $previous);
     }
 
     /**
@@ -60,13 +55,5 @@ class InvalidLegacyTranslationKeyException extends \Exception
     public function getKey(): string
     {
         return $this->key;
-    }
-
-    /**
-     * @param string $key
-     */
-    private function setKey(string $key)
-    {
-        $this->key = $key;
     }
 }

--- a/src/Core/Translation/Exception/InvalidLegacyTranslationKeyException.php
+++ b/src/Core/Translation/Exception/InvalidLegacyTranslationKeyException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,35 +24,49 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+declare(strict_types=1);
 
-namespace PrestaShopBundle\Entity\Repository;
+namespace PrestaShop\PrestaShop\Core\Translation\Exception;
 
-use Doctrine\ORM\EntityRepository;
-use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
-
-class TranslationRepository extends EntityRepository implements TranslationRepositoryInterface
+/**
+ * Thrown when an invalid key is found in a legacy translation file
+ */
+class InvalidLegacyTranslationKeyException extends \Exception
 {
     /**
-     * @param string $language
-     * @param string $theme
-     *
-     * @return array
+     * @var string The invalid key
      */
-    public function findByLanguageAndTheme($language, $theme = null)
+    private $key = '';
+
+    /**
+     * @param string $missingElement The missing element
+     * @param string $key The offending key
+     *
+     * @return InvalidLegacyTranslationKeyException
+     */
+    public static function missingElementFromKey(string $missingElement, string $key): self
     {
-        $queryBuilder = $this->createQueryBuilder('t');
-        $queryBuilder->where('lang = :language');
-        $queryBuilder->setParameter('language', $language);
+        $instance = new self(
+            sprintf('Invalid key in legacy translation file: "%s" (missing %s)', $key, $missingElement)
+        );
+        $instance->setKey($key);
 
-        if (null !== $theme) {
-            $queryBuilder->andWhere('theme = :theme');
-            $queryBuilder->setParameter('theme', $theme);
-        } else {
-            $queryBuilder->andWhere('theme IS NULL');
-        }
+        return $instance;
+    }
 
-        $query = $queryBuilder->getQuery();
+    /**
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
 
-        return $query->getResult();
+    /**
+     * @param string $key
+     */
+    private function setKey(string $key)
+    {
+        $this->key = $key;
     }
 }

--- a/src/Core/Translation/Exception/UnsupportedLocaleException.php
+++ b/src/Core/Translation/Exception/UnsupportedLocaleException.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Exception;
+
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
+
+/**
+ * Will be thrown if a locale is not supported in Legacy format
+ */
+final class UnsupportedLocaleException extends NotFoundResourceException
+{
+    /**
+     * @param string $filePath the expected file path of the translations
+     * @param string $locale the translation locale
+     *
+     * @return self
+     */
+    public static function fileNotFound(string $filePath, string $locale): self
+    {
+        $exceptionMessage = sprintf(
+            'The locale "%s" is not supported, because we can\'t find the related file in the module:
+            have you created the file "%s"?',
+            $locale,
+            $filePath
+        );
+
+        return new self($exceptionMessage);
+    }
+
+    /**
+     * @param string $locale the translation locale
+     *
+     * @return self
+     */
+    public static function invalidLocale($locale)
+    {
+        $exceptionMessage = sprintf(
+            'The provided locale `%s` is invalid.',
+            $locale
+        );
+
+        return new self($exceptionMessage);
+    }
+}

--- a/src/Core/Translation/Locale/Converter.php
+++ b/src/Core/Translation/Locale/Converter.php
@@ -44,7 +44,7 @@ final class Converter
     /**
      * @param string $translationsMappingFile
      */
-    public function __construct($translationsMappingFile)
+    public function __construct(string $translationsMappingFile)
     {
         $this->translationsMappingFile = $translationsMappingFile;
     }
@@ -53,8 +53,10 @@ final class Converter
      * @var string the locale (like "fr-FR")
      *
      * @return string|bool the legacy PrestaShop locale (like "fr")
+     *
+     * @throws Exception
      */
-    public function toLegacyLocale($locale)
+    public function toLegacyLocale(string $locale)
     {
         return array_search($locale, $this->getLangToLocalesMapping());
     }
@@ -63,8 +65,10 @@ final class Converter
      * @param string $legacyLocale the legacy PrestaShop locale
      *
      * @return string|bool the locale
+     *
+     * @throws Exception
      */
-    public function toLanguageTag($legacyLocale)
+    public function toLanguageTag(string $legacyLocale)
     {
         $mappingLocales = $this->getLangToLocalesMapping();
 
@@ -74,9 +78,11 @@ final class Converter
     /**
      * Get the PrestaShop locale from real locale (like "fr-FR")
      *
+     * @param string $locale
+     *
      * @return string The PrestaShop locale (like "fr_FR")
      */
-    public static function toPrestaShopLocale($locale)
+    public static function toPrestaShopLocale(string $locale): string
     {
         return str_replace('-', '_', $locale);
     }

--- a/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
+++ b/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
@@ -117,7 +117,7 @@ final class LegacyModuleExtractor implements LegacyModuleExtractorInterface
         $allWordings = $extractedCatalogue->all();
 
         // move default domain into the new domain (avoiding to overwrite existing translations)
-        $allWordings[$newDomain] = (isset($allWordings[$newDomain]))
+        $allWordings[$newDomain] = (isset($allWordings[$newDomain]) && is_array($allWordings[$newDomain]))
             ? array_merge($allWordings[$newDomain], $allWordings[$defaultDomain])
             : $allWordings[$defaultDomain];
 

--- a/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
+++ b/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Extractor;
+
+use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
+use Symfony\Component\Translation\Extractor\ExtractorInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Able to convert old translation files (in translations/es.php) into
+ * Symfony MessageCatalogue objects.
+ */
+final class LegacyModuleExtractor implements LegacyModuleExtractorInterface
+{
+    /**
+     * @var ExtractorInterface the PHP Code extractor
+     */
+    private $phpExtractor;
+
+    /**
+     * @var ExtractorInterface the Smarty Code extractor
+     */
+    private $smartyExtractor;
+
+    /**
+     * @var ExtractorInterface the Twig Code extractor
+     */
+    private $twigExtractor;
+
+    /**
+     * @var string the "modules" directory path
+     */
+    private $modulesDirectory;
+
+    /**
+     * @param ExtractorInterface $phpExtractor
+     * @param ExtractorInterface $smartyExtractor
+     * @param ExtractorInterface $twigExtractor
+     * @param string $modulesDirectory
+     */
+    public function __construct(
+        ExtractorInterface $phpExtractor,
+        ExtractorInterface $smartyExtractor,
+        ExtractorInterface $twigExtractor,
+        string $modulesDirectory
+    ) {
+        $this->phpExtractor = $phpExtractor;
+        $this->smartyExtractor = $smartyExtractor;
+        $this->twigExtractor = $twigExtractor;
+        $this->modulesDirectory = $modulesDirectory;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * WARNING: The domains in the returned catalogue are dot-separated
+     */
+    public function extract(string $moduleName, string $locale): MessageCatalogue
+    {
+        $extractedCatalogue = new MessageCatalogue($locale);
+
+        $this->phpExtractor->extract($this->modulesDirectory . '/' . $moduleName, $extractedCatalogue);
+        $extractedCatalogue = $this->postprocessPhpCatalogue($extractedCatalogue, $moduleName);
+
+        $this->smartyExtractor->extract($this->modulesDirectory . '/' . $moduleName, $extractedCatalogue);
+        $this->twigExtractor->extract($this->modulesDirectory . '/' . $moduleName, $extractedCatalogue);
+
+        return $extractedCatalogue;
+    }
+
+    /**
+     * Modules usually don't use domain names when calling the l() function in PHP files.
+     * Therefore, the PHP extractor will stores those calls in the default domain named "messages".
+     * This process moves all wordings in the "messages" domain to the inferred module domain.
+     *
+     * @param MessageCatalogue $extractedCatalogue
+     * @param string $moduleName
+     *
+     * @return MessageCatalogue
+     */
+    private function postprocessPhpCatalogue(MessageCatalogue $extractedCatalogue, string $moduleName): MessageCatalogue
+    {
+        $defaultDomain = 'messages';
+
+        if (!in_array($defaultDomain, $extractedCatalogue->getDomains())) {
+            return $extractedCatalogue;
+        }
+
+        $newDomain = DomainHelper::buildModuleDomainFromLegacySource($moduleName, '');
+
+        $allWordings = $extractedCatalogue->all();
+
+        // move default domain into the new domain (avoiding to overwrite existing translations)
+        $allWordings[$newDomain] = (isset($allWordings[$newDomain]))
+            ? array_merge($allWordings[$newDomain], $allWordings[$defaultDomain])
+            : $allWordings[$defaultDomain];
+
+        unset($allWordings[$defaultDomain]);
+
+        return new MessageCatalogue($extractedCatalogue->getLocale(), $allWordings);
+    }
+}

--- a/src/Core/Translation/Storage/Extractor/LegacyModuleExtractorInterface.php
+++ b/src/Core/Translation/Storage/Extractor/LegacyModuleExtractorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -24,34 +25,24 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShopBundle\Entity\Repository;
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Extractor;
 
-use Doctrine\ORM\EntityRepository;
-use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
+use Symfony\Component\Translation\MessageCatalogue;
 
-class TranslationRepository extends EntityRepository implements TranslationRepositoryInterface
+/**
+ * Parse code content of module, searching for l() calls and retrieve
+ * a Message Catalogue with all the keys and translations.
+ */
+interface LegacyModuleExtractorInterface
 {
     /**
-     * @param string $language
-     * @param string $theme
+     * Extracts the wordings from source code and returns the translation messages.
+     * Note that domain names will contain separating dots.
      *
-     * @return array
+     * @param string $moduleName
+     * @param string $locale The locale used for the message catalogue. Note that wordings won't be translated in this locale.
+     *
+     * @return MessageCatalogue
      */
-    public function findByLanguageAndTheme($language, $theme = null)
-    {
-        $queryBuilder = $this->createQueryBuilder('t');
-        $queryBuilder->where('lang = :language');
-        $queryBuilder->setParameter('language', $language);
-
-        if (null !== $theme) {
-            $queryBuilder->andWhere('theme = :theme');
-            $queryBuilder->setParameter('theme', $theme);
-        } else {
-            $queryBuilder->andWhere('theme IS NULL');
-        }
-
-        $query = $queryBuilder->getQuery();
-
-        return $query->getResult();
-    }
+    public function extract(string $moduleName, string $locale): MessageCatalogue;
 }

--- a/src/Core/Translation/Storage/Extractor/ThemeExtractor.php
+++ b/src/Core/Translation/Storage/Extractor/ThemeExtractor.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Extractor;
+
+use Exception;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueLayersProviderInterface;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\SmartyExtractor;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Extract all theme translations from Theme templates.
+ *
+ * xliff is the default file format, you can add custom File dumpers.
+ */
+class ThemeExtractor
+{
+    /**
+     * @var SmartyExtractor the Smarty Extractor
+     */
+    private $smartyExtractor;
+
+    public function __construct(SmartyExtractor $smartyExtractor)
+    {
+        $this->smartyExtractor = $smartyExtractor;
+    }
+
+    /**
+     * @param Theme $theme
+     * @param string|null $locale
+     *
+     * @return MessageCatalogue
+     *
+     * @throws Exception
+     */
+    public function extract(Theme $theme, ?string $locale = null): MessageCatalogue
+    {
+        if (null === $locale) {
+            $locale = CatalogueLayersProviderInterface::DEFAULT_LOCALE;
+        }
+
+        $catalogue = new MessageCatalogue($locale);
+
+        $this->smartyExtractor->extract(
+            rtrim($theme->getDirectory(), '/'),
+            $catalogue
+        );
+
+        return $this->normalize($catalogue);
+    }
+
+    /**
+     * Normalizes domains in a catalogue by removing dots
+     *
+     * @param MessageCatalogue $catalogue
+     *
+     * @return MessageCatalogue
+     */
+    private function normalize(MessageCatalogue $catalogue): MessageCatalogue
+    {
+        $newCatalogue = new MessageCatalogue($catalogue->getLocale());
+
+        foreach ($catalogue->all() as $domain => $messages) {
+            $newDomain = $this->normalizeDomain($domain);
+            $newCatalogue->add($messages, $newDomain);
+        }
+
+        foreach ($catalogue->getMetadata('', '') as $domain => $metadata) {
+            $newDomain = $this->normalizeDomain($domain);
+            foreach ($metadata as $key => $value) {
+                $newCatalogue->setMetadata($key, $value, $newDomain);
+            }
+        }
+
+        return $newCatalogue;
+    }
+
+    /**
+     * @param string $domain
+     *
+     * @return string
+     */
+    private function normalizeDomain(string $domain): string
+    {
+        return strtr($domain, ['.' => '']);
+    }
+}

--- a/src/Core/Translation/Storage/Loader/DatabaseTranslationLoader.php
+++ b/src/Core/Translation/Storage/Loader/DatabaseTranslationLoader.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Loader;
+
+use Doctrine\ORM\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Translation\TranslationInterface;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * The user translated catalogue is stored in database.
+ * This class is a helper to build the query for retrieving the translations.
+ * They depend on parameters like locale, theme or domain.
+ */
+class DatabaseTranslationLoader implements LoaderInterface
+{
+    /**
+     * @var LanguageRepositoryInterface
+     */
+    private $languageRepository;
+
+    /**
+     * @var TranslationRepositoryInterface
+     */
+    private $translationRepository;
+
+    public function __construct(
+        LanguageRepositoryInterface $languageRepository,
+        TranslationRepositoryInterface $translationRepository
+    ) {
+        $this->languageRepository = $languageRepository;
+        $this->translationRepository = $translationRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @todo: this method doesn't match the interface
+     */
+    public function load($resource, $locale, $domain = 'messages', $theme = null): MessageCatalogue
+    {
+        static $langs = [];
+        $catalogue = new MessageCatalogue($locale);
+
+        // do not try and load translations for a locale that cannot be saved to DB anyway
+        if ($locale === 'default') {
+            return $catalogue;
+        }
+
+        if (!array_key_exists($locale, $langs)) {
+            $langs[$locale] = $this->languageRepository->findOneBy(['locale' => $locale]);
+        }
+
+        $queryBuilder = $this->translationRepository->createQueryBuilder('t');
+
+        $this->addLangConstraint($queryBuilder, $langs[$locale]);
+
+        $this->addThemeConstraint($queryBuilder, $theme);
+
+        $this->addDomainConstraint($queryBuilder, $domain);
+
+        $translations = $queryBuilder
+            ->getQuery()
+            ->getResult();
+
+        /** @var TranslationInterface $translation */
+        foreach ($translations as $translation) {
+            $catalogue->set($translation->getKey(), $translation->getTranslation(), $translation->getDomain());
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param LanguageInterface $currentLang
+     */
+    private function addLangConstraint(QueryBuilder $queryBuilder, LanguageInterface $currentLang): void
+    {
+        $queryBuilder->andWhere('t.lang =:lang')
+            ->setParameter('lang', $currentLang);
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string|null $theme
+     */
+    private function addThemeConstraint(QueryBuilder $queryBuilder, ?string $theme = null): void
+    {
+        if (null === $theme) {
+            $queryBuilder->andWhere('t.theme IS NULL');
+        } else {
+            $queryBuilder
+                ->andWhere('t.theme = :theme')
+                ->setParameter('theme', $theme);
+        }
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string $domain
+     */
+    private function addDomainConstraint(QueryBuilder $queryBuilder, string $domain): void
+    {
+        if ($domain !== '*') {
+            $queryBuilder->andWhere('REGEXP(t.domain, :domain) = true')
+                ->setParameter('domain', $domain);
+        }
+    }
+}

--- a/src/Core/Translation/Storage/Loader/DatabaseTranslationLoader.php
+++ b/src/Core/Translation/Storage/Loader/DatabaseTranslationLoader.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Translation\TranslationInterface;
 use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
-use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -41,7 +40,7 @@ use Symfony\Component\Translation\MessageCatalogue;
  * This class is a helper to build the query for retrieving the translations.
  * They depend on parameters like locale, theme or domain.
  */
-class DatabaseTranslationLoader implements LoaderInterface
+class DatabaseTranslationLoader
 {
     /**
      * @var LanguageRepositoryInterface
@@ -62,11 +61,15 @@ class DatabaseTranslationLoader implements LoaderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Loads all user translations according to search parameters
      *
-     * @todo: this method doesn't match the interface
+     * @param string $locale Translation language
+     * @param string $domain Regex for domain pattern search
+     * @param string|null $theme A theme name
+     *
+     * @return MessageCatalogue A MessageCatalogue instance
      */
-    public function load($resource, $locale, $domain = 'messages', $theme = null): MessageCatalogue
+    public function load(string $locale, string $domain = 'messages', ?string $theme = null): MessageCatalogue
     {
         static $languages = [];
         $catalogue = new MessageCatalogue($locale);

--- a/src/Core/Translation/Storage/Loader/DatabaseTranslationLoader.php
+++ b/src/Core/Translation/Storage/Loader/DatabaseTranslationLoader.php
@@ -68,7 +68,7 @@ class DatabaseTranslationLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages', $theme = null): MessageCatalogue
     {
-        static $langs = [];
+        static $languages = [];
         $catalogue = new MessageCatalogue($locale);
 
         // do not try and load translations for a locale that cannot be saved to DB anyway
@@ -76,13 +76,13 @@ class DatabaseTranslationLoader implements LoaderInterface
             return $catalogue;
         }
 
-        if (!array_key_exists($locale, $langs)) {
-            $langs[$locale] = $this->languageRepository->findOneBy(['locale' => $locale]);
+        if (!array_key_exists($locale, $languages)) {
+            $languages[$locale] = $this->languageRepository->findOneBy(['locale' => $locale]);
         }
 
         $queryBuilder = $this->translationRepository->createQueryBuilder('t');
 
-        $this->addLangConstraint($queryBuilder, $langs[$locale]);
+        $this->addLangConstraint($queryBuilder, $languages[$locale]);
 
         $this->addThemeConstraint($queryBuilder, $theme);
 

--- a/src/Core/Translation/Storage/Loader/LegacyFileLoader.php
+++ b/src/Core/Translation/Storage/Loader/LegacyFileLoader.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Loader;
+
+use PrestaShop\PrestaShop\Core\Translation\Exception\InvalidLegacyTranslationKeyException;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Normalizer\DomainNormalizer;
+use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Able to convert old translation files (in translations/es.php) into
+ * Symfony MessageCatalogue objects.
+ */
+final class LegacyFileLoader implements LoaderInterface
+{
+    /**
+     * @var LegacyFileReader
+     */
+    private $fileReader;
+
+    /**
+     * @var DomainNormalizer
+     */
+    private $domainNormalizer;
+
+    /**
+     * @param LegacyFileReader $fileReader
+     */
+    public function __construct(LegacyFileReader $fileReader)
+    {
+        $this->fileReader = $fileReader;
+        $this->domainNormalizer = new DomainNormalizer();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Note that parameter "domain" is useless, as domain is inferred from source files
+     *
+     * @throws InvalidLegacyTranslationKeyException
+     */
+    public function load($path, $locale, $domain = 'messages'): MessageCatalogue
+    {
+        $catalogue = new MessageCatalogue($locale);
+
+        $tokens = $this->fileReader->load($path, $locale);
+
+        foreach ($tokens as $translationKey => $translationValue) {
+            $parsed = LegacyTranslationKey::buildFromString($translationKey);
+            $id = $parsed->getHash();
+            $catalogue->set($id, $translationValue, $this->buildDomain($parsed));
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * Builds the domain using information in the translation key
+     *
+     * @param LegacyTranslationKey $translationKey
+     *
+     * @return string
+     */
+    private function buildDomain(LegacyTranslationKey $translationKey): string
+    {
+        $newDomain = DomainHelper::buildModuleDomainFromLegacySource(
+            $translationKey->getModule(),
+            $translationKey->getSource()
+        );
+
+        return $this->domainNormalizer->normalize($newDomain);
+    }
+}

--- a/src/Core/Translation/Storage/Loader/LegacyFileReader.php
+++ b/src/Core/Translation/Storage/Loader/LegacyFileReader.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Loader;
+
+use PrestaShop\PrestaShop\Core\Translation\Exception\UnsupportedLocaleException;
+use PrestaShop\PrestaShop\Core\Translation\Locale\Converter;
+
+/**
+ * Reads legacy locale files
+ */
+class LegacyFileReader
+{
+    /**
+     * @var Converter Converts IETF language tags into two-letter language code
+     */
+    private $localeConverter;
+
+    public function __construct(Converter $converter)
+    {
+        $this->localeConverter = $converter;
+    }
+
+    /**
+     * Loads legacy translations from a file
+     *
+     * @param string $path Path where the locale file should be looked up
+     * @param string $locale IETF language tag
+     *
+     * @return array Translation tokens
+     */
+    public function load(string $path, string $locale): array
+    {
+        // Each legacy file declare this variable to store the translations
+        $_MODULE = [];
+
+        $shopLocale = $this->localeConverter->toLegacyLocale($locale);
+
+        $filePath = $path . "$shopLocale.php";
+
+        if (!file_exists($filePath)) {
+            throw UnsupportedLocaleException::fileNotFound($filePath, $locale);
+        }
+
+        // Load a global array $_MODULE
+        include_once $filePath;
+
+        return $_MODULE;
+    }
+}

--- a/src/Core/Translation/Storage/Loader/LegacyTranslationKey.php
+++ b/src/Core/Translation/Storage/Loader/LegacyTranslationKey.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Loader;
+
+use PrestaShop\PrestaShop\Core\Translation\Exception\InvalidLegacyTranslationKeyException;
+
+/**
+ * Parses a legacy translation key and returns its data
+ */
+class LegacyTranslationKey
+{
+    /**
+     * @var string the expected format of a legacy translation key
+     */
+    public const LEGACY_TRANSLATION_FORMAT = '#\<\{(?<module>[\w-]+)\}(?<theme>[\w-]+)\>(?<source>[\.\w_-]+)_(?<hash>[0-9a-f]+)#';
+
+    /**
+     * @var string
+     */
+    private $module;
+
+    /**
+     * @var string
+     */
+    private $theme;
+
+    /**
+     * @var string
+     */
+    private $source;
+
+    /**
+     * @var string
+     */
+    private $hash;
+
+    /**
+     * @param string $module
+     * @param string $theme
+     * @param string $source
+     * @param string $hash
+     */
+    public function __construct(string $module, string $theme, string $source, string $hash)
+    {
+        $this->module = $module;
+        $this->theme = $theme;
+        $this->source = $source;
+        $this->hash = $hash;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModule(): string
+    {
+        return $this->module;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTheme(): string
+    {
+        return $this->theme;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+
+    /**
+     * Parses a legacy translation key and returns its data
+     *
+     * @param string $key Legacy translation key
+     *
+     * @return LegacyTranslationKey
+     *
+     * @throws InvalidLegacyTranslationKeyException
+     */
+    public static function buildFromString(string $key): LegacyTranslationKey
+    {
+        $matches = [];
+        preg_match(self::LEGACY_TRANSLATION_FORMAT, $key, $matches);
+
+        foreach (['module', 'theme', 'source', 'hash'] as $item) {
+            if (!isset($matches[$item])) {
+                throw InvalidLegacyTranslationKeyException::missingElementFromKey($item, $key);
+            }
+        }
+
+        return new self($matches['module'], $matches['theme'], $matches['source'], $matches['hash']);
+    }
+}

--- a/src/Core/Translation/Storage/Loader/LegacyTranslationKey.php
+++ b/src/Core/Translation/Storage/Loader/LegacyTranslationKey.php
@@ -122,7 +122,7 @@ class LegacyTranslationKey
 
         foreach (['module', 'theme', 'source', 'hash'] as $item) {
             if (!isset($matches[$item])) {
-                throw InvalidLegacyTranslationKeyException::missingElementFromKey($item, $key);
+                throw new InvalidLegacyTranslationKeyException($item, $key);
             }
         }
 

--- a/src/Core/Translation/Storage/Normalizer/DomainNormalizer.php
+++ b/src/Core/Translation/Storage/Normalizer/DomainNormalizer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,35 +24,34 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+declare(strict_types=1);
 
-namespace PrestaShopBundle\Entity\Repository;
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Normalizer;
 
-use Doctrine\ORM\EntityRepository;
-use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
+use RuntimeException;
 
-class TranslationRepository extends EntityRepository implements TranslationRepositoryInterface
+/**
+ * Normalizes domain names by removing dots
+ */
+class DomainNormalizer
 {
     /**
-     * @param string $language
-     * @param string $theme
+     * @param string $domain Domain name
      *
-     * @return array
+     * @return string
+     *
+     * @throws RuntimeException
      */
-    public function findByLanguageAndTheme($language, $theme = null)
+    public function normalize(string $domain): string
     {
-        $queryBuilder = $this->createQueryBuilder('t');
-        $queryBuilder->where('lang = :language');
-        $queryBuilder->setParameter('language', $language);
+        // remove up to two dots from the domain name
+        // (because legacy domain translations CAN have dots in the third part)
+        $normalizedDomain = preg_replace('/\./', '', $domain, 2);
 
-        if (null !== $theme) {
-            $queryBuilder->andWhere('theme = :theme');
-            $queryBuilder->setParameter('theme', $theme);
-        } else {
-            $queryBuilder->andWhere('theme IS NULL');
+        if ($normalizedDomain === null) {
+            throw new RuntimeException(sprintf('An error occurred while normalizing domain "%s"', $domain));
         }
 
-        $query = $queryBuilder->getQuery();
-
-        return $query->getResult();
+        return $normalizedDomain;
     }
 }

--- a/src/Core/Translation/Storage/Provider/CatalogueProviderFactory.php
+++ b/src/Core/Translation/Storage/Provider/CatalogueProviderFactory.php
@@ -29,14 +29,14 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider;
 
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Translation\Exception\UnexpectedTranslationTypeException;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractorInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ThemeExtractor;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\AbstractCoreProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
-use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
-use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 
@@ -97,10 +97,6 @@ class CatalogueProviderFactory
     private $themesDirectory;
 
     /**
-     * @TODO We keep for now the dependency to PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader
-     *   We will create, in the core, a TranslationRepositoryInterface and inject to DatabaseTransloader the LangRepositoryInterface and TranslationRepositoryInterface as dependencies
-     *   to be fully independent from PrestaShopBundle
-     *
      * @param DatabaseTranslationLoader $databaseTranslationLoader
      * @param LegacyModuleExtractorInterface $legacyModuleExtractor
      * @param LoaderInterface $legacyFileLoader

--- a/src/Core/Translation/Storage/Provider/CoreCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/CoreCatalogueLayersProvider.php
@@ -28,10 +28,10 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider;
 
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\DefaultCatalogueFinder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\FileTranslatedCatalogueFinder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\UserTranslatedCatalogueFinder;
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**

--- a/src/Core/Translation/Storage/Provider/Finder/UserTranslatedCatalogueFinder.php
+++ b/src/Core/Translation/Storage/Provider/Finder/UserTranslatedCatalogueFinder.php
@@ -85,7 +85,6 @@ class UserTranslatedCatalogueFinder extends AbstractCatalogueFinder
 
         foreach ($this->translationDomains as $translationDomain) {
             $domainCatalogue = $this->databaseTranslationReader->load(
-                null,
                 $locale,
                 $translationDomain,
                 $this->themeName

--- a/src/Core/Translation/Storage/Provider/Finder/UserTranslatedCatalogueFinder.php
+++ b/src/Core/Translation/Storage/Provider/Finder/UserTranslatedCatalogueFinder.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder;
 
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**

--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
@@ -28,13 +28,13 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider;
 
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Exception\UnsupportedLocaleException;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractorInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Normalizer\DomainNormalizer;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\DefaultCatalogueFinder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\FileTranslatedCatalogueFinder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\UserTranslatedCatalogueFinder;
-use PrestaShopBundle\Translation\DomainNormalizer;
-use PrestaShopBundle\Translation\Exception\UnsupportedLocaleException;
-use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 

--- a/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
@@ -32,10 +32,10 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Translation\Exception\InvalidThemeException;
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ThemeExtractor;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\FileTranslatedCatalogueFinder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\UserTranslatedCatalogueFinder;
-use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -129,9 +129,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         bool $refreshCache = false
     ): MessageCatalogue {
         // Extracts wordings from the theme's templates
-        $catalogue = $this->themeExtractor->extract($this->theme, $locale, $refreshCache);
-
-        return $this->normalize($catalogue);
+        return $this->themeExtractor->extract($this->theme, $locale);
     }
 
     /**
@@ -207,41 +205,5 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         $this->filesystem->mkdir($resourceDirectory);
 
         return $resourceDirectory;
-    }
-
-    /**
-     * Normalizes domains in a catalogue by removing dots
-     *
-     * @param MessageCatalogue $catalogue
-     *
-     * @return MessageCatalogue
-     */
-    private function normalize(MessageCatalogue $catalogue): MessageCatalogue
-    {
-        $newCatalogue = new MessageCatalogue($catalogue->getLocale());
-
-        foreach ($catalogue->all() as $domain => $messages) {
-            $newDomain = $this->normalizeDomain($domain);
-            $newCatalogue->add($messages, $newDomain);
-        }
-
-        foreach ($catalogue->getMetadata('', '') as $domain => $metadata) {
-            $newDomain = $this->normalizeDomain($domain);
-            foreach ($metadata as $key => $value) {
-                $newCatalogue->setMetadata($key, $value, $newDomain);
-            }
-        }
-
-        return $newCatalogue;
-    }
-
-    /**
-     * @param string $domain
-     *
-     * @return string
-     */
-    private function normalizeDomain(string $domain): string
-    {
-        return strtr($domain, ['.' => '']);
     }
 }

--- a/src/Core/Translation/TranslationInterface.php
+++ b/src/Core/Translation/TranslationInterface.php
@@ -24,34 +24,38 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShopBundle\Entity\Repository;
+namespace PrestaShop\PrestaShop\Core\Translation;
 
-use Doctrine\ORM\EntityRepository;
-use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
-
-class TranslationRepository extends EntityRepository implements TranslationRepositoryInterface
+/**
+ * Interface TranslationInterface defines a translation object (id, key, translation, domain)
+ */
+interface TranslationInterface
 {
     /**
-     * @param string $language
-     * @param string $theme
+     * Database id
      *
-     * @return array
+     * @return int
      */
-    public function findByLanguageAndTheme($language, $theme = null)
-    {
-        $queryBuilder = $this->createQueryBuilder('t');
-        $queryBuilder->where('lang = :language');
-        $queryBuilder->setParameter('language', $language);
+    public function getId(): int;
 
-        if (null !== $theme) {
-            $queryBuilder->andWhere('theme = :theme');
-            $queryBuilder->setParameter('theme', $theme);
-        } else {
-            $queryBuilder->andWhere('theme IS NULL');
-        }
+    /**
+     * The translation key (wording)
+     *
+     * @return string
+     */
+    public function getKey(): string;
 
-        $query = $queryBuilder->getQuery();
+    /**
+     * The translated string (message)
+     *
+     * @return string
+     */
+    public function getTranslation(): string;
 
-        return $query->getResult();
-    }
+    /**
+     * The translation domain name
+     *
+     * @return string
+     */
+    public function getDomain(): string;
 }

--- a/src/Core/Translation/TranslationRepositoryInterface.php
+++ b/src/Core/Translation/TranslationRepositoryInterface.php
@@ -26,10 +26,20 @@
 
 namespace PrestaShop\PrestaShop\Core\Translation;
 
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ObjectRepository;
+
 /**
  * Interface TranslationRepositoryInterface allows to fetch a TranslationInterface
  * via different methods.
  */
-interface TranslationRepositoryInterface
+interface TranslationRepositoryInterface extends ObjectRepository
 {
+    /**
+     * @param mixed $alias
+     * @param mixed|null $indexBy
+     *
+     * @return QueryBuilder
+     */
+    public function createQueryBuilder($alias, $indexBy = null);
 }

--- a/src/Core/Translation/TranslationRepositoryInterface.php
+++ b/src/Core/Translation/TranslationRepositoryInterface.php
@@ -24,34 +24,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShopBundle\Entity\Repository;
+namespace PrestaShop\PrestaShop\Core\Translation;
 
-use Doctrine\ORM\EntityRepository;
-use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
-
-class TranslationRepository extends EntityRepository implements TranslationRepositoryInterface
+/**
+ * Interface TranslationRepositoryInterface allows to fetch a TranslationInterface
+ * via different methods.
+ */
+interface TranslationRepositoryInterface
 {
-    /**
-     * @param string $language
-     * @param string $theme
-     *
-     * @return array
-     */
-    public function findByLanguageAndTheme($language, $theme = null)
-    {
-        $queryBuilder = $this->createQueryBuilder('t');
-        $queryBuilder->where('lang = :language');
-        $queryBuilder->setParameter('language', $language);
-
-        if (null !== $theme) {
-            $queryBuilder->andWhere('theme = :theme');
-            $queryBuilder->setParameter('theme', $theme);
-        } else {
-            $queryBuilder->andWhere('theme IS NULL');
-        }
-
-        $query = $queryBuilder->getQuery();
-
-        return $query->getResult();
-    }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -31,7 +31,7 @@ services:
 
     #TRANSLATIONS PROVIDERS
     prestashop.translation.provider.catalogue_provider_factory:
-        class: PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFactory
         arguments:
             - '@prestashop.translation.database_loader'
             - '@prestashop.translation.legacy_module.extractor'
@@ -164,6 +164,12 @@ services:
         arguments:
             - "@prestashop.compiler.smarty.template"
             - true
+
+
+    prestashop.translation.extractor.theme:
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ThemeExtractor
+        arguments:
+            - "@prestashop.translation.extractor.smarty.legacy"
 
     prestashop.translation.theme_extractor:
         class: PrestaShopBundle\Translation\Extractor\ThemeExtractor

--- a/tests/Integration/Core/Translation/Storage/Provider/BackofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/BackofficeCatalogueLayersProviderTest.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\BackofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 
 /**
  * Test the provider of backOffice translations
@@ -126,7 +127,11 @@ class BackofficeCatalogueLayersProviderTest extends AbstractCatalogueLayersProvi
         $providerDefinition = new BackofficeProviderDefinition();
 
         return new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()

--- a/tests/Integration/Core/Translation/Storage/Provider/FrontofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/FrontofficeCatalogueLayersProviderTest.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -197,7 +198,11 @@ class FrontofficeCatalogueLayersProviderTest extends AbstractCatalogueLayersProv
         $providerDefinition = new FrontofficeProviderDefinition();
 
         return new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()

--- a/tests/Integration/Core/Translation/Storage/Provider/MailsBodyCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/MailsBodyCatalogueLayersProviderTest.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsBodyProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -173,7 +174,11 @@ class MailsBodyCatalogueLayersProviderTest extends AbstractCatalogueLayersProvid
         $providerDefinition = new MailsBodyProviderDefinition();
 
         return new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()

--- a/tests/Integration/Core/Translation/Storage/Provider/MailsCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/MailsCatalogueLayersProviderTest.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -173,7 +174,11 @@ class MailsCatalogueLayersProviderTest extends AbstractCatalogueLayersProviderTe
         $providerDefinition = new MailsProviderDefinition();
 
         return new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()

--- a/tests/Integration/Core/Translation/Storage/Provider/MockDatabaseTranslationLoader.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/MockDatabaseTranslationLoader.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -43,11 +43,11 @@ class MockDatabaseTranslationLoader extends DatabaseTranslationLoader
     /**
      * @param array<array{lang: string, key: string, translation: string, domain: string, theme: ?string}> $databaseContent
      */
-    public function __construct(array $databaseContent, $entityManager)
+    public function __construct(array $databaseContent, $languageRepository, $translationRepository)
     {
         $this->databaseContent = $databaseContent;
 
-        parent::__construct($entityManager);
+        parent::__construct($languageRepository, $translationRepository);
     }
 
     /**

--- a/tests/Integration/Core/Translation/Storage/Provider/MockDatabaseTranslationLoader.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/MockDatabaseTranslationLoader.php
@@ -53,7 +53,7 @@ class MockDatabaseTranslationLoader extends DatabaseTranslationLoader
     /**
      * {@inheritdoc}
      */
-    public function load($resource, $locale, $domainSearch = 'messages', $theme = null): MessageCatalogue
+    public function load(string $locale, string $domainSearch = 'messages', ?string $theme = null): MessageCatalogue
     {
         $catalogue = new MessageCatalogue($locale);
 

--- a/tests/Integration/Core/Translation/Storage/Provider/ModuleCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/ModuleCatalogueLayersProviderTest.php
@@ -27,14 +27,15 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractor;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractorInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\LegacyFileLoader;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\LegacyFileReader;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ModuleCatalogueLayersProvider;
-use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractor;
-use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
-use PrestaShopBundle\Translation\Loader\LegacyFileLoader;
-use PrestaShopBundle\Translation\Loader\LegacyFileReader;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -134,7 +135,11 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
 
         $providerDefinition = new ModuleProviderDefinition('translationtest');
         $provider = new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                [],
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $legacyModuleExtractor,
             $legacyFileLoader,
             $this->modulesDir,
@@ -216,7 +221,11 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         );
         $providerDefinition = new ModuleProviderDefinition('translationtest');
         $provider = new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader([], $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                [],
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $legacyModuleExtractor,
             $this->legacyFileLoader,
             $this->modulesDir,
@@ -356,7 +365,11 @@ class ModuleCatalogueLayersProviderTest extends KernelTestCase
         $providerDefinition = new ModuleProviderDefinition($moduleName);
 
         return new ModuleCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $this->legacyModuleExtractor,
             $this->legacyFileLoader,
             $this->modulesDir,

--- a/tests/Integration/Core/Translation/Storage/Provider/OthersCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/OthersCatalogueLayersProviderTest.php
@@ -27,9 +27,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Translation\Storage\Provider;
 
-use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
@@ -173,7 +174,11 @@ class OthersCatalogueLayersProviderTest extends AbstractCatalogueLayersProviderT
         $providerDefinition = new OthersProviderDefinition();
 
         return new CoreCatalogueLayersProvider(
-            new MockDatabaseTranslationLoader($databaseContent, $this->createMock(EntityManagerInterface::class)),
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
             $this->translationsDir,
             $providerDefinition->getFilenameFilters(),
             $providerDefinition->getTranslationDomains()

--- a/tests/Unit/Core/Translation/Storage/Provider/CatalogueProviderFactoryTest.php
+++ b/tests/Unit/Core/Translation/Storage/Provider/CatalogueProviderFactoryTest.php
@@ -31,6 +31,9 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeRepository;
 use PrestaShop\PrestaShop\Core\Translation\Exception\UnexpectedTranslationTypeException;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractorInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ThemeExtractor;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFactory;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\BackofficeProviderDefinition;
@@ -43,9 +46,6 @@ use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderD
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ModuleCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ThemeCatalogueLayersProvider;
-use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
-use PrestaShopBundle\Translation\Extractor\ThemeExtractor;
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 

--- a/tests/Unit/Core/Translation/Storage/Provider/Finder/UserTranslatedCatalogueFinderTest.php
+++ b/tests/Unit/Core/Translation/Storage/Provider/Finder/UserTranslatedCatalogueFinderTest.php
@@ -30,9 +30,9 @@ namespace Tests\Unit\Core\Translation\Storage\Provider\Finder;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueLayersProviderInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\UserTranslatedCatalogueFinder;
-use PrestaShopBundle\Translation\Loader\DatabaseTranslationLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 
 class UserTranslatedCatalogueFinderTest extends TestCase


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This is an intermediate PR to clean all the dependencies between PrestashopBundle components and the new Core ones.<br>The last remaining used components from PrestaShopBundle are moved to the Core<br><br>We also create a TranslationRepositoryInterface to avoid the usage of entities in DatabaseTranslationLoader<br><br>The tests are fixed to reflect the new structure and dependencies
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #19242
| How to test?      | The CI must be green


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<br><br>
## BC Breaks
**DatabaseTranslationLoader** no longer requires EntityManager but LanguageRepositoryInterface  and TranslationRepositoryInterface

**LanguageRepositoryInterface** now extends ObjectRepository interface 

**TranslationRepository** from PrestaShopBundle now implements TranslationRepositoryInterface from Core

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23649)
<!-- Reviewable:end -->
