### PR TITLE
A lot of HTML errors are breaking DOM parsing

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
@@ -142,7 +142,7 @@
 <div id="apply_discount_to_product_special" class="form-group">
  	<label class="control-label col-lg-3">
     <span class="label-tooltip" data-toggle="tooltip"
-        title="{l s='If enabled, the voucher will not apply to products already on sale.'}">
+        title="{l|escape s='If enabled, the voucher will not apply to products already on sale.'}">
     {l s='Exclude discounted products' d='Admin.Catalog.Feature'}
     </span>
   </label>

--- a/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
@@ -121,7 +121,7 @@
 		</p>
 		<p class="radio">
 			<label for="apply_discount_to_selection">
-				<input type="radio" name="apply_discount_to" id="apply_discount_to_selection" value="selection"{if $currentTab->getFieldValue($currentObject, 'reduction_product')|intval == -2} checked="checked"{/if}{if $product_rule_groups|@count == 0}disabled="disabled"{/if} />
+				<input type="radio" name="apply_discount_to" id="apply_discount_to_selection" value="selection"{if $currentTab->getFieldValue($currentObject, 'reduction_product')|intval == -2} checked="checked"{/if}{if $product_rule_groups|@count == 0} disabled="disabled"{/if} />
 				{l s='Selected product(s)' d='Admin.Catalog.Feature'}{if $product_rule_groups|@count == 0}&nbsp;<span id="apply_discount_to_selection_warning" class="text-muted clearfix"><i class="icon-warning-sign"></i> <a href="#" id="apply_discount_to_selection_shortcut">{l s='You must select some products before' d='Admin.Catalog.Notification'}</a></span>{/if}
 			</label>
 		</p>

--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -25,7 +25,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-			title="{l s='Optional: The cart rule will be available to everyone if you leave this field blank.' d='Admin.Catalog.Help'}">
+			title="{l|escape s='Optional: The cart rule will be available to everyone if you leave this field blank.' d='Admin.Catalog.Help'}">
 			{l s='Limit to a single customer' d='Admin.Catalog.Feature'}
 		</span>
 	</label>
@@ -42,7 +42,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-			title="{l s='The default period is one month.' d='Admin.Catalog.Help'}">
+			title="{l|escape s='The default period is one month.' d='Admin.Catalog.Help'}">
 			{l s='Valid' d='Admin.Catalog.Feature'}
 		</span>
 	</label>
@@ -71,7 +71,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-			title="{l s='You can choose a minimum amount for the cart either with or without the taxes and shipping.' d='Admin.Catalog.Help'}">
+			title="{l|escape s='You can choose a minimum amount for the cart either with or without the taxes and shipping.' d='Admin.Catalog.Help'}">
 			{l s='Minimum amount' d='Admin.Catalog.Feature'}
 		</span>
 	</label>
@@ -113,7 +113,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-			title="{l s='The cart rule will be applied to the first "X" customers only.' d='Admin.Catalog.Help'}">
+			title="{l|escape s='The cart rule will be applied to the first "X" customers only.' d='Admin.Catalog.Help'}">
 			{l s='Total available' d='Admin.Catalog.Feature'}
 		</span>
 	</label>
@@ -125,7 +125,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-			title="{l s='A customer will only be able to use the cart rule "X" time(s).' d='Admin.Catalog.Help'}">
+			title="{l|escape s='A customer will only be able to use the cart rule "X" time(s).' d='Admin.Catalog.Help'}">
 			{l s='Total available for each user' d='Admin.Catalog.Feature'}
 		</span>
 	</label>

--- a/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
@@ -25,7 +25,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3 required">
 		<span class="label-tooltip" data-toggle="tooltip"
-		title="{l s='This will be displayed in the cart summary, as well as on the invoice.' d='Admin.Catalog.Help'}">
+		title="{l|escape s='This will be displayed in the cart summary, as well as on the invoice.' d='Admin.Catalog.Help'}">
 			{l s='Name' d='Admin.Global'}
 		</span>
 	</label>
@@ -60,7 +60,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-		title="{l s='For your eyes only. This will never be displayed to the customer.' d='Admin.Catalog.Help'}">
+		title="{l|escape s='For your eyes only. This will never be displayed to the customer.' d='Admin.Catalog.Help'}">
 			{l s='Description' d='Admin.Global'}
 		</span>
 	</label>
@@ -72,7 +72,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-		title="{{l s='This is the code users should enter to apply the voucher to a cart. Either create your own code or generate one by clicking on "%generate_label%".' d='Admin.Catalog.Help'  sprintf=['%generate_label%' => {l s='Generate' d='Admin.Actions'}]}|escape:"html"}">
+		title="{{l|escape s='This is the code users should enter to apply the voucher to a cart. Either create your own code or generate one by clicking on "%generate_label%".' d='Admin.Catalog.Help'  sprintf=['%generate_label%' => {l s='Generate' d='Admin.Actions'}]}|escape:"html"}">
 			{l s='Code' d='Admin.Global'}
 		</span>
 	</label>
@@ -90,7 +90,7 @@
 <div class="form-group" id="cart-rules-highlight"{if !$currentTab->getFieldValue($currentObject, 'code')} style="display: none;"{/if}>
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-		title="{l s='If the voucher is not yet in the cart, it will be displayed in the cart summary.' d='Admin.Catalog.Help'}">
+		title="{l|escape s='If the voucher is not yet in the cart, it will be displayed in the cart summary.' d='Admin.Catalog.Help'}">
 			{l s='Highlight' d='Admin.Catalog.Feature'}
 		</span>
 	</label>
@@ -108,7 +108,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-		title="{l s='Only applicable if the voucher value is greater than the cart total.' d='Admin.Catalog.Help'}
+		title="{l|escape s='Only applicable if the voucher value is greater than the cart total.' d='Admin.Catalog.Help'}
 		{l s='If you do not allow partial use, the voucher value will be lowered to the total order amount. If you allow partial use, however, a new voucher will be created with the remainder.' d='Admin.Catalog.Help'}">
 			{l s='Partial use' d='Admin.Catalog.Feature'}
 		</span>
@@ -127,7 +127,7 @@
 <div class="form-group">
 	<label class="control-label col-lg-3">
 		<span class="label-tooltip" data-toggle="tooltip"
-		title="{l s='Cart rules are applied by priority. A cart rule with a priority of "1" will be processed before a cart rule with a priority of "2".' d='Admin.Catalog.Help'}">
+		title="{l|escape s='Cart rules are applied by priority. A cart rule with a priority of "1" will be processed before a cart rule with a priority of "2".' d='Admin.Catalog.Help'}">
 			{l s='Priority' d='Admin.Global'}
 		</span>
 	</label>

--- a/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
@@ -38,13 +38,13 @@
 			</div>
 			<div class="row">
 				<div class="col-lg-12">
-					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='This will restore your last registered address format.' d='Admin.International.Help'}" data-html="true"><a id="useLastDefaultLayout" href="javascript:void(0)" onclick="resetLayout('{$input.encoding_address_layout}', 'lastDefault');" class="btn btn-default">
+					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l|escape s='This will restore your last registered address format.' d='Admin.International.Help'}" data-html="true"><a id="useLastDefaultLayout" href="javascript:void(0)" onclick="resetLayout('{$input.encoding_address_layout}', 'lastDefault');" class="btn btn-default">
 						{l s='Use the last registered format' d='Admin.International.Feature'}</a></span>
-					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='This will restore the default address format for this country.' d='Admin.International.Help'}" data-html="true"><a id="useDefaultLayoutSystem" href="javascript:void(0)" onclick="resetLayout('{$input.encoding_default_layout}', 'defaultSystem');" class="btn btn-default">
+					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l|escape s='This will restore the default address format for this country.' d='Admin.International.Help'}" data-html="true"><a id="useDefaultLayoutSystem" href="javascript:void(0)" onclick="resetLayout('{$input.encoding_default_layout}', 'defaultSystem');" class="btn btn-default">
 						{l s='Use the default format' d='Admin.International.Feature'}</a></span>
-					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='This will restore your current address format.' d='Admin.International.Help'}" data-html="true"><a id="useCurrentLastModifiedLayout" href="javascript:void(0)" onclick="resetLayout(lastLayoutModified, 'currentModified')" class="btn btn-default">
+					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l|escape s='This will restore your current address format.' d='Admin.International.Help'}" data-html="true"><a id="useCurrentLastModifiedLayout" href="javascript:void(0)" onclick="resetLayout(lastLayoutModified, 'currentModified')" class="btn btn-default">
 						{l s='Use my current modified format' d='Admin.International.Feature'}</a></span>
-					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='This will delete the current address format' d='Admin.International.Help'}" data-html="true"><a id="eraseCurrentLayout" href="javascript:void(0)" onclick="resetLayout('', 'erase');" class="btn btn-default">
+					<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l|escape s='This will delete the current address format' d='Admin.International.Help'}" data-html="true"><a id="eraseCurrentLayout" href="javascript:void(0)" onclick="resetLayout('', 'erase');" class="btn btn-default">
 						<i class="icon-eraser"></i> {l s='Clear format' d='Admin.International.Feature'}</a></span>
 				</div>
 			</div>

--- a/admin-dev/themes/default/template/controllers/customer_threads/message.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/message.tpl
@@ -32,7 +32,7 @@
 			{else}
 				<i class="icon-user"></i>
 				{if !empty($message.id_customer)}
-					<a href="index.php?tab=AdminCustomers&amp;id_customer={$message.id_customer}&amp;viewcustomer&amp;token={getAdminToken tab='AdminCustomers'}" title="{l s='View customer' d='Admin.Orderscustomers.Feature'}">
+					<a href="index.php?tab=AdminCustomers&amp;id_customer={$message.id_customer}&amp;viewcustomer&amp;token={getAdminToken tab='AdminCustomers'}" title="{l|escape s='View customer' d='Admin.Orderscustomers.Feature'}">
 						{$message.customer_name}
 					</a>
 				{else}
@@ -45,7 +45,7 @@
 			<dl class="dl-horizontal">
 				<dt>{l s='Customer ID:' d='Admin.Orderscustomers.Feature'}</dt>
 				<dd>
-					<a href="index.php?tab=AdminCustomers&amp;id_customer={$message.id_customer}&amp;viewcustomer&amp;token={getAdminToken tab='AdminCustomers'}" title="{l s='View customer' d='Admin.Orderscustomers.Feature'}">
+					<a href="index.php?tab=AdminCustomers&amp;id_customer={$message.id_customer}&amp;viewcustomer&amp;token={getAdminToken tab='AdminCustomers'}" title="{l|escape s='View customer' d='Admin.Orderscustomers.Feature'}">
 						{$message.id_customer} <i class="icon-search"></i>
 					</a>
 				</dd>
@@ -66,7 +66,7 @@
 				<dt>{l s='File attachment' d='Admin.Orderscustomers.Feature'}</dt>
 				<dd>
 					<a href="index.php?tab=AdminCustomerThreads&amp;id_customer_thread={$message.id_customer_thread}&amp;viewcustomer_thread&amp;token={getAdminToken tab='AdminCustomerThreads'}&amp;filename={$message.file_name}"
-					title="{l s='View file' d='Admin.Orderscustomers.Feature'}">
+					title="{l|escape s='View file' d='Admin.Orderscustomers.Feature'}">
 						<i class="icon-search"></i>
 					</a>
 				</dd>
@@ -75,14 +75,14 @@
 			{if !empty($message.id_order) && $is_valid_order_id && empty($message.id_employee)}
 				<dl class="dl-horizontal">
 					<dt>{l s='Order #' d='Admin.Orderscustomers.Feature'}</dt>
-					<dd><a href="index.php?tab=AdminOrders&amp;id_order={$message.id_order}&amp;vieworder&amp;token={getAdminToken tab='AdminOrders'}" title="{l s='View order' d='Admin.Orderscustomers.Feature'}">{$message.id_order} <img src="../img/admin/search.gif" alt="{l s='View' d='Admin.Actions'}" /></a>
+					<dd><a href="index.php?tab=AdminOrders&amp;id_order={$message.id_order}&amp;vieworder&amp;token={getAdminToken tab='AdminOrders'}" title="{l|escape s='View order' d='Admin.Orderscustomers.Feature'}">{$message.id_order} <img src="../img/admin/search.gif" alt="{l s='View' d='Admin.Actions'}" /></a>
 					</dd>
 				</dl>
 			{/if}
 			{if !empty($message.id_product) && empty($message.id_employee)}
 				<dl class="dl-horizontal">
 					<dt>{l s='Product #' d='Admin.Orderscustomers.Feature'}</dt>
-					<dd><a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $message.id_product, 'updateproduct' => '1'])|escape:'html':'UTF-8'}" title="{l s='View order' d='Admin.Orderscustomers.Feature'}">{$message.id_product} <img src="../img/admin/search.gif" alt="{l s='View' d='Admin.Actions'}" /></a></dd>
+					<dd><a href="{$link->getAdminLink('AdminProducts', true, ['id_product' => $message.id_product, 'updateproduct' => '1'])|escape:'html':'UTF-8'}" title="{l|escape s='View order' d='Admin.Orderscustomers.Feature'}">{$message.id_product} <img src="../img/admin/search.gif" alt="{l s='View' d='Admin.Actions'}" /></a></dd>
 				</dl>
 			{/if}
 

--- a/admin-dev/themes/default/template/controllers/modules/list.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/list.tpl
@@ -38,7 +38,7 @@
 				<tr>
 					<td class="{{$smarty.capture.moduleStatutClass}} text-center" style="width: 1%;">
 						{if (isset($module->id) && $module->id > 0) || !isset($module->type) || $module->type != 'addonsMustHave'}
-						<input type="checkbox" name="modules" value="{$module->name|escape:'html':'UTF-8'}" class="noborder" title="{l s='Module %1s ' sprintf=[$module->name]}"{if !isset($module->confirmUninstall) OR empty($module->confirmUninstall)} data-rel="false"{else} data-rel="{$module->confirmUninstall|addslashes}"{/if}/>
+						<input type="checkbox" name="modules" value="{$module->name|escape:'html':'UTF-8'}" class="noborder" title="{l|escape s='Module %1s ' sprintf=[$module->name]}"{if !isset($module->confirmUninstall) OR empty($module->confirmUninstall)} data-rel="false"{else} data-rel="{$module->confirmUninstall|addslashes}"{/if}/>
 						{/if}
 					</td>
 					<td class="fixed-width-xs">

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -218,16 +218,16 @@
 
       {if isset($debug_mode) && $debug_mode == true}
       <div class="component hide-mobile-sm">
-          <a class="shop-state label-tooltip" id="debug-mode"
-             data-toggle="tooltip"
-             data-placement="bottom"
-             data-html="true"
-             title="<p class='text-left'><strong>{l s='Your shop is in debug mode.' d='Admin.Navigation.Notification'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>'] d='Admin.Navigation.Notification'}</p>"
+        <a class="shop-state label-tooltip" id="debug-mode"
+           data-toggle="tooltip"
+           data-placement="bottom"
+           data-html="true"
+           title="<p class=&quot;text-left&quot;><strong>{l s='Your shop is in debug mode.' d='Admin.Navigation.Notification'}</strong></p><p class=&quot;text-left&quot;>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>'] d='Admin.Navigation.Notification'}</p>"
              href="{$link->getAdminLink('AdminPerformance')|escape:'html':'UTF-8'}"
           >
-            <i class="material-icons">bug_report</i>
-            <span>{l s='Debug mode' d='Admin.Navigation.Header'}</span>
-          </a>
+          <i class="material-icons">bug_report</i>
+          <span>{l s='Debug mode' d='Admin.Navigation.Header'}</span>
+        </a>
       </div>
       {/if}
 
@@ -238,7 +238,7 @@
            data-toggle="tooltip"
            data-placement="bottom"
            data-html="true"
-           title="<p class='text-left text-nowrap'><strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' sprintf=['<br />'] d='Admin.Navigation.Notification'}</p>"
+           title="<p class=&quot;text-left text-nowrap&quot;><strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong></p><p class=&quot;text-left&quot;>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' sprintf=['<br />'] d='Admin.Navigation.Notification'}</p>"
         >
           <i class="material-icons">build</i>
           <span>{l s='Maintenance mode' d='Admin.Navigation.Header'}</span>

--- a/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/employee_dropdown.tpl
@@ -30,7 +30,7 @@
   <div class="dropdown-menu dropdown-menu-right">
     <div class="employee-wrapper-avatar">
 
-      <span class="employee-avatar"><img class="avatar rounded-circle" src="{$employee->getImage()}" /></span>
+      <span class="employee-avatar"><img class="avatar rounded-circle" src="{$employee->getImage()}" alt="{$employee->firstname}" /></span>
       <span class="employee_profile">{l s='Welcome back %name%' sprintf=['%name%' => $employee->firstname] d='Admin.Navigation.Header'}</span>
       <a class="dropdown-item employee-link profile-link" href="{$link->getAdminLink('AdminEmployees', true, [], ['id_employee' => $employee->id|intval, 'updateemployee' => 1])|escape:'html':'UTF-8'}">
       <i class="material-icons">edit</i>

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -35,7 +35,7 @@
              data-toggle="pstooltip"
              data-placement="bottom"
              data-html="true"
-             title="<p class='text-left'><strong>{l s='Your shop is in debug mode.' d='Admin.Navigation.Notification'}</strong></p><p class='text-left'>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>'] d='Admin.Navigation.Notification'}</p>"
+             title="<p class=&quot;text-left&quot;><strong>{l s='Your shop is in debug mode.' d='Admin.Navigation.Notification'}</strong></p><p class=&quot;text-left&quot;>{l s='All the PHP errors and messages are displayed. When you no longer need it, [1]turn off[/1] this mode.' html=true sprintf=['[1]' => '<strong>', '[/1]' => '</strong>'] d='Admin.Navigation.Notification'}</p>"
              href="{$link->getAdminLink('AdminPerformance')|escape:'html':'UTF-8'}"
           >
             <i class="material-icons">bug_report</i>
@@ -51,7 +51,7 @@
              data-toggle="pstooltip"
              data-placement="bottom"
              data-html="true"
-             title="<p class='text-left'><strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong></p><p class='text-left'>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' sprintf=['<br />'] d='Admin.Navigation.Notification'}</p>" href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
+             title="<p class=&quot;text-left&quot;><strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong></p><p class=&quot;text-left&quot;>{l s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' sprintf=['<br />'] d='Admin.Navigation.Notification'}</p>" href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
           >
             <i class="material-icons">build</i>
             <span>{l s='Maintenance mode' d='Admin.Navigation.Header'}</span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -35,7 +35,7 @@
     <div id="attributes-generator">
       <div class="alert alert-info" role="alert">
         <p class="alert-text">
-          {{ 'To add combinations, you first need to create proper attributes and values in [1]%attributes_and_features_label%[/1]. <br> When done, you may enter the wanted attributes (like "size" or "color") and their respective values ("XS", "red", "all", etc.) in the field below; or simply select them from the right column. Then click on "%generate_label%": it will automatically create all the combinations for you!'|trans({'%attributes_and_features_label%': 'Attributes & Features'|trans({}, 'Admin.Navigation.Menu'), '%generate_label%': 'Generate'|trans({}, 'Admin.Actions')}, 'Admin.Catalog.Help')|replace({'[1]': '<a class="alert-link" href=' ~ getAdminLink("AdminAttributesGroups") ~ ' target="_blank">', '[/1]': '</a>'})|raw }}
+          {{ 'To add combinations, you first need to create proper attributes and values in [1]%attributes_and_features_label%[/1]. <br> When done, you may enter the wanted attributes (like "size" or "color") and their respective values ("XS", "red", "all", etc.) in the field below; or simply select them from the right column. Then click on "%generate_label%": it will automatically create all the combinations for you!'|trans({'%attributes_and_features_label%': 'Attributes & Features'|trans({}, 'Admin.Navigation.Menu'), '%generate_label%': 'Generate'|trans({}, 'Admin.Actions')}, 'Admin.Catalog.Help')|replace({'[1]': '<a class="alert-link" href="' ~ getAdminLink("AdminAttributesGroups") ~ '" target="_blank">', '[/1]': '</a>'})|raw }}
         </p>
       </div>
       <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Themes/categories_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Themes/categories_theme.html.twig
@@ -36,15 +36,16 @@
 
 {% block choice_tree_item_widget -%}
   <li>
-    {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
+    {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) %}
 
     <div class="radio">
       <label class="category-label" for="form[{{ form.vars.id }}][tree]">{{ child.name }}
         <input
-            type="radio"
-            name="form[{{ form.vars.id }}][tree]"
-            value="{{ child.id_category }}" {{ checked }}
-            class="category float-right"
+          type="radio"
+          name="form[{{ form.vars.id }}][tree]"
+          value="{{ child.id_category }}"
+          {% if checked %}checked="checked"{% endif %}
+          class="category float-right"
         >
       </label>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig
@@ -97,8 +97,6 @@
           </span>
         </div>
 
-    </span>
-
       </div>
       <div class="form-group row type-text {% if not giftSettingsEnabled %}d-none{% endif %}">
         <div class="col-3">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -357,9 +357,9 @@
 
 {% block color_picker_widget %}
   {% spaceless %}
-    {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' colorpicker')|trim)}) %}
+    {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' form-control colorpicker')|trim)}) %}
     <div class="input-group colorpicker">
-      <input type="text" class="form-control" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+      <input type="text" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
     </div>
   {% endspaceless %}
 {% endblock color_picker_widget %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -335,10 +335,10 @@
 
 {% block date_picker_widget %}
   {% spaceless %}
-    {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' datepicker')|trim)}) %}
+    {%  set attr = attr|merge({'class': ((attr.class|default('') ~ ' datepicker form-control')|trim)}) %}
     {%- set attr = attr|merge({'aria-label': '%inputId% input'|trans({'%inputId%': form.vars.id}, 'Admin.Global')}) -%}
     <div class="input-group datepicker">
-      <input type="text" class="form-control" data-format="{{ date_format }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+      <input type="text" data-format="{{ date_format }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
       <div class="input-group-append">
         <div class="input-group-text">
           <i class="material-icons">date_range</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -183,11 +183,11 @@
 
 {% block choice_tree_item_widget -%}
   <li{% if defaultHidden is defined and defaultHidden is same as(true) %} class="more"{% endif %}>
-        {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) ? 'checked="checked"' : '' %}
+        {% set checked = (form.vars.submitted_values is defined and submitted_values[child.id_category] is defined) %}
         {% if multiple -%}
             <div class="checkbox">
                 <label>
-                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}" class="category" {{ checked }}>
+                    <input type="checkbox" name="{{ form.vars.full_name }}[tree][]" value="{{ child.id_category }}"{% if checked %} checked="checked"{% endif %}>
                     {% if child.active is defined and child.active == 0 %}
                         <i>{{ child.name }}</i>
                     {%- else -%}
@@ -200,8 +200,8 @@
             </div>
         {%- else -%}
             <div class="radio">
-                <label>
-                    <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}" {{ checked }} class="category"{% if required %} required{% endif %}>
+              <label>
+                <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}"{% if checked %} checked="checked"{% endif %} class="category"{% if required %} required{% endif %}>
                     {{ child.name }}
                     {% if defaultCategory is defined %}
                         <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -396,7 +396,15 @@
     <span class="ps-switch">
         {% for choice in choices %}
             {% set inputId = id ~'_' ~ choice.value %}
-            <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio" aria-label="{{ choice.label|trans({}, choice_translation_domain) }}">
+            <input id="{{inputId}}"
+                {{ block('attributes') }}
+                name="{{ full_name }}"
+                value="{{ choice.value }}"
+                {% if choice is selectedchoice(value) %}checked=""{% endif %}
+                {% if disabled %}disabled=""{% endif %}
+                type="radio"
+                aria-label="{{ choice.label|trans({}, choice_translation_domain) }}"
+                >
             <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
         {% endfor %}
         <span class="slide-button"></span>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -495,7 +495,14 @@
     <span class="ps-switch">
         {% for choice in choices %}
           {% set inputId = id ~'_' ~ choice.value %}
-          <input id="{{inputId}}" {{ block('attributes') }} name="{{ full_name }}" value="{{ choice.value }}" {%- if choice is selectedchoice(value) -%}checked="" {%- endif -%} {%- if disabled -%}disabled="" {%- endif -%} type="radio">
+          <input id="{{inputId}}"
+            {{ block('attributes') }}
+            name="{{ full_name }}"
+            value="{{ choice.value }}"
+            {% if choice is selectedchoice(value) %}checked=""{% endif %}
+            {% if disabled %}disabled=""{% endif %}
+            type="radio"
+          >
           <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
         {% endfor %}
         <span class="slide-button"></span>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -37,7 +37,7 @@
           {%- set attr = attr|merge({'class': (attr.class|default('') ~ ' form-control search typeahead ' ~ form.vars.id)|trim }) -%}
           {# We do not want the initial input name because the data is handled via a collection input with name="full_name[data][]" #}
           {%- set full_name = '' -%}
-          <input type="text" id="{{ form.vars.id }}" placeholder="{{ placeholder }}" autocomplete="off" {{ block('widget_attributes') }}>
+          <input type="text" placeholder="{{ placeholder }}" autocomplete="off" {{ block('widget_attributes') }}>
         </div>
         <small class="form-text text-muted text-right typeahead-hint">
         </small>

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -83,8 +83,7 @@
     >
       <span role="columnheader">{{ title }}</span>
       <span role="button" class="ps-sort" aria-label="{{ 'Sort by'|trans({}, 'Admin.Actions') }}"></span>
-    </div>
-  </th>
+  </div>
 {% endmacro %}
 
 {# Show link to import file sample #}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | By using the W3 validator, a lot of errors are spawning, I try to fix some of them without breaking the whole BO. Attributes are duplicated, malformed HTML, duplicate id, html tags are alone and crying in the dark.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23332 
| How to test?      | Tests cart rules page, the header about debug mode icon, product form combinations, category tree too. I'm pretty sure this one can be tested by devs.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23692)
<!-- Reviewable:end -->
