### PR TITLE
The spinner is not displayed on the product quantity field and the thumbnails clicks are not operating

### DIFF
--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -127,7 +127,7 @@ $(document).ready(() => {
   }
 
   function createProductSpin() {
-    const $quantityInput = $(prestashop.selectors.quantityWanted);
+    const $quantityInput = $(prestashop.themeSelectors.product.quantityWanted;
 
     $quantityInput.TouchSpin({
       verticalbuttons: true,
@@ -146,7 +146,7 @@ $(document).ready(() => {
       }
     });
 
-    $('body').on('change keyup', prestashop.selectors.quantityWanted, (e) => {
+    $('body').on('change keyup', prestashop.themeSelectors.product.quantityWanted, (e) => {
       if ($quantityInput.val() !== '') {
         $(e.currentTarget).trigger('touchspin.stopspin');
         prestashop.emit('updateProduct', {


### PR DESCRIPTION
Et voilà ! After changing the faulty variable by the new one, everything is working correctly again on the product page.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product qty spinner wasn't working because of a wrong variable name of selectors
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23683
| How to test?      | Go on product page and test product qty spinner
| Possible impacts? | Product FO page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23681)
<!-- Reviewable:end -->
