### PR TITLE
Fix static vars not using scss vars on new-theme and classic

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_dropzone.scss
+++ b/admin-dev/themes/new-theme/scss/components/_dropzone.scss
@@ -1,10 +1,10 @@
 .dropzone .dz-preview .dz-progress {
   height: 10px;
   background: none;
-  background-color: #363a41;
+  background-color: $gray-700;
 
   > .dz-upload {
     background: none;
-    background-color: #25b9d7;
+    background-color: $primary;
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -154,7 +154,7 @@ table .column-filters td:last-child .grid-reset-button {
         // styling for row that is being dragged
         &.dragging-row {
           cursor: move;
-          background: #fafbfc;
+          background: $gray-250;
 
           td {
             color: $white;

--- a/admin-dev/themes/new-theme/scss/components/_notifications.scss
+++ b/admin-dev/themes/new-theme/scss/components/_notifications.scss
@@ -70,7 +70,7 @@
       margin-left: -8px;
       border-color: transparent;
       border-width: 8px;
-      border-bottom-color: #bbcdd2;
+      border-bottom-color: $gray-300;
     }
 
     .nav {
@@ -126,7 +126,7 @@
               margin-top: 1rem;
               font-size: 1.625rem;
               // To be changed to var when UIKit sources are imported
-              color: #363a41;
+              color: $gray-700;
               opacity: 1;
             }
           }
@@ -144,7 +144,7 @@
 
           @include media-breakpoint-down("sm") {
             // To be changed to var when UIKit sources are imported
-            color: #363a41;
+            color: $gray-700;
           }
         }
       }

--- a/admin-dev/themes/new-theme/scss/components/_showcase-card.scss
+++ b/admin-dev/themes/new-theme/scss/components/_showcase-card.scss
@@ -111,7 +111,7 @@
   &__header {
     font-size: 20px;
     font-weight: 600;
-    color: #363a41;
+    color: $gray-700;
     opacity: 0.7;
   }
 
@@ -119,6 +119,6 @@
     max-width: 540px;
     font-size: 14px;
     line-height: 1.43;
-    color: #6c868e;
+    color: $gray-500;
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/_submittable_input.scss
+++ b/admin-dev/themes/new-theme/scss/components/_submittable_input.scss
@@ -10,7 +10,7 @@
     height: 100%;
     padding: 0;
     cursor: pointer;
-    background: #bbcdd2;
+    background: $gray-300;
     border: none;
     outline: none;
     @include border-top-right-radius(4px);
@@ -31,6 +31,6 @@
   }
 
   .check-button.active {
-    background: #25b9d7;
+    background: $primary;
   }
 }

--- a/admin-dev/themes/new-theme/scss/components/_tinymce.scss
+++ b/admin-dev/themes/new-theme/scss/components/_tinymce.scss
@@ -282,7 +282,7 @@ div.mce-tinymce-inline {
   position: absolute;
   width: 5px;
   height: 100%;
-  background-color: #000;
+  background-color: $black;
   border: 1px solid rgba(85, 85, 85, 0.6);
   @include border-radius(7px);
 }
@@ -380,7 +380,7 @@ div.mce-tinymce-inline {
   width: 100%;
   height: 100%;
   zoom: 1;
-  background: #000;
+  background: $black;
   filter: alpha(opacity = 0);
   opacity: 0;
 
@@ -505,7 +505,7 @@ body .mce-abs-layout-item {
   color: $white;
   text-align: center;
   white-space: normal;
-  background-color: #000;
+  background-color: $black;
   @include border-radius(3px);
 }
 
@@ -514,23 +514,23 @@ body .mce-abs-layout-item {
   width: 0;
   height: 0;
   line-height: 0;
-  border: 5px dashed #000;
+  border: 5px dashed $black;
 }
 
 .mce-tooltip-arrow-n {
-  border-bottom-color: #000;
+  border-bottom-color: $black;
 }
 
 .mce-tooltip-arrow-s {
-  border-top-color: #000;
+  border-top-color: $black;
 }
 
 .mce-tooltip-arrow-e {
-  border-left-color: #000;
+  border-left-color: $black;
 }
 
 .mce-tooltip-arrow-w {
-  border-left-color: #000;
+  border-left-color: $black;
 }
 
 .mce-tooltip-nw,

--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -20,7 +20,7 @@
       min-width: 13rem;
       padding: 1rem;
       background-color: $white;
-      box-shadow: 0 8px 16px 0 rgba(#000, 0.1);
+      box-shadow: 0 8px 16px 0 rgba($black, 0.1);
       @include border-radius($card-border-radius);
     }
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -400,7 +400,7 @@ $header-text-color: #4e6167 !default;
           overflow: hidden;
           border: none;
           border-top: 1px solid #eaebec;
-          box-shadow: 0 8px 16px 0 rgba(#000, 0.1);
+          box-shadow: 0 8px 16px 0 rgba($black, 0.1);
           @include border-radius(5px);
           transform: inherit !important;
           /* stylelint-enable */

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -276,7 +276,7 @@
 
         .material-icons {
           &:first-child {
-            color: #25b9d7;
+            color: $primary;
           }
         }
       }
@@ -284,7 +284,7 @@
 
     &:not(#subtab-AdminParentModulesSf) {
       i.material-icons.mi-extension {
-        color: #6c868e;
+        color: $gray-500;
       }
     }
 
@@ -312,7 +312,7 @@
       .sub-tabs-arrow {
         margin-left: auto;
         line-height: inherit;
-        color: #6c868e;
+        color: $gray-500;
         vertical-align: middle;
         visibility: hidden;
       }

--- a/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_right-sidebar.scss
@@ -101,7 +101,7 @@
     height: 50px;
     padding: 1.2em;
     color: $white;
-    background: #363a41;
+    background: $gray-700;
 
     h2{
       margin-bottom: 0;

--- a/admin-dev/themes/new-theme/scss/pages/_attribute.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_attribute.scss
@@ -2,5 +2,5 @@
   display: block;
   width: 40px;
   height: 25px;
-  border: solid 1px #000;
+  border: solid 1px $black;
 }

--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -93,7 +93,7 @@
 
 .module-menu-readmore > .tab-content {
   margin-top: 5px;
-  color: #000;
+  color: $black;
   text-align: justify;
 }
 

--- a/admin-dev/themes/new-theme/scss/pages/_themes_logo.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_themes_logo.scss
@@ -14,7 +14,7 @@
     color: $white;
     text-align: center;
     letter-spacing: -0.2px;
-    background-color: #6c868e;
+    background-color: $gray-500;
     @include border-radius(2px);
   }
 
@@ -23,15 +23,15 @@
     font-weight: 600;
     font-stretch: normal;
     line-height: normal;
-    color: #363a41;
+    color: $gray-700;
     text-align: center;
     letter-spacing: -0.2px;
     background-color: transparent;
-    border: 1px solid #6c858c;
+    border: 1px solid $gray-500;
   }
 
   .btn-tertiary:hover {
-    background-color: #363a41;
+    background-color: $gray-700;
   }
 
   .layout-configuration {
@@ -56,7 +56,7 @@
         font-weight: 400;
         font-stretch: normal;
         line-height: 1.33;
-        color: #6c868e;
+        color: $gray-500;
         letter-spacing: normal;
       }
     }

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -173,7 +173,7 @@
     }
 
     &.employee-message {
-      background-color: #d3f1f7;
+      background-color: $primary-disabled;
     }
 
     &.employee-message--private {

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -240,7 +240,7 @@
     }
 
     a {
-      color: #000;
+      color: $black;
       text-decoration: none;
     }
 
@@ -273,13 +273,13 @@
 
     .badge-dark,
     .badge-secondary {
-      color: #000;
+      color: $black;
       background-color: $white;
     }
 
     .badge-print-light {
       font-weight: 500;
-      color: #000 !important; // stylelint-disable-line
+      color: $black !important; // stylelint-disable-line
       background-color: $white !important; // stylelint-disable-line
     }
   }

--- a/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_configuration.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_configuration.scss
@@ -32,7 +32,7 @@
       font-weight: 400;
       font-stretch: normal;
       line-height: normal;
-      color: #6c868e;
+      color: $gray-500;
       letter-spacing: -0.0125rem;
     }
 
@@ -74,7 +74,7 @@
 
     .nav-link {
       &.active {
-        color: #363a41;
+        color: $gray-700;
         background-color: inherit;
       }
       height: 1.65rem;

--- a/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_theme_card.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_theme_card.scss
@@ -31,7 +31,7 @@
   font-style: normal;
   font-stretch: normal;
   line-height: normal;
-  color: #363a41;
+  color: $gray-700;
   text-align: center;
   letter-spacing: -0.01875rem;
 }
@@ -76,12 +76,12 @@
       font-weight: 400;
       font-stretch: normal;
       line-height: normal;
-      color: #363a41;
+      color: $gray-700;
       text-align: center;
       letter-spacing: -0.0125rem;
 
       .icon-current-theme {
-        color: #25b9d7;
+        color: $primary;
       }
     }
 

--- a/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_theme_card.scss
+++ b/admin-dev/themes/new-theme/scss/pages/partials/_theme_logo_theme_card.scss
@@ -3,7 +3,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  background-color: #000;
+  background-color: $black;
   opacity: 0.25;
 }
 

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -700,7 +700,7 @@ $product-page-padding-bottom: 80px !default;
       margin: 0;
       font-weight: 400;
       line-height: 1.25rem;
-      color: #000;
+      color: $black;
     }
 
     .ref {

--- a/themes/classic/_dev/css/components/categories.scss
+++ b/themes/classic/_dev/css/components/categories.scss
@@ -268,7 +268,7 @@
 
   a {
     font-weight: 600;
-    color: #000;
+    color: $black;
 
     &:not(.previous):not(.next) {
       letter-spacing: 0.125rem;

--- a/themes/classic/_dev/css/components/checkout.scss
+++ b/themes/classic/_dev/css/components/checkout.scss
@@ -492,7 +492,7 @@ body#checkout {
     }
 
     h4.black {
-      color: #000;
+      color: $black;
     }
 
     h4.addresshead {

--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -304,7 +304,7 @@
     height: 100%;
     text-align: center;
     cursor: pointer;
-    background: #000;
+    background: $black;
     background: rgba(0, 0, 0, 0.6);
     opacity: 0;
     @include transition(opacity 0.7s ease-in-out);

--- a/themes/classic/_dev/css/partials/_variables.scss
+++ b/themes/classic/_dev/css/partials/_variables.scss
@@ -1,4 +1,5 @@
 $white: #fff;
+$black: #000;
 $gray-dark: #363a42;
 $gray-darker: #232323;
 $gray: #7a7a7a;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Using static css vars instead of scss variable is making things unmaintanable when you need to replace every white by another color
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23759.
| How to test?      | It's not really testable tbh : search for #363a41, #25b9d7, #fafbfc, #bbcdd2... Maybe I missed some, but I don't think so!
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

⚠️ wait for https://github.com/PrestaShop/PrestaShop/pull/23760 to be merged before this one ⚠️ 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23760)
<!-- Reviewable:end -->
