### PR TITLE
Fixed cart not updated on voucher update

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -500,6 +500,9 @@ class CartCore extends ObjectModel
                     AND crl.id_lang = ' . (int) $this->id_lang . '
                 )
                 WHERE `id_cart` = ' . (int) $this->id . '
+                AND NOW() BETWEEN cr.date_from AND cr.date_to
+				AND cr.`active` = 1
+				AND cr.`quantity` > 0
                 ' . ($filter == CartRule::FILTER_ACTION_SHIPPING ? 'AND free_shipping = 1' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_GIFT ? 'AND gift_product != 0' : '') . '
                 ' . ($filter == CartRule::FILTER_ACTION_REDUCTION ? 'AND (reduction_percent != 0 OR reduction_amount != 0)' : '')


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Cart is not updated properly when there is a change in voucher 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19393 (#20009 is a duplicate)
| How to test?      | Create a cart rule auto applicable (without code) and set the cart rule inactive or with an  expired date or without quantity available. The cart rule will be applicated. Try again with the patch, it will fix that.
| Possible impacts? | No impacts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23831)
<!-- Reviewable:end -->
