### PR TITLE
array_key_exists is deprecated on objects. use property_exists instead

### DIFF
--- a/src/Adapter/EntityMapper.php
+++ b/src/Adapter/EntityMapper.php
@@ -84,7 +84,7 @@ class EntityMapper
                     if ($object_datas_lang = Db::getInstance()->executeS($sql)) {
                         foreach ($object_datas_lang as $row) {
                             foreach ($row as $key => $value) {
-                                if ($key != $entity_defs['primary'] && array_key_exists($key, $objectVars)) {
+                                if ($key != $entity_defs['primary'] && property_exists($entity, $key)) {
                                     if (!isset($object_datas[$key]) || !is_array($object_datas[$key])) {
                                         $object_datas[$key] = [];
                                     }
@@ -98,8 +98,7 @@ class EntityMapper
 
                 $entity->id = (int) $id;
                 foreach ($object_datas as $key => $value) {
-                    if (array_key_exists($key, $entity_defs['fields'])
-                        || array_key_exists($key, $objectVars)) {
+                    if (isset($entity_defs['fields'][$key]) || isset($entity->{$key})) {
                         $entity->{$key} = $value;
                     } else {
                         unset($object_datas[$key]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | array_key_exists is deprecated on objects. use property_exists instead. It's give error on api call.
| Type?             |  improvement 
| Category?         |  WS 
| BC breaks?        | yes 
| Deprecations?     | yes 
| Fixed ticket?     | Fixes #23710
| How to test?      | Test using webservices.
| Possible impacts? | Please webservices.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23731)
<!-- Reviewable:end -->
