### PR TITLE
Travis for cron only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ env:
 stages:
   - name: deploy
     if: type = cron
-  - name: test
-    if: type IN (push, pull_request)
 
 jobs:
   include:
@@ -51,7 +49,6 @@ jobs:
         - cd /tmp/ps-release
           && today=`date +%Y-%m-%d-`; for i in *; do mv $i $today$TRAVIS_BRANCH-$i; done
           && cd -
-      if: type = cron
       deploy:
         provider: gcs
         access_key_id: $GCS_ACCESS_KEY
@@ -75,19 +72,16 @@ after_failure: skip
 
 before_deploy:
   - |
-      if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-        mkdir -p ${HOME}/.ssh/;
-        echo $GC_INSTANCE_KEY | base64 --decode -i > ${HOME}/.ssh/google_compute_engine && \
-        echo $GC_INSTANCE_PUB | base64 --decode -i > ${HOME}/.ssh/google_compute_engine.pub && \
-        chmod 600 ${HOME}/.ssh/* && \
-        echo $GC_SERVICE_KEY | base64 --decode -i > ${HOME}/gcloud-service-key.json && \
-        gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json && \
-        gcloud config set project $GC_PROJECT_ID
-      fi
+      mkdir -p ${HOME}/.ssh/;
+      echo $GC_INSTANCE_KEY | base64 --decode -i > ${HOME}/.ssh/google_compute_engine && \
+      echo $GC_INSTANCE_PUB | base64 --decode -i > ${HOME}/.ssh/google_compute_engine.pub && \
+      chmod 600 ${HOME}/.ssh/* && \
+      echo $GC_SERVICE_KEY | base64 --decode -i > ${HOME}/gcloud-service-key.json && \
+      gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json && \
+      gcloud config set project $GC_PROJECT_ID
 
 after_deploy:
   - |
-    if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
       [[ $TRAVIS_BRANCH = "develop" ]] && INSTANCE_TYPE="develop" || INSTANCE_TYPE="release";
       # make sure instance is stopped. This step does not need to be chained
       gcloud compute instances stop --zone $GC_ZONE "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}";
@@ -96,4 +90,3 @@ after_deploy:
       gcloud compute instances add-metadata "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}" --zone $GC_ZONE --metadata-from-file startup-tests-script=tests/UI/scripts/run-nightly-tests.sh && \
       gcloud compute instances add-metadata "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}" --zone $GC_ZONE --metadata-from-file startup-reports-script=tests/UI/scripts/run-nightly-reports.sh && \
       gcloud compute instances start --zone $GC_ZONE "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}"
-    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,8 @@ jobs:
   include:
     - stage: deploy
       php: 7.3
-      before_install: skip
-      before_script: skip
-      install: skip
       script:
+        - php -v
         - mkdir -p /tmp/ps-release
         - php tools/build/CreateRelease.php --destination-dir=/tmp/ps-release
         - cd /tmp/ps-release
@@ -58,17 +56,6 @@ jobs:
         local_dir: "/tmp/ps-release"
         on:
           all_branches: true
-
-before_install: skip
-
-install: skip
-
-script:
-  - php -v
-
-after_script: skip
-
-after_failure: skip
 
 before_deploy:
   - |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Travis is no longer used for any other purpose then cron deploy.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | no
| How to test?      | The cron Travis job must pass as before.
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23916)
<!-- Reviewable:end -->
