### PR TITLE
Fix BOEvent not being on window object anymore

### DIFF
--- a/admin-dev/themes/default/js/bundle/default.js
+++ b/admin-dev/themes/default/js/bundle/default.js
@@ -65,7 +65,7 @@ const rightSidebar = (function () {
  *  BO Events Handler
  */
 // eslint-disable-next-line
-const BOEvent = {
+window.BOEvent = {
   on(eventName, callback, context) {
     document.addEventListener(eventName, (event) => {
       if (typeof context !== 'undefined') {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There was an error on module catalog page because BOEvent was not inside window object anymore due to the ESLint PR
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23842.
| How to test?      | Go on module catalog page and it should work properly
| Possible impacts? | Module page loading


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23844)
<!-- Reviewable:end -->
