### PR TITLE
Update state.xml - Distrito Federal changed to Ciudad de México

### DIFF
--- a/install-dev/data/xml/state.xml
+++ b/install-dev/data/xml/state.xml
@@ -201,8 +201,8 @@
     <state id="COL" id_country="MX" id_zone="North_America" iso_code="COL" tax_behavior="0" active="1">
       <name>Colima</name>
     </state>
-    <state id="DIF" id_country="MX" id_zone="North_America" iso_code="DIF" tax_behavior="0" active="1">
-      <name>Distrito Federal</name>
+    <state id="CMX" id_country="MX" id_zone="North_America" iso_code="CMX" tax_behavior="0" active="1">
+      <name>Ciudad de México</name>
     </state>
     <state id="DUR" id_country="MX" id_zone="North_America" iso_code="DUR" tax_behavior="0" active="1">
       <name>Durango</name>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is a file named `install-dev/data/xml/state.xml` which is used when you first install the prestashop on the server. It is used to create the the database table `ps_states` with the states values for all the countries (when available). I am just suggesting an update to this file, since it has been several years since Distrito Federal changed its name to Ciudad de México.
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixe #23860
| How to test?      | It just updates a city name in Mexico.
| Possible impacts? | Since everything is linked to the state_id and not to the state.name, I dont think it will impact anything.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


Changed:

```javascript
-    <state id="DIF" id_country="MX" id_zone="North_America" iso_code="DIF" tax_behavior="0" active="1">
-      <name>Distrito Federal</name> 
+    <state id="CMX" id_country="MX" id_zone="North_America" iso_code="CMX" tax_behavior="0" active="1">
+      <name>Ciudad de México</name>
```

name tag Distrito Federal to Ciudad de México
and its state tag properties id= and iso_code= to "CMX" according to its iso3166-2 code.


On 29 January 2016, Mexico City ceased to be the Federal District (Spanish: Distrito Federal or D.F.), and was officially renamed "Ciudad de México" (or "CDMX")

Source:
https://www.iso.org/obp/ui/#iso:code:3166:MX
https://en.wikipedia.org/wiki/Mexico_City#20th_century_to_present

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23828)
<!-- Reviewable:end -->
