### PR TITLE
Add sortable feature to product page v2 images dropzone

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/services/images.js
+++ b/admin-dev/themes/new-theme/js/pages/product/services/images.js
@@ -68,6 +68,20 @@ export const replaceImage = async (selectedFile, newFile, formName, token) => {
     data: formData,
     contentType: false,
     processData: false,
+};
+
+export const setImagesSort = async (productId, sort) => {
+  const sortUrl = router.generate('admin_products_v2_get_images', {
+    productId,
+    sort,
+  });
+
+  return $.ajax({
+    type: 'POST',
+    url: sortUrl,
+    data: {
+      json: JSON.stringify(sort),
+    },
   });
 };
 
@@ -75,4 +89,5 @@ export default {
   getProductImages,
   saveImageInformations,
   replaceImage,
+  setImagesSort,
 };

--- a/admin-dev/themes/new-theme/js/pages/product/services/images.js
+++ b/admin-dev/themes/new-theme/js/pages/product/services/images.js
@@ -67,7 +67,6 @@ export const replaceImage = async (selectedFile, newFile, formName, token) => {
   return $.ajax(replaceUrl, {
     method: 'POST',
     data: formData,
-    cache: false,
     processData: false,
     contentType: false,
   });

--- a/admin-dev/themes/new-theme/js/pages/product/services/images.js
+++ b/admin-dev/themes/new-theme/js/pages/product/services/images.js
@@ -49,7 +49,7 @@ export const saveImageInformations = async (selectedFile, token, formName) => {
   data[`${formName}[_token]`] = token;
 
   return $.ajax(saveUrl, {
-    method: 'POST',
+    method: 'PATCH',
     data,
   });
 };
@@ -62,26 +62,29 @@ export const replaceImage = async (selectedFile, newFile, formName, token) => {
   const formData = new FormData();
   formData.append(`${formName}[file]`, newFile);
   formData.append(`${formName}[_token]`, token);
+  formData.append('_method', 'PATCH');
 
   return $.ajax(replaceUrl, {
     method: 'POST',
     data: formData,
-    contentType: false,
+    cache: false,
     processData: false,
+    contentType: false,
+  });
 };
 
-export const setImagesSort = async (productId, sort) => {
-  const sortUrl = router.generate('admin_products_v2_get_images', {
-    productId,
-    sort,
+export const saveImagePosition = async (productImageId, newPosition, formName, token) => {
+  const sortUrl = router.generate('admin_products_v2_update_image', {
+    productImageId,
   });
 
-  return $.ajax({
-    type: 'POST',
-    url: sortUrl,
-    data: {
-      json: JSON.stringify(sort),
-    },
+  const data = {};
+  data[`${formName}[position]`] = newPosition;
+  data[`${formName}[_token]`] = token;
+
+  return $.ajax(sortUrl, {
+    method: 'PATCH',
+    data,
   });
 };
 
@@ -89,5 +92,5 @@ export default {
   getProductImages,
   saveImageInformations,
   replaceImage,
-  setImagesSort,
+  saveImagePosition,
 };

--- a/src/Adapter/Product/Image/CommandHandler/UpdateProductImageHandler.php
+++ b/src/Adapter/Product/Image/CommandHandler/UpdateProductImageHandler.php
@@ -98,11 +98,15 @@ class UpdateProductImageHandler implements UpdateProductImageHandlerInterface
         }
 
         if ($command->isCover()) {
-            $this->productImageUpdater->updateProductCover($command->getImageId());
+            $this->productImageUpdater->updateProductCover($image);
         }
 
         if (null !== $command->getFilePath()) {
             $this->productImageUploader->upload($image, $command->getFilePath());
+        }
+
+        if (null !== $command->getPosition()) {
+            $this->productImageUpdater->updatePosition($image, $command->getPosition());
         }
     }
 }

--- a/src/Adapter/Product/Image/Update/ProductImageUpdater.php
+++ b/src/Adapter/Product/Image/Update/ProductImageUpdater.php
@@ -137,11 +137,21 @@ class ProductImageUpdater
      */
     public function updatePosition(Image $image, int $newPosition): void
     {
+        $oldPosition = (int) $image->position;
+        // The images are sorted by their position values, but since only one of them as un updated value there will be
+        // two images with the same position, so we need to add an offset to the new position depending on the way it
+        // is being modified
+        if ($oldPosition < $newPosition) {
+            ++$newPosition;
+        } elseif ($oldPosition > $newPosition) {
+            --$newPosition;
+        }
+
         $positionsData = [
             'positions' => [
                 [
                     'rowId' => (int) $image->id_image,
-                    'oldPosition' => (int) $image->position,
+                    'oldPosition' => $oldPosition,
                     'newPosition' => $newPosition,
                 ],
             ],

--- a/src/Core/Domain/Product/Image/Command/UpdateProductImageCommand.php
+++ b/src/Core/Domain/Product/Image/Command/UpdateProductImageCommand.php
@@ -53,6 +53,11 @@ class UpdateProductImageCommand
     private $localizedLegends;
 
     /**
+     * @var int|null
+     */
+    private $position;
+
+    /**
      * @param int $imageId
      */
     public function __construct(int $imageId)
@@ -124,6 +129,26 @@ class UpdateProductImageCommand
     public function setLocalizedLegends(?array $localizedLegends): self
     {
         $this->localizedLegends = $localizedLegends;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int|null $position
+     *
+     * @return self
+     */
+    public function setPosition(?int $position): self
+    {
+        $this->position = $position;
 
         return $this;
     }

--- a/src/Core/Domain/Product/Image/Exception/CannotUpdateProductImageException.php
+++ b/src/Core/Domain/Product/Image/Exception/CannotUpdateProductImageException.php
@@ -39,4 +39,9 @@ class CannotUpdateProductImageException extends ProductImageException
      * When fails to update legends
      */
     public const FAILED_UPDATE_LEGENDS = 20;
+
+    /**
+     * When fails to update position
+     */
+    public const FAILED_UPDATE_POSITION = 30;
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/ProductImageFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ProductImageFormDataHandler.php
@@ -92,6 +92,10 @@ class ProductImageFormDataHandler implements FormDataHandlerInterface
             $command->setFilePath($uploadedFile->getPathname());
         }
 
+        if (isset($data['position'])) {
+            $command->setPosition((int) $data['position']);
+        }
+
         $this->bus->handle($command);
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductImageFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductImageFormDataProvider.php
@@ -61,6 +61,7 @@ class ProductImageFormDataProvider implements FormDataProviderInterface
         return [
             'legend' => $productImage->getLocalizedLegends(),
             'is_cover' => $productImage->isCover(),
+            'position' => $productImage->getPosition(),
         ];
     }
 

--- a/src/Core/Grid/Position/PositionDefinition.php
+++ b/src/Core/Grid/Position/PositionDefinition.php
@@ -53,21 +53,29 @@ final class PositionDefinition implements PositionDefinitionInterface
     private $parentIdField;
 
     /**
+     * @var int
+     */
+    private $firstPosition;
+
+    /**
      * @param string $table
      * @param string $idField
      * @param string $positionField
      * @param string|null $parentIdField
+     * @param int $firstPosition
      */
     public function __construct(
         $table,
         $idField,
         $positionField,
-        $parentIdField = null
+        $parentIdField = null,
+        int $firstPosition = 0
     ) {
         $this->table = $table;
         $this->idField = $idField;
         $this->positionField = $positionField;
         $this->parentIdField = $parentIdField;
+        $this->firstPosition = $firstPosition;
     }
 
     /**
@@ -100,5 +108,13 @@ final class PositionDefinition implements PositionDefinitionInterface
     public function getParentIdField()
     {
         return $this->parentIdField;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFirstPosition(): int
+    {
+        return $this->firstPosition;
     }
 }

--- a/src/Core/Grid/Position/PositionDefinitionInterface.php
+++ b/src/Core/Grid/Position/PositionDefinitionInterface.php
@@ -61,4 +61,11 @@ interface PositionDefinitionInterface
      * @return string|null
      */
     public function getParentIdField();
+
+    /**
+     * Which value should be used for the first position (can be 0, 1 or anything else)
+     *
+     * @return int
+     */
+    public function getFirstPosition(): int;
 }

--- a/src/Core/Grid/Position/UpdateHandler/DoctrinePositionUpdateHandler.php
+++ b/src/Core/Grid/Position/UpdateHandler/DoctrinePositionUpdateHandler.php
@@ -94,7 +94,7 @@ final class DoctrinePositionUpdateHandler implements PositionUpdateHandlerInterf
     {
         try {
             $this->connection->beginTransaction();
-            $positionIndex = 0;
+            $positionIndex = $positionDefinition->getFirstPosition();
             foreach ($newPositions as $rowId => $newPosition) {
                 $qb = $this->connection->createQueryBuilder();
                 $qb

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ImageController.php
@@ -108,7 +108,9 @@ class ImageController extends FrameworkBundleAdminController
      */
     public function updateImageAction(Request $request, int $productImageId): JsonResponse
     {
-        $imageForm = $this->getProductImageFormBuilder()->getFormFor($productImageId);
+        $imageForm = $this->getProductImageFormBuilder()->getFormFor($productImageId, [], [
+            'method' => $request->getMethod(),
+        ]);
         $imageForm->handleRequest($request);
 
         try {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ProductImageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ProductImageType.php
@@ -33,6 +33,7 @@ use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -47,6 +48,7 @@ class ProductImageType extends CommonAbstractType
         $builder
             ->add('product_id', HiddenType::class)
             ->add('file', FileType::class)
+            ->add('position', IntegerType::class)
             ->add('legend', TranslatableType::class, [
                 'type' => TextType::class,
             ])

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/image.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/image.yml
@@ -28,7 +28,7 @@ admin_products_v2_add_image:
 
 admin_products_v2_update_image:
     path: /images/{productImageId}/update
-    methods: [POST]
+    methods: [PATCH]
     defaults:
         _controller: PrestaShopBundle:Admin/Sell/Catalog/Product/Image:updateImage
         _legacy_controller: AdminProducts

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -63,6 +63,9 @@ services:
         arguments:
             - '@prestashop.adapter.product.image.repository.product_image_repository'
             - '@prestashop.adapter.product.image.uploader.product_image_uploader'
+            - '@prestashop.core.grid.position.position_update_factory'
+            - '@prestashop.core.grid.image.position_definition'
+            - '@prestashop.core.grid.position.doctrine_grid_position_updater'
 
     prestashop.adapter.product.image.product_image_path_factory:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_position_definition_factory.yml
@@ -39,3 +39,12 @@ services:
         $table: 'carrier'
         $idField: 'id_carrier'
         $positionField: 'position'
+
+  prestashop.core.grid.image.position_definition:
+      class: 'PrestaShop\PrestaShop\Core\Grid\Position\PositionDefinition'
+      arguments:
+          $table: 'image'
+          $idField: 'id_image'
+          $positionField: 'position'
+          $parentIdField: 'id_product'
+          $firstPosition: 1

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -131,6 +131,10 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
             $command->setLocalizedLegends($dataRows['legend']);
         }
 
+        if (isset($dataRows['position'])) {
+            $command->setPosition((int) $dataRows['position']);
+        }
+
         $this->getCommandBus()->handle($command);
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -285,8 +285,17 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
             'Expected and actual images count does not match'
         );
 
-        foreach ($dataRows as $key => $dataRow) {
-            $actualImage = $images[$key];
+        $imagesById = [];
+        foreach ($images as $image) {
+            $imagesById[$image->getImageId()] = $image;
+        }
+
+        foreach ($dataRows as $dataRow) {
+            $rowImageId = (int) $this->getSharedStorage()->get($dataRow['image reference']);
+            if (!isset($imagesById[$rowImageId])) {
+                throw new RuntimeException(sprintf('Cannot find image %s in product images.', $dataRow['image reference']));
+            }
+            $actualImage = $imagesById[$rowImageId];
 
             Assert::assertEquals(
                 PrimitiveUtils::castStringBooleanIntoBoolean($dataRow['is cover']),

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
@@ -83,6 +83,7 @@ Feature: Update product image from Back Office (BO)
       | image5          | false    |                  | 5        |
       | image6          | false    |                  | 6        |
 
+  @product-image-position
   Scenario: I update image positions
     When I update image "image2" with following information:
       | position | 5 |
@@ -100,6 +101,16 @@ Feature: Update product image from Back Office (BO)
       | image reference | is cover | legend[en-US] | position |
       | image1          | true     |               | 1        |
       | image6          | false    |               | 2        |
+      | image3          | false    |               | 3        |
+      | image4          | false    |               | 4        |
+      | image5          | false    |               | 5        |
+      | image2          | false    |               | 6        |
+    When I update image "image1" with following information:
+      | position | 2 |
+    Then product "product1" should have following images:
+      | image reference | is cover | legend[en-US] | position |
+      | image6          | false    |               | 1        |
+      | image1          | true     |               | 2        |
       | image3          | false    |               | 3        |
       | image4          | false    |               | 4        |
       | image5          | false    |               | 5        |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
@@ -21,17 +21,20 @@ Feature: Update product image from Back Office (BO)
     And product "product1" type should be standard
     And product "product1" should have no images
     When I add new image "image1" named "app_icon.png" to product "product1"
-    Then image "image1" should have same file as "app_icon.png"
-    And product "product1" should have following images:
-      | image reference | is cover | legend[en-US] | position |
-      | image1          | true     |               | 1        |
     When I add new image "image2" named "logo.jpg" to product "product1"
-    Then image "image2" should have same file as "logo.jpg"
+    When I add new image "image3" named "app_icon.png" to product "product1"
+    When I add new image "image4" named "logo.jpg" to product "product1"
+    When I add new image "image5" named "app_icon.png" to product "product1"
+    When I add new image "image6" named "logo.jpg" to product "product1"
     And product "product1" should have following images:
       | image reference | is cover | legend[en-US] | position |
       | image1          | true     |               | 1        |
       | image2          | false    |               | 2        |
-    And images "[image1, image2]" should have following types generated:
+      | image3          | false    |               | 3        |
+      | image4          | false    |               | 4        |
+      | image5          | false    |               | 5        |
+      | image6          | false    |               | 6        |
+    And images "[image1, image2, image3, image4, image5, image6]" should have following types generated:
       | name           | width | height |
       | cart_default   | 125   | 125    |
       | home_default   | 250   | 250    |
@@ -51,6 +54,10 @@ Feature: Update product image from Back Office (BO)
       | image reference | is cover | legend[en-US]    | position |
       | image1          | true     | preston is alive | 1        |
       | image2          | false    |                  | 2        |
+      | image3          | false    |                  | 3        |
+      | image4          | false    |                  | 4        |
+      | image5          | false    |                  | 5        |
+      | image6          | false    |                  | 6        |
 
   Scenario: I update image cover
     When I update image "image2" with following information:
@@ -59,6 +66,11 @@ Feature: Update product image from Back Office (BO)
       | image reference | is cover | legend[en-US] | position |
       | image1          | false    |               | 1        |
       | image2          | true     |               | 2        |
+      | image3          | false    |               | 3        |
+      | image4          | false    |               | 4        |
+      | image5          | false    |               | 5        |
+      | image6          | false    |               | 6        |
+    # Set cover false just to check it does not force the cover (it happened ^^)
     When I update image "image1" with following information:
       | legend[en-US] | preston is alive |
       | cover         | false            |
@@ -66,3 +78,49 @@ Feature: Update product image from Back Office (BO)
       | image reference | is cover | legend[en-US]    | position |
       | image1          | false    | preston is alive | 1        |
       | image2          | true     |                  | 2        |
+      | image3          | false    |                  | 3        |
+      | image4          | false    |                  | 4        |
+      | image5          | false    |                  | 5        |
+      | image6          | false    |                  | 6        |
+
+  Scenario: I update image positions
+    When I update image "image2" with following information:
+      | position | 5 |
+    Then product "product1" should have following images:
+      | image reference | is cover | legend[en-US] | position |
+      | image1          | true     |               | 1        |
+      | image3          | false    |               | 2        |
+      | image4          | false    |               | 3        |
+      | image5          | false    |               | 4        |
+      | image2          | false    |               | 5        |
+      | image6          | false    |               | 6        |
+    When I update image "image6" with following information:
+      | position | 2 |
+    Then product "product1" should have following images:
+      | image reference | is cover | legend[en-US] | position |
+      | image1          | true     |               | 1        |
+      | image6          | false    |               | 2        |
+      | image3          | false    |               | 3        |
+      | image4          | false    |               | 4        |
+      | image5          | false    |               | 5        |
+      | image2          | false    |               | 6        |
+    When I update image "image1" with following information:
+      | position | 42 |
+    Then product "product1" should have following images:
+      | image reference | is cover | legend[en-US] | position |
+      | image6          | false    |               | 1        |
+      | image3          | false    |               | 2        |
+      | image4          | false    |               | 3        |
+      | image5          | false    |               | 4        |
+      | image2          | false    |               | 5        |
+      | image1          | true     |               | 6        |
+    When I update image "image3" with following information:
+      | position | -8000 |
+    Then product "product1" should have following images:
+      | image reference | is cover | legend[en-US] | position |
+      | image3          | false    |               | 1        |
+      | image6          | false    |               | 2        |
+      | image4          | false    |               | 3        |
+      | image5          | false    |               | 4        |
+      | image2          | false    |               | 5        |
+      | image1          | true     |               | 6        |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds to possibility to sort images of product page v2 dropzone
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #19524.
| How to test?      | Go on product page v2, add at least 2-3-4 images and try to sort them to the order you want

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23672)
<!-- Reviewable:end -->

# Libraries

This PR uses jQuery Sortable (same as first product page) in order to avoid adding new library.

# BreakingChange

The `PositionDefinitionInterface` now includes a new function `getFirstPosition()` which is used the define which value should be used as first position when updating them (usually 0 or 1), it used to be hard coded to 0