### PR TITLE
Open tracking url in a new tab and add the link to the order preview

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -151,10 +151,12 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
         $state = new State($address->id_state);
 
         $carrierName = null;
+        $trackingUrl = null;
         $stateName = Validate::isLoadedObject($state) ? $state->name : null;
 
         if (Validate::isLoadedObject($carrier)) {
             $carrierName = $carrier->name;
+            $trackingUrl = $carrier->url;
         }
 
         $orderCarrierId = $order->getIdOrderCarrier();
@@ -176,7 +178,8 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
             $address->phone,
             $carrierName,
             $orderCarrier->tracking_number ?: null,
-            $dni
+            $dni,
+            $trackingUrl
         );
     }
 

--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -150,8 +150,7 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
         $carrier = new Carrier($order->id_carrier);
         $state = new State($address->id_state);
 
-        $carrierName = null;
-        $trackingUrl = null;
+        $carrierName = $trackingUrl = null;
         $stateName = Validate::isLoadedObject($state) ? $state->name : null;
 
         if (Validate::isLoadedObject($carrier)) {

--- a/src/Core/Domain/Order/QueryResult/OrderPreviewShippingDetails.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPreviewShippingDetails.php
@@ -102,6 +102,11 @@ class OrderPreviewShippingDetails
     private $dni;
 
     /**
+     * @var string|null
+     */
+    private $trackingUrl;
+
+    /**
      * InvoiceDetails constructor.
      *
      * @param string $firstName
@@ -118,6 +123,7 @@ class OrderPreviewShippingDetails
      * @param string|null $carrierName
      * @param string|null $trackingNumber
      * @param string|null $dni
+     * @param string|null $trackingUrl
      */
     public function __construct(
         string $firstName,
@@ -133,7 +139,8 @@ class OrderPreviewShippingDetails
         string $phone,
         ?string $carrierName,
         ?string $trackingNumber,
-        ?string $dni = null
+        ?string $dni = null,
+        ?string $trackingUrl = null
     ) {
         $this->firstName = $firstName;
         $this->lastName = $lastName;
@@ -149,6 +156,7 @@ class OrderPreviewShippingDetails
         $this->company = $company;
         $this->vatNumber = $vatNumber;
         $this->dni = $dni;
+        $this->trackingUrl = $trackingUrl;
     }
 
     /**
@@ -261,5 +269,13 @@ class OrderPreviewShippingDetails
     public function getDNI(): ?string
     {
         return $this->dni;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTrackingUrl(): ?string
+    {
+        return $this->trackingUrl;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -59,7 +59,7 @@
           <td>
             {% if carrier.trackingNumber %}
               {% if carrier.trackingUrl %}
-                <a href="{{ carrier.trackingUrl }}">{{ carrier.trackingNumber }}</a>
+                <a href="{{ carrier.trackingUrl }}" target="_blank">{{ carrier.trackingNumber }}</a>
               {% else %}
                 {{ carrier.trackingNumber }}
               {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -59,7 +59,7 @@
           <td>
             {% if carrier.trackingNumber %}
               {% if carrier.trackingUrl %}
-                <a href="{{ carrier.trackingUrl }}" target="_blank">{{ carrier.trackingNumber }}</a>
+                <a href="{{ carrier.trackingUrl }}" target="_blank" rel="noopener noreferrer nofollow">{{ carrier.trackingNumber }}</a>
               {% else %}
                 {{ carrier.trackingNumber }}
               {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -48,7 +48,7 @@
                 <strong>{{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}:</strong>
                 {% if not orderPreview.isVirtual and orderPreview.shippingDetails.trackingNumber is not empty %}
                   {% if orderPreview.shippingDetails.trackingUrl %}
-                    <a href="{{ orderPreview.shippingDetails.trackingUrl }}" target="_blank">{{ orderPreview.shippingDetails.trackingNumber }}</a>
+                    <a href="{{ orderPreview.shippingDetails.trackingUrl }}" target="_blank" rel="noopener noreferrer nofollow">{{ orderPreview.shippingDetails.trackingNumber }}</a>
                   {% else %}
                     {{ orderPreview.shippingDetails.trackingNumber }}
                   {% endif %}
@@ -200,4 +200,3 @@
   </div>
   {{ renderhook('displayOrderPreview', {'order_id': orderId}) }}
 {% endblock %}
-

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -47,7 +47,11 @@
               <p class="mb-0">
                 <strong>{{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}:</strong>
                 {% if not orderPreview.isVirtual and orderPreview.shippingDetails.trackingNumber is not empty %}
-                  {{ orderPreview.shippingDetails.trackingNumber }}
+                  {% if orderPreview.shippingDetails.trackingUrl %}
+                    <a href="{{ orderPreview.shippingDetails.trackingUrl }}" target="_blank">{{ orderPreview.shippingDetails.trackingNumber }}</a>
+                  {% else %}
+                    {{ orderPreview.shippingDetails.trackingNumber }}
+                  {% endif %}
                 {% else %}
                   -
                 {% endif %}

--- a/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
@@ -259,6 +259,17 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^carrier "(.+)" uses "(.+)" as tracking url$/
+     */
+    public function setCarrierTrackingUrl($carrierName, $url)
+    {
+        $this->checkCarrierWithNameExists($carrierName);
+        $carrier = $this->carriers[$carrierName];
+        $carrier->url = $url;
+        $carrier->save();
+    }
+
+    /**
      * @param $carrierName
      */
     public function checkCarrierWithNameExists($carrierName)

--- a/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
@@ -259,9 +259,9 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Given /^carrier "(.+)" uses "(.+)" as tracking url$/
+     * @Given /^the carrier "(.+)" uses "(.+)" as tracking url$/
      */
-    public function setCarrierTrackingUrl($carrierName, $url)
+    public function setCarrierTrackingUrl(string $carrierName, string $url): void
     {
         $this->checkCarrierWithNameExists($carrierName);
         $carrier = $this->carriers[$carrierName];

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -1435,6 +1435,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             'phone' => $shippingAddress->getPhone(),
             'carrierName' => $shippingAddress->getCarrierName(),
             'trackingNumber' => $shippingAddress->getTrackingNumber(),
+            'trackingUrl' => $shippingAddress->getTrackingUrl(),
         ];
 
         $expectedDetails = $table->getRowsHash();
@@ -1833,7 +1834,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 $address = $orderForViewing->getInvoiceAddress();
                 break;
             default:
-                throw new RuntimeException('Adress Type is invalid');
+                throw new RuntimeException('Address Type is invalid');
         }
 
         $expectedDetails = $table->getRowsHash();
@@ -1866,6 +1867,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @Then /^the preview order "(.+)" has following (shipping|invoice) address$/
+     * @Then /^the preview order "(.+)" has following (shipping) details$/
      *
      * @param string $orderReference
      * @param string $addressType
@@ -1886,7 +1888,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
                 $address = $orderPreview->getInvoiceDetails();
                 break;
             default:
-                throw new RuntimeException('Adress Type is invalid');
+                throw new RuntimeException('Address Type is invalid');
         }
 
         $expectedDetails = $table->getRowsHash();
@@ -1898,6 +1900,12 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             'Fullname' => $address->getFirstName() . ' ' . $address->getLastname(),
             'Postal code' => $address->getPostalCode(),
         ];
+        if ('shipping' === $addressType) {
+            $arrayActual += [
+                'Tracking number' => $address->getTrackingNumber(),
+                'Tracking URL' => $address->getTrackingUrl(),
+            ];
+        }
         foreach ($expectedDetails as $detailName => $expectedDetailValue) {
             if (!array_key_exists($detailName, $arrayActual)) {
                 throw new RuntimeException(sprintf('Invalid check for address field %s', $detailName));

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
@@ -125,7 +125,7 @@ Feature: Order from Back Office (BO)
     And the preview order "bo_order1" has following shipping details
       | Tracking number  |                              |
       | Tracking URL     |                              |
-    When carrier "tracking-carrier" uses "http://tracking.url" as tracking url
+    Given the carrier "tracking-carrier" uses "http://tracking.url" as tracking url
     And I update order "bo_order1" Tracking number to "42424242" and Carrier to "tracking-carrier"
     Then order "bo_order1" should have "tracking-carrier" as a carrier
     And the preview order "bo_order1" has following shipping details

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
@@ -20,7 +20,7 @@ Feature: Order from Back Office (BO)
     And I create an empty cart "dummy_cart" for customer "testCustomer"
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
 
-  Scenario: Check adress when DNI is not defined
+  Scenario: Check address when DNI is not defined
     Given I add new address to customer "testCustomer" with following details:
       | Address alias    | test-customer-france-address |
       | First name       | testFirstName                |
@@ -66,7 +66,7 @@ Feature: Order from Back Office (BO)
       | Postal code      | 75008                        |
       | DNI              |                              |
 
-  Scenario: Check adress when DNI not defined
+  Scenario: Check address when DNI not defined
     Given I add new address to customer "testCustomer" with following details:
       | Address alias    | test-customer-spain-address  |
       | First name       | testFirstName                |
@@ -111,3 +111,23 @@ Feature: Order from Back Office (BO)
       | Country          | Spain                        |
       | Postal code      | 28071                        |
       | DNI              | 12345                        |
+
+  Scenario: Check shipping details after updating carrier tracking number & url
+    Given there is a carrier named "tracking-carrier"
+    And I enable carrier "tracking-carrier"
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    And I update order "bo_order1" Tracking number to "" and Carrier to "tracking-carrier"
+    Then order "bo_order1" should have "tracking-carrier" as a carrier
+    And the preview order "bo_order1" has following shipping details
+      | Tracking number  |                              |
+      | Tracking URL     |                              |
+    When carrier "tracking-carrier" uses "http://tracking.url" as tracking url
+    And I update order "bo_order1" Tracking number to "42424242" and Carrier to "tracking-carrier"
+    Then order "bo_order1" should have "tracking-carrier" as a carrier
+    And the preview order "bo_order1" has following shipping details
+      | Tracking number  | 42424242                     |
+      | Tracking URL     | http://tracking.url          |

--- a/tests/Unit/Core/Domain/Order/QueryResult/OrderPreviewShippingDetailsTest.php
+++ b/tests/Unit/Core/Domain/Order/QueryResult/OrderPreviewShippingDetailsTest.php
@@ -48,6 +48,7 @@ class OrderPreviewShippingDetailsTest extends TestCase
         $this->assertEquals('l', $instance->getCarrierName());
         $this->assertEquals('m', $instance->getTrackingNumber());
         $this->assertNull($instance->getDNI());
+        $this->assertNull($instance->getTrackingUrl());
     }
 
     public function testConstructWithDNI(): void
@@ -67,5 +68,26 @@ class OrderPreviewShippingDetailsTest extends TestCase
         $this->assertEquals('l', $instance->getCarrierName());
         $this->assertEquals('m', $instance->getTrackingNumber());
         $this->assertEquals('n', $instance->getDni());
+        $this->assertNull($instance->getTrackingUrl());
+    }
+
+    public function testConstructWithTrackingUrl(): void
+    {
+        $instance = new OrderPreviewShippingDetails('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o');
+        $this->assertEquals('a', $instance->getFirstName());
+        $this->assertEquals('b', $instance->getLastName());
+        $this->assertEquals('c', $instance->getCompany());
+        $this->assertEquals('d', $instance->getVatNumber());
+        $this->assertEquals('e', $instance->getAddress1());
+        $this->assertEquals('f', $instance->getAddress2());
+        $this->assertEquals('g', $instance->getCity());
+        $this->assertEquals('h', $instance->getPostalCode());
+        $this->assertEquals('i', $instance->getStateName());
+        $this->assertEquals('j', $instance->getCountry());
+        $this->assertEquals('k', $instance->getPhone());
+        $this->assertEquals('l', $instance->getCarrierName());
+        $this->assertEquals('m', $instance->getTrackingNumber());
+        $this->assertEquals('n', $instance->getDni());
+        $this->assertEquals('o', $instance->getTrackingUrl());
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Tracking url links should open in a new tab. Also, there was no link in the order preview on the order list page. This PR fixes both issues.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23401
| How to test?      | Please see #23401
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23819)
<!-- Reviewable:end -->
