### PR TITLE
Fix breadcrumb and h1 on prices drop page

### DIFF
--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -61,7 +61,7 @@ class PricesDropControllerCore extends ProductListingFrontController
     public function getListingLabel()
     {
         return $this->trans(
-            'On sale',
+            'Prices drop',
             [],
             'Shop.Theme.Catalog'
         );
@@ -72,7 +72,7 @@ class PricesDropControllerCore extends ProductListingFrontController
         $breadcrumb = parent::getBreadcrumbLinks();
 
         $breadcrumb['links'][] = [
-            'title' => $this->trans('On sale', [], 'Shop.Theme.Catalog'),
+            'title' => $this->trans('Prices drop', [], 'Shop.Theme.Catalog'),
             'url' => $this->context->link->getPageLink('prices-drop', true),
         ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | fix breadcrumb and h1 on prices-drop page
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19145
| How to test?      | See the prices-drop page in FO and verify the h1 and the breadcrumb, it should be displayed "Prices drop" instead of "On sale" 
| Possible impacts? | Nothing


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23858)
<!-- Reviewable:end -->
