### PR TITLE
Fix options is undefined on right-sidebar of default theme

### DIFF
--- a/admin-dev/themes/default/js/bundle/right-sidebar.js
+++ b/admin-dev/themes/default/js/bundle/right-sidebar.js
@@ -99,7 +99,7 @@
     return this.each(function () {
       const $this = $(this);
       let data = $this.data('bs.sidebar');
-      const options = $.extend({}, Sidebar.DEFAULTS, $this.data(), typeof options === 'object' && option);
+      const options = $.extend({}, Sidebar.DEFAULTS, $this.data(), typeof this.options === 'object' && option);
 
       if (!data && options.toggle && option === 'show') {
         // eslint-disable-next-line


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Clicking on help button wasn't working anymore because of a wrong type checking
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23843.
| How to test?      | Go on invoices page, click on the help button, it should display the sidebar
| Possible impacts? | Every help buttons content of every pages


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23846)
<!-- Reviewable:end -->
