### PR TITLE
Disable add new customer button in all shops or in a group context

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -115,6 +115,7 @@ class CustomerController extends AbstractAdminController
             'deleteCustomersForm' => $deleteCustomerForm->createView(),
             'showcaseCardName' => ShowcaseCard::CUSTOMERS_CARD,
             'isShowcaseCardClosed' => $showcaseCardIsClosed,
+            'layoutHeaderToolbarBtn' => $this->getCustomerToolbarButtons(),
         ]);
     }
 
@@ -991,5 +992,32 @@ class CustomerController extends AbstractAdminController
                 $messages[$messageId]
             );
         }
+    }
+
+    /**
+     * @return array
+     */
+    private function getCustomerToolbarButtons(): array
+    {
+        $toolbarButtons = [];
+
+        $isSingleShopContext = $this->get('prestashop.adapter.shop.context')->isSingleShopContext();
+
+        $toolbarButtons['add'] = [
+            'href' => $this->generateUrl('admin_customers_create'),
+            'desc' => $this->trans('Add new customer', 'Admin.Orderscustomers.Feature'),
+            'icon' => 'add_circle_outline',
+            'disabled' => !$isSingleShopContext,
+        ];
+
+        if (!$isSingleShopContext) {
+            $toolbarButtons['add']['help'] = $this->trans(
+                'You can use this feature in a single shop context only. Switch context to enable it.',
+                'Admin.Orderscustomers.Feature'
+            );
+            $toolbarButtons['add']['href'] = '#';
+        }
+
+        return $toolbarButtons;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
@@ -26,16 +26,6 @@
 {% set enableSidebar = true %}
 {% set layoutTitle = 'Manage your Customers'|trans({}, 'Admin.Orderscustomers.Feature') %}
 
-{% if isSingleShopContext %}
-  {% set layoutHeaderToolbarBtn = {
-    'add': {
-      'href': path('admin_customers_create'),
-      'desc': 'Add new customer'|trans({}, 'Admin.Orderscustomers.Feature'),
-      'icon': 'add_circle_outline'
-    }
-  } %}
-{% endif %}
-
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block content %}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Disable header toolbar button "Add" for Add an Customer when shop context is not single
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/19397
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/19397
| Possible impacts? | I modified how the "Add a customer" button is rendered when shop context is not a "single shop" context.


## Details about the content PR

### Goal

This PR implements what has been specified in https://github.com/PrestaShop/PrestaShop/issues/19397 . Display has been validated by @marionf . It's is almost identical to https://github.com/PrestaShop/PrestaShop/pull/23907

![screenshot_add_order](https://user-images.githubusercontent.com/3830050/113743377-e6ee3900-9703-11eb-9e18-23c5b095a3cc.png)

### Code modifications

I removed the header toolbar buttons being rendered in Twig because it was static. I moved the header toolbar buttons logic inside the Controller.

I added some business logic inside the CustomerController to configure properly the header toolbar button "Add a customer" when shop context is not a "single shop" context.

It's a PR that continues the work introduced in https://github.com/PrestaShop/PrestaShop/pull/23907

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23940)
<!-- Reviewable:end -->
