### PR TITLE
Parse float for attributes wholesale price

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -339,6 +339,9 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['combinations'][$k]['attribute_unity'] = abs(
                 $this->floatParser->fromString($combination['attribute_unity'])
             );
+            $form_data['combinations'][$k]['attribute_wholesale_price'] = abs(
+                $this->floatParser->fromString($combination['attribute_wholesale_price'])
+            );
         }
 
         //map suppliers


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Add a float parser for the wholesale price of attributes
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23922.
| How to test?      | From the Back-Office Catalog / Products, click to edit a Product with attributes<br/>Go to the Attributes tab, and then edit an attribute<br/>Enter a wholesale price for the attribute (e.g. 1.55)<br/>Save and go back to the product listing<br/>Click to edit the same product<br/>Click on Save and go back to the product listing<br/>Click to edit the same product (for the 3rd time), go to the Attributes tab and click on the attribute : the wholesale price is not rounded anymore.
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23923)
<!-- Reviewable:end -->
