### PR TITLE
Remove code related to CACHE_FILE_MODULES_LIST

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1676,59 +1676,11 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getNonNativeModuleList()
     {
-        $db = Db::getInstance();
-        $module_list_xml = _PS_ROOT_DIR_ . self::CACHE_FILE_MODULES_LIST;
-        $native_modules = @simplexml_load_file($module_list_xml);
-        if ($native_modules) {
-            $native_modules = $native_modules->modules;
-        }
-
-        $arr_native_modules = [];
-        if (is_object($native_modules)) {
-            foreach ($native_modules as $native_modules_type) {
-                if (in_array($native_modules_type['type'], ['native', 'partner'])) {
-                    $arr_native_modules[] = '""';
-                    foreach ($native_modules_type->module as $module) {
-                        $arr_native_modules[] = '"' . pSQL($module['name']) . '"';
-                    }
-                }
-            }
-        }
-
-        if ($arr_native_modules) {
-            return $db->executeS('SELECT * FROM `' . _DB_PREFIX_ . 'module` m WHERE `name` NOT IN (' . implode(',', $arr_native_modules) . ') ');
-        }
-
         return false;
     }
 
     public static function getNativeModuleList()
     {
-        $module_list_xml = _PS_ROOT_DIR_ . self::CACHE_FILE_MODULES_LIST;
-        if (!file_exists($module_list_xml)) {
-            return false;
-        }
-
-        $native_modules = @simplexml_load_file($module_list_xml);
-
-        if ($native_modules) {
-            $native_modules = $native_modules->modules;
-        }
-
-        $modules = [];
-        if (is_object($native_modules)) {
-            foreach ($native_modules as $native_modules_type) {
-                if (in_array($native_modules_type['type'], ['native', 'partner'])) {
-                    foreach ($native_modules_type->module as $module) {
-                        $modules[] = $module['name'];
-                    }
-                }
-            }
-        }
-        if ($modules) {
-            return $modules;
-        }
-
         return false;
     }
 
@@ -1762,7 +1714,6 @@ abstract class ModuleCore implements ModuleInterface
     final public static function isModuleTrusted($module_name)
     {
         static $trusted_modules_list_content = null;
-        static $modules_list_content = null;
         static $default_country_modules_list_content = null;
         static $untrusted_modules_list_content = null;
 
@@ -1786,11 +1737,6 @@ abstract class ModuleCore implements ModuleInterface
             }
         }
 
-        $modulesListCacheFilepath = _PS_ROOT_DIR_ . self::CACHE_FILE_MODULES_LIST;
-        if ($modules_list_content === null && is_readable($modulesListCacheFilepath)) {
-            $modules_list_content = Tools::file_get_contents($modulesListCacheFilepath);
-        }
-
         if ($default_country_modules_list_content === null) {
             $default_country_modules_list_content = Tools::file_get_contents(_PS_ROOT_DIR_ . self::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST);
         }
@@ -1803,9 +1749,7 @@ abstract class ModuleCore implements ModuleInterface
 
         if (stripos($trusted_modules_list_content, $module_name) !== false) {
             // If the module is not a partner, then return 1 (which means the module is "trusted")
-            if (stripos($modules_list_content, '<module name="' . $module_name . '"/>') == false) {
-                return 1;
-            } elseif (stripos($default_country_modules_list_content, '<name><![CDATA[' . $module_name . ']]></name>') !== false) {
+            if (stripos($default_country_modules_list_content, '<name><![CDATA[' . $module_name . ']]></name>') !== false) {
                 // The module is a parter. If the module is in the file that contains module for this country then return 1 (which means the module is "trusted")
                 return 1;
             }

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -124,28 +124,6 @@ class AdminModulesControllerCore extends AdminController
             'PS_SHOW_ENABLED_MODULES_' . (int) $this->id_employee,
             'PS_SHOW_CAT_MODULES_' . (int) $this->id_employee,
         ]);
-
-        // Load cache file modules list (natives and partners modules)
-        $xml_modules = false;
-        if (file_exists(_PS_ROOT_DIR_ . Module::CACHE_FILE_MODULES_LIST)) {
-            $xml_modules = @simplexml_load_file(_PS_ROOT_DIR_ . Module::CACHE_FILE_MODULES_LIST);
-        }
-        if ($xml_modules) {
-            foreach ($xml_modules->children() as $xml_module) {
-                /** @var SimpleXMLElement $xml_module */
-                foreach ($xml_module->children() as $module) {
-                    /** @var SimpleXMLElement $module */
-                    foreach ($module->attributes() as $key => $value) {
-                        if ($xml_module->attributes() == 'native' && $key == 'name') {
-                            $this->list_natives_modules[] = (string) $value;
-                        }
-                        if ($xml_module->attributes() == 'partner' && $key == 'name') {
-                            $this->list_partners_modules[] = (string) $value;
-                        }
-                    }
-                }
-            }
-        }
     }
 
     public function checkCategoriesNames($a, $b)
@@ -169,11 +147,9 @@ class AdminModulesControllerCore extends AdminController
 
     public function ajaxProcessRefreshModuleList($force_reload_cache = false)
     {
-        // Refresh modules_list.xml every week
-        if (!Tools::isFileFresh(Module::CACHE_FILE_MODULES_LIST, 86400) || $force_reload_cache) {
-            if (Tools::refreshFile(Module::CACHE_FILE_MODULES_LIST, 'https://' . $this->xml_modules_list)) {
-                $this->status = 'refresh';
-            } elseif (Tools::refreshFile(Module::CACHE_FILE_MODULES_LIST, 'http://' . $this->xml_modules_list)) {
+        // Refresh default country native modules list every day
+        if (!Tools::isFileFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 86400) || $force_reload_cache) {
+            if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'))) {
                 $this->status = 'refresh';
             } else {
                 $this->status = 'error';
@@ -182,27 +158,14 @@ class AdminModulesControllerCore extends AdminController
             $this->status = 'cache';
         }
 
-        // If logged to Addons Webservices, refresh default country native modules list every day
-        if ($this->status != 'error') {
-            if (!Tools::isFileFresh(Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, 86400) || $force_reload_cache) {
-                if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_DEFAULT_COUNTRY_MODULES_LIST, Tools::addonsRequest('native'))) {
-                    $this->status = 'refresh';
-                } else {
-                    $this->status = 'error';
-                }
+        if (!Tools::isFileFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, 86400) || $force_reload_cache) {
+            if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'))) {
+                $this->status = 'refresh';
             } else {
-                $this->status = 'cache';
+                $this->status = 'error';
             }
-
-            if (!Tools::isFileFresh(Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, 86400) || $force_reload_cache) {
-                if (file_put_contents(_PS_ROOT_DIR_ . Module::CACHE_FILE_MUST_HAVE_MODULES_LIST, Tools::addonsRequest('must-have'))) {
-                    $this->status = 'refresh';
-                } else {
-                    $this->status = 'error';
-                }
-            } else {
-                $this->status = 'cache';
-            }
+        } else {
+            $this->status = 'cache';
         }
 
         // If logged to Addons Webservices, refresh customer modules list every 5 minutes
@@ -1109,10 +1072,6 @@ class AdminModulesControllerCore extends AdminController
                     }
                 }
 
-                if (in_array($module->name, $this->list_partners_modules)) {
-                    $module->type = 'addonsPartner';
-                }
-
                 if ($perm) {
                     $this->fillModuleData($module, 'array', null, $install_source_tracking);
                     if ($module->id) {
@@ -1308,15 +1267,9 @@ class AdminModulesControllerCore extends AdminController
 
         // Filter on module type and author
         $show_type_modules = $this->filter_configuration['PS_SHOW_TYPE_MODULES_' . (int) $this->id_employee];
-        if ($show_type_modules == 'nativeModules' && !in_array($module->name, $this->list_natives_modules)) {
-            return true;
-        } elseif ($show_type_modules == 'partnerModules' && !in_array($module->name, $this->list_partners_modules)) {
-            return true;
-        } elseif ($show_type_modules == 'addonsModules' && (!isset($module->type) || $module->type != 'addonsBought')) {
+        if ($show_type_modules == 'addonsModules' && (!isset($module->type) || $module->type != 'addonsBought')) {
             return true;
         } elseif ($show_type_modules == 'mustHaveModules' && (!isset($module->type) || $module->type != 'addonsMustHave')) {
-            return true;
-        } elseif ($show_type_modules == 'otherModules' && (in_array($module->name, $this->list_partners_modules) || in_array($module->name, $this->list_natives_modules))) {
             return true;
         } elseif (strpos($show_type_modules, 'authorModules[') !== false) {
             // setting selected author in authors set


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Since we merge this pull request #19944 request from the addons API to generate modules and partner could not be performed anymore, and because it's related to the 1.6 behaviour, the code is useless. I think it's a bc break since these methods are no longer returning something interesting instead of false value. If this change is breaking other things, we should revert the #19944 commits in order to restore the old behavior.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #23642 
| How to test?      | Try to use the check update feature inside a module configuration page.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.



# BC breaks
- `getNonNativeModuleList` now return always false
- `getNativeModuleList` now return always false

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23834)
<!-- Reviewable:end -->
