### PR TITLE
Product form adaptation

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.js
@@ -48,6 +48,7 @@ $(() => {
 
   const $productForm = $(ProductMap.productForm);
   const productId = parseInt($productForm.data('productId'), 10);
+  const productType = $productForm.data('productType');
 
   // Combinations manager must be initialised before nav handler, or it won't trigger the pagination if the tab is
   // selected on load, but only when productId exists (edition mode)
@@ -85,7 +86,10 @@ $(() => {
   // From here we init component specific to edition
   const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);
   new ProductPartialUpdater(window.prestashop.instance.eventEmitter, $productForm, $productFormSubmitButton).watch();
-  new ProductSuppliersManager();
   new FeatureValuesManager(window.prestashop.instance.eventEmitter);
   new CustomizationsManager();
+
+  if (productType !== 'combination') {
+    new ProductSuppliersManager();
+  }
 });

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicInformationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/BasicInformationType.php
@@ -54,6 +54,7 @@ class BasicInformationType extends TranslatorAwareType
                     $this->trans('Standard product', 'Admin.Catalog.Feature') => ProductType::TYPE_STANDARD,
                     $this->trans('Pack of products', 'Admin.Catalog.Feature') => ProductType::TYPE_PACK,
                     $this->trans('Virtual product', 'Admin.Catalog.Feature') => ProductType::TYPE_VIRTUAL,
+                    $this->trans('Product with combinations', 'Admin.Catalog.Feature') => ProductType::TYPE_COMBINATION,
                 ],
                 'choice_translation_domain' => 'Admin.Catalog.Feature',
                 'attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/FeatureValueListener.php
@@ -65,7 +65,7 @@ class FeatureValueListener implements EventSubscriberInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'updateFeatureValuesOptions',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product\EventListener;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * This listener dynamically updates the form depending on the product type, like
+ * is it virtual, a pack, does it have combinations, ...
+ */
+class ProductTypeListener implements EventSubscriberInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::PRE_SET_DATA => 'adaptProductForm',
+            FormEvents::PRE_SUBMIT => 'adaptProductForm',
+        ];
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function adaptProductForm(FormEvent $event): void
+    {
+        $form = $event->getForm();
+        $data = $event->getData();
+
+        if (ProductType::TYPE_COMBINATION === $data['basic']['type']) {
+            $form->remove('suppliers');
+        }
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -42,7 +42,7 @@ class ProductTypeListener implements EventSubscriberInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'adaptProductForm',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductFormType.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
@@ -42,7 +43,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 /**
  * This is the parent product form type
  */
-class ProductType extends TranslatorAwareType
+class ProductFormType extends TranslatorAwareType
 {
     /**
      * @var ProductProvider
@@ -124,13 +125,17 @@ class ProductType extends TranslatorAwareType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        $productType = $options['data']['basic']['type'] ?? ProductType::TYPE_STANDARD;
+        $formVars = [
+            'attr' => [
+                'data-product-type' => $productType,
+            ],
+        ];
+
         if (!empty($options['product_id'])) {
-            $view->vars = array_replace($view->vars, [
-                'attr' => [
-                    'data-product-id' => $options['product_id'],
-                ],
-            ]);
+            $formVars['attr']['data-product-id'] = $options['product_id'];
         }
+        $view->vars = array_replace($view->vars, $formVars);
     }
 
     /**
@@ -142,7 +147,17 @@ class ProductType extends TranslatorAwareType
 
         $resolver->setDefaults([
             'product_id' => null,
+            'product_type' => null,
         ]);
         $resolver->setAllowedTypes('product_id', ['null', 'int']);
+        $resolver->setAllowedTypes('product_type', ['null', 'string']);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'product';
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -49,17 +50,25 @@ class ProductType extends TranslatorAwareType
     private $productUrlProvider;
 
     /**
+     * @var EventSubscriberInterface
+     */
+    private $productTypeListener;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param ProductProvider $productUrlProvider
+     * @param EventSubscriberInterface $productTypeListener
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        ProductProvider $productUrlProvider
+        ProductProvider $productUrlProvider,
+        EventSubscriberInterface $productTypeListener
     ) {
         parent::__construct($translator, $locales);
         $this->productUrlProvider = $productUrlProvider;
+        $this->productTypeListener = $productTypeListener;
     }
 
     /**
@@ -102,6 +111,12 @@ class ProductType extends TranslatorAwareType
                 ])
             ;
         }
+
+        /**
+         * This listener adapts the content of the form based on the Product type, it can remove add or transforms some
+         * of the internal fields @see ProductTypeListener
+         */
+        $builder->addEventSubscriber($this->productTypeListener);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductType.php
@@ -112,7 +112,7 @@ class ProductType extends TranslatorAwareType
             ;
         }
 
-        /**
+        /*
          * This listener adapts the content of the form based on the Product type, it can remove add or transforms some
          * of the internal fields @see ProductTypeListener
          */

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1250,6 +1250,7 @@ services:
         public: true
         arguments:
             - '@prestashop.adapter.shop.url.product_provider'
+            - '@form.type.sell.product.event_listener.product_type_listener'
         tags:
             - { name: form.type }
 
@@ -1407,6 +1408,10 @@ services:
         arguments:
             - '@prestashop.adapter.form.choice_provider.feature_values_choice_provider'
             - '@form.form_cloner'
+        public: true
+
+    form.type.sell.product.event_listener.product_type_listener:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\EventListener\ProductTypeListener'
         public: true
 
     form.type.sell.product.combination_list_type:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1244,8 +1244,8 @@ services:
       tags:
         - { name: form.type }
 
-    form.type.sell.product.product_type:
-        class: 'PrestaShopBundle\Form\Admin\Sell\Product\ProductType'
+    form.type.sell.product.product_form_type:
+        class: 'PrestaShopBundle\Form\Admin\Sell\Product\ProductFormType'
         parent: 'form.type.translatable.aware'
         public: true
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -187,5 +187,5 @@ services:
       class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
       factory: 'prestashop.core.form.builder.form_builder_factory:create'
       arguments:
-          - 'PrestaShopBundle\Form\Admin\Sell\Product\ProductType'
+          - 'PrestaShopBundle\Form\Admin\Sell\Product\ProductFormType'
           - '@prestashop.core.form.identifiable_object.data_provider.product_form_data_provider'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -26,7 +26,10 @@
 {% set isPriceTabValid = productForm.price.vars.valid %}
 {% set isShippingTabValid = productForm.shipping.vars.valid %}
 {% set isSEOTabValid = productForm.seo.vars.valid and productForm.redirect_option.vars.valid %}
-{% set isOptionsTabValid = productForm.options.vars.valid  and productForm.suppliers.vars.valid %}
+
+{% set isSuppliersValid = productForm.suppliers is not defined or productForm.suppliers.vars.valid %}
+{% set isOptionsTabValid = productForm.options.vars.valid and isSuppliersValid %}
+
 {% set isStockTabValid = productForm.stock.vars.valid %}
 
 <div class="tabs js-tabs">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/options.html.twig
@@ -1,0 +1,39 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="options-tab">
+  {{ form_widget(productForm.options) }}
+
+  {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/customizations.html.twig', {
+    'productForm': productForm,
+  }) }}
+
+  {# For product with combinations suppliers are not here but in the combination form #}
+  {% if productForm.suppliers is defined %}
+    {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/suppliers.html.twig', {
+      'productForm': productForm,
+    }) }}
+  {% endif %}
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -93,17 +93,9 @@
       {% endblock %}
 
       {% block product_tab_options %}
-        <div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="options-tab">
-          {{ form_widget(productForm.options) }}
-
-          {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/customizations.html.twig', {
-            'productForm': productForm,
-          }) }}
-
-          {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/suppliers.html.twig', {
-            'productForm': productForm,
-          }) }}
-        </div>
+        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/options.html.twig', {
+          'productForm': productForm,
+        }) }}
       {% endblock %}
 
       {% block product_extra_tabs %}

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/FeatureValueListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/FeatureValueListenerTest.php
@@ -34,14 +34,12 @@ use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Sell\Product\EventListener\FeatureValueListener;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\FormCloner;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 
-class FeatureValueListenerTest extends KernelTestCase
+class FeatureValueListenerTest extends FormListenerTestCase
 {
     /**
      * @var FormCloner
@@ -54,7 +52,6 @@ class FeatureValueListenerTest extends KernelTestCase
     protected function setUp()
     {
         parent::setUp();
-        self::bootKernel();
         $this->formCloner = new FormCloner();
     }
 
@@ -82,7 +79,7 @@ class FeatureValueListenerTest extends KernelTestCase
         $providerMock = $this->createChoiceProviderMock($choices, $expectedFilters);
         $listener = new FeatureValueListener($providerMock, $this->formCloner);
 
-        $form = $this->createForm(SimpleFormTest::class);
+        $form = $this->createForm(SimpleFeaturesFormTest::class);
         $this->assertFormChoices($form, []);
 
         $eventMock = $this->createEventMock($formData, $form);
@@ -262,41 +259,9 @@ class FeatureValueListenerTest extends KernelTestCase
 
         return $providerMock;
     }
-
-    /**
-     * @param array $data
-     * @param FormInterface $form
-     *
-     * @return MockObject|FormEvent
-     */
-    private function createEventMock(array $data, FormInterface $form)
-    {
-        $eventMock = $this->getMockBuilder(FormEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getData', 'getForm'])
-            ->getMock()
-        ;
-
-        $eventMock->expects($this->once())->method('getData')->willReturn($data);
-        $eventMock->expects($this->once())->method('getForm')->willReturn($form);
-
-        return $eventMock;
-    }
-
-    /**
-     * @param string $type
-     * @param array $options
-     * @param null $data
-     *
-     * @return FormInterface
-     */
-    private function createForm(string $type, array $options = [], $data = null): FormInterface
-    {
-        return self::$kernel->getContainer()->get('form.factory')->create($type, $data, $options);
-    }
 }
 
-class SimpleFormTest extends CommonAbstractType
+class SimpleFeaturesFormTest extends CommonAbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/FormListenerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/FormListenerTestCase.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\EventListener;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormInterface;
+
+class FormListenerTestCase extends KernelTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        self::bootKernel();
+    }
+
+    /**
+     * @param array $data
+     * @param FormInterface $form
+     *
+     * @return MockObject|FormEvent
+     */
+    protected function createEventMock(array $data, FormInterface $form)
+    {
+        $eventMock = $this->getMockBuilder(FormEvent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getData', 'getForm'])
+            ->getMock()
+        ;
+
+        $eventMock->expects($this->once())->method('getData')->willReturn($data);
+        $eventMock->expects($this->once())->method('getForm')->willReturn($form);
+
+        return $eventMock;
+    }
+
+    /**
+     * @param string $type
+     * @param array $options
+     * @param null $data
+     *
+     * @return FormInterface
+     */
+    protected function createForm(string $type, array $options = [], $data = null): FormInterface
+    {
+        return self::$kernel->getContainer()->get('form.factory')->create($type, $data, $options);
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Form\EventListener;
+
+use Generator;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductType;
+use PrestaShopBundle\Form\Admin\Sell\Product\EventListener\ProductTypeListener;
+use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use Symfony\Component\Form\Exception\OutOfBoundsException;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+
+class ProductTypeListenerTest extends FormListenerTestCase
+{
+    public function testSubscribedEvents(): void
+    {
+        // Only events are relevant, the matching function is up to implementation
+        $expectedSubscribedEvents = [
+            FormEvents::PRE_SET_DATA,
+            FormEvents::PRE_SUBMIT,
+        ];
+        $subscribedEvents = ProductTypeListener::getSubscribedEvents();
+        $this->assertSame($expectedSubscribedEvents, array_keys($subscribedEvents));
+    }
+
+    /**
+     * @dataProvider getTestValues
+     *
+     * @param string $productType
+     * @param bool $expectedSuppliers
+     */
+    public function testAdaptProductForm(string $productType, bool $expectedSuppliers): void
+    {
+        $listener = new ProductTypeListener();
+
+        $form = $this->createForm(SimpleProductFormTest::class);
+        $this->assertNotNull($form->get('suppliers'));
+
+        $formData = [
+            'basic' => [
+                'type' => $productType,
+            ],
+        ];
+        $eventMock = $this->createEventMock($formData, $form);
+        $listener->adaptProductForm($eventMock);
+
+        if ($expectedSuppliers) {
+            $this->assertNotNull($form->get('suppliers'));
+        } else {
+            $this->expectException(OutOfBoundsException::class);
+            $form->get('suppliers');
+        }
+    }
+
+    public function getTestValues(): Generator
+    {
+        yield [
+            ProductType::TYPE_STANDARD,
+            true,
+        ];
+
+        yield [
+            ProductType::TYPE_PACK,
+            true,
+        ];
+
+        yield [
+            ProductType::TYPE_VIRTUAL,
+            true,
+        ];
+
+        yield [
+            ProductType::TYPE_COMBINATION,
+            false,
+        ];
+    }
+}
+
+class SimpleProductFormTest extends CommonAbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('suppliers', ChoiceType::class)
+        ;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add form listener to adapt Product form content depending on its type This fixes the bug we had when editing combination products, because a command to remove suppliers was sent but not allowed for this kind of product
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23668)
<!-- Reviewable:end -->
