### PR TITLE
Disable shop context switching from the multistore header if the shop has no URL

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_multishop-modal.scss
+++ b/admin-dev/themes/new-theme/scss/components/_multishop-modal.scss
@@ -112,6 +112,14 @@ $component-name: multishop-modal;
     }
   }
 
+  &-shop-name.#{$component-name}-no-url {
+    cursor: not-allowed;
+  }
+
+  &-shop-name.#{$component-name}-no-url:hover {
+    color: #4a4a4a;
+  }
+
   &-all-name,
   &-group-name {
     font-weight: 600;

--- a/src/Adapter/Shop/QueryHandler/SearchShopsHandler.php
+++ b/src/Adapter/Shop/QueryHandler/SearchShopsHandler.php
@@ -86,7 +86,7 @@ final class SearchShopsHandler implements SearchShopsHandlerInterface
             if (!$shop->hasMainUrl()) {
                 continue;
             }
-            
+
             $result[] = new FoundShop(
                 $shop->getId(),
                 $shop->getColor() ?? '',

--- a/src/Adapter/Shop/QueryHandler/SearchShopsHandler.php
+++ b/src/Adapter/Shop/QueryHandler/SearchShopsHandler.php
@@ -83,16 +83,18 @@ final class SearchShopsHandler implements SearchShopsHandlerInterface
         }
 
         foreach ($shopList as $shop) {
-            if ($shop->hasMainUrl()) {
-                $result[] = new FoundShop(
-                    $shop->getId(),
-                    $shop->getColor() ?? '',
-                    $shop->getName(),
-                    $shop->getShopGroup()->getId(),
-                    $shop->getShopGroup()->getName(),
-                    $shop->getShopGroup()->getColor()
-                );
+            if (!$shop->hasMainUrl()) {
+                continue;
             }
+            
+            $result[] = new FoundShop(
+                $shop->getId(),
+                $shop->getColor() ?? '',
+                $shop->getName(),
+                $shop->getShopGroup()->getId(),
+                $shop->getShopGroup()->getName(),
+                $shop->getShopGroup()->getColor()
+            );
         }
 
         return $result;

--- a/src/Adapter/Shop/QueryHandler/SearchShopsHandler.php
+++ b/src/Adapter/Shop/QueryHandler/SearchShopsHandler.php
@@ -83,14 +83,16 @@ final class SearchShopsHandler implements SearchShopsHandlerInterface
         }
 
         foreach ($shopList as $shop) {
-            $result[] = new FoundShop(
-                $shop->getId(),
-                $shop->getColor() ?? '',
-                $shop->getName(),
-                $shop->getShopGroup()->getId(),
-                $shop->getShopGroup()->getName(),
-                $shop->getShopGroup()->getColor()
-            );
+            if ($shop->hasMainUrl()) {
+                $result[] = new FoundShop(
+                    $shop->getId(),
+                    $shop->getColor() ?? '',
+                    $shop->getName(),
+                    $shop->getShopGroup()->getId(),
+                    $shop->getShopGroup()->getName(),
+                    $shop->getShopGroup()->getColor()
+                );
+            }
         }
 
         return $result;

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/header.html.twig
@@ -99,7 +99,7 @@
                     <i class="material-icons">check</i>
                     <a class="multishop-modal-color"{% if shop.color is not empty %} style="background-color: {{shop.color}};"{% endif %} href="{{ getAdminLink('AdminShop', true, {'shop_id' : shop.id, 'updateshop' : true}) }}" data-toggle="popover" data-trigger="hover" data-placement="top" data-content="{{ "Edit color"|trans({}, 'Admin.Global') }}" data-original-title="" title=""></a>
                   </span>
-                    <a class="multishop-modal-shop-name" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>
+                    <a class="multishop-modal-shop-name{% if shop.hasMainUrl() == false %} multishop-modal-no-url">{{ shop.name }}</a>{% else %}" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>{% endif %}
                   </div>
                   {% if shop.hasMainUrl() %}
                     <a class="multishop-modal-shop-view" href="{{ link.getBaseLink(shop.id) }}" target="_blank" rel="noreferrer">{{ "View my shop"|trans({}, 'Admin.Navigation.Header') }} <i class="material-icons">visibility</i></a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/header.html.twig
@@ -53,11 +53,7 @@
 
     {% if isShopContext %}
       <div class="header-multishop-right">
-        {% if currentContext.hasMainUrl() %}
-          <a class="header-multishop-view-action" href="{{ link.getBaseLink(currentContext.id) }}" target="_blank" rel="nofollow">{{ "View my shop"|trans({}, 'Admin.Navigation.Header') }} <i class="material-icons">visibility</i></a>
-        {% else %}
-          <a class="header-multishop-view-action" href="{{ getAdminLink('AdminShop', true, {'shop_id' : currentContext.id}) }}" rel="nofollow">{{ "Configure URL"|trans({}, 'Admin.Actions') }} <i class="material-icons">visibility</i></a>
-        {% endif %}
+        <a class="header-multishop-view-action" href="{{ link.getBaseLink(currentContext.id) }}" target="_blank" rel="nofollow">{{ "View my shop"|trans({}, 'Admin.Navigation.Header') }} <i class="material-icons">visibility</i></a>
       </div>
     {% endif %}
 

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -138,7 +138,7 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
      * @param string $reference
      * @param string $shopReference
      */
-    public function addShopUrl(string $reference, string $shopReference)
+    public function addShopUrl(string $reference, string $shopReference): void
     {
         $shop = SharedStorage::getStorage()->get($shopReference);
         $shopUrl = new ShopUrl();

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\QueryResult\FoundShopGroup;
 use RuntimeException;
 use Shop;
 use ShopGroup;
+use ShopUrl;
 use Tests\Integration\Behaviour\Features\Context\Domain\AbstractDomainFeatureContext;
 
 class ShopFeatureContext extends AbstractDomainFeatureContext
@@ -129,6 +130,30 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
         $shop->setTheme();
 
         SharedStorage::getStorage()->set($reference, $shop);
+    }
+
+    /**
+     * @Given I add a shop url :reference to shop :shopReference
+     *
+     * @param string $reference
+     * @param string $shopReference
+     */
+    public function addShopUrl(string $reference, string $shopReference)
+    {
+        $shop = SharedStorage::getStorage()->get($shopReference);
+        $shopUrl = new ShopUrl();
+        $shopUrl->id_shop = $shop->id;
+        $shopUrl->active = true;
+        $shopUrl->main = true;
+        $shopUrl->domain = 'localhost';
+        $shopUrl->domain_ssl = 'localhost';
+        $shopUrl->physical_uri = '/prestatest/';
+        $shopUrl->virtual_uri = '/prestatest/';
+        if (!$shopUrl->add()) {
+            throw new RuntimeException(sprintf('Could not create shop url: %s', Db::getInstance()->getMsgError()));
+        }
+
+        SharedStorage::getStorage()->set($reference, $shopUrl);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -133,12 +133,11 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Given I add a shop url :reference to shop :shopReference
+     * @Given I add a shop url to shop :shopReference
      *
-     * @param string $reference
      * @param string $shopReference
      */
-    public function addShopUrl(string $reference, string $shopReference): void
+    public function addShopUrl(string $shopReference): void
     {
         $shop = SharedStorage::getStorage()->get($shopReference);
         $shopUrl = new ShopUrl();
@@ -152,8 +151,6 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
         if (!$shopUrl->add()) {
             throw new RuntimeException(sprintf('Could not create shop url: %s', Db::getInstance()->getMsgError()));
         }
-
-        SharedStorage::getStorage()->set($reference, $shopUrl);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Shop/search_shops.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shop/search_shops.feature
@@ -17,9 +17,9 @@ Feature: Search shops given a search term (BO)
     And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "test_second_shop_group"
     And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
     And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
-    And I add a shop url "shop_url1" to shop "shop1"
-    And I add a shop url "shop_url2" to shop "shop2"
-    And I add a shop url "shop_url3" to shop "shop3"
+    And I add a shop url to shop "shop1"
+    And I add a shop url to shop "shop2"
+    And I add a shop url to shop "shop3"
     When I search for the term "test" I should get the following results:
       | name             | group_name             | color | group_color | is_shop_group |
       | test_shop        | Default                |       |             | false         |

--- a/tests/Integration/Behaviour/Features/Scenario/Shop/search_shops.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shop/search_shops.feature
@@ -16,6 +16,10 @@ Feature: Search shops given a search term (BO)
     Given I add a shop group "shopGroup3" with name "empty_shop_group" and color "blue"
     And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "test_second_shop_group"
     And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And I add a shop url "shop_url1" to shop "shop1"
+    And I add a shop url "shop_url2" to shop "shop2"
+    And I add a shop url "shop_url3" to shop "shop3"
     When I search for the term "test" I should get the following results:
       | name             | group_name             | color | group_color | is_shop_group |
       | test_shop        | Default                |       |             | false         |
@@ -36,4 +40,5 @@ Feature: Search shops given a search term (BO)
       | test_second_shop_group  |                 | green |             | true          |
     When I search for the term "empty_shop_group" I should not get any results
     When I search for the term "doesnt_exist" I should not get any results
+    When I search for the term "test_shop_without_url" I should not get any results
     When I search for the term " " I should get a SearchShopException


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR disable shop context URL in the multistore header if the shop has no URL defined. The link is not clickable and the autocomplete search bar doesn't return the shop. Behat tests have been updated accordingly.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23785
| How to test?      | In multistore context, create a shop without defining its URL. Then go on a migrated page, you should not be able to switch context on this shop, and the shop should not be returned in the autocomplete search bar.
| Possible impacts? | 

Eventually, people should be able to configure their shop even if it has no URL specified yet. In legacy it is not possible, by making it possible we noticed some strange behaviors that need to be fixed. For now we disable it, just like in legacy, once we have fixed those issues we will enable it again.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23840)
<!-- Reviewable:end -->
