### PR TITLE
BO: ProductFromAction : Handle old controller errors

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -561,6 +561,18 @@ class ProductController extends FrameworkBundleAdminController
 
                     $adminProductController->processWarehouses();
 
+                    //Will be deprecated when all controls will be done in $form->isValid()
+                    if (count($adminProductController->errors)) {
+                        $taberror = [];
+                        foreach ($adminProductController->errors as $error) {
+                            $taberror['error'][] = $error;
+                        }
+
+                        return $this->returnErrorJsonResponse(
+                            $taberror,
+                            Response::HTTP_BAD_REQUEST
+                        );
+                    }
                     $response = new JsonResponse();
                     $response->setData([
                         'product' => $product,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Not wonderful, but better than nothing (and before). Based on admin-dev/themes/default/js/bundle/product/form.js ajax call in send function line 648, we can understand what kind of data is awaited by error(). Then we just have to build the right array and send it as a jsonError.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #23299.
| How to test?      | I didn't test all the cases leading to get an error with the former ProductAdminController still called by new version. For instance, you can put an oversized custom feature value or a feature value with forbidden characters like '<>={}'. Before you got an "success" popup, now you get an error.
| Possible impacts? | AJAX receive a failure instead of a success but going through error() doesn't look to be a trouble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23795)
<!-- Reviewable:end -->
