### PR TITLE
Fix bug - shipped email has no tracking number

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -194,7 +194,6 @@ class OrderCore extends ObjectModel
             'id_lang' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'id_customer' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'id_carrier' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
-            'current_state' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'secure_key' => ['type' => self::TYPE_STRING, 'validate' => 'isMd5'],
             'payment' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true],
             'module' => ['type' => self::TYPE_STRING, 'validate' => 'isModuleName', 'required' => true],
@@ -221,6 +220,7 @@ class OrderCore extends ObjectModel
             'round_mode' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'round_type' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'shipping_number' => ['type' => self::TYPE_STRING, 'validate' => 'isTrackingNumber'],
+            'current_state' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'conversion_rate' => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'required' => true],
             'invoice_number' => ['type' => self::TYPE_INT],
             'delivery_number' => ['type' => self::TYPE_INT],
@@ -246,10 +246,6 @@ class OrderCore extends ObjectModel
             'id_lang' => ['xlink_resource' => 'languages'],
             'id_customer' => ['xlink_resource' => 'customers'],
             'id_carrier' => ['xlink_resource' => 'carriers'],
-            'current_state' => [
-                'xlink_resource' => 'order_states',
-                'setter' => 'setWsCurrentState',
-            ],
             'module' => ['required' => true],
             'invoice_number' => [],
             'invoice_date' => [],
@@ -261,6 +257,10 @@ class OrderCore extends ObjectModel
             'shipping_number' => [
                 'getter' => 'getWsShippingNumber',
                 'setter' => 'setWsShippingNumber',
+            ],
+            'current_state' => [
+                'xlink_resource' => 'order_states',
+                'setter' => 'setWsCurrentState',
             ],
             'note' => [],
         ],


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This is a bug fix whereby "shipped" emails do not contain the tracking number. If a web service PUT request updates the order state and tracking number in the same request, the shipped email gets sent before the tracking number is updated.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | None
| How to test?      | 
| Possible impacts? | Should not impact anything, nothing as been added or removed, just the order changed.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23839)
<!-- Reviewable:end -->
