### PR TITLE
Can't show module on the Left Column

### DIFF
--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -62,7 +62,7 @@
           {block name="left_column"}
             <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
               {if $page.page_name == 'product'}
-                {hook h='displayLeftColumnProduct'}
+                {hook h='displayLeftColumnProduct' product=$product category=$category}
               {else}
                 {hook h="displayLeftColumn"}
               {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Partialy fix issue #18137 by adding required information in to hook to displayLeftColumnProduct 
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #18137.
| How to test?      | The content of the hook displayLeftColumnProduct should be visible for module ,<br> with module **ps_qualityassurance**  : here is the content send to the hook displayLeftColumnProduct before the modification<br> `{"smarty":"Object Smarty_Internal_Template","cookie":"Object Cookie","cart":"Object Cart","altern":"1"}`<br />And here is the content after ( for product id 1 with prestashop sample data )<br />`{"product":"Object PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray","category":"Object Category","smarty":"Object Smarty_Internal_Template","cookie":"Object Cookie","cart":"Object Cart","altern":"1"}`
| Possible impacts? | I seen none as the condition is related to the product page where vars $product and $category should be defined


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23698)
<!-- Reviewable:end -->
