### PR TITLE
Fixed legacy "view my shop" link when multistore is not used

### DIFF
--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -59,7 +59,7 @@
         </div>
       {/if}
 
-      {if !isset($hideLegacyStoreContextSelector)}
+      {if !$hideLegacyStoreContextSelector || !isset($hideLegacyStoreContextSelector)}
         <div class="component" id="header-shop-list-container">
           {include file="components/layout/shop_list.tpl"}
         </div>

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -59,7 +59,7 @@
         </div>
       {/if}
 
-      {if !$hideLegacyStoreContextSelector || !isset($hideLegacyStoreContextSelector)}
+      {if !isset($hideLegacyStoreContextSelector) || !$hideLegacyStoreContextSelector}
         <div class="component" id="header-shop-list-container">
           {include file="components/layout/shop_list.tpl"}
         </div>

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -173,7 +173,8 @@ class AdminLegacyLayoutControllerCore extends AdminController
             'js_router_metadata' => $this->jsRouterMetadata,
             /* allow complex <h1> structure. @since 1.7.7 */
             'use_regular_h1_structure' => $this->useRegularH1Structure,
-            'hideLegacyStoreContextSelector' => true,
+            // legacy context selector is hidden on migrated pages when multistore feature is used
+            'hideLegacyStoreContextSelector' => $this->container->get('prestashop.adapter.multistore_feature')->isUsed(),
         ];
 
         if ($this->helpLink === false || !empty($this->helpLink)) {

--- a/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
+++ b/tests-legacy/PrestaShopBundle/Controller/ControllerTest.php
@@ -35,6 +35,7 @@ use Link;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\EntityMapper;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShop\PrestaShop\Core\Foundation\IoC\Container as LegacyContainer;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
@@ -266,6 +267,8 @@ class ControllerTest extends TestCase
             ->willReturn($localeRepositoryProphecy->reveal());
         $containerProphecy->get('prestashop.core.admin.multistore')
             ->willReturn($this->prophesizeMultistoreController()->reveal());
+        $containerProphecy->get('prestashop.adapter.multistore_feature')
+            ->willReturn($this->prophesizeMultistoreFeature()->reveal());
 
         return $containerProphecy;
     }
@@ -369,5 +372,16 @@ class ControllerTest extends TestCase
         $multistoreControllerProphecy->header(Argument::any())->willReturn($responseProphecy->reveal());
 
         return $multistoreControllerProphecy;
+    }
+
+    /**
+     * @return ObjectProphecy
+     */
+    protected function prophesizeMultistoreFeature(): ObjectProphecy
+    {
+        $multistoreFeatureProphecy = $this->prophesize(FeatureInterface::class);
+        $multistoreFeatureProphecy->isUsed()->willReturn(false);
+
+        return $multistoreFeatureProphecy;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The "view my shop" in the legacy header was hidden when multistore was not used. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23804
| How to test?      |  - Go to BO<br>- Sign in<br>- Go to a symfony page (Orders for example)<br>-  => link should appear (see issue)
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23818)
<!-- Reviewable:end -->
