### PR TITLE
Fix return, null instead (float)

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3776,7 +3776,7 @@ class ProductCore extends ObjectModel
         }
 
         if (!isset(self::$_pricesLevel2[$cache_id_2][(int) $id_product_attribute])) {
-            return;
+            return 0;
         }
 
         $result = self::$_pricesLevel2[$cache_id_2][(int) $id_product_attribute];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.7.x
| Description?      | An error is triggered when price is null, after migration form 1.7.6 to 1.7.7 <br>   FormatPrice '' is not a number <br> in <br>  391 /src/Adapter/Product/AdminProductDataProvider.php <br>  $product['price'] = $localeCldr->formatPrice( $product['price'], $currency->iso_code);  
| Type?             | bug fix 
| Category?         | BO (observed in BO, but all may be concerned) 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | not
| How to test?      |  need product without price (maybe programmatically added before)
| Possible impacts? | (that just made the things work like the documentation say)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23806)
<!-- Reviewable:end -->
