### PR TITLE
Remove duplicate of module_card inclusion on product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -304,7 +304,6 @@
   <script src="{{ asset('themes/default/js/bundle/product/default-category.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/product/product-combinations.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/category-tree.js') }}"></script>
-  <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/modal-confirmation.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/product_page.bundle.js') }}"></script>
   <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | module_card.js was included 2 times on product page, it was causing a trivial error in the console
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23899.
| How to test?      | Go on product page v1 and see in the console if there are no errors :)
| Possible impacts? | Nothing

⚠️ DON'T MERGE

The second file is included by ps_mbo module, I think we shouldn't remove it inside the core

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23905)
<!-- Reviewable:end -->
