### PR TITLE
Prevent error when ps_versions_compliancy is NULL

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -271,6 +271,9 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function __construct($name = null, Context $context = null)
     {
+        if (is_null($this->ps_versions_compliancy))
+            $this->ps_versions_compliancy = [];
+
         if (isset($this->ps_versions_compliancy) && !isset($this->ps_versions_compliancy['min'])) {
             $this->ps_versions_compliancy['min'] = '1.4.0.0';
         }


### PR DESCRIPTION
It happens that ps_versions_compliancy is unexpectedly NULL for ps_accounts module. In that case cart API will fail.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It happens that ps_versions_compliancy is unexpectedly NULL for ps_accounts module. In that case cart API will fail emitting several notices leading API calls to a 500 error.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | no
| How to test?      | Invoke a post to the cart resource via WebService.
| Possible impacts? | The fix itself is quite simple, it just set a default value to the ps_versions_compliancy of ModuleCore when it is set to NULL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23908)
<!-- Reviewable:end -->
