### PR TITLE
Fix autocomplete UI going under the header on classic theme

### DIFF
--- a/themes/classic/_dev/css/partials/_commons.scss
+++ b/themes/classic/_dev/css/partials/_commons.scss
@@ -611,3 +611,7 @@ input[type="number"] {
   }
   /* stylelint-enable */
 }
+
+.ui-autocomplete.ui-front {
+  z-index: 999;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Autocompelete beginning of the list on search component in the header was ununsable because it was under the header
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23817.
| How to test?      | Go on the front-office and try to search inside the search bar of the header, you should be able to use the aucomplete result easily
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

![image](https://user-images.githubusercontent.com/14963751/113155991-e3593e80-9239-11eb-9a27-6080c622b674.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23841)
<!-- Reviewable:end -->
