### PR TITLE
Fix translator bug when iso code is unknown

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -54,6 +54,10 @@ trait PrestaShopTranslatorTrait
             unset($parameters['legacy']);
         }
 
+        if (empty($locale)) {
+            $locale = null;
+        }
+
         $translated = parent::trans($id, [], $this->normalizeDomain($domain), $locale);
 
         // @todo to remove after the legacy translation system has ben phased out


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When adding a new Language with an unknown iso code, the locale is set to an empty string. This empty string is then passed to the symfony translator that throw an exception because an empty string is not a valid locale. To get rid of this exception this PR set the locale to null when it is empty so the symfony translator can use the default locale.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23506
| How to test?      | Please see #23506
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23925)
<!-- Reviewable:end -->
