### PR TITLE
Fixed the quantity calculation of packs when containing product variations

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -292,7 +292,7 @@ class PackCore extends Product
             $items = array_values(Pack::getItems($idProduct, Configuration::get('PS_LANG_DEFAULT')));
 
             foreach ($items as $index => $item) {
-                $itemQuantity = Product::getQuantity($item->id, $item->id_pack_product_attribute, null, $cart, $idCustomization);
+                $itemQuantity = Product::getQuantity($item->id, $item->id_pack_product_attribute ?: null, null, $cart, $idCustomization);
                 $nbPackAvailableForItem = (int) floor($itemQuantity / $item->pack_quantity);
 
                 // Initialize packQuantity with the first product quantity

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -292,7 +292,7 @@ class PackCore extends Product
             $items = array_values(Pack::getItems($idProduct, Configuration::get('PS_LANG_DEFAULT')));
 
             foreach ($items as $index => $item) {
-                $itemQuantity = Product::getQuantity($item->id, null, null, $cart, $idCustomization);
+                $itemQuantity = Product::getQuantity($item->id, $item->id_pack_product_attribute, null, $cart, $idCustomization);
                 $nbPackAvailableForItem = (int) floor($itemQuantity / $item->pack_quantity);
 
                 // Initialize packQuantity with the first product quantity


### PR DESCRIPTION
Use the variation product attribute id in the pack quantity calculation.

The issue was that in the pack quantity calculation, it was getting the item quantity in the pack without using the product attribute id, which was getting always the quantities of all variations.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes the quantity calculation of packs when 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #13769 #9671
| How to test?      | Follow steps in issue description of #13769
| Possible impacts? | It should fix many incoherences with the packs calculations, but I can't tell if some processes were depending on this wrong value previously calculated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23742)
<!-- Reviewable:end -->
