### PR TITLE
[WIP] Add cover feature to product page v2 dropzone

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -74,6 +74,7 @@
       @removeSelection="removeSelection"
       @selectAll="selectAll"
       :files="files"
+      @coverChanged="changeCover"
     />
 
     <div class="dz-template d-none">
@@ -105,6 +106,9 @@
             </label>
           </div>
         </div>
+        <div class="iscover">
+          {{ $t('window.cover') }}
+        </div>
       </div>
     </div>
   </div>
@@ -112,7 +116,7 @@
 
 <script>
   import Router from '@components/router';
-  import {getProductImages} from '@pages/product/services/images';
+  import {getProductImages, setCoverImage} from '@pages/product/services/images';
   import DropzoneWindow from './DropzoneWindow';
 
   const {$} = window;
@@ -196,6 +200,10 @@
               this.selectedFiles = this.selectedFiles.filter((e) => e !== file);
               file.previewElement.classList.toggle('selected');
             }
+
+            if (file.isCover) {
+              file.previewElement.classList.add('is-cover');
+            }
           });
 
           this.files.push(file);
@@ -256,6 +264,16 @@
           $(element).remove();
         });
       },
+      /**
+       * Manage cover checkbox changes
+       */
+      async changeCover(event) {
+        try {
+          await setCoverImage(this.productId, event.target.value);
+        } catch (error) {
+          $.growl.error({message: error.message});
+        }
+      },
     },
   };
 </script>
@@ -281,6 +299,16 @@
     .dz-preview {
       position: relative;
       cursor: pointer;
+
+      .iscover {
+        display: none;
+      }
+
+      &.is-cover {
+        .iscover {
+          display: block;
+        }
+      }
 
       &:not(.openfilemanager) {
         border: 3px solid transparent;

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/DropzoneWindow.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/DropzoneWindow.vue
@@ -72,7 +72,11 @@
       v-if="selectedFiles.length === 1"
     >
       <label>
-        <input type="checkbox">
+        <input
+          type="checkbox"
+          v-model="isCover"
+          @change="$emit('coverChanged', $event)"
+        >
         <i class="md-checkbox-control" />
         {{ $t("window.useAsCover") }}
       </label>
@@ -110,6 +114,11 @@
         type: Array,
         default: () => [],
       },
+    },
+    data() {
+      return {
+        isCover: this.selectedFiles.length === 1 && this.selectedFiles[0].isCover,
+      };
     },
     mounted() {
       window.prestaShopUiKit.initToolTips();

--- a/admin-dev/themes/new-theme/js/pages/product/services/images.js
+++ b/admin-dev/themes/new-theme/js/pages/product/services/images.js
@@ -36,6 +36,16 @@ export const getProductImages = async (productId) => {
   return $.get(imagesUrl);
 };
 
+export const setCoverImage = async (productId, checked) => {
+  const setCoverUrl = router.generate('admin_products_v2_get_images', {
+    productId,
+    checked,
+  });
+
+  return $.post(setCoverUrl);
+};
+
 export default {
   getProductImages,
+  setCoverImage,
 };


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | User should be able to select or unselect an image as cover
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19524.
| How to test?      | Go on product page v2, select an image, select it as a cover, also, try to reload the page, select another cover...


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23675)
<!-- Reviewable:end -->
