### PR TITLE
Change install demo datas string on install

### DIFF
--- a/install-dev/theme/views/configure.php
+++ b/install-dev/theme/views/configure.php
@@ -55,7 +55,7 @@
 
 	<!-- Install type (with fixtures or not) -->
 	<div class="field clearfix">
-		<label class="aligned"><?php echo $this->translator->trans('Install demo products', array(), 'Install'); ?></label>
+		<label class="aligned"><?php echo $this->translator->trans('Install demonstration data', array(), 'Install'); ?></label>
 		<div class="contentinput">
 			<label>
 				<input value="full" type="radio" name="db_mode" style="vertical-align: middle;" <?php if ($this->install_type == 'full'): ?>checked="checked"<?php endif; ?> autocomplete="off" />


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Install demo products was wrong because it was including every demo datas
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23651.
| How to test?      | Go on installation, see if the wording for demo datas is "Install demonstration data"
| Possible impacts? | Installation understanding


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23689)
<!-- Reviewable:end -->
