### PR TITLE
Bug fix for number of decimals in product price

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5569,7 +5569,7 @@ class ProductCore extends ObjectModel
             (int) $row['id_product'],
             false,
             $id_product_attribute,
-            (self::$_taxCalculationMethod == PS_TAX_EXC ? 2 : 6),
+            (self::$_taxCalculationMethod == PS_TAX_EXC ? Context::getContext()->getComputingPrecision() : 6),
             null,
             false,
             true,

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -107,7 +107,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            $this->getMinFractionDigits($positivePattern),
+            (int) $currency->getDecimalPrecision() ?? $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -107,7 +107,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            (int) $currency->getDecimalPrecision() ?? $this->getMinFractionDigits($positivePattern),
+            is_int($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -214,6 +214,90 @@ class FactoryTest extends TestCase
         $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
     }
 
+    /**
+     * Given a valid CLDR locale
+     * Given a Max Fractions digits to display in a number's decimal
+     * Given a boolean to define if we should group digits in a number's integer part
+     * Given an integer to specify max fraction digits
+     * Then calling buildPriceSpecification() should return an NumberSpecification
+     *
+     * @dataProvider getPriceData
+     */
+    public function testBuildPriceSpecificationWithPrecisionFallback($data, $expected)
+    {
+        // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
+        // see PrestaShop\PrestaShop\Core\Localization\Specification\Number
+        // The dataProvider provides minFractionDigits === 2
+        $precisions = [
+            [
+                'currencyPrecision' => 6,
+                'maxFractionDigits' => 3,
+                'expectedMinFractionDigits' => 3,
+            ], //minFractionDigits will be equal to 3
+            [
+                'currencyPrecision' => 6,
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 6,
+            ], //minFractionDigits will be equal to 6
+            [
+                'currencyPrecision' => 1,
+                'maxFractionDigits' => 3,
+                'expectedMinFractionDigits' => 1,
+            ], //minFractionDigits will be equal to 1
+            [
+                'currencyPrecision' => '4',
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+            [
+                'currencyPrecision' => null,
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+            [
+                'currencyPrecision' => [],
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+        ];
+
+        foreach ($precisions as $expectedPrecisions) {
+            $currencyPrecision = $expectedPrecisions['currencyPrecision'];
+            $maxFractionDigits = $expectedPrecisions['maxFractionDigits'];
+            $expectedMinFractionDigits = $expectedPrecisions['expectedMinFractionDigits'];
+
+            $specification = $this->factory->buildPriceSpecification(
+                $data[0],
+                $this->createLocale(
+                    ...$data
+                ),
+                new Currency(
+                    null,
+                    null,
+                    'EUR',
+                    '978',
+                    [
+                        $data[0] => '€',
+                    ],
+                    $currencyPrecision,
+                    [
+                        $data[0] => 'Euro',
+                    ]
+                ),
+                3,
+                true,
+                $maxFractionDigits
+            );
+            $expected['maxFractionDigits'] = $maxFractionDigits;
+            $expected['minFractionDigits'] = $expectedMinFractionDigits;
+            $this->assertEquals(
+                $expected,
+                $specification->toArray()
+            );
+            $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+        }
+    }
+
     public function getPriceData()
     {
         return [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Decimals feature does not work.<br/><br/>By default it's set to two, and it's stuck to 2 and it does not change according to the configuration in backoffice International->Localization->Currencies->edit for a currency->Decimals. So, this pull request fixes this issue. Actually the problem has two parts.<br/><br/>One which is fixed in Product.php is that the number of Decimals is fixed to two, and another issue is that the extra 0 won't be added to match the number of decimals chosen in configuration which is fixed in Factory.php file.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | nno
| Fixed ticket?     | Fixes #23868
| How to test?      | Change decimals in backoffice and check the product price in front office 
| Possible impacts? | I really got the root cause, exactly the points where the problem comes from 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23912)
<!-- Reviewable:end -->
