### PR TITLE
Fixed toggle inactive category in the BO product page category tree

### DIFF
--- a/admin-dev/themes/default/js/bundle/category-tree.js
+++ b/admin-dev/themes/default/js/bundle/category-tree.js
@@ -62,7 +62,7 @@
         event.stopPropagation();
 
         if ($ui.next('ul').length === 0) {
-          $ui = $ui.parent();
+          $ui = $ui.closest('div');
         }
 
         $ui.next('ul').toggle();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the BO product page, then in the category tree, if a category is inactive, it's inside ```<i>```. In this case in the category-tree.js code, your not where you believe you are but on a level under. The easier is to change .parent() to .closest('div'), this way you always get the div you need, whatever the situation.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #23945
| How to test?      | Create a level 3 category. Make its parent inactive. Go to the BO product page. In the category tree, collapse all. Then clic on the inactive parent. It doesn't work. With this patch, it works.
| Possible impacts? | None to my mind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23926)
<!-- Reviewable:end -->
