### PR TITLE
Enable header toolbar buttons to be disabled and use it for Add an Order

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_button.scss
+++ b/admin-dev/themes/new-theme/scss/components/_button.scss
@@ -13,3 +13,7 @@
     }
   }
 }
+
+a.btn.auto-pointer-events {
+  pointer-events: auto;
+}

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -35,7 +35,7 @@
               {if $k != 'back' && $k != 'modules-list'}
                 {* TODO: REFACTOR ALL THIS THINGS *}
                 <a
-                  class="btn btn-primary {if isset($btn.target) && $btn.target} _blank{/if} {if isset($btn.disabled) && $btn.disabled} disabled auto-pointer-events{/if} pointer"{if isset($btn.href)}
+                  class="btn btn-primary{if isset($btn.target) && $btn.target} _blank{/if}{if isset($btn.disabled) && $btn.disabled} disabled auto-pointer-events{/if} pointer"{if isset($btn.href)}
                   id="page-header-desc-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"
                   href="{$btn.href|escape}"{/if}
                   title="{if isset($btn.help)}{$btn.help}{else}{$btn.desc|escape}{/if}"{if isset($btn.js) && $btn.js}

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -35,7 +35,7 @@
               {if $k != 'back' && $k != 'modules-list'}
                 {* TODO: REFACTOR ALL THIS THINGS *}
                 <a
-                  class="btn btn-primary {if isset($btn.target) && $btn.target} _blank{/if} pointer"{if isset($btn.href)}
+                  class="btn btn-primary {if isset($btn.target) && $btn.target} _blank{/if} {if isset($btn.disabled) && $btn.disabled} disabled auto-pointer-events{/if} pointer"{if isset($btn.href)}
                   id="page-header-desc-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"
                   href="{$btn.href|escape}"{/if}
                   title="{if isset($btn.help)}{$btn.help}{else}{$btn.desc|escape}{/if}"{if isset($btn.js) && $btn.js}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -496,11 +496,13 @@ class OrderController extends FrameworkBundleAdminController
 
         try {
             $this->dispatchHook(
-                'actionGetAdminOrderButtons', [
-                'controller' => $this,
-                'id_order' => $orderId,
-                'actions_bar_buttons_collection' => $backOfficeOrderButtons,
-            ]);
+                'actionGetAdminOrderButtons',
+                [
+                    'controller' => $this,
+                    'id_order' => $orderId,
+                    'actions_bar_buttons_collection' => $backOfficeOrderButtons,
+                ]
+            );
 
             $cancelProductForm = $formBuilder->getFormFor($orderId);
         } catch (Exception $e) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -163,11 +163,22 @@ class OrderController extends FrameworkBundleAdminController
     {
         $toolbarButtons = [];
 
+        $isSingleShopContext = $this->get('prestashop.adapter.shop.context')->isSingleShopContext();
+
         $toolbarButtons['add'] = [
             'href' => $this->generateUrl('admin_orders_create'),
             'desc' => $this->trans('Add new order', 'Admin.Orderscustomers.Feature'),
             'icon' => 'add_circle_outline',
+            'disabled' => !$isSingleShopContext,
         ];
+
+        if (!$isSingleShopContext) {
+            $toolbarButtons['add']['help'] = $this->trans(
+                'You can use this feature in a single shop context only. Switch context to enable it.',
+                'Admin.Orderscustomers.Feature'
+            );
+            $toolbarButtons['add']['href'] = '#';
+        }
 
         return $toolbarButtons;
     }
@@ -486,10 +497,10 @@ class OrderController extends FrameworkBundleAdminController
         try {
             $this->dispatchHook(
                 'actionGetAdminOrderButtons', [
-                    'controller' => $this,
-                    'id_order' => $orderId,
-                    'actions_bar_buttons_collection' => $backOfficeOrderButtons,
-                ]);
+                'controller' => $this,
+                'id_order' => $orderId,
+                'actions_bar_buttons_collection' => $backOfficeOrderButtons,
+            ]);
 
             $cancelProductForm = $formBuilder->getFormFor($orderId);
         } catch (Exception $e) {
@@ -2043,19 +2054,19 @@ class OrderController extends FrameworkBundleAdminController
                 ) : '',
             CustomerMessageConstraintException::class => [
                 CustomerMessageConstraintException::MISSING_MESSAGE => $this->trans(
-                        'The %s field is not valid',
-                        'Admin.Notifications.Error',
-                        [
-                            sprintf('"%s"', $this->trans('Message', 'Admin.Global')),
-                        ]
-                    ),
+                    'The %s field is not valid',
+                    'Admin.Notifications.Error',
+                    [
+                        sprintf('"%s"', $this->trans('Message', 'Admin.Global')),
+                    ]
+                ),
                 CustomerMessageConstraintException::INVALID_MESSAGE => $this->trans(
-                        'The %s field is not valid',
-                        'Admin.Notifications.Error',
-                        [
-                            sprintf('"%s"', $this->trans('Message', 'Admin.Global')),
-                        ]
-                    ),
+                    'The %s field is not valid',
+                    'Admin.Notifications.Error',
+                    [
+                        sprintf('"%s"', $this->trans('Message', 'Admin.Global')),
+                    ]
+                ),
             ],
         ];
     }


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Enable header toolbar buttons to be disabled and use it for Add an Order. See below for details
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/19396
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/19396
| Possible impacts? | I modified 1 SCSS file but it's only used for header toolbar buttons. I modified how the "Add an order" button is rendered when shop context is not a "single shop" context.


## Details about the content PR

### Goal

This PR implements what has been specified in https://github.com/PrestaShop/PrestaShop/issues/19396 . Display has been validated by @marionf .

![Capture d’écran 2021-04-06 à 18 11 45](https://user-images.githubusercontent.com/3830050/113743377-e6ee3900-9703-11eb-9e18-23c5b095a3cc.png)

### Code modifications

I modified the twig rendering for header toolbar buttons so I can disable them.

I added some business logic inside the OrderController to configure properly the header toolbar button "Add an order" when shop context is not a "single shop" context. All configuration settings use the regular header toolbar buttons configuration settings (with the new ones I introduced).

## Details about the rendering

I used Bootstrap [disabled](https://www.w3schools.com/tags/att_button_disabled.asp) behavior and [tooltip](https://www.w3schools.com/bootstrap/bootstrap_tooltip.asp) behaviors.

However Bootstrap buttons or link-that-act-as-buttons cannot have a hover message ⚠️  . The hover message is disabled. This is why I introduced a `auto-pointer-events` CSS class that allows me to bypass this native behavior and allows me to display the hover message.

Additionnally, I replace the `href` by `#` because it's [impossible to disable links](https://css-tricks.com/how-to-disable-links/). So I make the link an anchor to make it "useless".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23907)
<!-- Reviewable:end -->
