### PR TITLE
Fix issue in Dispatcher after an upgrade from 1.6 to 1.7

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -686,7 +686,7 @@ class DispatcherCore
             }
         }
 
-        // Move 'index' route to the first position on every languaje route array.
+        // Move 'index' route to the first position on every language route array.
         // 'index' route must be the first checked, to avoid false matches within '/' url in the nexts routes regexp.
         foreach($this->routes as $id_shop => $lang_routes){
             foreach($lang_routes as $id_lang => $route){

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -688,11 +688,11 @@ class DispatcherCore
 
         // Move 'index' route to the first position on every language route array.
         // 'index' route must be the first checked, to avoid false matches within '/' url in the nexts routes regexp.
-        foreach($this->routes as $id_shop => $lang_routes){
-            foreach($lang_routes as $id_lang => $route){
+        foreach($this->routes as $id_shop => $lang_routes) {
+            foreach($lang_routes as $id_lang => $route) {
                 $index_route = $route['index'];
                 unset($this->routes[$id_shop][$id_lang]['index']);
-                $this->routes[$id_shop][$id_lang] = array_merge (array('index' => $index_route), $this->routes[$id_shop][$id_lang]);
+                $this->routes[$id_shop][$id_lang] = array_merge (['index' => $index_route], $this->routes[$id_shop][$id_lang]);
             }
         }
     }

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -685,6 +685,16 @@ class DispatcherCore
                 }
             }
         }
+
+        // Move 'index' route to the first position on every languaje route array.
+        // 'index' route must be the first checked, to avoid false matches within '/' url in the nexts routes regexp.
+        foreach($this->routes as $id_shop => $lang_routes){
+            foreach($lang_routes as $id_lang => $route){
+                $index_route = $route['index'];
+                unset($this->routes[$id_shop][$id_lang]['index']);
+                $this->routes[$id_shop][$id_lang] = array_merge (array('index' => $index_route), $this->routes[$id_shop][$id_lang]);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | after prestashop upgrade from 1.6.x to 1.7.7.2 homepage throws 404 error. This is an issue related to the order where routes are stored in the routes array in Dispatcher.php
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no 
| Deprecations?     | no
| Fixed ticket?     | Fixes #23712
| How to test?      | Just install PS 1.6.x and upgrade to 1.7.2.2, then go to homepage and check that it is throwing 404 error.
| Possible impacts? | May check that all other routes are not affected after this fix.

Having found a case where after an upgrade from PS 1.6 to 1.7.7.2, the homepage throws 404 error, we can observe that the 'index' route is placed at the end of every lang route array in the 'routes' property inside Dispatcher.php.

Have found that the regex for the categories route  ( 'category_rule': "regexp" => "#^/(?P<rewrite_category>[_a-zA-Z0-9-\pL]*)$#u") can match the homepage '/' url too. In this case, when we go to homepage url, it tries to route it through the category route because this is placed before the 'index' route within the routes array and, as homepage isn't a category, it throws a 404 error.

By moving the 'index' route to the first position on every routes array, we force getController() to check for homepage route the first, by this way we avoid false positives from the nexts routes regexp like the category one.

![image](https://user-images.githubusercontent.com/22943974/112054731-37876300-8b56-11eb-9901-753569022e94.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->



Note that array_unshift place the new element in the [0] array position. Have opted for array_merge to set the 'index' key within this first position for homepage route.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23730)
<!-- Reviewable:end -->
