### PR TITLE
Change signature of TranslationFinder::getTranslationFilesFromPath to accept null pattern

### DIFF
--- a/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationFinder.php
@@ -86,13 +86,13 @@ class TranslationFinder
 
     /**
      * @param string[] $paths
-     * @param string $pattern
+     * @param string|null $pattern
      *
      * @return Finder
      *
      * @throws FileNotFoundException
      */
-    private function getTranslationFilesFromPath(array $paths, string $pattern): Finder
+    private function getTranslationFilesFromPath(array $paths, ?string $pattern = null): Finder
     {
         $finder = new Finder();
 

--- a/tests/Integration/PrestaShopBundle/Translation/Provider/TranslationFinderTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Provider/TranslationFinderTest.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Integration\PrestaShopBundle\Translation\Provider;
 
 use PrestaShopBundle\Translation\Provider\TranslationFinder;
@@ -43,7 +45,7 @@ class TranslationFinderTest extends KernelTestCase
      */
     private $resourcesDir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         self::bootKernel();
         $this->resourcesDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
@@ -51,7 +53,7 @@ class TranslationFinderTest extends KernelTestCase
         $this->finder = new TranslationFinder();
     }
 
-    public function testGetCatalogueFromPathsReturnsAllDomainsIfNoPatternGiven()
+    public function testGetCatalogueFromPathsReturnsAllDomainsIfNoPatternGiven(): void
     {
         $catalogue = $this->finder->getCatalogueFromPaths([$this->resourcesDir], 'fr-FR');
 
@@ -71,7 +73,7 @@ class TranslationFinderTest extends KernelTestCase
         ], $domains);
     }
 
-    public function testGetCatalogueFromPathsFiltersDomainsIfPatternIsGiven()
+    public function testGetCatalogueFromPathsFiltersDomainsIfPatternIsGiven(): void
     {
         $catalogue = $this->finder->getCatalogueFromPaths([$this->resourcesDir], 'fr-FR', '#^Admin[A-Z]#');
 

--- a/tests/Integration/PrestaShopBundle/Translation/Provider/TranslationFinderTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Provider/TranslationFinderTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\PrestaShopBundle\Translation\Provider;
+
+use PrestaShopBundle\Translation\Provider\TranslationFinder;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Tests the provider for backoffice translations
+ */
+class TranslationFinderTest extends KernelTestCase
+{
+    /**
+     * @var TranslationFinder
+     */
+    private $finder;
+    /**
+     * @var string
+     */
+    private $resourcesDir;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+        $this->resourcesDir = self::$kernel->getContainer()->getParameter('test_translations_dir');
+
+        $this->finder = new TranslationFinder();
+    }
+
+    public function testGetCatalogueFromPathsReturnsAllDomainsIfNoPatternGiven()
+    {
+        $catalogue = $this->finder->getCatalogueFromPaths([$this->resourcesDir], 'fr-FR');
+
+        $domains = $catalogue->getDomains();
+        sort($domains, SORT_STRING);
+
+        $this->assertSame([
+            'AdminActions',
+            'EmailsBody',
+            'EmailsSubject',
+            'ModulesCheckpaymentAdmin',
+            'ModulesCheckpaymentShop',
+            'ModulesWirepaymentAdmin',
+            'ModulesWirepaymentShop',
+            'ShopNotificationsWarning',
+            'messages',
+        ], $domains);
+    }
+
+    public function testGetCatalogueFromPathsFiltersDomainsIfPatternIsGiven()
+    {
+        $catalogue = $this->finder->getCatalogueFromPaths([$this->resourcesDir], 'fr-FR', '#^Admin[A-Z]#');
+
+        $this->assertSame([
+            'AdminActions',
+        ], $catalogue->getDomains());
+
+        $catalogue = $this->finder->getCatalogueFromPaths([$this->resourcesDir], 'fr-FR', '#^Modules[A-Z]#');
+
+        $domains = $catalogue->getDomains();
+        sort($domains, SORT_STRING);
+
+        $this->assertSame([
+            'ModulesCheckpaymentAdmin',
+            'ModulesCheckpaymentShop',
+            'ModulesWirepaymentAdmin',
+            'ModulesWirepaymentShop',
+        ], $domains);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | TranslationFinder::getTranslationFilesFromPath arguments was untyped before https://github.com/PrestaShop/PrestaShop/commit/e80e74027275760c19950625c41292a0f2afb436#diff-4e7fbb6e634e3c056fc15d7dfc353f8b0d7f668166e289476c93e6b8fa2fcdcf that means that null values was allowed. When we typed them, we forgot to allow NULL for $pattern. This PR fixes that
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23344 
| How to test?      | See the issue


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23857)
<!-- Reviewable:end -->
