### PR TITLE
Delete In stock

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -1246,7 +1246,7 @@
 				<label class="control-label col-lg-3" for="qty">{l s='Quantity' d='Admin.Global'}</label>
 				<div class="col-lg-9">
 					<input type="text" name="qty" id="qty" class="form-control fixed-width-sm" value="1" />
-					<p class="help-block">{l s='In stock' d='Admin.Orderscustomers.Feature'} <span id="qty_in_stock"></span></p>
+					{if $PS_STOCK_MANAGEMENT}<p class="help-block">{l s='In stock' d='Admin.Orderscustomers.Feature'} <span id="qty_in_stock"></span></p>{/if}
 				</div>
 			</div>
 

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -265,6 +265,7 @@ class AdminOrdersControllerCore extends AdminController
             'toolbar_btn' => $this->toolbar_btn,
             'toolbar_scroll' => $this->toolbar_scroll,
             'PS_CATALOG_MODE' => Configuration::get('PS_CATALOG_MODE'),
+            'PS_STOCK_MANAGEMENT' => Configuration::get('PS_STOCK_MANAGEMENT'),
             'title' => array($this->trans('Orders', array(), 'Admin.Orderscustomers.Feature'), $this->trans('Create order', array(), 'Admin.Orderscustomers.Feature')),
         ));
         $this->content .= $this->createTemplate('form.tpl')->fetch();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When Stock management is disabled, when creating an Order from BO, the qty_in_stock label is  not displayed anymore
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | NO
| Deprecations?     | no
| Fixed ticket?     | Fixes #23216
| How to test?      | 1. BO>CONFIGURE>Product Settings 2. Scroll down to Products stock block 3. Disable the Enable stock management option 3. Save 4. BO>SELL>Orders>Orders 5. Create an Order 6. Choose a customer and select it 7. Choose a product 8. Check that In stock doesn't appear anymore
| Possible impacts? | Admin Controller Orders.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23805)
<!-- Reviewable:end -->
