### PR TITLE
Fixes issue with credit slip not downloading

### DIFF
--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -63,6 +63,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
 
         $this->order->products = $products;
         $this->smarty = $smarty;
+        $this->smarty->assign('isTaxEnabled', (bool) Configuration::get('PS_TAX'));
 
         // header informations
         $this->date = Tools::displayDate($this->order_slip->date_add);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I encountered the issue myself and it seemed quite easy fix. I believe the issue came from this commit https://github.com/PrestaShop/PrestaShop/commit/9f79c582ef1465741e7ab4fb6af0dc1aebc5c475 and it happened because same template files used in multiple PDF's? so I am just doing the same thing in another PDF class.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23422
| How to test?      | Try to download credit slip
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23752)
<!-- Reviewable:end -->
