### PR TITLE
Enable to extends module `card_list.html.twig` and use custom actions

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -94,15 +94,17 @@
           {% endblock %}
         </div>
         <div class="col-sm-12 col-md-12 col-lg-3 text-md-right">
-          {% if requireBulkActions is defined and requireBulkActions == true %}
-            <div class="module-checkbox-bulk-list md-checkbox">
-              <label>
-                <input type="checkbox" data-name="{{ module.attributes.displayName }}" data-tech-name="{{module.attributes.name}}" />
-                <i class="md-checkbox-control"></i>
-              </label>
-            </div>
-          {% endif %}
-          {% include '@PrestaShop/Admin/Module/Includes/action_menu.html.twig' with { 'module': module } %}
+          {% block module_actions %}
+            {% if requireBulkActions is defined and requireBulkActions == true %}
+              <div class="module-checkbox-bulk-list md-checkbox">
+                <label>
+                  <input type="checkbox" data-name="{{ module.attributes.displayName }}" data-tech-name="{{module.attributes.name}}" />
+                  <i class="md-checkbox-control"></i>
+                </label>
+              </div>
+            {% endif %}
+            {% include '@PrestaShop/Admin/Module/Includes/action_menu.html.twig' with { 'module': module } %}
+          {% endblock %}
         </div>
         {% include '@PrestaShop/Admin/Module/Includes/modal_read_more.html.twig' with { 'module': module, 'additionalModalSuffix': additionalModalSuffix|default('') } %}
         {% include '@PrestaShop/Admin/Module/Includes/modal_confirm.html.twig' with { 'module': module } %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Enable to extends module list block actions. Add actions block in modules card_list.html.twig
| Type?             | improvement 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | N/A
| Possible impacts? | N/A

## Ability to extends `card_list.html.twig` and use custom actions 

My custom module card list :

```twig
{% extends '@PrestaShop/Admin/Module/Includes/card_list.html.twig' %}
{% block module_actions %}
     // My custom action buttons here
{% endblock %}

```

![image](https://user-images.githubusercontent.com/16455155/113308893-ea01b780-9306-11eb-8372-2947071f1de6.png)




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23863)
<!-- Reviewable:end -->
