### PR TITLE
Fix `Validate::isArrayWithIds` method issue

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1191,7 +1191,7 @@ class ValidateCore
      */
     public static function isArrayWithIds($ids)
     {
-        if (count($ids) < 1) {
+        if (!is_array($ids) || count($ids) < 1) {
             return false;
         }
 

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1192,7 +1192,7 @@ class ValidateCore
     public static function isArrayWithIds($ids)
     {
         if (count($ids) < 1) {
-            return false
+            return false;
         }
 
         foreach ($ids as $id) {

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1187,15 +1187,17 @@ class ValidateCore
     /**
      * @param array $ids
      *
-     * @return bool return true if the array contain only unsigned int value
+     * @return bool return true if the array contain only unsigned int value and not empty
      */
     public static function isArrayWithIds($ids)
     {
-        if (count($ids)) {
-            foreach ($ids as $id) {
-                if ($id == 0 || !Validate::isUnsignedInt($id)) {
-                    return false;
-                }
+        if (count($ids) < 1) {
+            return false
+        }
+
+        foreach ($ids as $id) {
+            if ($id == 0 || !Validate::isUnsignedInt($id)) {
+                return false;
             }
         }
 

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -377,6 +377,7 @@ class ValidateCoreTest extends TestCase
     public function isArrayWithIdsDataProvider()
     {
         return array(
+            array(false, 'This is not an array'),
             array(true, [666]),
             array(true, [4, 5, 9, 14]),
             array(true, ['2', 5, 4]),

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -379,23 +379,23 @@ class ValidateCoreTest extends TestCase
 
     public function isArrayWithIdsDataProvider(): array
     {
-        return array(
-            array(false, 'This is not an array'),
-            array(false, 42),
-            array(false, '42'),
-            array(true, [666]),
-            array(true, [4, 5, 9, 14]),
-            array(true, ['2', 5, 4]),
-            array(true, ['7', '8', '12']),
-            array(false, []),
-            array(false, [69, 1, [], 5]),
-            array(false, [12, 2.5, 14]),
-            array(false, [-1, 6, 12]),
-            array(false, ['A', 1, 9]),
-            array(false, ['+', 666, '+']),
-            array(false, [0, 2, 253]),
-            array(false, [0, 0, 0]),
-            array(false, [45, true, 9]),
-        );
+        return [
+            [false, 'This is not an array'],
+            [false, 42],
+            [false, '42'],
+            [true, [666]],
+            [true, [4, 5, 9, 14]],
+            [true, ['2', 5, 4]],
+            [true, ['7', '8', '12']],
+            [false, []],
+            [false, [69, 1, [], 5]],
+            [false, [12, 2.5, 14]],
+            [false, [-1, 6, 12]],
+            [false, ['A', 1, 9]],
+            [false, ['+', 666, '+']],
+            [false, [0, 2, 253]],
+            [false, [0, 0, 0]],
+            [false, [45, true, 9]],
+        ];
     }
 }

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -132,6 +132,14 @@ class ValidateCoreTest extends TestCase
         $this->assertSame($expected, Validate::isOptFloat($input));
     }
 
+    /**
+     * @dataProvider isArrayWithIdsDataProvider
+     */
+    public function testIsArrayWithIds($expected, $input)
+    {
+        $this->assertSame($expected, Validate::isArrayWithIds($input));
+    }
+
     // --- providers ---
 
     public function isIp2LongDataProvider()
@@ -363,6 +371,25 @@ class ValidateCoreTest extends TestCase
                 array(false, 'A'),
                 array(false, null),
             )
+        );
+    }
+
+    public function isArrayWithIdsDataProvider()
+    {
+        return array(
+            array(true, [666]),
+            array(true, [4, 5, 9, 14]),
+            array(true, ['2', 5, 4]),
+            array(true, ['7', '8', '12']),
+            array(false, []),
+            array(false, [69, 1, [], 5]),
+            array(false, [12, 2.5, 14]),
+            array(false, [-1, 6, 12]),
+            array(false, ['A', 1, 9]),
+            array(false, ['+', 666, '+']),
+            array(false, [0, 2, 253]),
+            array(false, [0, 0, 0]),
+            array(false, [45, true, 9]),
         );
     }
 }

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -378,6 +378,8 @@ class ValidateCoreTest extends TestCase
     {
         return array(
             array(false, 'This is not an array'),
+            array(false, 42),
+            array(false, '42'),
             array(true, [666]),
             array(true, [4, 5, 9, 14]),
             array(true, ['2', 5, 4]),

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -134,8 +134,11 @@ class ValidateCoreTest extends TestCase
 
     /**
      * @dataProvider isArrayWithIdsDataProvider
+     *
+     * @param bool $expected
+     * @param string|int|array<string|int|bool|array> $input
      */
-    public function testIsArrayWithIds($expected, $input)
+    public function testIsArrayWithIds(bool $expected, $input)
     {
         $this->assertSame($expected, Validate::isArrayWithIds($input));
     }

--- a/tests-legacy/Unit/Classes/ValidateCoreTest.php
+++ b/tests-legacy/Unit/Classes/ValidateCoreTest.php
@@ -374,7 +374,7 @@ class ValidateCoreTest extends TestCase
         );
     }
 
-    public function isArrayWithIdsDataProvider()
+    public function isArrayWithIdsDataProvider(): array
     {
         return array(
             array(false, 'This is not an array'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | The method `Validate::isArrayWithIds` return `true` when array is empty instead of  `false`.
| Type?             | bug fix 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | See https://github.com/PrestaShop/PrestaShop/issues/23791
| How to test?      | Unit test must be happy :)
| Possible impacts? | N/A.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23789)
<!-- Reviewable:end -->
