### PR TITLE
Migrate database dump/restore to native php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
   "require-dev": {
     "behat/behat": "^3.5",
     "friendsofphp/php-cs-fixer": "^2.16.1",
-    "ifsnop/mysqldump-php": "^2.9",
+    "ifsnop/mysqldump-php": "2.3.*",
     "johnkary/phpunit-speedtrap": "^3",
     "mikey179/vfsstream": "^1.6",
     "phake/phake": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -136,12 +136,13 @@
   "require-dev": {
     "behat/behat": "^3.5",
     "friendsofphp/php-cs-fixer": "^2.16.1",
+    "ifsnop/mysqldump-php": "^2.9",
     "johnkary/phpunit-speedtrap": "^3",
     "mikey179/vfsstream": "^1.6",
     "phake/phake": "@stable",
     "phpstan/phpstan": "^0.12.48",
-    "prestashop/phpstan-prestashop": "^1.0",
     "phpunit/phpunit": "~7.5.18",
+    "prestashop/phpstan-prestashop": "^1.0",
     "symfony/phpunit-bridge": "^3.4"
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ad7294cf53c22e177f9bc74a1126476",
+    "content-hash": "d6f2d1010926ac49e0778328972d8cb5",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -8736,23 +8736,23 @@
         },
         {
             "name": "ifsnop/mysqldump-php",
-            "version": "v2.9",
+            "version": "v2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ifsnop/mysqldump-php.git",
-                "reference": "fc9c119fe5d70af9a685cad6a8ac612fd7589e25"
+                "reference": "1806317c2ce897cb38fbae5283f17d1451308244"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ifsnop/mysqldump-php/zipball/fc9c119fe5d70af9a685cad6a8ac612fd7589e25",
-                "reference": "fc9c119fe5d70af9a685cad6a8ac612fd7589e25",
+                "url": "https://api.github.com/repos/ifsnop/mysqldump-php/zipball/1806317c2ce897cb38fbae5283f17d1451308244",
+                "reference": "1806317c2ce897cb38fbae5283f17d1451308244",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.8.36",
+                "phpunit/phpunit": "3.7.*",
                 "squizlabs/php_codesniffer": "1.*"
             },
             "type": "library",
@@ -8763,7 +8763,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-3.0-or-later"
+                "MIT"
             ],
             "authors": [
                 {
@@ -8772,26 +8772,23 @@
                     "role": "Developer"
                 }
             ],
-            "description": "PHP version of mysqldump cli that comes with MySQL",
+            "description": "This is a php version of linux's mysqldump in terminal \"$ mysqldump -u username -p...\"",
             "homepage": "https://github.com/ifsnop/mysqldump-php",
             "keywords": [
-                "PHP7",
+                "backup",
                 "database",
-                "hhvm",
-                "mariadb",
+                "dump",
+                "export",
                 "mysql",
-                "mysql-backup",
                 "mysqldump",
                 "pdo",
-                "php",
-                "php5",
-                "sql"
+                "sqlite"
             ],
             "support": {
                 "issues": "https://github.com/ifsnop/mysqldump-php/issues",
                 "source": "https://github.com/ifsnop/mysqldump-php/tree/master"
             },
-            "time": "2020-04-03T14:40:40+00:00"
+            "time": "2017-05-07T22:27:29+00:00"
         },
         {
             "name": "johnkary/phpunit-speedtrap",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26b0d4f0c511a6fb6f9afe2d6fef1e91",
+    "content-hash": "6ad7294cf53c22e177f9bc74a1126476",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -8735,6 +8735,65 @@
             "time": "2020-12-17T16:41:55+00:00"
         },
         {
+            "name": "ifsnop/mysqldump-php",
+            "version": "v2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ifsnop/mysqldump-php.git",
+                "reference": "fc9c119fe5d70af9a685cad6a8ac612fd7589e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ifsnop/mysqldump-php/zipball/fc9c119fe5d70af9a685cad6a8ac612fd7589e25",
+                "reference": "fc9c119fe5d70af9a685cad6a8ac612fd7589e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.36",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ifsnop\\": "src/Ifsnop/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Diego Torres",
+                    "homepage": "https://github.com/ifsnop",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP version of mysqldump cli that comes with MySQL",
+            "homepage": "https://github.com/ifsnop/mysqldump-php",
+            "keywords": [
+                "PHP7",
+                "database",
+                "hhvm",
+                "mariadb",
+                "mysql",
+                "mysql-backup",
+                "mysqldump",
+                "pdo",
+                "php",
+                "php5",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/ifsnop/mysqldump-php/issues",
+                "source": "https://github.com/ifsnop/mysqldump-php/tree/master"
+            },
+            "time": "2020-04-03T14:40:40+00:00"
+        },
+        {
             "name": "johnkary/phpunit-speedtrap",
             "version": "v3.2.0",
             "source": {
@@ -10501,5 +10560,5 @@
     "platform-overrides": {
         "php": "7.1.3"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -99,7 +99,7 @@ class DatabaseDump
     /**
      * The actual dump function.
      */
-    private function dump(): void
+    public function dump(): void
     {
         $dumper = $this->createMysqldumper();
         $dumper->start($this->dumpFile);

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -27,7 +27,6 @@
 
 namespace PrestaShopBundle\Install;
 
-use Exception;
 use Ifsnop\Mysqldump\Mysqldump;
 use PDO;
 
@@ -98,79 +97,18 @@ class DatabaseDump
     }
 
     /**
-     * Wrapper to easily build mysql commands: sets password, port, user.
-     *
-     * @param string $executable
-     * @param array $arguments
-     *
-     * @return string
-     */
-    private function buildMySQLCommand($executable, array $arguments = [])
-    {
-        $parts = [
-            escapeshellarg($executable),
-            '-u', escapeshellarg($this->user),
-            '-P', escapeshellarg($this->port),
-            '-h', escapeshellarg($this->host),
-        ];
-
-        if ($this->password) {
-            $parts[] = '-p' . escapeshellarg($this->password);
-        }
-
-        $parts = array_merge($parts, array_map('escapeshellarg', $arguments));
-
-        return implode(' ', $parts);
-    }
-
-    /**
-     * Like exec, but will raise an exception if the command failed.
-     *
-     * @param string $command
-     *
-     * @return array
-     *
-     * @throws Exception
-     */
-    private function exec($command)
-    {
-        $output = [];
-        $ret = 1;
-        exec($command, $output, $ret);
-
-        if ($ret !== 0) {
-            throw new Exception(sprintf('Unable to exec command: `%s`, missing a binary?', $command));
-        }
-
-        return $output;
-    }
-
-    /**
      * The actual dump function.
      */
-    private function dump()
+    private function dump(): void
     {
-        $dumpCommand = $this->buildMySQLCommand('mysqldump', [$this->databaseName]);
-        $dumpCommand .= ' > ' . escapeshellarg($this->dumpFile) . ' 2> /dev/null';
-        $this->exec($dumpCommand);
-
-        echo "\n" . '>>>mysqldump' . str_repeat('-', 80) . "\n"
-            . file_get_contents($this->dumpFile)
-            . "\n" . '<<<' . str_repeat('-', 80) . "\n";
-        unlink($this->dumpFile);
-
         $dumper = $this->createMysqldumper();
         $dumper->start($this->dumpFile);
-
-        echo "\n" . '>>>native' . str_repeat('-', 80) . "\n"
-            . file_get_contents($this->dumpFile)
-            . "\n" . '<<<' . str_repeat('-', 80) . "\n";
     }
 
     /**
      * Restore the dump to the actual database.
      */
-    public function restore()
+    public function restore(): void
     {
         $pdo = $this->createPdo();
         $pdo->exec(file_get_contents($this->dumpFile));
@@ -179,7 +117,7 @@ class DatabaseDump
     /**
      * Make a database dump.
      */
-    public static function create()
+    public static function create(): void
     {
         $dump = new static();
 
@@ -189,7 +127,7 @@ class DatabaseDump
     /**
      * Restore a database dump.
      */
-    public static function restoreDb()
+    public static function restoreDb(): void
     {
         $dump = new static();
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migrate database dump/restore to native php. Increase portability (do not require exec function) and possibly allow sqlite in the future.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | CI must pass
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23911)
<!-- Reviewable:end -->

SQL dump was compared and except minor SQL comments formatting is the same:

![image](https://user-images.githubusercontent.com/2228672/113792846-30ac4300-9747-11eb-8240-0fe8536a5ea1.png)

