### PR TITLE
Get categories tree query and endpoint

### DIFF
--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -63,6 +63,8 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
         $categoriesTree = [];
         foreach ($categories as $category) {
             $categoryId = (int) $category['id_category'];
+            $childCategories = [];
+
             if (!empty($category['children'])) {
                 $childCategories = $this->buildCategoriesTree($category['children'], $productCategoryIds);
             }

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Category\QueryHandler;
+
+use Category;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryHandler\GetCategoriesTreeHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\CategoryForTree;
+use Product;
+
+final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(GetCategoriesTree $query): array
+    {
+        $nestedCategories = Category::getNestedCategories(null, $query->getLanguageId()->getValue());
+
+        if ($query->getAssociatedProductId()) {
+            $productCategoryIds = Product::getProductCategories();
+        }
+
+        //@todo: finish up
+        $categoriesTree = [];
+        foreach ($nestedCategories as $nestedCategory) {
+            $categoriesTree[] = new CategoryForTree(
+                (int) $nestedCategory['id_category'],
+                $nestedCategory['name'],
+                false
+            );
+        }
+
+        return $categoriesTree;
+    }
+}

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -73,10 +73,10 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
         $categoriesTree = [];
         foreach ($categories as $category) {
             $categoryId = (int) $category['id_category'];
-            $childCategories = [];
+            $categoryChildren = [];
 
             if (!empty($category['children'])) {
-                $childCategories = $this->buildCategoriesTree($category['children'], $langId);
+                $categoryChildren = $this->buildCategoriesTree($category['children'], $langId);
             }
 
             $categoriesTree[] = new CategoryForTree(
@@ -84,7 +84,7 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
                 // @todo: it is always only one language now,
                 //   but this way it doesn't require changing the contract when we want to allow retrieving multiple languages
                 [$langId => $category['name']],
-                $childCategories ?? []
+                $categoryChildren
             );
         }
 

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -31,7 +31,6 @@ use Category;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryHandler\GetCategoriesTreeHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\CategoryForTree;
-use Product;
 
 /**
  * Handles @see GetCategoriesTree using legacy object model
@@ -45,20 +44,15 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
     {
         $nestedCategories = Category::getNestedCategories(null, $query->getLanguageId()->getValue());
 
-        if ($productId = $query->getAssociatedProductId()) {
-            $productCategoryIds = array_map('intval', Product::getProductCategories($productId->getValue()));
-        }
-
-        return $this->buildCategoriesTree($nestedCategories, $productCategoryIds ?? []);
+        return $this->buildCategoriesTree($nestedCategories);
     }
 
     /**
      * @param array<string, array<string, mixed>> $categories
-     * @param int[] $productCategoryIds
      *
      * @return CategoryForTree[]
      */
-    private function buildCategoriesTree(array $categories, array $productCategoryIds): array
+    private function buildCategoriesTree(array $categories): array
     {
         $categoriesTree = [];
         foreach ($categories as $category) {
@@ -66,14 +60,13 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
             $childCategories = [];
 
             if (!empty($category['children'])) {
-                $childCategories = $this->buildCategoriesTree($category['children'], $productCategoryIds);
+                $childCategories = $this->buildCategoriesTree($category['children']);
             }
 
             $categoriesTree[] = new CategoryForTree(
                 $categoryId,
                 $category['name'],
-                $childCategories ?? [],
-                in_array($categoryId, $productCategoryIds, true)
+                $childCategories ?? []
             );
         }
 

--- a/src/Core/Domain/Category/Query/GetCategoriesTree.php
+++ b/src/Core/Domain/Category/Query/GetCategoriesTree.php
@@ -35,23 +35,23 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 final class GetCategoriesTree
 {
     /**
-     * @var LanguageId
+     * @var LanguageId|null
      */
     private $languageId;
 
     /**
-     * @param int $languageId
+     * @param int|null $languageId
      */
     public function __construct(
-        int $languageId
+        ?int $languageId = null
     ) {
-        $this->languageId = new LanguageId($languageId);
+        $this->languageId = $languageId ? new LanguageId($languageId) : null;
     }
 
     /**
-     * @return LanguageId
+     * @return LanguageId|null
      */
-    public function getLanguageId(): LanguageId
+    public function getLanguageId(): ?LanguageId
     {
         return $this->languageId;
     }

--- a/src/Core/Domain/Category/Query/GetCategoriesTree.php
+++ b/src/Core/Domain/Category/Query/GetCategoriesTree.php
@@ -39,7 +39,7 @@ final class GetCategoriesTree
     private $languageId;
 
     /**
-     * @var int|null
+     * @var ProductId|null
      */
     private $associatedProductId;
 
@@ -66,9 +66,9 @@ final class GetCategoriesTree
     }
 
     /**
-     * @return int|null
+     * @return ProductId|null
      */
-    public function getAssociatedProductId(): ?int
+    public function getAssociatedProductId(): ?ProductId
     {
         return $this->associatedProductId;
     }

--- a/src/Core/Domain/Category/Query/GetCategoriesTree.php
+++ b/src/Core/Domain/Category/Query/GetCategoriesTree.php
@@ -31,6 +31,9 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
+/**
+ * Provides Category tree list where each category holds its child categories
+ */
 final class GetCategoriesTree
 {
     /**

--- a/src/Core/Domain/Category/Query/GetCategoriesTree.php
+++ b/src/Core/Domain/Category/Query/GetCategoriesTree.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Category\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+final class GetCategoriesTree
+{
+    /**
+     * @var LanguageId
+     */
+    private $languageId;
+
+    /**
+     * @var int|null
+     */
+    private $associatedProductId;
+
+    /**
+     * @param int $languageId
+     * @param int|null $associatedProductId provide this to mark categories that are associated with specified product
+     *
+     * @throws ProductConstraintException
+     */
+    public function __construct(
+        int $languageId,
+        ?int $associatedProductId
+    ) {
+        $this->languageId = new LanguageId($languageId);
+        $this->associatedProductId = $associatedProductId ? new ProductId($associatedProductId) : null;
+    }
+
+    /**
+     * @return LanguageId
+     */
+    public function getLanguageId(): LanguageId
+    {
+        return $this->languageId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getAssociatedProductId(): ?int
+    {
+        return $this->associatedProductId;
+    }
+}

--- a/src/Core/Domain/Category/Query/GetCategoriesTree.php
+++ b/src/Core/Domain/Category/Query/GetCategoriesTree.php
@@ -28,8 +28,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Category\Query;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
 /**
  * Provides Category tree list where each category holds its child categories
@@ -42,22 +40,12 @@ final class GetCategoriesTree
     private $languageId;
 
     /**
-     * @var ProductId|null
-     */
-    private $associatedProductId;
-
-    /**
      * @param int $languageId
-     * @param int|null $associatedProductId provide this to mark categories that are associated with specified product
-     *
-     * @throws ProductConstraintException
      */
     public function __construct(
-        int $languageId,
-        ?int $associatedProductId
+        int $languageId
     ) {
         $this->languageId = new LanguageId($languageId);
-        $this->associatedProductId = $associatedProductId ? new ProductId($associatedProductId) : null;
     }
 
     /**
@@ -66,13 +54,5 @@ final class GetCategoriesTree
     public function getLanguageId(): LanguageId
     {
         return $this->languageId;
-    }
-
-    /**
-     * @return ProductId|null
-     */
-    public function getAssociatedProductId(): ?ProductId
-    {
-        return $this->associatedProductId;
     }
 }

--- a/src/Core/Domain/Category/QueryHandler/GetCategoriesTreeHandlerInterface.php
+++ b/src/Core/Domain/Category/QueryHandler/GetCategoriesTreeHandlerInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Category\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree;
+use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\CategoryForTree;
+
+/**
+ * Defines contract for handling @see GetCategoriesTree query
+ */
+interface GetCategoriesTreeHandlerInterface
+{
+    /**
+     * @param GetCategoriesTree $query
+     *
+     * @return CategoryForTree[]
+     */
+    public function handle(GetCategoriesTree $query): array;
+}

--- a/src/Core/Domain/Category/QueryHandler/GetCategoriesTreeHandlerInterface.php
+++ b/src/Core/Domain/Category/QueryHandler/GetCategoriesTreeHandlerInterface.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Category\QueryHandler;
 

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -40,6 +40,11 @@ class CategoryForTree
     private $categoryName;
 
     /**
+     * @var CategoryForTree[]
+     */
+    private $childCategories;
+
+    /**
      * @var bool
      */
     private $associatedWithProduct;
@@ -47,16 +52,19 @@ class CategoryForTree
     /**
      * @param int $categoryId
      * @param string $categoryName
-     * @param bool $associatedWithProduct
+     * @param array $childCategories
+     * @param bool $associatedWithProduct tells if category is associated with product specified in query
      */
     public function __construct(
         int $categoryId,
         string $categoryName,
+        array $childCategories,
         bool $associatedWithProduct
     ) {
         $this->categoryId = $categoryId;
         $this->categoryName = $categoryName;
         $this->associatedWithProduct = $associatedWithProduct;
+        $this->childCategories = $childCategories;
     }
 
     /**
@@ -73,6 +81,14 @@ class CategoryForTree
     public function getCategoryName(): string
     {
         return $this->categoryName;
+    }
+
+    /**
+     * @return CategoryForTree[]
+     */
+    public function getChildCategories(): array
+    {
+        return $this->childCategories;
     }
 
     /**

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -42,21 +42,21 @@ class CategoryForTree
     /**
      * @var CategoryForTree[]
      */
-    private $childCategories;
+    private $children;
 
     /**
      * @param int $categoryId
      * @param array<int, string> $localizedNames
-     * @param array $childCategories
+     * @param array $children
      */
     public function __construct(
         int $categoryId,
         array $localizedNames,
-        array $childCategories
+        array $children
     ) {
         $this->categoryId = $categoryId;
         $this->localizedNames = $localizedNames;
-        $this->childCategories = $childCategories;
+        $this->children = $children;
     }
 
     /**
@@ -78,8 +78,8 @@ class CategoryForTree
     /**
      * @return CategoryForTree[]
      */
-    public function getChildCategories(): array
+    public function getChildren(): array
     {
-        return $this->childCategories;
+        return $this->children;
     }
 }

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -45,25 +45,17 @@ class CategoryForTree
     private $childCategories;
 
     /**
-     * @var bool
-     */
-    private $associatedWithProduct;
-
-    /**
      * @param int $categoryId
      * @param string $categoryName
      * @param array $childCategories
-     * @param bool $associatedWithProduct tells if category is associated with product specified in query
      */
     public function __construct(
         int $categoryId,
         string $categoryName,
-        array $childCategories,
-        bool $associatedWithProduct
+        array $childCategories
     ) {
         $this->categoryId = $categoryId;
         $this->categoryName = $categoryName;
-        $this->associatedWithProduct = $associatedWithProduct;
         $this->childCategories = $childCategories;
     }
 
@@ -89,13 +81,5 @@ class CategoryForTree
     public function getChildCategories(): array
     {
         return $this->childCategories;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isAssociatedWithProduct(): bool
-    {
-        return $this->associatedWithProduct;
     }
 }

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -35,9 +35,9 @@ class CategoryForTree
     private $categoryId;
 
     /**
-     * @var string
+     * @var array<int, string>
      */
-    private $categoryName;
+    private $localizedNames;
 
     /**
      * @var CategoryForTree[]
@@ -46,16 +46,16 @@ class CategoryForTree
 
     /**
      * @param int $categoryId
-     * @param string $categoryName
+     * @param array<int, string> $localizedNames
      * @param array $childCategories
      */
     public function __construct(
         int $categoryId,
-        string $categoryName,
+        array $localizedNames,
         array $childCategories
     ) {
         $this->categoryId = $categoryId;
-        $this->categoryName = $categoryName;
+        $this->localizedNames = $localizedNames;
         $this->childCategories = $childCategories;
     }
 
@@ -68,11 +68,11 @@ class CategoryForTree
     }
 
     /**
-     * @return string
+     * @return array<int, string>
      */
-    public function getCategoryName(): string
+    public function getLocalizedNames(): array
     {
-        return $this->categoryName;
+        return $this->localizedNames;
     }
 
     /**

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Category\QueryResult;
+
+class CategoryForTree
+{
+    /**
+     * @var int
+     */
+    private $categoryId;
+
+    /**
+     * @var string
+     */
+    private $categoryName;
+
+    /**
+     * @var bool
+     */
+    private $associatedWithProduct;
+
+    /**
+     * @param int $categoryId
+     * @param string $categoryName
+     * @param bool $associatedWithProduct
+     */
+    public function __construct(
+        int $categoryId,
+        string $categoryName,
+        bool $associatedWithProduct
+    ) {
+        $this->categoryId = $categoryId;
+        $this->categoryName = $categoryName;
+        $this->associatedWithProduct = $associatedWithProduct;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCategoryId(): int
+    {
+        return $this->categoryId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCategoryName(): string
+    {
+        return $this->categoryName;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAssociatedWithProduct(): bool
+    {
+        return $this->associatedWithProduct;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -781,16 +781,19 @@ class CategoryController extends FrameworkBundleAdminController
      */
     private function formatCategoriesTreeForPresentation(array $categoriesTree, int $langId): array
     {
+        if (empty($categoriesTree)) {
+            return [];
+        }
+
         $formattedCategories = [];
         foreach ($categoriesTree as $categoryForTree) {
-            if (!empty($categoryForTree->getChildCategories())) {
-                $childCategories = $this->formatCategoriesTreeForPresentation($categoryForTree->getChildCategories(), $langId);
-            }
+            $children = $this->formatCategoriesTreeForPresentation($categoryForTree->getChildren(), $langId);
 
+            $names = $categoryForTree->getLocalizedNames();
             $formattedCategories[] = [
                 'id' => $categoryForTree->getCategoryId(),
-                'name' => $categoryForTree->getLocalizedNames()[$langId] ?? $categoryForTree->getLocalizedNames()[0],
-                'childCategories' => $childCategories ?? [],
+                'name' => $names[$langId] ?? reset($names),
+                'children' => $children,
             ];
         }
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
@@ -149,7 +149,7 @@ admin_categories_update_position:
         _legacy_link: AdminCategories:updatePositions
 
 admin_categories_get_categories_tree:
-    path: /categories-tree
+    path: /tree
     methods: [GET]
     defaults:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:getCategoriesTree

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
@@ -147,3 +147,10 @@ admin_categories_update_position:
         _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:updatePosition
         _legacy_controller: AdminCategories
         _legacy_link: AdminCategories:updatePositions
+
+admin_categories_get_categories_tree:
+    path: /categories-tree
+    methods: [GET]
+    defaults:
+        _controller: PrestaShopBundle:Admin\Sell\Catalog\Category:getCategoriesTree
+        _legacy_controller: AdminCategories

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -119,4 +119,4 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Category\QueryHandler\GetCategoriesTreeHandler
     tags:
       - name: tactician.handler
-        command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree }
+        command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -114,3 +114,9 @@ services:
 
   prestashop.adapter.category.repository.category_repository:
     class: PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository
+
+  prestashop.adapter.category.query_handler.get_categories_tree_handler:
+    class: PrestaShop\PrestaShop\Adapter\Category\QueryHandler\GetCategoriesTreeHandler
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -117,6 +117,8 @@ services:
 
   prestashop.adapter.category.query_handler.get_categories_tree_handler:
     class: PrestaShop\PrestaShop\Adapter\Category\QueryHandler\GetCategoriesTreeHandler
+    arguments:
+        - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 use Behat\Gherkin\Node\TableNode;
 use Category;
 use Configuration;
+use Language;
 use PHPUnit\Framework\Assert as Assert;
 use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CategoryTreeChoiceProvider;
 use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\GroupByIdChoiceProvider;
@@ -44,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditRootCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\SetCategoryIsEnabledCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\UpdateCategoryPositionCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryIsEnabled;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
@@ -85,6 +87,32 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         $this->container = $this->getContainer();
         $this->defaultLanguageId = Configuration::get('PS_LANG_DEFAULT');
         $this->psCatImgDir = _PS_CAT_IMG_DIR_;
+    }
+
+    /**
+     * @Then I should see following categories tree for product ":productReference" in ":langIso" language:
+     *
+     * @param TableNode $tableNode
+     * @param string $langIso
+     * @param string|null $productReference
+     */
+    public function assertCategoriesTreeInDefaultLang(TableNode $tableNode, string $langIso, ?string $productReference): void
+    {
+        $langId = Language::getIdByIso($langIso);
+        $productId = isset($productReference) ? $this->getSharedStorage()->get($productReference) : null;
+
+        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId, $productId));
+
+        $expectedCategories = $tableNode->getColumnsHash();
+        Assert::assertEquals(
+            count($categoriesTree),
+            count($expectedCategories),
+            'Expected and actual categories count does not match'
+        );
+
+        foreach ($expectedCategories as $expectedCategory) {
+            //@todo: assert
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -549,11 +549,6 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
 
             Assert::assertEquals($expectedId, $category->getCategoryId(), 'Unexpected category id');
             Assert::assertEquals($expectedCategory['category name'], $category->getCategoryName(), 'Unexpected category name');
-            Assert::assertEquals(
-                PrimitiveUtils::castStringBooleanIntoBoolean($expectedCategory['is associated with product']),
-                $category->isAssociatedWithProduct(),
-                'Unexpected category association with product'
-            );
 
             foreach ($actualChildCategories as $index => $childCategory) {
                 Assert::assertEquals($expectedChildCategoryIds[$index], $childCategory->getCategoryId());

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -479,6 +479,24 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Given category ":categoryReference" parent is category ":expectedParentReference"
+     *
+     * @param string $categoryReference
+     * @param string $expectedParentReference
+     */
+    public function assertCategoryParent(string $categoryReference, string $expectedParentReference)
+    {
+        $editableCategory = $this->getEditableCategory($categoryReference);
+        $parentId = $this->getSharedStorage()->get($expectedParentReference);
+
+        Assert::assertEquals(
+            $editableCategory->getParentId(),
+            $parentId,
+            'Unexpected parent category'
+        );
+    }
+
+    /**
      * @param array $testCaseData
      * @param int $categoryId
      * @param array|null $coverImage

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -92,25 +92,36 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @Then I should see following root categories in ":langIso" language:
-     * @Then I should see following categories in ":parentReference" category in ":langIso" language:
      *
      * @param TableNode $tableNode
      * @param string $langIso
-     * @param string|null $parentReference
      */
-    public function assertCategoriesTree(TableNode $tableNode, string $langIso, ?string $parentReference = null): void
+    public function assertRootCategoriesTree(TableNode $tableNode, string $langIso): void
     {
         $langId = Language::getIdByIso($langIso);
         $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId));
 
         Assert::assertNotEmpty($categoriesTree, 'Categories tree is empty');
 
-        if (!$parentReference) {
-            $actualCategories = $categoriesTree;
-        } else {
-            $parentCategoryId = $this->getSharedStorage()->get($parentReference);
-            $actualCategories = $this->extractCategoriesByParent($categoriesTree, $parentCategoryId);
-        }
+        $this->assertCategoriesInTree($categoriesTree, $tableNode->getColumnsHash(), $langId);
+    }
+
+    /**
+     * @Then I should see following categories in ":parentReference" category in ":langIso" language:
+     *
+     * @param TableNode $tableNode
+     * @param string $langIso
+     * @param string $parentReference
+     */
+    public function assertCategoriesTree(TableNode $tableNode, string $langIso, string $parentReference): void
+    {
+        $langId = Language::getIdByIso($langIso);
+        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId));
+
+        Assert::assertNotEmpty($categoriesTree, 'Categories tree is empty');
+
+        $parentCategoryId = $this->getSharedStorage()->get($parentReference);
+        $actualCategories = $this->extractCategoriesByParent($categoriesTree, $parentCategoryId);
 
         $this->assertCategoriesInTree($actualCategories, $tableNode->getColumnsHash(), $langId);
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -511,7 +511,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      * @param array<int, array<string, string>> $expectedCategories
      * @param int $langId
      */
-    private function assertCategoriesInTree(array $actualCategories, array $expectedCategories, int $langId)
+    private function assertCategoriesInTree(array $actualCategories, array $expectedCategories, int $langId): void
     {
         Assert::assertEquals(
             count($actualCategories),
@@ -522,22 +522,22 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         foreach ($actualCategories as $key => $category) {
             $expectedCategory = $expectedCategories[$key];
             $expectedId = $this->getSharedStorage()->get($expectedCategory['id reference']);
-            $expectedChildCategoryIds = array_map(function (string $childCategoryReference): int {
+            $expectedChildrenCategoryIds = array_map(function (string $childCategoryReference): int {
                 return $this->getSharedStorage()->get($childCategoryReference);
             }, PrimitiveUtils::castStringArrayIntoArray($expectedCategory['direct child categories']));
 
-            $actualChildCategories = $category->getChildCategories();
+            $actualCategoryChildren = $category->getChildren();
             Assert::assertEquals(
-                count($actualChildCategories),
-                count($expectedChildCategoryIds),
-                'Unexpected child categories count'
+                count($actualCategoryChildren),
+                count($expectedChildrenCategoryIds),
+                'Unexpected children categories count'
             );
 
             Assert::assertEquals($expectedId, $category->getCategoryId(), 'Unexpected category id');
             Assert::assertEquals([$langId => $expectedCategory['category name']], $category->getLocalizedNames(), 'Unexpected category name');
 
-            foreach ($actualChildCategories as $index => $childCategory) {
-                Assert::assertEquals($expectedChildCategoryIds[$index], $childCategory->getCategoryId());
+            foreach ($actualCategoryChildren as $index => $childCategory) {
+                Assert::assertEquals($expectedChildrenCategoryIds[$index], $childCategory->getCategoryId());
             }
         }
     }
@@ -570,16 +570,16 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
     {
         foreach ($categoriesTree as $category) {
             if ($category->getCategoryId() === $parentCategoryId) {
-                return $category->getChildCategories();
+                return $category->getChildren();
             }
 
-            $inChildCategories = $this->extractCategoriesByParent($category->getChildCategories(), $parentCategoryId);
+            $extractedChildren = $this->extractCategoriesByParent($category->getChildren(), $parentCategoryId);
 
-            if (empty($inChildCategories)) {
+            if (empty($extractedChildren)) {
                 continue;
             }
 
-            return $inChildCategories;
+            return $extractedChildren;
         }
 
         return [];

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -25,24 +25,19 @@ Feature: Show category tree in product page (BO)
     And category "art" parent is category "home"
 
   Scenario: I can see categories tree with product associations
-    Given I add product "product1" with following information:
-      | name[en-US] | unisex sneakers |
-      | type        | standard        |
-    And product "product1" type should be standard
-    And product "product1" should be assigned to default category
-    Then I should see following root categories for product "product1" in "en" language:
+    Given I should see following root categories in "en" language:
       | id reference | category name | direct child categories   |
       | home         | Home          | [clothes,accessories,art] |
-    And I should see following categories in "home" category for product "product1" in "en" language:
+    And I should see following categories in "home" category in "en" language:
       | id reference | category name | direct child categories       |
       | clothes      | Clothes       | [men,women]                   |
       | accessories  | Accessories   | [stationery,home_accessories] |
       | art          | Art           |                               |
-    And I should see following categories in "clothes" category for product "product1" in "en" language:
+    And I should see following categories in "clothes" category in "en" language:
       | id reference | category name | direct child categories |
       | men          | Men           |                         |
       | women        | Women         |                         |
-    And I should see following categories in "accessories" category for product "product1" in "en" language:
+    And I should see following categories in "accessories" category in "en" language:
       | id reference     | category name    | direct child categories |
       | stationery       | Stationery       |                         |
       | home_accessories | Home Accessories |                         |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -30,14 +30,19 @@ Feature: Show category tree in product page (BO)
       | type        | standard        |
     And product "product1" type should be standard
     And product "product1" should be assigned to default category
-    Then I should see following categories tree for product "product1" in "en" language:
-#     @todo: how to assert parent-child category tree?
-      | id reference     | category name    | is associated with product |
-      | home             | Home             | true                       |
-      | clothes          | Clothes          | false                      |
-      | men              | Men              | false                      |
-      | women            | Women            | false                      |
-      | accessories      | Accessories      | false                      |
-      | stationery       | Stationery       | false                      |
-      | home_accessories | Home Accessories | false                      |
-      | art              | Art              | false                      |
+    Then I should see following root categories for product "product1" in "en" language:
+      | id reference | category name | direct child categories   | is associated with product |
+      | home         | Home          | [clothes,accessories,art] | true                       |
+    And I should see following categories in "home" category for product "product1" in "en" language:
+      | id reference | category name | direct child categories       | is associated with product |
+      | clothes      | Clothes       | [men,women]                   | false                      |
+      | accessories  | Accessories   | [stationery,home_accessories] | false                      |
+      | art          | Art           |                               | false                      |
+    And I should see following categories in "clothes" category for product "product1" in "en" language:
+      | id reference | category name | direct child categories | is associated with product |
+      | men          | Men           |                         | false                      |
+      | women        | Women         |                         | false                      |
+    And I should see following categories in "accessories" category for product "product1" in "en" language:
+      | id reference     | category name    | direct child categories | is associated with product |
+      | stationery       | Stationery       |                         | false                      |
+      | home_accessories | Home Accessories |                         | false                      |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -1,0 +1,24 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags category-tree
+@reset-database-before-feature
+@clear-cache-before-feature
+@category-tree
+Feature: Show category tree in product page (BO)
+  As an employee
+  I need to be able to see category tree in product page with marked product-category associations
+
+  Background:
+    Given category "home" in default language named "Home" exists
+    And category "clothes" in default language named "Clothes" exists
+    And category "clothes" parent is category "home"
+    And category "men" in default language named "Men" exists
+    And category "men" parent is category "clothes"
+    And category "women" in default language named "Women" exists
+    And category "women" parent is category "clothes"
+    And category "accessories" in default language named "Accessories" exists
+    And category "accessories" parent is category "home"
+    And category "stationery" in default language named "Stationery" exists
+    And category "stationery" parent is category "accessories"
+    And category "home_accessories" in default language named "Home Accessories" exists
+    And category "home_accessories" parent is category "accessories"
+    And category "art" in default language named "Art" exists
+    And category "art" parent is category "home"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -31,18 +31,18 @@ Feature: Show category tree in product page (BO)
     And product "product1" type should be standard
     And product "product1" should be assigned to default category
     Then I should see following root categories for product "product1" in "en" language:
-      | id reference | category name | direct child categories   | is associated with product |
-      | home         | Home          | [clothes,accessories,art] | true                       |
+      | id reference | category name | direct child categories   |
+      | home         | Home          | [clothes,accessories,art] |
     And I should see following categories in "home" category for product "product1" in "en" language:
-      | id reference | category name | direct child categories       | is associated with product |
-      | clothes      | Clothes       | [men,women]                   | false                      |
-      | accessories  | Accessories   | [stationery,home_accessories] | false                      |
-      | art          | Art           |                               | false                      |
+      | id reference | category name | direct child categories       |
+      | clothes      | Clothes       | [men,women]                   |
+      | accessories  | Accessories   | [stationery,home_accessories] |
+      | art          | Art           |                               |
     And I should see following categories in "clothes" category for product "product1" in "en" language:
-      | id reference | category name | direct child categories | is associated with product |
-      | men          | Men           |                         | false                      |
-      | women        | Women         |                         | false                      |
+      | id reference | category name | direct child categories |
+      | men          | Men           |                         |
+      | women        | Women         |                         |
     And I should see following categories in "accessories" category for product "product1" in "en" language:
-      | id reference     | category name    | direct child categories | is associated with product |
-      | stationery       | Stationery       |                         | false                      |
-      | home_accessories | Home Accessories |                         | false                      |
+      | id reference     | category name    | direct child categories |
+      | stationery       | Stationery       |                         |
+      | home_accessories | Home Accessories |                         |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -7,7 +7,8 @@ Feature: Show category tree in product page (BO)
   I need to be able to see category tree in product page with marked product-category associations
 
   Background:
-    Given category "home" in default language named "Home" exists
+    Given language with iso code "en" is the default one
+    And category "home" in default language named "Home" exists
     And category "clothes" in default language named "Clothes" exists
     And category "clothes" parent is category "home"
     And category "men" in default language named "Men" exists
@@ -22,3 +23,21 @@ Feature: Show category tree in product page (BO)
     And category "home_accessories" parent is category "accessories"
     And category "art" in default language named "Art" exists
     And category "art" parent is category "home"
+
+  Scenario: I can see categories tree with product associations
+    Given I add product "product1" with following information:
+      | name[en-US] | unisex sneakers |
+      | type        | standard        |
+    And product "product1" type should be standard
+    And product "product1" should be assigned to default category
+    Then I should see following categories tree for product "product1" in "en" language:
+#     @todo: how to assert parent-child category tree?
+      | id reference     | category name    | is associated with product |
+      | home             | Home             | true                       |
+      | clothes          | Clothes          | false                      |
+      | men              | Men              | false                      |
+      | women            | Women            | false                      |
+      | accessories      | Accessories      | false                      |
+      | stationery       | Stationery       | false                      |
+      | home_accessories | Home Accessories | false                      |
+      | art              | Art              | false                      |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Query and api endpoint to retrieve nested categories tree for js categories widget
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | part of #19518
| How to test?      | visit `admin-dev/index.php/sell/catalog/categories/categories-tree` and you can see json list with categories tree. Each category holds name, id and a list of child categories (each of them has the same structure)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23913)
<!-- Reviewable:end -->
