### PR TITLE
Fix jquery selector warning with ps_currencyselector

### DIFF
--- a/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
+++ b/themes/classic/modules/ps_currencyselector/ps_currencyselector.tpl
@@ -26,7 +26,7 @@
 <div id="_desktop_currency_selector">
   <div class="currency-selector dropdown js-dropdown">
     <span id="currency-selector-label">{l s='Currency:' d='Shop.Theme.Global'}</span>
-    <button data-target="#" data-toggle="dropdown" class="hidden-sm-down btn-unstyle" aria-haspopup="true" aria-expanded="false" aria-label="{l s='Currency dropdown' d='Shop.Theme.Global'}">
+    <button data-toggle="dropdown" class="hidden-sm-down btn-unstyle" aria-haspopup="true" aria-expanded="false" aria-label="{l s='Currency dropdown' d='Shop.Theme.Global'}">
       <span class="expand-more _gray-darker">{$current_currency.iso_code} {$current_currency.sign}</span>
       <i class="material-icons expand-more">&#xE5C5;</i>
     </button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | There was a warning when you've 2 currencies because the data-target of ps_currencyselector was useless but filled by a #
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21228.
| How to test?      | You need to have 2 currencies, then go in FO and open a quickview of a product, the warning about jQuery selector '#' shouldn't be appearing
| Possible impacts? | Nothing


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23802)
<!-- Reviewable:end -->
