### PR TITLE
Use new components on translation BO interface

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
@@ -265,7 +265,8 @@
         this.modifiedTranslations = [];
         const targetTheme = (window.data.type === 'modules') ? '' : window.data.selected;
 
-        this.$store.state.modifiedTranslations.forEach((translation) => {
+        Object.keys(this.$store.state.modifiedTranslations).forEach((key) => {
+          const translation = this.$store.state.modifiedTranslations[key];
           this.modifiedTranslations.push({
             default: translation.default,
             edited: translation.edited,
@@ -278,7 +279,7 @@
         return this.modifiedTranslations;
       },
       edited() {
-        return this.$store.state.modifiedTranslations.length > 0;
+        return Object.keys(this.$store.state.modifiedTranslations).length > 0;
       },
     },
     mounted() {

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
@@ -265,8 +265,7 @@
         this.modifiedTranslations = [];
         const targetTheme = (window.data.type === 'modules') ? '' : window.data.selected;
 
-        Object.keys(this.$store.state.modifiedTranslations).forEach((key) => {
-          const translation = this.$store.state.modifiedTranslations[key];
+        Object.values(this.$store.state.modifiedTranslations).forEach((translation) => {
           this.modifiedTranslations.push({
             default: translation.default,
             edited: translation.edited,

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/translation-input.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/translation-input.vue
@@ -72,11 +72,11 @@
     computed: {
       getTranslated: {
         get() {
-          return this.translated.database ? this.translated.database : this.translated.xliff;
+          return this.translated.user ? this.translated.user : this.translated.project;
         },
         set(modifiedValue) {
           const modifiedTranslated = this.translated;
-          modifiedTranslated.database = modifiedValue;
+          modifiedTranslated.user = modifiedValue;
           modifiedTranslated.edited = modifiedValue;
           this.$emit('input', modifiedTranslated);
           this.$emit('editedAction', {

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/sidebar/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/sidebar/index.vue
@@ -145,7 +145,7 @@
        * @returns {boolean}
        */
       edited: function edited() {
-        return this.$store.state.modifiedTranslations.length > 0;
+        return Object.keys(this.$store.state.modifiedTranslations).length > 0;
       },
     },
     components: {

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
@@ -78,9 +78,6 @@ export default class FormFieldToggle {
     const $modulesFormGroup = $('.js-module-form-group');
     const $emailFormGroup = $('.js-email-form-group');
     const $themesFormGroup = $('.js-theme-form-group');
-    const $themesSelect = $themesFormGroup.find('select');
-    const $noThemeOption = $themesSelect.find('.js-no-theme');
-    const $firstThemeOption = $themesSelect.find('option:not(.js-no-theme):first');
 
     switch (selectedOption) {
       case back:
@@ -89,11 +86,7 @@ export default class FormFieldToggle {
         break;
 
       case themes:
-        if ($noThemeOption.is(':selected')) {
-          $themesSelect.val($firstThemeOption.val());
-        }
-
-        this.hide($modulesFormGroup, $emailFormGroup, $noThemeOption);
+        this.hide($modulesFormGroup, $emailFormGroup);
         this.show($themesFormGroup);
         break;
 

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
@@ -23,6 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+
+import TranslationSettingsMap from './TranslationSettingsMap';
+
 const {$} = window;
 
 /**
@@ -64,8 +67,8 @@ const emailContentBody = 'body';
 
 export default class FormFieldToggle {
   constructor() {
-    $('.js-translation-type').on('change', this.toggleFields.bind(this));
-    $('.js-email-content-type').on('change', this.toggleEmailFields.bind(this));
+    $(TranslationSettingsMap.translationType).on('change', this.toggleFields.bind(this));
+    $(TranslationSettingsMap.emailContentType).on('change', this.toggleEmailFields.bind(this));
 
     this.toggleFields();
   }
@@ -74,11 +77,11 @@ export default class FormFieldToggle {
    * Toggle dependant translations fields, based on selected translation type
    */
   toggleFields() {
-    const selectedOption = $('.js-translation-type').val();
-    const $modulesFormGroup = $('.js-module-form-group');
-    const $emailFormGroup = $('.js-email-form-group');
-    const $themesFormGroup = $('.js-theme-form-group');
-    const $defaultThemeOption = $themesFormGroup.find('.js-default-theme');
+    const selectedOption = $(TranslationSettingsMap.translationType).val();
+    const $modulesFormGroup = $(TranslationSettingsMap.modulesFormGroup);
+    const $emailFormGroup = $(TranslationSettingsMap.emailFormGroup);
+    const $themesFormGroup = $(TranslationSettingsMap.themesFormGroup);
+    const $defaultThemeOption = $themesFormGroup.find(TranslationSettingsMap.defaultThemeOption);
 
     switch (selectedOption) {
       case back:
@@ -112,14 +115,14 @@ export default class FormFieldToggle {
    * Toggles fields, which are related to email translations
    */
   toggleEmailFields() {
-    if ($('.js-translation-type').val() !== mails) {
+    if ($(TranslationSettingsMap.translationType).val() !== mails) {
       return;
     }
 
-    const selectedEmailContentType = $('.js-email-form-group').find('select').val();
-    const $themesFormGroup = $('.js-theme-form-group');
-    const $noThemeOption = $themesFormGroup.find('.js-no-theme');
-    const $defaultThemeOption = $themesFormGroup.find('.js-default-theme');
+    const selectedEmailContentType = $(TranslationSettingsMap.emailFormGroup).find('select').val();
+    const $themesFormGroup = $(TranslationSettingsMap.themesFormGroup);
+    const $noThemeOption = $themesFormGroup.find(TranslationSettingsMap.noThemeOption);
+    const $defaultThemeOption = $themesFormGroup.find(TranslationSettingsMap.defaultThemeOption);
 
     if (selectedEmailContentType === emailContentBody) {
       $noThemeOption.prop('selected', true);

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
@@ -78,6 +78,7 @@ export default class FormFieldToggle {
     const $modulesFormGroup = $('.js-module-form-group');
     const $emailFormGroup = $('.js-email-form-group');
     const $themesFormGroup = $('.js-theme-form-group');
+    const $defaultThemeOption = $themesFormGroup.find('.js-default-theme');
 
     switch (selectedOption) {
       case back:
@@ -86,8 +87,8 @@ export default class FormFieldToggle {
         break;
 
       case themes:
-        this.hide($modulesFormGroup, $emailFormGroup);
         this.show($themesFormGroup);
+        this.hide($modulesFormGroup, $emailFormGroup, $defaultThemeOption);
         break;
 
       case modules:
@@ -118,12 +119,13 @@ export default class FormFieldToggle {
     const selectedEmailContentType = $('.js-email-form-group').find('select').val();
     const $themesFormGroup = $('.js-theme-form-group');
     const $noThemeOption = $themesFormGroup.find('.js-no-theme');
+    const $defaultThemeOption = $themesFormGroup.find('.js-default-theme');
 
     if (selectedEmailContentType === emailContentBody) {
       $noThemeOption.prop('selected', true);
-      this.show($noThemeOption, $themesFormGroup);
+      this.show($noThemeOption, $themesFormGroup, $defaultThemeOption);
     } else {
-      this.hide($noThemeOption, $themesFormGroup);
+      this.hide($noThemeOption, $themesFormGroup, $defaultThemeOption);
     }
   }
 

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+export default {
+    translationType: '.js-translation-type',
+    emailContentType: '.js-email-content-type',
+    emailFormGroup: '.js-email-form-group',
+    modulesFormGroup: '.js-module-form-group',
+    themesFormGroup: '.js-theme-form-group',
+    defaultThemeOption: '.js-default-theme',
+    noThemeOption: '.js-no-theme',
+};

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.js
@@ -24,11 +24,11 @@
  */
 
 export default {
-    translationType: '.js-translation-type',
-    emailContentType: '.js-email-content-type',
-    emailFormGroup: '.js-email-form-group',
-    modulesFormGroup: '.js-module-form-group',
-    themesFormGroup: '.js-theme-form-group',
-    defaultThemeOption: '.js-default-theme',
-    noThemeOption: '.js-no-theme',
+  translationType: '.js-translation-type',
+  emailContentType: '.js-email-content-type',
+  emailFormGroup: '.js-email-form-group',
+  modulesFormGroup: '.js-module-form-group',
+  themesFormGroup: '.js-theme-form-group',
+  defaultThemeOption: '.js-default-theme',
+  noThemeOption: '.js-no-theme',
 };

--- a/src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/TranslationTypeChoiceProvider.php
@@ -54,7 +54,7 @@ final class TranslationTypeChoiceProvider implements FormChoiceProviderInterface
     {
         return [
             $this->translator->trans('Back office translations', [], 'Admin.International.Feature') => 'back',
-            $this->translator->trans('Themes translations', [], 'Admin.International.Feature') => 'themes',
+            $this->translator->trans('Front office Translations', [], 'Admin.International.Feature') => 'themes',
             $this->translator->trans('Installed modules translations', [], 'Admin.International.Feature') => 'modules',
             $this->translator->trans('Email translations', [], 'Admin.International.Feature') => 'mails',
             $this->translator->trans('Other translations', [], 'Admin.International.Feature') => 'others',

--- a/src/Core/Translation/Builder/Map/Message.php
+++ b/src/Core/Translation/Builder/Map/Message.php
@@ -94,18 +94,17 @@ class Message
      */
     public function contains(array $search): bool
     {
+        if (empty($search)) {
+            return false;
+        }
+
         foreach ($search as $s) {
-            $s = strtolower($s);
-            if (
-                false !== strpos(strtolower($this->defaultTranslation), $s)
-                || (null !== $this->fileTranslation && false !== strpos(strtolower($this->fileTranslation), $s))
-                || (null !== $this->userTranslation && false !== strpos(strtolower($this->userTranslation), $s))
-            ) {
-                return true;
+            if (!$this->containsWord($s)) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     /**
@@ -118,5 +117,19 @@ class Message
             'project' => $this->fileTranslation,
             'user' => $this->userTranslation,
         ];
+    }
+
+    private function containsWord(string $s): bool
+    {
+        $s = strtolower($s);
+        if (
+            false !== strpos(strtolower($this->defaultTranslation), $s)
+            || (null !== $this->fileTranslation && false !== strpos(strtolower($this->fileTranslation), $s))
+            || (null !== $this->userTranslation && false !== strpos(strtolower($this->userTranslation), $s))
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Core/Translation/Builder/Map/Message.php
+++ b/src/Core/Translation/Builder/Map/Message.php
@@ -122,14 +122,11 @@ class Message
     private function containsWord(string $s): bool
     {
         $s = strtolower($s);
-        if (
+
+        return
             false !== strpos(strtolower($this->defaultTranslation), $s)
             || (null !== $this->fileTranslation && false !== strpos(strtolower($this->fileTranslation), $s))
             || (null !== $this->userTranslation && false !== strpos(strtolower($this->userTranslation), $s))
-        ) {
-            return true;
-        }
-
-        return false;
+        ;
     }
 }

--- a/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
+++ b/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Translation\Builder\Map\Message;
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Exception\UnexpectedTranslationTypeException;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFactory;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 
@@ -65,7 +66,7 @@ class TranslationCatalogueBuilder
      * Each domain will have counters (number of items and missing translations) as metadata.
      * 'Normalization' will add extra data.
      *
-     * @param ProviderDefinitionInterface $providerDefinition
+     * @param ProviderDefinitionInterface $providerDefinition Translation storage provider configuration
      * @param string $locale
      * @param string $domain
      * @param array $search
@@ -87,7 +88,7 @@ class TranslationCatalogueBuilder
         // see PrestaShop\PrestaShop\Core\Translation\Builder\Map\Domain::mergeTree
         // When getting messages for a domain, we have to do the reverse operation to match the catalogue domain
         $catalogueDomain = $domain;
-        if ($catalogueDomain !== 'messages') {
+        if ($catalogueDomain !== OthersProviderDefinition::OTHERS_DOMAIN_NAME) {
             $catalogueDomain = ucfirst(Inflector::camelize($catalogueDomain));
         }
 
@@ -121,7 +122,7 @@ class TranslationCatalogueBuilder
      * User-translated will override file-translated, which will override default catalogue.
      * Each domain will have counters (number of items and missing translations) as metadata.
      *
-     * @param ProviderDefinitionInterface $providerDefinition
+     * @param ProviderDefinitionInterface $providerDefinition Translation storage provider configuration
      * @param string $locale
      * @param array $search
      *
@@ -149,7 +150,7 @@ class TranslationCatalogueBuilder
      * User-translated will override file-translated, which will override default catalogue.
      * Each domain will have counters (number of items and missing translations) as metadata.
      *
-     * @param ProviderDefinitionInterface $providerDefinition
+     * @param ProviderDefinitionInterface $providerDefinition Translation storage provider configuration
      * @param string $locale
      * @param array $search
      * @param string|null $domain
@@ -208,7 +209,7 @@ class TranslationCatalogueBuilder
     }
 
     /**
-     * @param ProviderDefinitionInterface $providerDefinition
+     * @param ProviderDefinitionInterface $providerDefinition Translation storage provider configuration
      * @param string $locale
      * @param array $search
      * @param string|null $domain

--- a/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
+++ b/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Builder;
 
+use Doctrine\Common\Inflector\Inflector;
 use InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Translation\Builder\Map\Catalogue;
 use PrestaShop\PrestaShop\Core\Translation\Builder\Map\Domain;
@@ -82,15 +83,23 @@ class TranslationCatalogueBuilder
     ): array {
         $this->validateParameters($providerDefinition, $locale, $search, $domain);
 
+        // When building tree, we keep 3 leaves of Domain i.e OneTwoThreeFour will become OneTwoThree_four
+        // see PrestaShop\PrestaShop\Core\Translation\Builder\Map\Domain::mergeTree
+        // When getting messages for a domain, we have to do the reverse operation to match the catalogue domain
+        $catalogueDomain = $domain;
+        if ($catalogueDomain !== 'messages') {
+            $catalogueDomain = ucfirst(Inflector::camelize($catalogueDomain));
+        }
+
         $domainTranslation = $this->getRawCatalogue(
             $providerDefinition,
             $locale,
             $search,
-            $domain
-        )->getDomain($domain);
+            $catalogueDomain
+        )->getDomain($catalogueDomain);
 
         if (null === $domainTranslation) {
-            $domainTranslation = new Domain($domain);
+            $domainTranslation = new Domain($catalogueDomain);
         }
 
         return [

--- a/src/Core/Translation/Builder/TranslationsTreeBuilder.php
+++ b/src/Core/Translation/Builder/TranslationsTreeBuilder.php
@@ -153,6 +153,12 @@ class TranslationsTreeBuilder
             $current['children'][] = $this->recursivelyBuildApiTree($routeParams, $value, $name, (string) $fullSubtreeName . $name);
         }
 
+        if (isset($current['children'])) {
+            usort($current['children'], function (array $child1, array $child2) {
+                return strcmp($child1['name'], $child2['name']);
+            });
+        }
+
         return $current;
     }
 

--- a/src/Core/Translation/Storage/Provider/Definition/BackofficeProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/BackofficeProviderDefinition.php
@@ -32,6 +32,14 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class BackofficeProviderDefinition extends AbstractCoreProviderDefinition
 {
+    private const FILENAME_FILTERS_REGEX = [
+        '#^Admin[A-Z]#',
+    ];
+
+    private const TRANSLATION_DOMAINS_REGEX = [
+        '^Admin[A-Z]',
+    ];
+
     /**
      * {@inheritdoc}
      */
@@ -45,9 +53,7 @@ class BackofficeProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return [
-            '#^Admin[A-Z]#',
-        ];
+        return self::FILENAME_FILTERS_REGEX;
     }
 
     /**
@@ -55,8 +61,6 @@ class BackofficeProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return [
-            '^Admin[A-Z]',
-        ];
+        return self::TRANSLATION_DOMAINS_REGEX;
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/CoreDomainProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/CoreDomainProviderDefinition.php
@@ -32,6 +32,13 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class CoreDomainProviderDefinition extends AbstractCoreProviderDefinition
 {
+    private const FILENAME_FILTERS_REGEX = [
+        '#^%s([A-Za-z]|\.|$)#',
+    ];
+    private const TRANSLATION_DOMAINS_REGEX = [
+        '^%s([A-Za-z]|$)',
+    ];
+
     /**
      * @var string
      */
@@ -66,7 +73,9 @@ class CoreDomainProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return ['#^' . preg_quote($this->domainName, '#') . '([A-Za-z]|\.|$)#'];
+        return array_map(function (string $filenameFilter) {
+            return sprintf($filenameFilter, preg_quote($this->domainName, '#'));
+        }, self::FILENAME_FILTERS_REGEX);
     }
 
     /**
@@ -74,6 +83,8 @@ class CoreDomainProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return ['^' . preg_quote($this->domainName) . '([A-Za-z]|$)'];
+        return array_map(function (string $translationDomain) {
+            return sprintf($translationDomain, preg_quote($this->domainName, '#'));
+        }, self::TRANSLATION_DOMAINS_REGEX);
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/CoreDomainProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/CoreDomainProviderDefinition.php
@@ -23,49 +23,57 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
 
-interface ProviderDefinitionInterface
+/**
+ * Properties container for core translation provider filtering by a single domain name.
+ */
+class CoreDomainProviderDefinition extends AbstractCoreProviderDefinition
 {
-    public const TYPE_BACK = 'back';
-    public const TYPE_FRONT = 'front';
-    public const TYPE_MAILS = 'mails';
-    public const TYPE_MAILS_BODY = 'mails_body';
-    public const TYPE_OTHERS = 'others';
-    public const TYPE_MODULES = 'modules';
-    public const TYPE_THEMES = 'themes';
-    public const TYPE_CORE_DOMAIN = 'core_domain';
+    /**
+     * @var string
+     */
+    private $domainName;
 
-    public const ALLOWED_TYPES = [
-        self::TYPE_BACK,
-        self::TYPE_FRONT,
-        self::TYPE_MAILS,
-        self::TYPE_MAILS_BODY,
-        self::TYPE_OTHERS,
-        self::TYPE_MODULES,
-        self::TYPE_THEMES,
-        self::TYPE_CORE_DOMAIN,
-    ];
+    /**
+     * @param string $domainName
+     */
+    public function __construct(string $domainName)
+    {
+        $this->domainName = $domainName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_CORE_DOMAIN;
+    }
 
     /**
      * @return string
      */
-    public function getType(): string;
+    public function getDomainName(): string
+    {
+        return $this->domainName;
+    }
 
     /**
-     * Returns a list of patterns to filter catalogue files.
-     * Depends on the translation type.
-     *
-     * @return array<int, string>
+     * {@inheritdoc}
      */
-    public function getFilenameFilters(): array;
+    public function getFilenameFilters(): array
+    {
+        return ['#^' . preg_quote($this->domainName, '#') . '([A-Za-z]|\.|$)#'];
+    }
 
     /**
-     * Returns a list of patterns to filter translation domains.
-     * Depends on the translation type.
-     *
-     * @return array<int, string>
+     * {@inheritdoc}
      */
-    public function getTranslationDomains(): array;
+    public function getTranslationDomains(): array
+    {
+        return ['^' . preg_quote($this->domainName) . '([A-Za-z]|$)'];
+    }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/FrontofficeProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/FrontofficeProviderDefinition.php
@@ -32,6 +32,16 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class FrontofficeProviderDefinition extends AbstractCoreProviderDefinition
 {
+    private const FILENAME_FILTERS_REGEX = [
+        '#^Shop*#',
+        '#^Modules(.*)Shop#',
+    ];
+
+    private const TRANSLATION_DOMAINS_REGEX = [
+        '^Shop*',
+        '^Modules(.*)Shop',
+    ];
+
     /**
      * {@inheritdoc}
      */
@@ -45,10 +55,7 @@ class FrontofficeProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return [
-            '#^Shop*#',
-            '#^Modules(.*)Shop#',
-        ];
+        return self::FILENAME_FILTERS_REGEX;
     }
 
     /**
@@ -56,9 +63,6 @@ class FrontofficeProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return [
-            '^Shop*',
-            '^Modules(.*)Shop',
-        ];
+        return self::TRANSLATION_DOMAINS_REGEX;
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/FrontofficeProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/FrontofficeProviderDefinition.php
@@ -32,15 +32,9 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class FrontofficeProviderDefinition extends AbstractCoreProviderDefinition
 {
-    private const FILENAME_FILTERS_REGEX = [
-        '#^Shop*#',
-        '#^Modules(.*)Shop#',
-    ];
+    private const FILENAME_FILTERS_REGEX = ['#^Shop*#'];
 
-    private const TRANSLATION_DOMAINS_REGEX = [
-        '^Shop*',
-        '^Modules(.*)Shop',
-    ];
+    private const TRANSLATION_DOMAINS_REGEX = ['^Shop*'];
 
     /**
      * {@inheritdoc}

--- a/src/Core/Translation/Storage/Provider/Definition/MailsBodyProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/MailsBodyProviderDefinition.php
@@ -32,6 +32,10 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class MailsBodyProviderDefinition extends AbstractCoreProviderDefinition
 {
+    private const FILENAME_FILTERS_REGEX = ['#EmailsBody*#'];
+
+    private const TRANSLATION_DOMAINS_REGEX = ['EmailsBody*'];
+
     /**
      * {@inheritdoc}
      */
@@ -45,7 +49,7 @@ class MailsBodyProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return ['#EmailsBody*#'];
+        return self::FILENAME_FILTERS_REGEX;
     }
 
     /**
@@ -53,6 +57,6 @@ class MailsBodyProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return ['EmailsBody*'];
+        return self::TRANSLATION_DOMAINS_REGEX;
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/MailsProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/MailsProviderDefinition.php
@@ -32,6 +32,10 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class MailsProviderDefinition extends AbstractCoreProviderDefinition
 {
+    private const FILENAME_FILTERS_REGEX = ['#EmailsSubject*#'];
+
+    private const TRANSLATION_DOMAINS_REGEX = ['EmailsSubject*'];
+
     /**
      * {@inheritdoc}
      */
@@ -45,7 +49,7 @@ class MailsProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return ['#EmailsSubject*#'];
+        return self::FILENAME_FILTERS_REGEX;
     }
 
     /**
@@ -53,6 +57,6 @@ class MailsProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return ['EmailsSubject*'];
+        return self::TRANSLATION_DOMAINS_REGEX;
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/ModuleProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/ModuleProviderDefinition.php
@@ -34,6 +34,10 @@ use PrestaShop\TranslationToolsBundle\Translation\Helper\DomainHelper;
  */
 class ModuleProviderDefinition extends AbstractCoreProviderDefinition
 {
+    private const FILENAME_FILTERS_REGEX = ['#^%s([A-Z]|\.|$)#'];
+
+    private const TRANSLATION_DOMAINS_REGEX = ['^%s([A-Z]|$)'];
+
     /**
      * @var string
      */
@@ -65,7 +69,9 @@ class ModuleProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return ['#^' . preg_quote(DomainHelper::buildModuleBaseDomain($this->moduleName)) . '([A-Z]|\.|$)#'];
+        return array_map(function (string $filenameFilter) {
+            return sprintf($filenameFilter, preg_quote(DomainHelper::buildModuleBaseDomain($this->moduleName)));
+        }, self::FILENAME_FILTERS_REGEX);
     }
 
     /**
@@ -73,6 +79,8 @@ class ModuleProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return ['^' . preg_quote(DomainHelper::buildModuleBaseDomain($this->moduleName)) . '([A-Z]|$)'];
+        return array_map(function (string $translationDomain) {
+            return sprintf($translationDomain, preg_quote(DomainHelper::buildModuleBaseDomain($this->moduleName)));
+        }, self::TRANSLATION_DOMAINS_REGEX);
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/OthersProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/OthersProviderDefinition.php
@@ -32,6 +32,8 @@ namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
  */
 class OthersProviderDefinition extends AbstractCoreProviderDefinition
 {
+    public const OTHERS_DOMAIN_NAME = 'messages';
+
     /**
      * {@inheritdoc}
      */
@@ -45,7 +47,7 @@ class OthersProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return ['#^messages*#'];
+        return ['#^' . self::OTHERS_DOMAIN_NAME . '*#'];
     }
 
     /**
@@ -53,6 +55,6 @@ class OthersProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return ['^messages*'];
+        return ['^' . self::OTHERS_DOMAIN_NAME . '*'];
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/OthersProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/OthersProviderDefinition.php
@@ -34,6 +34,10 @@ class OthersProviderDefinition extends AbstractCoreProviderDefinition
 {
     public const OTHERS_DOMAIN_NAME = 'messages';
 
+    private const FILENAME_FILTERS_REGEX = ['#^' . self::OTHERS_DOMAIN_NAME . '*#'];
+
+    private const TRANSLATION_DOMAINS_REGEX = ['^' . self::OTHERS_DOMAIN_NAME . '*'];
+
     /**
      * {@inheritdoc}
      */
@@ -47,7 +51,7 @@ class OthersProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getFilenameFilters(): array
     {
-        return ['#^' . self::OTHERS_DOMAIN_NAME . '*#'];
+        return self::FILENAME_FILTERS_REGEX;
     }
 
     /**
@@ -55,6 +59,6 @@ class OthersProviderDefinition extends AbstractCoreProviderDefinition
      */
     public function getTranslationDomains(): array
     {
-        return ['^' . self::OTHERS_DOMAIN_NAME . '*'];
+        return self::TRANSLATION_DOMAINS_REGEX;
     }
 }

--- a/src/Core/Translation/Storage/Provider/Definition/ProviderDefinitionFactory.php
+++ b/src/Core/Translation/Storage/Provider/Definition/ProviderDefinitionFactory.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
+
+use RuntimeException;
+
+class ProviderDefinitionFactory
+{
+    public function build(
+        string $type,
+        ?string $selectedValue = null
+    ): ProviderDefinitionInterface {
+        switch ($type) {
+            case ProviderDefinitionInterface::TYPE_MODULES:
+                return new ModuleProviderDefinition($selectedValue);
+            case ProviderDefinitionInterface::TYPE_THEMES:
+                return new ThemeProviderDefinition($selectedValue);
+            case ProviderDefinitionInterface::TYPE_CORE_DOMAIN:
+                return new CoreDomainProviderDefinition($selectedValue);
+            case ProviderDefinitionInterface::TYPE_BACK:
+                return new BackofficeProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_FRONT:
+                return new FrontofficeProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_MAILS:
+                return new MailsProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_MAILS_BODY:
+                return new MailsBodyProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_OTHERS:
+                return new OthersProviderDefinition();
+            default:
+                throw new RuntimeException(sprintf('Unrecognized type: %s', $type));
+        }
+    }
+}

--- a/src/Core/Translation/Storage/Provider/Definition/ProviderDefinitionInterface.php
+++ b/src/Core/Translation/Storage/Provider/Definition/ProviderDefinitionInterface.php
@@ -26,6 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
 
+/**
+ * Defines translation type and any element to know how and where to find translations catalogue
+ */
 interface ProviderDefinitionInterface
 {
     public const TYPE_BACK = 'back';

--- a/src/Core/Translation/Storage/Provider/Definition/ThemeProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/ThemeProviderDefinition.php
@@ -34,6 +34,10 @@ class ThemeProviderDefinition implements ProviderDefinitionInterface
 {
     public const DEFAULT_THEME_NAME = 'classic';
 
+    private const FILENAME_FILTERS_REGEX = [];
+
+    private const TRANSLATION_DOMAINS_REGEX = [];
+
     /**
      * @var string
      */
@@ -72,7 +76,7 @@ class ThemeProviderDefinition implements ProviderDefinitionInterface
      */
     public function getFilenameFilters(): array
     {
-        return [];
+        return self::FILENAME_FILTERS_REGEX;
     }
 
     /**
@@ -80,6 +84,6 @@ class ThemeProviderDefinition implements ProviderDefinitionInterface
      */
     public function getTranslationDomains(): array
     {
-        return [];
+        return self::TRANSLATION_DOMAINS_REGEX;
     }
 }

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderD
 use PrestaShopBundle\Api\QueryTranslationParamsCollection;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Exception\InvalidLanguageException;
+use PrestaShopBundle\Form\Admin\Improve\International\Translations\ModifyTranslationsType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\TranslationService;
 use PrestaShopBundle\Translation\Exception\UnsupportedLocaleException;
@@ -126,7 +127,10 @@ class TranslationController extends ApiController
                 throw new Exception(sprintf("The 'type' parameter '%s' is not valid", $type));
             }
 
-            if (ProviderDefinitionInterface::TYPE_THEMES === $type && '0' === $selected) {
+            if (
+                ProviderDefinitionInterface::TYPE_THEMES === $type
+                && ModifyTranslationsType::CORE_TRANSLATIONS_CHOICE_INDEX === $selected
+            ) {
                 $type = ProviderDefinitionInterface::TYPE_FRONT;
             }
 

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -28,7 +28,11 @@ namespace PrestaShopBundle\Controller\Api;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShopBundle\Api\QueryTranslationParamsCollection;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Exception\InvalidLanguageException;
@@ -83,7 +87,23 @@ class TranslationController extends ApiController
                 throw UnsupportedLocaleException::invalidLocale($locale);
             }
 
-            $catalog = $translationService->listDomainTranslation($locale, $domain, $theme, $this->searchExpressionToArray($search), $module);
+            if (ucfirst(OthersProviderDefinition::OTHERS_DOMAIN_NAME) === $domain) {
+                $domain = OthersProviderDefinition::OTHERS_DOMAIN_NAME;
+            }
+
+            if (!empty($module)) {
+                $providerDefinition = new ModuleProviderDefinition($module);
+            } elseif (
+                !empty($theme)
+                // Default theme is not considered like other themes because its translations belong to the Core
+                && ThemeProviderDefinition::DEFAULT_THEME_NAME !== $theme
+            ) {
+                $providerDefinition = new ThemeProviderDefinition($theme);
+            } else {
+                $providerDefinition = new CoreDomainProviderDefinition($domain);
+            }
+
+            $catalog = $translationService->listDomainTranslation($providerDefinition, $locale, $domain, $this->searchExpressionToArray($search));
             $info = [
                 'Total-Pages' => ceil(count($catalog['data']) / $queryParams['page_size']),
             ];
@@ -352,7 +372,7 @@ class TranslationController extends ApiController
      *
      * @throws Exception
      */
-    private function getTree(string $lang, string $type, array $search, ?string $selectedValue = null)
+    private function getTree(string $lang, string $type, array $search, ?string $selectedValue = null): array
     {
         $locale = $this->translationService->langToLocale($lang);
         $providerDefinitionFactory = $this->container->get('prestashop.translation.factory.provider_definition');

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -27,23 +27,14 @@
 namespace PrestaShopBundle\Controller\Api;
 
 use Exception;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\BackofficeProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsBodyProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShopBundle\Api\QueryTranslationParamsCollection;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Exception\InvalidLanguageException;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\TranslationService;
 use PrestaShopBundle\Translation\Exception\UnsupportedLocaleException;
-use PrestaShopBundle\Translation\View\TreeBuilder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -322,149 +313,6 @@ class TranslationController extends ApiController
     }
 
     /**
-     * Returns a translation domain tree
-     *
-     * @param string $lang
-     * @param string $type "themes", "modules", "mails", "mails_body", "back", "front" or "others"
-     * @param array $search Search strings
-     * @param string|null $selectedValue Depends on the type. It's a theme name if type = "themes" or a module name if type = "modules"
-     *
-     * @return array
-     *
-     * @throws Exception
-     */
-    private function getTree(string $lang, string $type, array $search, ?string $selectedValue = null)
-    {
-        $locale = $this->translationService->langToLocale($lang);
-
-        return $this->translationService->getTranslationsTree(
-            $this->buildProviderDefinitionByType($type, $selectedValue),
-            $locale,
-            $search
-        );
-    }
-
-    /**
-     * @param string $type
-     * @param string|null $selectedValue
-     *
-     * @return ProviderDefinitionInterface
-     */
-    private function buildProviderDefinitionByType(
-        string $type,
-        ?string $selectedValue = null
-    ): ProviderDefinitionInterface {
-        switch ($type) {
-            case ProviderDefinitionInterface::TYPE_MODULES:
-                return new ModuleProviderDefinition($selectedValue);
-            case ProviderDefinitionInterface::TYPE_THEMES:
-                return new ThemeProviderDefinition($selectedValue);
-            case ProviderDefinitionInterface::TYPE_CORE_DOMAIN:
-                return new CoreDomainProviderDefinition($selectedValue);
-            case ProviderDefinitionInterface::TYPE_BACK:
-                return new BackofficeProviderDefinition();
-            case ProviderDefinitionInterface::TYPE_FRONT:
-                return new FrontofficeProviderDefinition();
-            case ProviderDefinitionInterface::TYPE_MAILS:
-                return new MailsProviderDefinition();
-            case ProviderDefinitionInterface::TYPE_MAILS_BODY:
-                return new MailsBodyProviderDefinition();
-            case ProviderDefinitionInterface::TYPE_OTHERS:
-                return new OthersProviderDefinition();
-            default:
-                throw new \RuntimeException(sprintf('Unrecognized type: %s', $type));
-        }
-    }
-
-    /**
-     * @param string $lang
-     * @param string|null $type
-     * @param string $theme Selected theme name
-     * @param null $search
-     *
-     * @return array
-     */
-    private function getNormalTree($lang, $type, $theme, $search = null)
-    {
-        $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $theme);
-        $catalogue = $this->translationService->getTranslationsCatalogue($lang, $type, $theme, $search);
-
-        return $this->getCleanTree($treeBuilder, $catalogue, $theme, $search);
-    }
-
-    /**
-     * @param string $lang Two-letter iso code
-     * @param string $selectedModuleName Selected module name
-     * @param string|null $search
-     *
-     * @return array
-     */
-    private function getModulesTree($lang, $selectedModuleName, $search = null)
-    {
-        $theme = null;
-        $locale = $this->translationService->langToLocale($lang);
-
-        $moduleProvider = $this->container->get('prestashop.translation.external_module_provider');
-        $moduleProvider->setModuleName($selectedModuleName);
-
-        $treeBuilder = new TreeBuilder($locale, $theme);
-        $catalogue = $treeBuilder->makeTranslationArray($moduleProvider, $search);
-
-        return $this->getCleanTree($treeBuilder, $catalogue, $theme, $search, $selectedModuleName);
-    }
-
-    /**
-     * @param string $lang Two-letter iso code
-     * @param null $search
-     *
-     * @return array
-     */
-    private function getMailsSubjectTree($lang, $search = null)
-    {
-        $theme = null;
-
-        $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $theme);
-        $catalogue = $this->translationService->getTranslationsCatalogue($lang, 'mails', $theme, $search);
-
-        return $this->getCleanTree($treeBuilder, $catalogue, $theme, $search);
-    }
-
-    /**
-     * @param string $lang Two-letter iso code
-     * @param null $search
-     *
-     * @return array
-     */
-    private function getMailsBodyTree($lang, $search = null)
-    {
-        $theme = null;
-
-        $treeBuilder = new TreeBuilder($this->translationService->langToLocale($lang), $theme);
-        $catalogue = $this->translationService->getTranslationsCatalogue($lang, 'mails_body', $theme, $search);
-
-        return $this->getCleanTree($treeBuilder, $catalogue, $theme, $search);
-    }
-
-    /**
-     * Make final tree.
-     *
-     * @param TreeBuilder $treeBuilder
-     * @param array $catalogue
-     * @param string|null $theme
-     * @param string|null $search
-     * @param string|null $module
-     *
-     * @return array
-     */
-    private function getCleanTree(TreeBuilder $treeBuilder, $catalogue, $theme, $search = null, $module = null)
-    {
-        $translationsTree = $treeBuilder->makeTranslationsTree($catalogue);
-        $translationsTree = $treeBuilder->cleanTreeToApi($translationsTree, $this->container->get('router'), $theme, $search, $module);
-
-        return $translationsTree;
-    }
-
-    /**
      * Trigger translation of multilingual content in database according to which domains have been modified
      *
      * @param string[] $modifiedDomains List of modified domains
@@ -486,6 +334,30 @@ class TranslationController extends ApiController
                 ->buildFromTableName('tab', $lang->getLocale())
                 ->translate($lang->getId(), \Context::getContext()->shop->id);
         }
+    }
+
+    /**
+     * Returns a translation domain tree
+     *
+     * @param string $lang
+     * @param string $type "themes", "modules", "mails", "mails_body", "back", "front" or "others"
+     * @param array $search Search strings
+     * @param string|null $selectedValue Depends on the type. It's a theme name if type = "themes" or a module name if type = "modules"
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+    private function getTree(string $lang, string $type, array $search, ?string $selectedValue = null)
+    {
+        $locale = $this->translationService->langToLocale($lang);
+        $providerDefinitionFactory = $this->container->get('prestashop.translation.factory.provider_definition');
+
+        return $this->translationService->getTranslationsTree(
+            $providerDefinitionFactory->build($type, $selectedValue),
+            $locale,
+            $search
+        );
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -27,6 +27,15 @@
 namespace PrestaShopBundle\Controller\Api;
 
 use Exception;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\BackofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsBodyProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
 use PrestaShopBundle\Api\QueryTranslationParamsCollection;
 use PrestaShopBundle\Entity\Lang;
@@ -60,7 +69,7 @@ class TranslationController extends ApiController
      *
      * @return JsonResponse
      */
-    public function listDomainTranslationAction(Request $request)
+    public function listDomainTranslationAction(Request $request): JsonResponse
     {
         try {
             $queryParamsCollection = $this->queryParams->fromRequest($request);
@@ -82,27 +91,10 @@ class TranslationController extends ApiController
                 throw UnsupportedLocaleException::invalidLocale($locale);
             }
 
-            $catalog = $translationService->listDomainTranslation($locale, $domain, $theme, $search, $module);
+            $catalog = $translationService->listDomainTranslation($locale, $domain, $theme, $this->searchExpressionToArray($search), $module);
             $info = [
                 'Total-Pages' => ceil(count($catalog['data']) / $queryParams['page_size']),
             ];
-
-            $catalog['info'] = array_merge(
-                $catalog['info'],
-                [
-                    'locale' => $locale,
-                    'domain' => $domain,
-                    'theme' => $theme,
-                    'total_translations' => count($catalog['data']),
-                    'total_missing_translations' => 0,
-                ]
-            );
-
-            foreach ($catalog['data'] as $message) {
-                if (empty($message['xliff']) && empty($message['database'])) {
-                    ++$catalog['info']['total_missing_translations'];
-                }
-            }
 
             $catalog['data'] = array_slice(
                 $catalog['data'],
@@ -139,31 +131,22 @@ class TranslationController extends ApiController
 
             $search = $request->query->get('search');
 
-            if (in_array($type, ['modules', 'themes']) && empty($selected)) {
-                throw new Exception('This \'selected\' param is not valid.');
+            if (!in_array($type, ProviderDefinitionInterface::ALLOWED_TYPES)) {
+                throw new Exception(sprintf("The 'type' parameter '%s' is not valid", $type));
             }
 
-            switch ($type) {
-                case 'themes':
-                    $tree = $this->getNormalTree($lang, $type, $selected, $search);
-                    break;
-
-                case 'modules':
-                    $tree = $this->getModulesTree($lang, $selected, $search);
-                    break;
-
-                case 'mails':
-                    $tree = $this->getMailsSubjectTree($lang, $search);
-                    break;
-
-                case 'mails_body':
-                    $tree = $this->getMailsBodyTree($lang, $search);
-                    break;
-
-                default:
-                    $tree = $this->getNormalTree($lang, $type, null, $search);
-                    break;
+            if (ProviderDefinitionInterface::TYPE_THEMES === $type && '0' === $selected) {
+                $type = ProviderDefinitionInterface::TYPE_FRONT;
             }
+
+            if (
+                in_array($type, [ProviderDefinitionInterface::TYPE_MODULES, ProviderDefinitionInterface::TYPE_THEMES])
+                && empty($selected)
+            ) {
+                throw new Exception("The 'selected' parameter is empty.");
+            }
+
+            $tree = $this->getTree($lang, $type, $this->searchExpressionToArray($search), $selected);
 
             return $this->jsonResponse($tree, $request);
         } catch (Exception $exception) {
@@ -339,6 +322,61 @@ class TranslationController extends ApiController
     }
 
     /**
+     * Returns a translation domain tree
+     *
+     * @param string $lang
+     * @param string $type "themes", "modules", "mails", "mails_body", "back", "front" or "others"
+     * @param array $search Search strings
+     * @param string|null $selectedValue Depends on the type. It's a theme name if type = "themes" or a module name if type = "modules"
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+    private function getTree(string $lang, string $type, array $search, ?string $selectedValue = null)
+    {
+        $locale = $this->translationService->langToLocale($lang);
+
+        return $this->translationService->getTranslationsTree(
+            $this->buildProviderDefinitionByType($type, $selectedValue),
+            $locale,
+            $search
+        );
+    }
+
+    /**
+     * @param string $type
+     * @param string|null $selectedValue
+     *
+     * @return ProviderDefinitionInterface
+     */
+    private function buildProviderDefinitionByType(
+        string $type,
+        ?string $selectedValue = null
+    ): ProviderDefinitionInterface {
+        switch ($type) {
+            case ProviderDefinitionInterface::TYPE_MODULES:
+                return new ModuleProviderDefinition($selectedValue);
+            case ProviderDefinitionInterface::TYPE_THEMES:
+                return new ThemeProviderDefinition($selectedValue);
+            case ProviderDefinitionInterface::TYPE_CORE_DOMAIN:
+                return new CoreDomainProviderDefinition($selectedValue);
+            case ProviderDefinitionInterface::TYPE_BACK:
+                return new BackofficeProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_FRONT:
+                return new FrontofficeProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_MAILS:
+                return new MailsProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_MAILS_BODY:
+                return new MailsBodyProviderDefinition();
+            case ProviderDefinitionInterface::TYPE_OTHERS:
+                return new OthersProviderDefinition();
+            default:
+                throw new \RuntimeException(sprintf('Unrecognized type: %s', $type));
+        }
+    }
+
+    /**
      * @param string $lang
      * @param string|null $type
      * @param string $theme Selected theme name
@@ -448,5 +486,19 @@ class TranslationController extends ApiController
                 ->buildFromTableName('tab', $lang->getLocale())
                 ->translate($lang->getId(), \Context::getContext()->shop->id);
         }
+    }
+
+    /**
+     * @param string|array $search
+     *
+     * @return array
+     */
+    private function searchExpressionToArray($search): array
+    {
+        if (is_array($search)) {
+            return $search;
+        }
+
+        return empty($search) ? [] : [$search];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\International\Translations;
 
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -112,7 +113,7 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'js-theme-form-group d-none',
                 ],
-                'choices' => [$noTheme => 0] + $this->themeChoices,
+                'choices' => [$noTheme => 0] + $this->excludeDefaultThemeFromChoices($this->themeChoices),
                 'choice_attr' => [
                     $noTheme => [
                         'class' => 'js-no-theme',
@@ -139,5 +140,17 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'choices' => $this->getLocaleChoices(),
                 'choice_translation_domain' => false,
             ]);
+    }
+
+    /**
+     * @param array $themeChoices
+     *
+     * @return array
+     */
+    private function excludeDefaultThemeFromChoices(array $themeChoices): array
+    {
+        unset($themeChoices[ThemeProviderDefinition::DEFAULT_THEME_NAME]);
+
+        return $themeChoices;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -38,6 +38,7 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class ModifyTranslationsType extends TranslatorAwareType
 {
+    public const CORE_TRANSLATIONS_CHOICE_INDEX = '0';
     /**
      * @var array
      */
@@ -125,7 +126,7 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'js-theme-form-group d-none',
                 ],
-                'choices' => [$noTheme => 0] + $this->themeChoices,
+                'choices' => [$noTheme => self::CORE_TRANSLATIONS_CHOICE_INDEX] + $this->themeChoices,
                 'choice_attr' => $themeChoiceAttributes,
                 'choice_translation_domain' => false,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ModifyTranslationsType.php
@@ -88,6 +88,18 @@ class ModifyTranslationsType extends TranslatorAwareType
     {
         $noTheme = $this->trans('Core (no theme selected)', 'Admin.International.Feature');
 
+        $themeChoiceAttributes = [
+            $noTheme => [
+                'class' => 'js-no-theme',
+            ],
+        ];
+
+        if (isset($this->themeChoices[ThemeProviderDefinition::DEFAULT_THEME_NAME])) {
+            $themeChoiceAttributes[ThemeProviderDefinition::DEFAULT_THEME_NAME] = [
+                'class' => 'js-default-theme',
+            ];
+        }
+
         $builder
             ->add('translation_type', ChoiceType::class, [
                 'label' => $this->trans('Type of translation', 'Admin.International.Feature'),
@@ -113,12 +125,8 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'js-theme-form-group d-none',
                 ],
-                'choices' => [$noTheme => 0] + $this->excludeDefaultThemeFromChoices($this->themeChoices),
-                'choice_attr' => [
-                    $noTheme => [
-                        'class' => 'js-no-theme',
-                    ],
-                ],
+                'choices' => [$noTheme => 0] + $this->themeChoices,
+                'choice_attr' => $themeChoiceAttributes,
                 'choice_translation_domain' => false,
             ])
             ->add('module', ChoiceType::class, [
@@ -140,17 +148,5 @@ class ModifyTranslationsType extends TranslatorAwareType
                 'choices' => $this->getLocaleChoices(),
                 'choice_translation_domain' => false,
             ]);
-    }
-
-    /**
-     * @param array $themeChoices
-     *
-     * @return array
-     */
-    private function excludeDefaultThemeFromChoices(array $themeChoices): array
-    {
-        unset($themeChoices[ThemeProviderDefinition::DEFAULT_THEME_NAME]);
-
-        return $themeChoices;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -29,6 +29,9 @@ services:
     ps.theme_translations_factory:
         alias: "prestashop.translation.theme_translations_factory"
 
+    prestashop.translation.factory.provider_definition:
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionFactory
+
     #TRANSLATIONS PROVIDERS
     prestashop.translation.provider.catalogue_provider_factory:
         class: PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFactory

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -2,13 +2,13 @@ services:
     _defaults:
         public: true
 
-    prestashop.translation.view.translation_tree:
-        class: PrestaShopBundle\Translation\View\TranslationsTreeBuilder
+    prestashop.translation.builder.translation_tree:
+        class: PrestaShop\PrestaShop\Core\Translation\Builder\TranslationsTreeBuilder
         arguments:
             - '@router.default'
-            - '@prestashop.translation.translation_catalogue_builder'
+            - '@prestashop.translation.builder.translation_catalogue'
 
-    prestashop.translation.translation_catalogue_builder:
+    prestashop.translation.builder.translation_catalogue:
         class: PrestaShop\PrestaShop\Core\Translation\Builder\TranslationCatalogueBuilder
         arguments:
             - '@prestashop.translation.provider.catalogue_provider_factory'
@@ -33,10 +33,10 @@ services:
     prestashop.translation.provider.catalogue_provider_factory:
         class: PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFactory
         arguments:
-            - '@prestashop.translation.database_loader'
-            - '@prestashop.translation.legacy_module.extractor'
-            - '@prestashop.translation.legacy_file_loader'
-            - '@prestashop.translation.theme_extractor'
+            - '@prestashop.translation.loader.database'
+            - '@prestashop.translation.extractor.legacy_module'
+            - '@prestashop.translation.loader.legacy_file'
+            - '@prestashop.translation.extractor.theme'
             - '@prestashop.core.addon.theme.repository'
             - '@filesystem'
             - '%themes_translations_dir%'
@@ -140,15 +140,33 @@ services:
         tags:
             - {name: translation.loader, alias: db}
 
+    prestashop.translation.loader.database:
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader
+        arguments:
+            - "@prestashop.core.admin.lang.repository"
+            - "@prestashop.core.admin.translation.repository"
+
     prestashop.translation.sql_loader:
         class: PrestaShopBundle\Translation\Loader\SqlTranslationLoader
         tags:
             - {name: translation.loader, alias: db}
 
+    prestashop.translation.reader.legacy_file:
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Loader\LegacyFileReader
+        arguments:
+            - "@prestashop.core.translation.locale.converter"
+
     prestashop.translation.legacy_file_reader:
         class: PrestaShopBundle\Translation\Loader\LegacyFileReader
         arguments:
             - "@prestashop.core.translation.locale.converter"
+
+    prestashop.translation.loader.legacy_file:
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Loader\LegacyFileLoader
+        arguments:
+            - "@prestashop.translation.reader.legacy_file"
+        tags:
+            - {name: translation.loader, alias: legacy_files}
 
     prestashop.translation.legacy_file_loader:
       class: PrestaShopBundle\Translation\Loader\LegacyFileLoader
@@ -175,6 +193,14 @@ services:
         class: PrestaShopBundle\Translation\Extractor\ThemeExtractor
         arguments:
             - "@prestashop.translation.extractor.smarty.legacy"
+
+    prestashop.translation.extractor.legacy_module:
+        class: PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractor
+        arguments:
+            - "@prestashop.translation.extractor.php"
+            - "@prestashop.translation.extractor.smarty.legacy"
+            - "@prestashop.translation.extractor.twig"
+            - "%modules_dir%"
 
     prestashop.translation.legacy_module.extractor:
         class: PrestaShopBundle\Translation\Extractor\LegacyModuleExtractor

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -192,8 +192,6 @@ class TranslationService
             $domain = OthersProviderDefinition::OTHERS_DOMAIN_NAME;
         }
 
-        $translationCatalogueBuilder = $this->container->get('prestashop.translation.builder.translation_catalogue');
-
         if (!empty($module)) {
             $providerDefinition = new ModuleProviderDefinition($module);
         } elseif (
@@ -206,7 +204,7 @@ class TranslationService
             $providerDefinition = new CoreDomainProviderDefinition($domain);
         }
 
-        $domainCatalogue = $translationCatalogueBuilder->getDomainCatalogue(
+        $domainCatalogue = $this->container->get('prestashop.translation.builder.translation_catalogue')->getDomainCatalogue(
             $providerDefinition,
             $locale,
             $domain,

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -27,11 +27,14 @@
 namespace PrestaShopBundle\Service;
 
 use Exception;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Entity\Translation;
 use PrestaShopBundle\Exception\InvalidLanguageException;
 use PrestaShopBundle\Translation\Constraints\PassVsprintf;
-use PrestaShopBundle\Translation\Provider\UseModuleInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Validator\Validation;
 
@@ -113,6 +116,8 @@ class TranslationService
      */
     public function getTranslationsCatalogue($lang, $type, $theme, $search = null)
     {
+        $translationCatalogueBuilder = $this->container->get('prestashop.translation.builder.translation_catalogue');
+
         $factory = $this->container->get('ps.translations_factory');
 
         if ($this->requiresThemeTranslationsFactory($theme, $type)) {
@@ -127,6 +132,25 @@ class TranslationService
         $locale = $this->langToLocale($lang);
 
         return $factory->createTranslationsArray($type, $locale, $theme, $search);
+    }
+
+    /**
+     * @param ProviderDefinitionInterface $providerDefinition
+     * @param string $locale
+     * @param array $search
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function getTranslationsTree(
+        ProviderDefinitionInterface $providerDefinition,
+        string $locale,
+        array $search
+    ): array {
+        $translationTreeBuilder = $this->container->get('prestashop.translation.builder.translation_tree');
+
+        return $translationTreeBuilder->getTree($providerDefinition, $locale, $search);
     }
 
     /**
@@ -149,65 +173,50 @@ class TranslationService
      * @param string $locale
      * @param string $domain
      * @param string|null $theme
-     * @param string|null $search
+     * @param array|null $search
      * @param string|null $module
      *
      * @return array
      */
-    public function listDomainTranslation($locale, $domain, $theme = null, $search = null, $module = null)
-    {
-        if (!empty($theme) && 'classic' !== $theme) {
-            $translationProvider = $this->container->get('prestashop.translation.theme_provider');
-            $translationProvider->setThemeName($theme);
-        } else {
-            $translationProvider = $this->container->get('prestashop.translation.search_provider');
-            if ($module !== null && $translationProvider instanceof UseModuleInterface) {
-                $translationProvider->setModuleName($module);
-            }
-        }
+    public function listDomainTranslation(
+        string $locale,
+        string $domain,
+        ?string $theme = null,
+        ?array $search = null,
+        ?string $module = null
+    ): array {
         if ('Messages' === $domain) {
             $domain = 'messages';
         }
 
-        $translationProvider->setDomain($domain);
-        $translationProvider->setLocale($locale);
+        $translationCatalogueBuilder = $this->container->get('prestashop.translation.builder.translation_catalogue');
+
+        if (!empty($module)) {
+            $providerDefinition = new ModuleProviderDefinition($module);
+        } elseif (
+            !empty($theme)
+            // Default theme is not considered like other themes because his translations are within the Core
+            && ThemeProviderDefinition::DEFAULT_THEME_NAME !== $theme
+        ) {
+            $providerDefinition = new ThemeProviderDefinition($theme);
+        } else {
+            $providerDefinition = new CoreDomainProviderDefinition($domain);
+        }
+
+        $domainCatalogue = $translationCatalogueBuilder->getDomainCatalogue(
+            $providerDefinition,
+            $locale,
+            $domain,
+            $search
+        );
 
         $router = $this->container->get('router');
-        $domains = [
-            'info' => [
-                'edit_url' => $router->generate('api_translation_value_edit'),
-                'reset_url' => $router->generate('api_translation_value_reset'),
-            ],
-            'data' => [],
-        ];
-        $treeDomain = preg_split('/(?=[A-Z])/', $domain, -1, PREG_SPLIT_NO_EMPTY);
-        if (!empty($theme) && 'classic' !== $theme) {
-            $defaultCatalog = current($translationProvider->getThemeCatalogue()->all());
-        } else {
-            $defaultCatalog = current($translationProvider->getDefaultCatalogue()->all());
-        }
+        $domainCatalogue['info'] = array_merge($domainCatalogue['info'], [
+            'edit_url' => $router->generate('api_translation_value_edit'),
+            'reset_url' => $router->generate('api_translation_value_reset'),
+        ]);
 
-        $xliffCatalog = current($translationProvider->getXliffCatalogue()->all());
-        $dbCatalog = current($translationProvider->getDatabaseCatalogue($theme)->all());
-
-        foreach ($defaultCatalog as $key => $message) {
-            $data = [
-                'default' => $key,
-                'xliff' => (array_key_exists($key, (array) $xliffCatalog) ? $xliffCatalog[$key] : null),
-                'database' => (array_key_exists($key, (array) $dbCatalog) ? $dbCatalog[$key] : null),
-                'tree_domain' => $treeDomain,
-            ];
-            // if search is empty or is in catalog default|xlf|database
-            if (empty($search) || $this->dataContainsSearchWord($search, $data)) {
-                if (empty($data['xliff']) && empty($data['database'])) {
-                    array_unshift($domains['data'], $data);
-                } else {
-                    $domains['data'][] = $data;
-                }
-            }
-        }
-
-        return $domains;
+        return $domainCatalogue;
     }
 
     /**

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Service;
 use Exception;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShopBundle\Entity\Lang;
@@ -177,6 +178,8 @@ class TranslationService
      * @param string|null $module
      *
      * @return array
+     *
+     * @throws Exception
      */
     public function listDomainTranslation(
         string $locale,
@@ -185,8 +188,8 @@ class TranslationService
         ?array $search = null,
         ?string $module = null
     ): array {
-        if ('Messages' === $domain) {
-            $domain = 'messages';
+        if (ucfirst(OthersProviderDefinition::OTHERS_DOMAIN_NAME) === $domain) {
+            $domain = OthersProviderDefinition::OTHERS_DOMAIN_NAME;
         }
 
         $translationCatalogueBuilder = $this->container->get('prestashop.translation.builder.translation_catalogue');
@@ -217,39 +220,6 @@ class TranslationService
         ]);
 
         return $domainCatalogue;
-    }
-
-    /**
-     * Check if data contains search word.
-     *
-     * @param string|array|null $search
-     * @param array $data
-     *
-     * @return bool
-     */
-    private function dataContainsSearchWord($search, $data)
-    {
-        if (is_string($search)) {
-            $search = strtolower($search);
-
-            return false !== strpos(strtolower($data['default']), $search) ||
-                false !== strpos(strtolower($data['xliff']), $search) ||
-                false !== strpos(strtolower($data['database']), $search);
-        }
-
-        if (is_array($search)) {
-            $contains = true;
-            foreach ($search as $s) {
-                $s = strtolower($s);
-                $contains &= false !== strpos(strtolower($data['default']), $s) ||
-                    false !== strpos(strtolower($data['xliff']), $s) ||
-                    false !== strpos(strtolower($data['database']), $s);
-            }
-
-            return $contains;
-        }
-
-        return false;
     }
 
     /**

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -27,11 +27,7 @@
 namespace PrestaShopBundle\Service;
 
 use Exception;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use PrestaShopBundle\Entity\Lang;
 use PrestaShopBundle\Entity\Translation;
 use PrestaShopBundle\Exception\InvalidLanguageException;
@@ -117,8 +113,6 @@ class TranslationService
      */
     public function getTranslationsCatalogue($lang, $type, $theme, $search = null)
     {
-        $translationCatalogueBuilder = $this->container->get('prestashop.translation.builder.translation_catalogue');
-
         $factory = $this->container->get('ps.translations_factory');
 
         if ($this->requiresThemeTranslationsFactory($theme, $type)) {
@@ -136,6 +130,24 @@ class TranslationService
     }
 
     /**
+     * Returns the translation domains tree and counters with total of wording and total of missing translations
+     * The tree should look like
+     *  tree => [
+     *      total_translations => int
+     *      total_missing_translations => int
+     *      children => [
+     *          [
+     *              name => string
+     *              full_name => string
+     *              domain_catalog_link => string
+     *              total_translations => int
+     *              total_missing_translations => int
+     *              children => [
+     *                  ...
+     *              ]
+     *          ]
+     *   ]
+     *
      * @param ProviderDefinitionInterface $providerDefinition
      * @param string $locale
      * @param array $search
@@ -168,42 +180,23 @@ class TranslationService
     /**
      * List translations for a specific domain.
      *
-     * @todo: we need module information here
-     * @todo: we need to improve the Vuejs application to send the information
-     *
+     * @param ProviderDefinitionInterface $providerDefinition
      * @param string $locale
      * @param string $domain
-     * @param string|null $theme
      * @param array|null $search
-     * @param string|null $module
      *
      * @return array
      *
      * @throws Exception
+     * @todo: we need module information here
+     * @todo: we need to improve the Vuejs application to send the information
      */
     public function listDomainTranslation(
+        ProviderDefinitionInterface $providerDefinition,
         string $locale,
         string $domain,
-        ?string $theme = null,
-        ?array $search = null,
-        ?string $module = null
+        ?array $search = null
     ): array {
-        if (ucfirst(OthersProviderDefinition::OTHERS_DOMAIN_NAME) === $domain) {
-            $domain = OthersProviderDefinition::OTHERS_DOMAIN_NAME;
-        }
-
-        if (!empty($module)) {
-            $providerDefinition = new ModuleProviderDefinition($module);
-        } elseif (
-            !empty($theme)
-            // Default theme is not considered like other themes because its translations belong to the Core
-            && ThemeProviderDefinition::DEFAULT_THEME_NAME !== $theme
-        ) {
-            $providerDefinition = new ThemeProviderDefinition($theme);
-        } else {
-            $providerDefinition = new CoreDomainProviderDefinition($domain);
-        }
-
         $domainCatalogue = $this->container->get('prestashop.translation.builder.translation_catalogue')->getDomainCatalogue(
             $providerDefinition,
             $locale,

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -198,7 +198,7 @@ class TranslationService
             $providerDefinition = new ModuleProviderDefinition($module);
         } elseif (
             !empty($theme)
-            // Default theme is not considered like other themes because his translations are within the Core
+            // Default theme is not considered like other themes because its translations belong to the Core
             && ThemeProviderDefinition::DEFAULT_THEME_NAME !== $theme
         ) {
             $providerDefinition = new ThemeProviderDefinition($theme);

--- a/tests/Integration/Core/Translation/Storage/Provider/CoreDomainCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/CoreDomainCatalogueLayersProviderTest.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Translation\Storage\Provider;
+
+use PrestaShop\PrestaShop\Core\Language\LanguageRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Test the core translations provider filtering by domain
+ */
+class CoreDomainCatalogueLayersProviderTest extends KernelTestCase
+{
+    /**
+     * @var string
+     */
+    protected $translationsDir;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+        $this->translationsDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+    }
+
+    /**
+     * Test it loads a XLIFF catalogue from the locale's `translations` directory
+     */
+    public function testItLoadsCatalogueFromXliffFilesInLocaleDirectory(): void
+    {
+        // load catalogue from translations/fr-FR
+        $catalogue = $this->getFileTranslatedCatalogue('AdminActions', 'fr-FR');
+
+        $expected = [
+            'AdminActions' => [
+                'count' => 90,
+                'translations' => [
+                    'Save and stay' => 'Enregistrer et rester',
+                    'Uninstall' => 'Désinstaller',
+                ],
+            ],
+        ];
+
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
+
+        // load catalogue from translations/fr-FR
+        $catalogue = $this->getFileTranslatedCatalogue('ModulesCheckpaymentAdmin', 'fr-FR');
+
+        $expected = [
+            'ModulesCheckpaymentAdmin' => [
+                'count' => 15,
+                'translations' => [
+                    'The "Payee" and "Address" fields must be configured before using this module.' => 'Les champs "Nom du bénéficiaire" et "Adresse" doivent être configurés avant d\'utiliser ce module.',
+                    'No currency has been set for this module.' => 'Aucune devise disponible pour ce module',
+                ],
+            ],
+        ];
+
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
+    }
+
+    /**
+     * Test it loads a default catalogue from the `translations` default directory
+     */
+    public function testItExtractsDefaultCatalogueFromTranslationsDefaultFiles(): void
+    {
+        // load catalogue from translations/default
+        $catalogue = $this->getDefaultCatalogue('AdminActions', 'fr-FR');
+
+        $expected = [
+            'AdminActions' => [
+                'count' => 91,
+                'translations' => [
+                    'Save and stay' => '',
+                    'Uninstall' => '',
+                ],
+            ],
+        ];
+
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
+
+        // load catalogue from translations/default
+        $catalogue = $this->getDefaultCatalogue('ModulesCheckpaymentAdmin', 'fr-FR');
+
+        $expected = [
+            'ModulesCheckpaymentAdmin' => [
+                'count' => 15,
+                'translations' => [
+                    'The "Payee" and "Address" fields must be configured before using this module.' => '',
+                    'No currency has been set for this module.' => '',
+                ],
+            ],
+        ];
+
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
+    }
+
+    public function testItLoadsCustomizedTranslationsFromDatabase(): void
+    {
+        $databaseContent = [
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Uninstall',
+                'translation' => 'Traduction customisée',
+                'domain' => 'AdminActions',
+                'theme' => null,
+            ],
+            [
+                'lang' => 'fr-FR',
+                'key' => 'Some made up text',
+                'translation' => 'Un texte inventé',
+                'domain' => 'ShopActions',
+                'theme' => null,
+            ],
+        ];
+
+        // load catalogue from database translations
+        $catalogue = $this->getUserTranslatedCatalogue('AdminActions', 'fr-FR', $databaseContent);
+
+        $expected = [
+            'AdminActions' => [
+                'count' => 1,
+                'translations' => [
+                    'Save and stay' => 'Save and stay',
+                    'Uninstall' => 'Traduction customisée',
+                ],
+            ],
+        ];
+
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
+
+        // load catalogue from database translations
+        $catalogue = $this->getUserTranslatedCatalogue('ShopActions', 'fr-FR', $databaseContent);
+
+        $expected = [
+            'ShopActions' => [
+                'count' => 1,
+                'translations' => [
+                    'Some made up text' => 'Un texte inventé',
+                    'Uninstall' => 'Uninstall',
+                ],
+            ],
+        ];
+
+        // verify all catalogues are loaded
+        $this->assertResultIsAsExpected($expected, $catalogue);
+    }
+
+    private function getDefaultCatalogue(string $domain, string $locale): MessageCatalogue
+    {
+        return $this->getProvider($domain)->getDefaultCatalogue($locale);
+    }
+
+    private function getFileTranslatedCatalogue(string $domain, string $locale): MessageCatalogue
+    {
+        return $this->getProvider($domain)->getFileTranslatedCatalogue($locale);
+    }
+
+    private function getUserTranslatedCatalogue(string $domain, string $locale, array $databaseContent = []): MessageCatalogue
+    {
+        return $this->getProvider($domain, $databaseContent)->getUserTranslatedCatalogue($locale);
+    }
+
+    /**
+     * @param array $expected
+     * @param MessageCatalogue $catalogue
+     */
+    private function assertResultIsAsExpected(array $expected, MessageCatalogue $catalogue): void
+    {
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+
+        // Check integrity of translations
+        $messages = $catalogue->all();
+        $domains = $catalogue->getDomains();
+        sort($domains);
+
+        $this->assertSame(array_keys($expected), $domains);
+
+        // verify that the catalogues are complete
+        foreach ($expected as $expectedDomain => $expectedValues) {
+            $this->assertCount($expectedValues['count'], $messages[$expectedDomain]);
+
+            foreach ($expectedValues['translations'] as $translationKey => $translationValue) {
+                $this->assertSame($translationValue, $catalogue->get($translationKey, $expectedDomain));
+            }
+        }
+    }
+
+    /**
+     * @param string $domain
+     * @param array $databaseContent
+     *
+     * @return CoreCatalogueLayersProvider
+     */
+    private function getProvider(string $domain, array $databaseContent = []): CoreCatalogueLayersProvider
+    {
+        $providerDefinition = new CoreDomainProviderDefinition($domain);
+
+        return new CoreCatalogueLayersProvider(
+            new MockDatabaseTranslationLoader(
+                $databaseContent,
+                $this->createMock(LanguageRepositoryInterface::class),
+                $this->createMock(TranslationRepositoryInterface::class)
+            ),
+            $this->translationsDir,
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+    }
+}

--- a/tests/Integration/Core/Translation/Storage/Provider/FrontofficeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/FrontofficeCatalogueLayersProviderTest.php
@@ -47,16 +47,6 @@ class FrontofficeCatalogueLayersProviderTest extends AbstractCatalogueLayersProv
         $catalogue = $this->getFileTranslatedCatalogue('fr-FR');
 
         $expected = [
-            'ModulesCheckpaymentShop' => [
-                'count' => 19,
-                'translations' => [],
-            ],
-            'ModulesWirepaymentShop' => [
-                'count' => 15,
-                'translations' => [
-                    '(order processing will be longer)' => '(le traitement de la commande sera plus long)',
-                ],
-            ],
             'ShopNotificationsWarning' => [
                 'count' => 8,
                 'translations' => [
@@ -78,16 +68,6 @@ class FrontofficeCatalogueLayersProviderTest extends AbstractCatalogueLayersProv
         $catalogue = $this->getDefaultCatalogue('fr-FR');
 
         $expected = [
-            'ModulesCheckpaymentShop' => [
-                'count' => 19,
-                'translations' => [],
-            ],
-            'ModulesWirepaymentShop' => [
-                'count' => 20,
-                'translations' => [
-                    '(order processing will be longer)' => '',
-                ],
-            ],
             'ShopNotificationsWarning' => [
                 'count' => 8,
                 'translations' => [
@@ -123,12 +103,6 @@ class FrontofficeCatalogueLayersProviderTest extends AbstractCatalogueLayersProv
         $catalogue = $this->getUserTranslatedCatalogue('fr-FR', $databaseContent);
 
         $expected = [
-            'ModulesWirepaymentShop' => [
-                'count' => 1,
-                'translations' => [
-                    'Install' => 'Install Traduction customisée',
-                ],
-            ],
             'ShopNotificationsWarning' => [
                 'count' => 1,
                 'translations' => [

--- a/tests/Integration/Core/Translation/Storage/Provider/ThemeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/ThemeCatalogueLayersProviderTest.php
@@ -92,16 +92,6 @@ class ThemeCatalogueLayersProviderTest extends AbstractCatalogueLayersProviderTe
         $catalogue = $this->getFileTranslatedCatalogue('fr-FR');
 
         $expected = [
-            'ModulesCheckpaymentShop' => [
-                'count' => 19,
-                'translations' => [
-                    'Send your check to this address' => 'Envoyez votre chèque à cette adresse',
-                ],
-            ],
-            'ModulesWirepaymentShop' => [
-                'count' => 15,
-                'translations' => [],
-            ],
             'ShopNotificationsWarning' => [
                 'count' => 8,
                 'translations' => [],

--- a/tests/UI/campaigns/functional/BO/11_international/04_translations/01_modifyTranslation.js
+++ b/tests/UI/campaigns/functional/BO/11_international/04_translations/01_modifyTranslation.js
@@ -51,7 +51,7 @@ describe('Edit translation', async () => {
   it('should choose the translation to modify', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'modifyTranslation', baseContext);
 
-    await translationsPage.modifyTranslation(page, 'Themes translations', 'classic', Languages.french.name);
+    await translationsPage.modifyTranslation(page, 'Front office Translations', 'classic', Languages.french.name);
     const pageTitle = await translationsPage.getPageTitle(page);
     await expect(pageTitle).to.contains(translationsPage.pageTitle);
   });

--- a/tests/Unit/Core/Translation/Builder/TranslationTreeBuilderTest.php
+++ b/tests/Unit/Core/Translation/Builder/TranslationTreeBuilderTest.php
@@ -32,7 +32,7 @@ use PrestaShop\PrestaShop\Core\Translation\Builder\TranslationCatalogueBuilder;
 use PrestaShop\PrestaShop\Core\Translation\Builder\TranslationsTreeBuilder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueLayersProviderInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFactory;
-use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\BackofficeProviderDefinition;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -112,11 +112,9 @@ class TranslationTreeBuilderTest extends TestCase
     public function testGetTreeStructure()
     {
         $tree = $this->treeBuilder->getTree(
-             ProviderDefinitionInterface::TYPE_BACK,
+            new BackofficeProviderDefinition(),
             self::LOCALE,
-            [],
-            'theme',
-            'module'
+            []
         );
 
         $this->assertArrayHasKey('tree', $tree);
@@ -147,11 +145,9 @@ class TranslationTreeBuilderTest extends TestCase
     public function testGetTreeContent()
     {
         $tree = $this->treeBuilder->getTree(
-            ProviderDefinitionInterface::TYPE_BACK,
+            new BackofficeProviderDefinition(),
             self::LOCALE,
-            [],
-            'theme',
-            'module'
+            []
         );
 
         $this->assertArrayHasKey('tree', $tree);

--- a/tests/Unit/Core/Translation/Storage/Provider/Definition/ProviderDefinitionFactoryTest.php
+++ b/tests/Unit/Core/Translation/Storage/Provider/Definition/ProviderDefinitionFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Translation\Storage\Provider\Definition;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\BackofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsBodyProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\MailsProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
+use RuntimeException;
+
+class ProviderDefinitionFactoryTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $factory = new ProviderDefinitionFactory();
+        $definitions = [
+            ProviderDefinitionInterface::TYPE_MODULES => ModuleProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_THEMES => ThemeProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_CORE_DOMAIN => CoreDomainProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_BACK => BackofficeProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_FRONT => FrontofficeProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_MAILS => MailsProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_MAILS_BODY => MailsBodyProviderDefinition::class,
+            ProviderDefinitionInterface::TYPE_OTHERS => OthersProviderDefinition::class,
+        ];
+
+        foreach ($definitions as $type => $definitionClass) {
+            $this->assertInstanceOf($definitionClass, $factory->build($type, 'whatever'));
+        }
+    }
+
+    public function testBuildThrowsExceptionIfTypeNotKnown(): void
+    {
+        $factory = new ProviderDefinitionFactory();
+        $this->expectException(RuntimeException::class);
+        $factory->build('fakeType');
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use new translation components in the Core to list domains and tree on the BO interface, through TranslationService
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23763
| How to test?      | Open BO > International > Translations, the display and behaviour must be the same before and after this PR _with less bugs_ :D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23696)
<!-- Reviewable:end -->


## BC breaks

**TranslationCatalogueBuilder**
Methods _getDomainCatalogue_, _getCatalogue_ and _getRawCatalogue_ no longer require *type* as string but receive a *ProviderDefinitionInterface*
Parameters *theme* and *module* are holded by the *ProviderDefinitionInterface*

**TranslationsTreeBuilder**
Method _getTree_ no longer requires *type* as string but receive a *ProviderDefinitionInterface*
Parameters *theme* and *module* are holded by the *ProviderDefinitionInterface*