### PR TITLE
Update call to configuration variable ps_search_end

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -1039,7 +1039,7 @@ class SearchCore
     {
         $word = str_replace(['%', '_'], ['\\%', '\\_'], $word);
         $start_search = Configuration::get('PS_SEARCH_START') ? '%' : '';
-        $end_search = Configuration::get('PS_SEARCH_END') ? '' : '%';
+        $end_search = Configuration::get('PS_SEARCH_END') ? '%' : '';
         $psSearchMawWordLenth = self::getMaximumWordLength();
         $start_pos = (int) ($word[0] == '-');
 


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | this class (classes/Search.php) call badly to configuration variable ps_search_end, if this option will be select, the variable that call ps_search_end in ternary operation it will be empty. Because of that the filter is wrong and don't show the products that should show.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     |  
| How to test?      | verify configuration in search BO and test in front searching products.
| Possible impacts? | if move other code part to fix that and not fix the root of the problem maybe can cause troubles.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23707)
<!-- Reviewable:end -->
