### PR TITLE
Update ps_contactinfo-rich.tpl

### DIFF
--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -55,8 +55,8 @@
       <div class="icon"><i class="material-icons">&#xE158;</i></div>
       <div class="data email">
         {l s='Email us:' d='Shop.Theme.Global'}<br/>
-      </div>
       {mailto address=$contact_infos.email encode="javascript"}
+      </div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
Simply moves the terminating div tag to after the mailto link. Stops the email address (if particularly long) overflowing to below the email icon and now stays inline in a column.
I understand this is a tiny fix, but given I rely on the default theme heavily (child theme) I'd rather not implement a custom variant in my theme (for upgradability's sake), and believe this is desirable for all using this theme.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.7.x
| Description?      | Just a minor adjustment to the way the default theme displays the email address on the contact page. Prevents overflow of text to below the email icon, instead retaining a column style arrangement.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Should be obvious if a store is configured using the default theme with a long(ish) contact email address.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23829)
<!-- Reviewable:end -->
