### PR TITLE
Add composer.json CS normalizer to CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,9 @@ jobs:
       -   name: Run PHPCSFixer
           run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
+      -   name: Run ergebnis/composer-normalize
+          run: composer normalize --dry-run --no-check-lock
+
   phpstan:
     name: PHP Static Analysis
     runs-on: ubuntu-20.04

--- a/composer.json
+++ b/composer.json
@@ -132,6 +132,7 @@
   ],
   "require-dev": {
     "behat/behat": "^3.5",
+    "ergebnis/composer-normalize": "^2.8",
     "friendsofphp/php-cs-fixer": "^2.16.1",
     "johnkary/phpunit-speedtrap": "^3",
     "mikey179/vfsstream": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -1,259 +1,259 @@
 {
-  "name": "prestashop/prestashop",
-  "description": "PrestaShop offers a free, fully scalable, Open Source e-commerce solution.",
-  "type": "project",
-  "require": {
-    "php": "^7.1.3",
-    "ext-curl": "*",
-    "ext-dom": "*",
-    "ext-fileinfo": "*",
-    "ext-gd": "*",
-    "ext-iconv": "*",
-    "ext-intl": "*",
-    "ext-json": "*",
-    "ext-mbstring": "*",
-    "ext-simplexml": "*",
-    "ext-zip": "*",
-    "beberlei/doctrineextensions": "^1.0",
-    "composer/ca-bundle": "^1.0",
-    "composer/installers": "^1.0.21",
-    "csa/guzzle-bundle": "dev-compat-php",
-    "cssjanus/cssjanus": "dev-patch-1",
-    "curl/curl": "^1.2.1",
-    "defuse/php-encryption": "~2.0.1",
-    "doctrine/cache": "^1.8",
-    "doctrine/doctrine-bundle": "^1.6",
-    "doctrine/orm": "^2.7",
-    "egulias/email-validator": "^2.1",
-    "ezyang/htmlpurifier": "^4.10",
-    "friendsofsymfony/jsrouting-bundle": "^2.4",
-    "geoip2/geoip2": "~2.4.2",
-    "greenlion/php-sql-parser": "^4.3",
-    "guzzlehttp/cache-subscriber": "^0.2.0",
-    "guzzlehttp/guzzle": "~5.0",
-    "incenteev/composer-parameter-handler": "~2.0",
-    "ircmaxell/password-compat": "^1.0.4",
-    "ircmaxell/random-lib": "^1.2.0",
-    "jakeasmith/http_build_url": "^1",
-    "league/tactician-bundle": "^1.0",
-    "martinlindhe/php-mb-helpers": "^0.1.6",
-    "matthiasmullie/minify": "~1.3.0",
-    "mobiledetect/mobiledetectlib": "~2.8.34",
-    "mrclay/minify": "~2.3.0",
-    "nikic/php-parser": "^4.0",
-    "paragonie/random_compat": "^2.0",
-    "pear/archive_tar": "^1.4.12",
-    "pelago/emogrifier": "^2.1",
-    "phpoffice/phpspreadsheet": "~1.5",
-    "prestashop/blockreassurance": "^5",
-    "prestashop/blockwishlist": "^2.0",
-    "prestashop/circuit-breaker": "^3.0",
-    "prestashop/contactform": "^4",
-    "prestashop/dashactivity": "^2",
-    "prestashop/dashgoals": "^2",
-    "prestashop/dashproducts": "^2",
-    "prestashop/dashtrends": "^2",
-    "prestashop/decimal": "^1.4",
-    "prestashop/graphnvd3": "^2",
-    "prestashop/gridhtml": "^2",
-    "prestashop/gsitemap": "^4",
-    "prestashop/pagesnotfound": "^2",
-    "prestashop/productcomments": "^4.0",
-    "prestashop/ps_banner": "^2",
-    "prestashop/ps_categorytree": "^2",
-    "prestashop/ps_checkpayment": "^2",
-    "prestashop/ps_contactinfo": "^3.2",
-    "prestashop/ps_crossselling": "^2.0",
-    "prestashop/ps_currencyselector": "^2",
-    "prestashop/ps_customeraccountlinks": "^3",
-    "prestashop/ps_customersignin": "^2",
-    "prestashop/ps_customtext": "^4",
-    "prestashop/ps_dataprivacy": "^2.0",
-    "prestashop/ps_emailsubscription": "^2.5",
-    "prestashop/ps_facetedsearch": "^3.2.1",
-    "prestashop/ps_faviconnotificationbo": "^2",
-    "prestashop/ps_featuredproducts": "^2",
-    "prestashop/ps_imageslider": "^3",
-    "prestashop/ps_languageselector": "^2",
-    "prestashop/ps_linklist": "^4",
-    "prestashop/ps_mainmenu": "^2",
-    "prestashop/ps_searchbar": "^2",
-    "prestashop/ps_sharebuttons": "^2",
-    "prestashop/ps_shoppingcart": "^2",
-    "prestashop/ps_socialfollow": "^2",
-    "prestashop/ps_themecusto": "^1",
-    "prestashop/ps_wirepayment": "^2",
-    "prestashop/statsbestcategories": "^2",
-    "prestashop/statsbestcustomers": "^2",
-    "prestashop/statsbestmanufacturers": "^2",
-    "prestashop/statsbestproducts": "^2",
-    "prestashop/statsbestsuppliers": "^2",
-    "prestashop/statsbestvouchers": "^2",
-    "prestashop/statscarrier": "^2",
-    "prestashop/statscatalog": "^2",
-    "prestashop/statscheckup": "^2",
-    "prestashop/statsdata": "^2",
-    "prestashop/statsforecast": "^2",
-    "prestashop/statsnewsletter": "^2",
-    "prestashop/statspersonalinfos": "^2",
-    "prestashop/statsproduct": "^2",
-    "prestashop/statsregistrations": "^2",
-    "prestashop/statssales": "^2",
-    "prestashop/statssearch": "^2",
-    "prestashop/statsstock": "^2",
-    "prestashop/translationtools-bundle": "^4.0",
-    "prestashop/welcome": "^6",
-    "sensio/distribution-bundle": "^5.0",
-    "sensio/framework-extra-bundle": "^5.1",
-    "shudrum/array-finder": "^1.1.0",
-    "smarty/smarty": "^3.1.39",
-    "soundasleep/html2text": "^0.5.0",
-    "swiftmailer/swiftmailer": "~6.2",
-    "symfony/monolog-bundle": "^3.1.0",
-    "symfony/polyfill-apcu": "^1.0",
-    "symfony/polyfill-php73": "^1.10",
-    "symfony/swiftmailer-bundle": "^3.1",
-    "symfony/symfony": "^3.4.37",
-    "tecnickcom/tcpdf": "^6.2.12",
-    "tijsverkoyen/css-to-inline-styles": "^2.2",
-    "twig/twig": "^1.38"
-  },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/PrestaShop/php-cssjanus",
-      "canonical": false
+    "name": "prestashop/prestashop",
+    "type": "project",
+    "description": "PrestaShop offers a free, fully scalable, Open Source e-commerce solution.",
+    "license": "OSL-3.0",
+    "authors": [
+        {
+            "name": "PrestaShop SA",
+            "email": "contact@prestashop.com"
+        },
+        {
+            "name": "PrestaShop Community",
+            "homepage": "https://contributors.prestashop.com/"
+        }
+    ],
+    "require": {
+        "php": "^7.1.3",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-fileinfo": "*",
+        "ext-gd": "*",
+        "ext-iconv": "*",
+        "ext-intl": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-simplexml": "*",
+        "ext-zip": "*",
+        "beberlei/doctrineextensions": "^1.0",
+        "composer/ca-bundle": "^1.0",
+        "composer/installers": "^1.0.21",
+        "csa/guzzle-bundle": "dev-compat-php",
+        "cssjanus/cssjanus": "dev-patch-1",
+        "curl/curl": "^1.2.1",
+        "defuse/php-encryption": "~2.0.1",
+        "doctrine/cache": "^1.8",
+        "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/orm": "^2.7",
+        "egulias/email-validator": "^2.1",
+        "ezyang/htmlpurifier": "^4.10",
+        "friendsofsymfony/jsrouting-bundle": "^2.4",
+        "geoip2/geoip2": "~2.4.2",
+        "greenlion/php-sql-parser": "^4.3",
+        "guzzlehttp/cache-subscriber": "^0.2.0",
+        "guzzlehttp/guzzle": "~5.0",
+        "incenteev/composer-parameter-handler": "~2.0",
+        "ircmaxell/password-compat": "^1.0.4",
+        "ircmaxell/random-lib": "^1.2.0",
+        "jakeasmith/http_build_url": "^1",
+        "league/tactician-bundle": "^1.0",
+        "martinlindhe/php-mb-helpers": "^0.1.6",
+        "matthiasmullie/minify": "~1.3.0",
+        "mobiledetect/mobiledetectlib": "~2.8.34",
+        "mrclay/minify": "~2.3.0",
+        "nikic/php-parser": "^4.0",
+        "paragonie/random_compat": "^2.0",
+        "pear/archive_tar": "^1.4.12",
+        "pelago/emogrifier": "^2.1",
+        "phpoffice/phpspreadsheet": "~1.5",
+        "prestashop/blockreassurance": "^5",
+        "prestashop/blockwishlist": "^2.0",
+        "prestashop/circuit-breaker": "^3.0",
+        "prestashop/contactform": "^4",
+        "prestashop/dashactivity": "^2",
+        "prestashop/dashgoals": "^2",
+        "prestashop/dashproducts": "^2",
+        "prestashop/dashtrends": "^2",
+        "prestashop/decimal": "^1.4",
+        "prestashop/graphnvd3": "^2",
+        "prestashop/gridhtml": "^2",
+        "prestashop/gsitemap": "^4",
+        "prestashop/pagesnotfound": "^2",
+        "prestashop/productcomments": "^4.0",
+        "prestashop/ps_banner": "^2",
+        "prestashop/ps_categorytree": "^2",
+        "prestashop/ps_checkpayment": "^2",
+        "prestashop/ps_contactinfo": "^3.2",
+        "prestashop/ps_crossselling": "^2.0",
+        "prestashop/ps_currencyselector": "^2",
+        "prestashop/ps_customeraccountlinks": "^3",
+        "prestashop/ps_customersignin": "^2",
+        "prestashop/ps_customtext": "^4",
+        "prestashop/ps_dataprivacy": "^2.0",
+        "prestashop/ps_emailsubscription": "^2.5",
+        "prestashop/ps_facetedsearch": "^3.2.1",
+        "prestashop/ps_faviconnotificationbo": "^2",
+        "prestashop/ps_featuredproducts": "^2",
+        "prestashop/ps_imageslider": "^3",
+        "prestashop/ps_languageselector": "^2",
+        "prestashop/ps_linklist": "^4",
+        "prestashop/ps_mainmenu": "^2",
+        "prestashop/ps_searchbar": "^2",
+        "prestashop/ps_sharebuttons": "^2",
+        "prestashop/ps_shoppingcart": "^2",
+        "prestashop/ps_socialfollow": "^2",
+        "prestashop/ps_themecusto": "^1",
+        "prestashop/ps_wirepayment": "^2",
+        "prestashop/statsbestcategories": "^2",
+        "prestashop/statsbestcustomers": "^2",
+        "prestashop/statsbestmanufacturers": "^2",
+        "prestashop/statsbestproducts": "^2",
+        "prestashop/statsbestsuppliers": "^2",
+        "prestashop/statsbestvouchers": "^2",
+        "prestashop/statscarrier": "^2",
+        "prestashop/statscatalog": "^2",
+        "prestashop/statscheckup": "^2",
+        "prestashop/statsdata": "^2",
+        "prestashop/statsforecast": "^2",
+        "prestashop/statsnewsletter": "^2",
+        "prestashop/statspersonalinfos": "^2",
+        "prestashop/statsproduct": "^2",
+        "prestashop/statsregistrations": "^2",
+        "prestashop/statssales": "^2",
+        "prestashop/statssearch": "^2",
+        "prestashop/statsstock": "^2",
+        "prestashop/translationtools-bundle": "^4.0",
+        "prestashop/welcome": "^6",
+        "sensio/distribution-bundle": "^5.0",
+        "sensio/framework-extra-bundle": "^5.1",
+        "shudrum/array-finder": "^1.1.0",
+        "smarty/smarty": "^3.1.39",
+        "soundasleep/html2text": "^0.5.0",
+        "swiftmailer/swiftmailer": "~6.2",
+        "symfony/monolog-bundle": "^3.1.0",
+        "symfony/polyfill-apcu": "^1.0",
+        "symfony/polyfill-php73": "^1.10",
+        "symfony/swiftmailer-bundle": "^3.1",
+        "symfony/symfony": "^3.4.37",
+        "tecnickcom/tcpdf": "^6.2.12",
+        "tijsverkoyen/css-to-inline-styles": "^2.2",
+        "twig/twig": "^1.38"
     },
-    {
-      "type": "vcs",
-      "url": "https://github.com/PrestaShop/CsaGuzzleBundle",
-      "canonical": false
+    "require-dev": {
+        "behat/behat": "^3.5",
+        "ergebnis/composer-normalize": "^2.8",
+        "friendsofphp/php-cs-fixer": "^2.16.1",
+        "johnkary/phpunit-speedtrap": "^3",
+        "mikey179/vfsstream": "^1.6",
+        "phake/phake": "@stable",
+        "phpstan/phpstan": "^0.12.48",
+        "phpunit/phpunit": "~7.5.18",
+        "prestashop/phpstan-prestashop": "^1.0",
+        "symfony/phpunit-bridge": "^3.4"
+    },
+    "config": {
+        "platform": {
+            "php": "7.1.3"
+        },
+        "sort-packages": true
+    },
+    "extra": {
+        "incenteev-parameters": {
+            "file": "app/config/parameters.yml"
+        },
+        "symfony": {
+            "require": "~3.4"
+        },
+        "symfony-app-dir": "app",
+        "symfony-assets-install": "relative",
+        "symfony-bin-dir": "bin",
+        "symfony-tests-dir": "tests",
+        "symfony-var-dir": "var",
+        "symfony-web-dir": "."
+    },
+    "autoload": {
+        "psr-4": {
+            "PrestaShop\\PrestaShop\\": "src/",
+            "PrestaShopBundle\\": "src/PrestaShopBundle/"
+        },
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppCache.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "LegacyTests\\": "tests-legacy/",
+            "Tests\\": "tests/"
+        },
+        "files": [
+            "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php"
+        ]
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/PrestaShop/php-cssjanus",
+            "canonical": false
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/PrestaShop/CsaGuzzleBundle",
+            "canonical": false
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "scripts": {
+        "post-install-cmd": [
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+        ],
+        "post-update-cmd": [
+            "PrestaShopBundle\\Install\\Upgrade::migrateSettingsFile",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+        ],
+        "create-release": "@php tools/build/CreateRelease.php",
+        "create-test-db": [
+            "@php ./tests-legacy/create-test-db.php"
+        ],
+        "git-hook-install": "@php .github/contrib/install.php",
+        "git-hook-uninstall": "@php .github/contrib/uninstall.php",
+        "integration-behaviour-tests": [
+            "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
+        ],
+        "integration-tests": [
+            "@composer create-test-db",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit.xml"
+        ],
+        "phpunit-admin": [
+            "@composer create-test-db",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-admin.xml"
+        ],
+        "phpunit-controllers": [
+            "@composer create-test-db",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/old-controllers.xml"
+        ],
+        "phpunit-endpoints": [
+            "@composer create-test-db",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
+        ],
+        "phpunit-legacy": [
+            "@composer create-test-db",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
+        ],
+        "phpunit-sf": [
+            "@composer create-test-db",
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/sf-tests.xml"
+        ],
+        "test-all": [
+            "@composer phpunit-admin",
+            "@composer phpunit-legacy",
+            "@composer unit-tests",
+            "@composer phpunit-sf",
+            "@composer integration-tests",
+            "@composer phpunit-controllers",
+            "@composer integration-behaviour-tests"
+        ],
+        "unit-tests": [
+            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"
+        ]
+    },
+    "scripts-descriptions": {
+        "create-release": "Create a release of PrestaShop, run the command with -h/--help argument for more information.",
+        "create-test-db": "Create a Database for testing purposes",
+        "test-all": "Launch all PHPUnit test suites"
     }
-  ],
-  "require-dev": {
-    "behat/behat": "^3.5",
-    "ergebnis/composer-normalize": "^2.8",
-    "friendsofphp/php-cs-fixer": "^2.16.1",
-    "johnkary/phpunit-speedtrap": "^3",
-    "mikey179/vfsstream": "^1.6",
-    "phake/phake": "@stable",
-    "phpstan/phpstan": "^0.12.48",
-    "prestashop/phpstan-prestashop": "^1.0",
-    "phpunit/phpunit": "~7.5.18",
-    "symfony/phpunit-bridge": "^3.4"
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "LegacyTests\\": "tests-legacy/",
-      "Tests\\": "tests/"
-    },
-    "files": [
-      "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php"
-    ]
-  },
-  "autoload": {
-    "psr-4": {
-      "PrestaShop\\PrestaShop\\": "src/",
-      "PrestaShopBundle\\": "src/PrestaShopBundle/"
-    },
-    "classmap": [
-      "app/AppKernel.php",
-      "app/AppCache.php"
-    ]
-  },
-  "scripts": {
-    "post-install-cmd": [
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
-    ],
-    "post-update-cmd": [
-      "PrestaShopBundle\\Install\\Upgrade::migrateSettingsFile",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
-    ],
-    "create-test-db": [
-      "@php ./tests-legacy/create-test-db.php"
-    ],
-    "test-all": [
-      "@composer phpunit-admin",
-      "@composer phpunit-legacy",
-      "@composer unit-tests",
-      "@composer phpunit-sf",
-      "@composer integration-tests",
-      "@composer phpunit-controllers",
-      "@composer integration-behaviour-tests"
-    ],
-    "phpunit-legacy": [
-      "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
-    ],
-    "phpunit-endpoints": [
-      "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
-    ],
-    "unit-tests": [
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"
-    ],
-    "integration-tests": [
-      "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit.xml"
-    ],
-    "phpunit-admin": [
-      "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-admin.xml"
-    ],
-    "phpunit-sf": [
-      "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/sf-tests.xml"
-    ],
-    "phpunit-controllers": [
-      "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/old-controllers.xml"
-    ],
-    "integration-behaviour-tests": [
-      "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
-    ],
-    "create-release": "@php tools/build/CreateRelease.php",
-    "git-hook-install": "@php .github/contrib/install.php",
-    "git-hook-uninstall": "@php .github/contrib/uninstall.php"
-  },
-  "scripts-descriptions": {
-    "test-all": "Launch all PHPUnit test suites",
-    "create-test-db": "Create a Database for testing purposes",
-    "create-release": "Create a release of PrestaShop, run the command with -h/--help argument for more information."
-  },
-  "config": {
-    "platform": {
-      "php": "7.1.3"
-    },
-    "sort-packages": true
-  },
-  "extra": {
-    "symfony-app-dir": "app",
-    "symfony-bin-dir": "bin",
-    "symfony-var-dir": "var",
-    "symfony-web-dir": ".",
-    "symfony-tests-dir": "tests",
-    "symfony-assets-install": "relative",
-    "incenteev-parameters": {
-      "file": "app/config/parameters.yml"
-    },
-    "symfony": {
-      "require": "~3.4"
-    }
-  },
-  "authors": [
-    {
-      "name": "PrestaShop SA",
-      "email": "contact@prestashop.com"
-    },
-    {
-      "name": "PrestaShop Community",
-      "homepage": "https://contributors.prestashop.com/"
-    }
-  ],
-  "license": "OSL-3.0",
-  "minimum-stability": "dev",
-  "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60d9108cb4ab26009097336451e81bb2",
+    "content-hash": "57c69a04756def9111f315174f5eb57f",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c358cf1134c48302bdce6d1687b4404a",
+    "content-hash": "60d9108cb4ab26009097336451e81bb2",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -9310,6 +9310,252 @@
             "time": "2020-08-19T10:27:58+00:00"
         },
         {
+            "name": "ergebnis/composer-normalize",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/composer-normalize.git",
+                "reference": "7ff01c87ae8e805d4aceeae5fc7a2c336293f3ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/7ff01c87ae8e805d4aceeae5fc7a2c336293f3ad",
+                "reference": "7ff01c87ae8e805d4aceeae5fc7a2c336293f3ad",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0.0",
+                "ergebnis/json-normalizer": "~0.13.0",
+                "ergebnis/json-printer": "^3.1.0",
+                "justinrainbow/json-schema": "^5.2.10",
+                "localheinz/diff": "^1.1.1",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.10.8 || ^2.0.0",
+                "composer/package-versions-deprecated": "^1.11.99",
+                "ergebnis/phpstan-rules": "~0.15.1",
+                "ergebnis/test-util": "^1.0.0",
+                "jangregor/phpstan-prophecy": "~0.8.0",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "~0.12.40",
+                "phpstan/phpstan-deprecation-rules": "~0.12.5",
+                "phpstan/phpstan-phpunit": "~0.12.16",
+                "phpstan/phpstan-strict-rules": "~0.12.4",
+                "phpunit/phpunit": "^7.5.20",
+                "symfony/filesystem": "^4.4.11"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Ergebnis\\Composer\\Normalize\\NormalizePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Composer\\Normalize\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a composer plugin for normalizing composer.json.",
+            "homepage": "https://github.com/ergebnis/composer-normalize",
+            "keywords": [
+                "composer",
+                "normalize",
+                "normalizer",
+                "plugin"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/composer-normalize/issues",
+                "source": "https://github.com/ergebnis/composer-normalize"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-08-28T17:43:42+00:00"
+        },
+        {
+            "name": "ergebnis/json-normalizer",
+            "version": "0.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-normalizer.git",
+                "reference": "a532e078c3d77d01f79925bb7507a9b52bf6f9e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/a532e078c3d77d01f79925bb7507a9b52bf6f9e8",
+                "reference": "a532e078c3d77d01f79925bb7507a9b52bf6f9e8",
+                "shasum": ""
+            },
+            "require": {
+                "ergebnis/json-printer": "^3.1.0",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2.10",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/license": "~1.0.0",
+                "ergebnis/php-cs-fixer-config": "^2.2.1",
+                "ergebnis/phpstan-rules": "~0.15.0",
+                "ergebnis/test-util": "~1.0.0",
+                "infection/infection": "~0.13.6",
+                "jangregor/phpstan-prophecy": "~0.8.0",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "~0.12.32",
+                "phpstan/phpstan-deprecation-rules": "~0.12.4",
+                "phpstan/phpstan-phpunit": "~0.12.8",
+                "phpstan/phpstan-strict-rules": "~0.12.2",
+                "phpunit/phpunit": "^7.5.20",
+                "psalm/plugin-phpunit": "~0.10.1",
+                "vimeo/psalm": "^3.12.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Normalizer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
+            "homepage": "https://github.com/ergebnis/json-normalizer",
+            "keywords": [
+                "json",
+                "normalizer"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-normalizer/issues",
+                "source": "https://github.com/ergebnis/json-normalizer"
+            },
+            "funding": [
+                {
+                    "url": "https://cottonbureau.com/people/andreas-moller",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://paypal.me/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.buymeacoffee.com/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-04T21:41:41+00:00"
+        },
+        {
+            "name": "ergebnis/json-printer",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-printer.git",
+                "reference": "776a5c85ce3c67d97c6af08a67c917adbdb4758e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-printer/zipball/776a5c85ce3c67d97c6af08a67c917adbdb4758e",
+                "reference": "776a5c85ce3c67d97c6af08a67c917adbdb4758e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/license": "~1.0.0",
+                "ergebnis/php-cs-fixer-config": "^2.2.1",
+                "ergebnis/phpstan-rules": "~0.15.0",
+                "ergebnis/test-util": "~1.0.0",
+                "infection/infection": "~0.13.6",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "~0.12.32",
+                "phpstan/phpstan-deprecation-rules": "~0.12.4",
+                "phpstan/phpstan-phpunit": "~0.12.11",
+                "phpstan/phpstan-strict-rules": "~0.12.2",
+                "phpunit/phpunit": "^7.5.20",
+                "psalm/plugin-phpunit": "~0.10.1",
+                "vimeo/psalm": "^3.12.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Printer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a JSON printer, allowing for flexible indentation.",
+            "homepage": "https://github.com/ergebnis/json-printer",
+            "keywords": [
+                "formatter",
+                "json",
+                "printer"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-printer/issues",
+                "source": "https://github.com/ergebnis/json-printer"
+            },
+            "funding": [
+                {
+                    "url": "https://cottonbureau.com/people/andreas-moller",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://paypal.me/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.buymeacoffee.com/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-04T17:09:39+00:00"
+        },
+        {
             "name": "friendsofphp/php-cs-fixer",
             "version": "v2.17.2",
             "source": {
@@ -9464,6 +9710,136 @@
                 "source": "https://github.com/johnkary/phpunit-speedtrap/tree/v3.2.0"
             },
             "time": "2020-02-12T16:19:51+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
+            },
+            "time": "2020-05-27T16:41:55+00:00"
+        },
+        {
+            "name": "localheinz/diff",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/diff.git",
+                "reference": "851bb20ea8358c86f677f5f111c4ab031b1c764c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/diff/zipball/851bb20ea8358c86f677f5f111c4ab031b1c764c",
+                "reference": "851bb20ea8358c86f677f5f111c4ab031b1c764c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Fork of sebastian/diff for use with ergebnis/composer-normalize",
+            "homepage": "https://github.com/localheinz/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "source": "https://github.com/localheinz/diff/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-06T04:49:32+00:00"
         },
         {
             "name": "mikey179/vfsstream",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add composer.json CS normalizer. Even `composer.json` is configured to have deps sorted, it does not. Thus enforce clean composer.json format and reduces possible merge conflicts.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | CI must pass
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23886)
<!-- Reviewable:end -->
