### PR TITLE
Fix exception when adding only a space in the payment method in the orders page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderPaymentType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderPaymentType.php
@@ -102,6 +102,7 @@ class OrderPaymentType extends AbstractType
                 'date_format' => 'YYYY-MM-DD H:m:s',
             ])
             ->add('payment_method', TextType::class, [
+                'empty_data' => '',
                 'data_list' => $this->installedPaymentModulesChoiceProvider->getChoices(),
             ])
             ->add('transaction_id', TextType::class, [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When adding a payment with a space (` `) as  "Payment method", an exception is thrown. We should not be able to set an empty string as payment method. This PR aims to fix this.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23287
| How to test?      | Please see #23287
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23694)
<!-- Reviewable:end -->
