### PR TITLE
Remove instock

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -251,6 +251,7 @@ class OrderController extends FrameworkBundleAdminController
             'enableSidebar' => true,
             'recycledPackagingEnabled' => (bool) $configuration->get('PS_RECYCLABLE_PACK'),
             'giftSettingsEnabled' => (bool) $configuration->get('PS_GIFT_WRAPPING'),
+            'stockManagementEnabled' => (bool) $configuration->get('PS_STOCK_MANAGEMENT'),
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -220,11 +220,13 @@
     <td class="js-product-ref"></td>
     <td><input class="form-control js-product-unit-input" type="text"></td>
     <td>
-      <input type="number" min="1" class="form-control js-product-qty-input" style="max-width: 100px;">
-      <small class="form-text">
+      <input type="number" min="1" class="form-control js-product-qty-input" style="max-width: 100px;{% if not stockManagementEnabled %}margin-top:0px;{% endif %}">
+      {% if stockManagementEnabled %}
+      <small class="form-text">  
         {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
         <span class="js-product-qty-stock"></span>
       </small>
+      {% endif %}
     </td>
     <td class="js-product-total-price"></td>
     <td class="text-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -98,10 +98,10 @@
               <div class="col-2">
                 <input name="product_quantity" id="quantity-input" type="number" min="1" value="1" class="form-control">
                 {% if stockManagementEnabled %}
-                <small class="form-text">
-                  {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
-                  <span class="js-in-stock-counter"></span>
-                </small>
+                  <small class="form-text">
+                    {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                    <span class="js-in-stock-counter"></span>
+                  </small>
                 {% endif %}
               </div>
             </div>
@@ -222,10 +222,10 @@
     <td>
       <input type="number" min="1" class="form-control js-product-qty-input" style="max-width: 100px;{% if not stockManagementEnabled %}margin-top:0px;{% endif %}">
       {% if stockManagementEnabled %}
-      <small class="form-text">  
-        {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        <span class="js-product-qty-stock"></span>
-      </small>
+        <small class="form-text">  
+          {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          <span class="js-product-qty-stock"></span>
+        </small>
       {% endif %}
     </td>
     <td class="js-product-total-price"></td>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -97,10 +97,12 @@
               </div>
               <div class="col-2">
                 <input name="product_quantity" id="quantity-input" type="number" min="1" value="1" class="form-control">
+                {% if stockManagementEnabled %}
                 <small class="form-text">
                   {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
                   <span class="js-in-stock-counter"></span>
                 </small>
+                {% endif %}
               </div>
             </div>
             <div class="row mt-3">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When Stock management is disabled, when creating an Order from BO, the qty_in_stock label is not displayed anymore
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23216
| How to test?      | 1. BO>CONFIGURE>Product Settings<br>2. Scroll down to Products stock block<br>3. Disable the Enable stock management option<br>4. Save<br>5. BO>SELL>Orders>Orders<br>6. Create an Order<br>7. Choose a customer and select it<br>8. Choose a product<br>9. Check that In stock doesn't appear anymore
| Possible impacts? | Admin Controller Orders.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23811)
<!-- Reviewable:end -->
