### PR TITLE
Display customer company when creating an order in the BO

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.ts
@@ -49,6 +49,7 @@ export default {
   customerSearchResultEmail: '.js-customer-email',
   customerSearchResultId: '.js-customer-id',
   customerSearchResultBirthday: '.js-customer-birthday',
+  customerSearchResultCompany: '.js-customer-company',
   customerDetailsBtn: '.js-details-customer-btn',
   customerSearchResultColumn: '.js-customer-search-result-col',
   customerSearchBlock: '#customer-search-block',

--- a/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
@@ -70,6 +70,7 @@ export default class CustomerRenderer {
           customerResult.birthday !== '0000-00-00'
             ? customerResult.birthday
             : ' ',
+        company: customerResult.company
       };
 
       this.renderFoundCustomer(customer);
@@ -349,6 +350,9 @@ export default class CustomerRenderer {
     $template
       .find(createOrderMap.customerSearchResultBirthday)
       .text(customer.birthday);
+    $template
+      .find(createOrderMap.customerSearchResultCompany)
+      .text(customer.company);
     $template
       .find(createOrderMap.chooseCustomerBtn)
       .data('customer-id', customer.id);

--- a/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
@@ -70,7 +70,7 @@ export default class CustomerRenderer {
           customerResult.birthday !== '0000-00-00'
             ? customerResult.birthday
             : ' ',
-        company: customerResult.company
+        company: customerResult.company,
       };
 
       this.renderFoundCustomer(customer);

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -94,7 +94,7 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
 
                 $isB2BEnabled = $this->configuration->getBoolean('PS_B2B_ENABLE');
 
-                if(!$isB2BEnabled) {
+                if (!$isB2BEnabled) {
                     unset(
                         $customerArray['company']
                     );

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Customer\QueryHandler;
 
 use Customer;
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryHandler\SearchCustomersHandlerInterface;
 
@@ -37,6 +38,20 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\QueryHandler\SearchCustomersHandl
  */
 final class SearchCustomersHandler implements SearchCustomersHandlerInterface
 {
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @param Configuration $configuration
+     */
+    public function __construct(
+        Configuration $configuration
+    ) {
+        $this->configuration = $configuration;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -76,6 +91,15 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
                     $customerArray['reset_password_token'],
                     $customerArray['reset_password_validity']
                 );
+
+                $isB2BEnabled = $this->configuration->getBoolean('PS_B2B_ENABLE');
+
+                if(!$isB2BEnabled) {
+                    unset(
+                        $customerArray['company']
+                    );
+                }
+
                 $customers[$customerArray['id_customer']] = $customerArray;
             }
         }

--- a/src/Core/Domain/Customer/Query/SearchCustomers.php
+++ b/src/Core/Domain/Customer/Query/SearchCustomers.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Customer\Query;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
 
 /**
- * Searchers for customers by phrases matching customer's first name, last name, email and id
+ * Searchers for customers by phrases matching customer's first name, last name, email, company name and id
  */
 class SearchCustomers
 {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -261,7 +261,7 @@ class OrderController extends FrameworkBundleAdminController
             'recycledPackagingEnabled' => (bool) $configuration->get('PS_RECYCLABLE_PACK'),
             'giftSettingsEnabled' => (bool) $configuration->get('PS_GIFT_WRAPPING'),
             'stockManagementEnabled' => (bool) $configuration->get('PS_STOCK_MANAGEMENT'),
-            'B2BEnabled' => (bool) $configuration->get('PS_B2B_ENABLE'),
+            'isB2BEnabled' => (bool) $configuration->get('PS_B2B_ENABLE'),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -261,6 +261,7 @@ class OrderController extends FrameworkBundleAdminController
             'recycledPackagingEnabled' => (bool) $configuration->get('PS_RECYCLABLE_PACK'),
             'giftSettingsEnabled' => (bool) $configuration->get('PS_GIFT_WRAPPING'),
             'stockManagementEnabled' => (bool) $configuration->get('PS_STOCK_MANAGEMENT'),
+            'B2BEnabled' => (bool) $configuration->get('PS_B2B_ENABLE'),
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
@@ -85,6 +85,8 @@ services:
 
   prestashop.adapter.customer.query_handler.search_customers:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\QueryHandler\SearchCustomersHandler'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -152,7 +152,9 @@
       <div class="card-body">
         <p class="mb-0 js-customer-email"></p>
         <p class="mb-0 js-customer-birthday"></p>
-        <p class="mb-0 js-customer-company"></p>
+        {% if B2BEnabled %}
+          <p class="mb-0 js-customer-company"></p>
+        {% endif %}
       </div>
       <div class="card-footer">
         <a class="btn btn-outline-secondary js-details-customer-btn">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -152,6 +152,7 @@
       <div class="card-body">
         <p class="mb-0 js-customer-email"></p>
         <p class="mb-0 js-customer-birthday"></p>
+        <p class="mb-0 js-customer-company"></p>
       </div>
       <div class="card-footer">
         <a class="btn btn-outline-secondary js-details-customer-btn">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -152,7 +152,7 @@
       <div class="card-body">
         <p class="mb-0 js-customer-email"></p>
         <p class="mb-0 js-customer-birthday"></p>
-        {% if B2BEnabled %}
+        {% if isB2BEnabled %}
           <p class="mb-0 js-customer-company"></p>
         {% endif %}
       </div>

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -27,14 +27,17 @@
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
+use Configuration;
 use Exception;
 use Group;
+use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetPrivateNoteAboutCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Group\Exception\GroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Group\Provider\DefaultGroupsProviderInterface;
 use RuntimeException;
@@ -165,6 +168,10 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
             (isset($data['birthday']) ? $data['birthday'] : null)
         );
 
+        if (Configuration::get('PS_B2B_ENABLE')) {
+            $command->setCompanyName($data['companyName']);
+        }
+
         /** @var CustomerId $id */
         $id = $commandBus->handle($command);
         SharedStorage::getStorage()->set($customerReference, $id->getValue());
@@ -228,5 +235,97 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
     public function assertGroupNotFound(): void
     {
         $this->assertLastErrorIs(GroupNotFoundException::class);
+    }
+
+    /** @Transform table:firstName,lastName,email,birthday,companyName
+     *
+     * @param TableNode $tableNode
+     *
+     * @return array
+     */
+    public function transformCustomers(TableNode $customersTable): array
+    {
+        return $customersTable->getHash();
+    }
+
+    /**
+     * @When I search for the phrases :searchPhrases I should get the following results:
+     *
+     * @param string $searchPhrases
+     * @param array $expectedCustomers
+     */
+    public function assertFoundCustomers(string $searchPhrases, array $expectedCustomers): void
+    {
+        $foundCustomers = $this->getQueryBus()->handle(new SearchCustomers(explode(' ', $searchPhrases)));
+
+        foreach ($expectedCustomers as $currentExpectedCustomer) {
+            $wasCurrentExpectedCustomerFound = false;
+            foreach ($foundCustomers as $currentFoundCustomer) {
+                if ($currentExpectedCustomer['email'] === $currentFoundCustomer['email']) {
+                    $wasCurrentExpectedCustomerFound = true;
+
+                    Assert::assertEquals(
+                        $currentExpectedCustomer['firstName'],
+                        $currentFoundCustomer['firstname'],
+                        sprintf(
+                            'Expected and found customers\'s first names don\'t match (%s and %s)',
+                            $currentExpectedCustomer['firstName'],
+                            $currentFoundCustomer['firstname']
+                        )
+                    );
+
+                    Assert::assertEquals(
+                        $currentExpectedCustomer['lastName'],
+                        $currentFoundCustomer['lastname'],
+                        sprintf(
+                            'Expected and found customers\'s last names don\'t match (%s and %s)',
+                            $currentExpectedCustomer['lastName'],
+                            $currentFoundCustomer['lastname']
+                        )
+                    );
+
+                    Assert::assertEquals(
+                        $currentExpectedCustomer['birthday'],
+                        $currentFoundCustomer['birthday'],
+                        sprintf(
+                            'Expected and found customers\'s birthdays don\'t match (%s and %s)',
+                            $currentExpectedCustomer['birthday'],
+                            $currentFoundCustomer['birthday']
+                        )
+                    );
+
+                    if (Configuration::get('PS_B2B_ENABLE')) {
+                        Assert::assertEquals(
+                            $currentExpectedCustomer['companyName'],
+                            $currentFoundCustomer['company'],
+                            sprintf(
+                                'Expected and found customers\'s companies don\'t match (%s and %s)',
+                                $currentExpectedCustomer['companyName'],
+                                $currentFoundCustomer['company']
+                            )
+                        );
+                    }
+
+                    continue;
+                }
+            }
+            if (!$wasCurrentExpectedCustomerFound) {
+                throw new RuntimeException(sprintf(
+                    'Expected customer with email %s was not found',
+                    $currentExpectedCustomer['email']
+                ));
+            }
+        }
+    }
+
+    /**
+     * @When I search for the phrases :searchPhrases I should not get any results
+     *
+     * @param string $searchPhrases
+     */
+    public function assertNoCustomersWasFound(string $searchPhrases)
+    {
+        $foundCustomers = $this->getQueryBus()->handle(new SearchCustomers(explode(' ', $searchPhrases)));
+        Assert::assertEmpty($foundCustomers);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -298,7 +298,7 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
                     );
 
                     if (!$isB2BEnabled) {
-                        if (isset($currentExpectedCustomer['companyName']) 
+                        if (isset($currentExpectedCustomer['companyName'])
                             || isset($currentFoundCustomer['company'])
                         ) {
                             throw new RuntimeException(sprintf(

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -325,7 +325,7 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
      *
      * @param string $searchPhrases
      */
-    public function assertNoCustomersWasFound(string $searchPhrases)
+    public function assertNoCustomersWasFound(string $searchPhrases): void
     {
         $foundCustomers = $this->getQueryBus()->handle(new SearchCustomers(explode(' ', $searchPhrases)));
         Assert::assertEmpty($foundCustomers);

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -237,7 +237,9 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
         $this->assertLastErrorIs(GroupNotFoundException::class);
     }
 
-    /** @Transform table:firstName,lastName,email,birthday,companyName
+    /**
+     * @Transform table:firstName,lastName,email,birthday
+     * @Transform table:firstName,lastName,email,birthday,companyName
      *
      * @param TableNode $tableNode
      *

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -259,6 +259,7 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
     public function assertFoundCustomers(string $searchPhrases, array $expectedCustomers): void
     {
         $foundCustomers = $this->getQueryBus()->handle(new SearchCustomers(explode(' ', $searchPhrases)));
+        $isB2BEnabled = Configuration::get('PS_B2B_ENABLE');
 
         foreach ($expectedCustomers as $currentExpectedCustomer) {
             $wasCurrentExpectedCustomerFound = false;
@@ -296,7 +297,16 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
                         )
                     );
 
-                    if (Configuration::get('PS_B2B_ENABLE')) {
+                    if (!$isB2BEnabled) {
+                        if (isset($currentExpectedCustomer['companyName']) 
+                            || isset($currentFoundCustomer['company'])
+                        ) {
+                            throw new RuntimeException(sprintf(
+                                'Company name isn\'t expected when B2B mode is disabled.',
+                                $currentExpectedCustomer['email']
+                            ));
+                        }
+                    } else {
                         Assert::assertEquals(
                             $currentExpectedCustomer['companyName'],
                             $currentFoundCustomer['company'],
@@ -307,8 +317,6 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
                             )
                         );
                     }
-
-                    continue;
                 }
             }
             if (!$wasCurrentExpectedCustomerFound) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -302,7 +302,7 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
                             || isset($currentFoundCustomer['company'])
                         ) {
                             throw new RuntimeException(sprintf(
-                                'Company name isn\'t expected when B2B mode is disabled.',
+                                'Company name isn\'t expected when B2B mode is disabled',
                                 $currentExpectedCustomer['email']
                             ));
                         }

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
@@ -1,0 +1,42 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags search-customers
+@reset-database-before-feature
+@clear-cache-before-feature
+@search-customers
+
+Feature: Search customers given a search term (BO)
+  As a BO user
+  I want to get a list of customers for a given search term
+
+  Scenario: I search for existing customers
+    Given shop configuration for "PS_B2B_ENABLE" is set to 1
+    When I create customer "CUST-1" with following details:
+      | firstName   | Mathieu                    |
+      | lastName    | Napoler                    |
+      | email       | napoler.dev@prestashop.com |
+      | password    | PrestaShopForever1_!       |
+      | birthday    | 1996-05-04                 |
+      | companyName | Test company               |
+    When I create customer "CUST-2" with following details:
+      | firstName   | Mathieu                   |
+      | lastName    | Polarn                    |
+      | email       | polarn.dev@prestashop.com |
+      | password    | PrestaShopForever1_!      |
+      | birthday    | 1998-10-12                |
+      | companyName | Test company              |
+    When I search for the phrases "mathieu napoler" I should get the following results:
+      | firstName | lastName | email                      | birthday   | companyName  |
+      | Mathieu   | Napoler  | napoler.dev@prestashop.com | 1996-05-04 | Test company |
+    When I search for the phrases "mathieu polarn" I should get the following results:
+      | firstName | lastName | email                     | birthday   | companyName  |
+      | Mathieu   | Polarn   | polarn.dev@prestashop.com | 1998-10-12 | Test company |
+    When I search for the phrases "test" I should get the following results:
+      | firstName | lastName | email                      | birthday   | companyName  |
+      | Mathieu   | Napoler  | napoler.dev@prestashop.com | 1996-05-04 | Test company |
+      | Mathieu   | Polarn   | polarn.dev@prestashop.com  | 1998-10-12 | Test company |
+    When I search for the phrases "TEST" I should get the following results:
+      | firstName | lastName | email                      | birthday   | companyName  |
+      | Mathieu   | Napoler  | napoler.dev@prestashop.com | 1996-05-04 | Test company |
+      | Mathieu   | Polarn   | polarn.dev@prestashop.com  | 1998-10-12 | Test company |
+    When I search for the phrases "no customers" I should not get any results
+    When I search for the phrases "no companies" I should not get any results
+    When I search for the phrases " " I should not get any results

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
@@ -40,3 +40,11 @@ Feature: Search customers given a search term (BO)
     When I search for the phrases "no customers" I should not get any results
     When I search for the phrases "no companies" I should not get any results
     When I search for the phrases " " I should not get any results
+
+    Given shop configuration for "PS_B2B_ENABLE" is set to 0
+    When I search for the phrases "prestashop" I should get the following results:
+      | firstName | lastName | email                      | birthday   |
+      | Mathieu   | Napoler  | napoler.dev@prestashop.com | 1996-05-04 |
+      | Mathieu   | Polarn   | polarn.dev@prestashop.com  | 1998-10-12 |
+    When I search for the phrases "test" I should not get any results
+    

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
@@ -47,4 +47,3 @@ Feature: Search customers given a search term (BO)
       | Mathieu   | Napoler  | napoler.dev@prestashop.com | 1996-05-04 |
       | Mathieu   | Polarn   | polarn.dev@prestashop.com  | 1998-10-12 |
     When I search for the phrases "test" I should not get any results
-    


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customer's company wasn't displayed in customer search result when creating an order from the BO with B2B mode enabled.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22643.
| How to test?      | Enable B2B mode, create a customer with a company and search him when creating an order in the BO.
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Possible BC breaks ?
### BC breaks

The constructor of the file `src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php` has a new parameter: `PrestaShop\PrestaShop\Adapter\Configuration $configuration` -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23889)
<!-- Reviewable:end -->
