### PR TITLE
Improve compatibility in legacy code for new product_type field

### DIFF
--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -448,7 +448,7 @@ class PackCore extends Product
 
     public static function deleteItems($id_product)
     {
-        return Db::getInstance()->update('product', ['cache_is_pack' => 0, 'product_type' => ProductType::TYPE_UNDEFINED], 'id_product = ' . (int) $id_product) &&
+        return Db::getInstance()->update('product', ['cache_is_pack' => 0], 'id_product = ' . (int) $id_product) &&
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'pack` WHERE `id_product_pack` = ' . (int) $id_product) &&
             Configuration::updateGlobalValue('PS_PACK_FEATURE_ACTIVE', Pack::isCurrentlyUsed());
     }

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -23,7 +23,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 
 class PackCore extends Product
 {
@@ -446,7 +448,7 @@ class PackCore extends Product
 
     public static function deleteItems($id_product)
     {
-        return Db::getInstance()->update('product', ['cache_is_pack' => 0], 'id_product = ' . (int) $id_product) &&
+        return Db::getInstance()->update('product', ['cache_is_pack' => 0, 'product_type' => ProductType::TYPE_UNDEFINED], 'id_product = ' . (int) $id_product) &&
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'pack` WHERE `id_product_pack` = ' . (int) $id_product) &&
             Configuration::updateGlobalValue('PS_PACK_FEATURE_ACTIVE', Pack::isCurrentlyUsed());
     }
@@ -467,7 +469,7 @@ class PackCore extends Product
     {
         $id_attribute_item = (int) $id_attribute_item ? (int) $id_attribute_item : Product::getDefaultAttribute((int) $id_item);
 
-        return Db::getInstance()->update('product', ['cache_is_pack' => 1], 'id_product = ' . (int) $id_product) &&
+        return Db::getInstance()->update('product', ['cache_is_pack' => 1, 'product_type' => ProductType::TYPE_PACK], 'id_product = ' . (int) $id_product) &&
             Db::getInstance()->insert('pack', [
                 'id_product_pack' => (int) $id_product,
                 'id_product_item' => (int) $id_item,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -8304,7 +8304,20 @@ class ProductCore extends ObjectModel
         // Default value is the one saved, but in case it is not set we use dynamic definition
         if (!empty($this->product_type) && in_array($this->product_type, ProductType::AVAILABLE_TYPES)) {
             return $this->product_type;
-        } elseif ($this->is_virtual) {
+        }
+
+        return $this->getDynamicProductType();
+    }
+
+    /**
+     * Returns product type based on existing associations without taking the saved value
+     * in database into account.
+     *
+     * @return string
+     */
+    public function getDynamicProductType(): string
+    {
+        if ($this->is_virtual) {
             return ProductType::TYPE_VIRTUAL;
         } elseif (Pack::isPack($this->id)) {
             return ProductType::TYPE_PACK;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -376,12 +376,12 @@ class ProductCore extends ObjectModel
     public $delivery_out_stock;
 
     /**
-     * For now default value remains empty, to keep compatibility with page v1 and former products.
+     * For now default value remains undefined, to keep compatibility with page v1 and former products.
      * But once the v2 is merged the default value should be ProductType::TYPE_STANDARD
      *
      * @var string
      */
-    public $product_type = '';
+    public $product_type = ProductType::TYPE_UNDEFINED;
 
     /**
      * @var int|null
@@ -483,7 +483,7 @@ class ProductCore extends ObjectModel
             'product_type' => [
                 'type' => self::TYPE_STRING,
                 'validate' => 'isGenericName',
-                // For now empty value is still allowed, in 179 we should use ProductType::AVAILABLE_TYPES here
+                // For now undefined value is still allowed, in 179 we should use ProductType::AVAILABLE_TYPES here
                 'values' => [
                     ProductType::TYPE_STANDARD,
                     ProductType::TYPE_PACK,
@@ -1147,13 +1147,17 @@ class ProductCore extends ObjectModel
      */
     public static function updateIsVirtual($id_product, $is_virtual = true)
     {
-        // We cannot be sure of the target type, so we set it to undefined this way dynamic type will be used
-        $productType = $is_virtual ? ProductType::TYPE_VIRTUAL : ProductType::TYPE_UNDEFINED;
+        $isVirtual = (bool) $is_virtual;
+        $updateData = [
+            'is_virtual' => $isVirtual,
+        ];
 
-        Db::getInstance()->update('product', [
-            'is_virtual' => (bool) $is_virtual,
-            'product_type' => $productType,
-        ], 'id_product = ' . (int) $id_product);
+        // We only update the type if we are sure it is virtual
+        if ($isVirtual) {
+            $updateData['product_type'] = ProductType::TYPE_VIRTUAL;
+        }
+
+        Db::getInstance()->update('product', $updateData, 'id_product = ' . (int) $id_product);
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -376,9 +376,12 @@ class ProductCore extends ObjectModel
     public $delivery_out_stock;
 
     /**
+     * For now default value remains empty, to keep compatibility with page v1 and former products.
+     * But once the v2 is merged the default value should be ProductType::TYPE_STANDARD
+     *
      * @var string
      */
-    public $product_type = ProductType::TYPE_STANDARD;
+    public $product_type = '';
 
     /**
      * @var int|null
@@ -480,8 +483,16 @@ class ProductCore extends ObjectModel
             'product_type' => [
                 'type' => self::TYPE_STRING,
                 'validate' => 'isGenericName',
-                'values' => ProductType::AVAILABLE_TYPES,
-                'default' => ProductType::TYPE_STANDARD,
+                // For now empty value is still allowed, in 179 we should use ProductType::AVAILABLE_TYPES here
+                'values' => [
+                    ProductType::TYPE_STANDARD,
+                    ProductType::TYPE_PACK,
+                    ProductType::TYPE_VIRTUAL,
+                    ProductType::TYPE_COMBINATIONS,
+                    '',
+                ],
+                // This default value should be enabled in 179 when the v2 page is fully migrated
+                // 'default' => ProductType::TYPE_STANDARD,
             ],
 
             /* Shop fields */

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1963,14 +1963,19 @@ class ProductCore extends ObjectModel
      */
     public function setDefaultAttribute($id_product_attribute)
     {
+        // We cannot be sure of the target type, so we set it to empty this way dynamic type will be used
+        $productType = !empty($id_product_attribute) ? ProductType::TYPE_COMBINATIONS : '';
+
         $result = ObjectModel::updateMultishopTable('Combination', [
             'default_on' => 1,
         ], 'a.`id_product` = ' . (int) $this->id . ' AND a.`id_product_attribute` = ' . (int) $id_product_attribute);
 
         $result &= ObjectModel::updateMultishopTable('product', [
             'cache_default_attribute' => (int) $id_product_attribute,
+            'product_type' => $productType,
         ], 'a.`id_product` = ' . (int) $this->id);
         $this->cache_default_attribute = (int) $id_product_attribute;
+        $this->product_type = $productType;
 
         return $result;
     }
@@ -1984,12 +1989,16 @@ class ProductCore extends ObjectModel
     {
         $id_default_attribute = (int) Product::getDefaultAttribute($id_product, 0, true);
 
+        // We cannot be sure of the target type, so we set it to empty this way dynamic type will be used
+        $productType = !empty($id_default_attribute) ? ProductType::TYPE_COMBINATIONS : '';
+
         $result = Db::getInstance()->update('product_shop', [
             'cache_default_attribute' => $id_default_attribute,
         ], 'id_product = ' . (int) $id_product . Shop::addSqlRestriction());
 
         $result &= Db::getInstance()->update('product', [
             'cache_default_attribute' => $id_default_attribute,
+            'product_type' => $productType,
         ], 'id_product = ' . (int) $id_product);
 
         if ($result && $id_default_attribute) {
@@ -2330,6 +2339,7 @@ class ProductCore extends ObjectModel
                 $this->setAvailableDate();
             }
         }
+        $this->product_type = ProductType::TYPE_COMBINATIONS;
 
         if (!empty($id_images)) {
             $combination->setImages($id_images);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -489,7 +489,7 @@ class ProductCore extends ObjectModel
                     ProductType::TYPE_PACK,
                     ProductType::TYPE_VIRTUAL,
                     ProductType::TYPE_COMBINATIONS,
-                    '',
+                    ProductType::TYPE_UNDEFINED,
                 ],
                 // This default value should be enabled in 179 when the v2 page is fully migrated
                 // 'default' => ProductType::TYPE_STANDARD,
@@ -1964,7 +1964,7 @@ class ProductCore extends ObjectModel
     public function setDefaultAttribute($id_product_attribute)
     {
         // We cannot be sure of the target type, so we set it to empty this way dynamic type will be used
-        $productType = !empty($id_product_attribute) ? ProductType::TYPE_COMBINATIONS : '';
+        $productType = !empty($id_product_attribute) ? ProductType::TYPE_COMBINATIONS : ProductType::TYPE_UNDEFINED;
 
         $result = ObjectModel::updateMultishopTable('Combination', [
             'default_on' => 1,
@@ -1990,7 +1990,7 @@ class ProductCore extends ObjectModel
         $id_default_attribute = (int) Product::getDefaultAttribute($id_product, 0, true);
 
         // We cannot be sure of the target type, so we set it to empty this way dynamic type will be used
-        $productType = !empty($id_default_attribute) ? ProductType::TYPE_COMBINATIONS : '';
+        $productType = !empty($id_default_attribute) ? ProductType::TYPE_COMBINATIONS : ProductType::TYPE_UNDEFINED;
 
         $result = Db::getInstance()->update('product_shop', [
             'cache_default_attribute' => $id_default_attribute,
@@ -8017,6 +8017,7 @@ class ProductCore extends ObjectModel
 
         $this->cache_is_pack = ($type == Product::PTYPE_PACK);
         $this->is_virtual = ($type == Product::PTYPE_VIRTUAL);
+        $this->product_type = $this->getDynamicProductType();
 
         return true;
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -772,6 +772,10 @@ class ProductCore extends ObjectModel
      */
     public function add($autodate = true, $null_values = false)
     {
+        if ($this->is_virtual) {
+            $this->product_type = ProductType::TYPE_VIRTUAL;
+        }
+
         if (!parent::add($autodate, $null_values)) {
             return false;
         }
@@ -802,6 +806,10 @@ class ProductCore extends ObjectModel
      */
     public function update($null_values = false)
     {
+        if ($this->is_virtual) {
+            $this->product_type = ProductType::TYPE_VIRTUAL;
+        }
+
         $return = parent::update($null_values);
         $this->setGroupReduction();
 
@@ -1139,8 +1147,12 @@ class ProductCore extends ObjectModel
      */
     public static function updateIsVirtual($id_product, $is_virtual = true)
     {
+        // We cannot be sure of the target type, so we set it to undefined this way dynamic type will be used
+        $productType = $is_virtual ? ProductType::TYPE_VIRTUAL : ProductType::TYPE_UNDEFINED;
+
         Db::getInstance()->update('product', [
             'is_virtual' => (bool) $is_virtual,
+            'product_type' => $productType,
         ], 'id_product = ' . (int) $id_product);
     }
 
@@ -1963,7 +1975,7 @@ class ProductCore extends ObjectModel
      */
     public function setDefaultAttribute($id_product_attribute)
     {
-        // We cannot be sure of the target type, so we set it to empty this way dynamic type will be used
+        // We cannot be sure of the target type, so we set it to undefined this way dynamic type will be used
         $productType = !empty($id_product_attribute) ? ProductType::TYPE_COMBINATIONS : ProductType::TYPE_UNDEFINED;
 
         $result = ObjectModel::updateMultishopTable('Combination', [
@@ -1989,7 +2001,7 @@ class ProductCore extends ObjectModel
     {
         $id_default_attribute = (int) Product::getDefaultAttribute($id_product, 0, true);
 
-        // We cannot be sure of the target type, so we set it to empty this way dynamic type will be used
+        // We cannot be sure of the target type, so we set it to undefined this way dynamic type will be used
         $productType = !empty($id_default_attribute) ? ProductType::TYPE_COMBINATIONS : ProductType::TYPE_UNDEFINED;
 
         $result = Db::getInstance()->update('product_shop', [

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -491,8 +491,8 @@ class ProductCore extends ObjectModel
                     ProductType::TYPE_COMBINATIONS,
                     ProductType::TYPE_UNDEFINED,
                 ],
-                // This default value should be enabled in 179 when the v2 page is fully migrated
-                // 'default' => ProductType::TYPE_STANDARD,
+                // This default value should be replaced with ProductType::TYPE_STANDARD in 179 when the v2 page is fully migrated
+                'default' => ProductType::TYPE_UNDEFINED,
             ],
 
             /* Shop fields */

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1670,8 +1670,8 @@ CREATE TABLE `PREFIX_product` (
   `pack_stock_type` int(11) unsigned DEFAULT '3' NOT NULL,
   `state` int(11) unsigned NOT NULL DEFAULT '1',
   `product_type` ENUM(
-    'standard', 'pack', 'virtual', 'combinations'
-  ) NOT NULL DEFAULT 'standard',
+    'standard', 'pack', 'virtual', 'combinations', ''
+  ) NOT NULL DEFAULT '',
   PRIMARY KEY (`id_product`),
   INDEX reference_idx(`reference`),
   INDEX supplier_reference_idx(`supplier_reference`),

--- a/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
+++ b/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
@@ -105,7 +105,7 @@ class AdminAttributeGeneratorControllerWrapper
                 Tools::clearColorListCache((int) $product->id);
                 if (!$product->hasAttributes()) {
                     $product->cache_default_attribute = 0;
-                    $product->product_type = '';
+                    $product->product_type = ProductType::TYPE_UNDEFINED;
                     $product->update();
                 } else {
                     Product::updateDefaultAttribute($idProduct);

--- a/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
+++ b/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Attribute;
 use AdminAttributeGeneratorController;
 use Combination;
 use Context;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use Product;
 use SpecificPriceRule;
 use Stock;
@@ -105,7 +104,6 @@ class AdminAttributeGeneratorControllerWrapper
                 Tools::clearColorListCache((int) $product->id);
                 if (!$product->hasAttributes()) {
                     $product->cache_default_attribute = 0;
-                    $product->product_type = ProductType::TYPE_UNDEFINED;
                     $product->update();
                 } else {
                     Product::updateDefaultAttribute($idProduct);

--- a/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
+++ b/src/Adapter/Attribute/AdminAttributeGeneratorControllerWrapper.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Attribute;
 use AdminAttributeGeneratorController;
 use Combination;
 use Context;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use Product;
 use SpecificPriceRule;
 use Stock;
@@ -104,6 +105,7 @@ class AdminAttributeGeneratorControllerWrapper
                 Tools::clearColorListCache((int) $product->id);
                 if (!$product->hasAttributes()) {
                     $product->cache_default_attribute = 0;
+                    $product->product_type = '';
                     $product->update();
                 } else {
                     Product::updateDefaultAttribute($idProduct);

--- a/src/Core/Domain/Product/ValueObject/ProductType.php
+++ b/src/Core/Domain/Product/ValueObject/ProductType.php
@@ -57,6 +57,15 @@ class ProductType
     public const TYPE_COMBINATIONS = 'combinations';
 
     /**
+     * Product created before 178 or via the legacy page may have empty product type, so it is
+     * undefined. To know the product type you can use Product::getDynamicProductType() which
+     * computes it based on the existing associations.
+     *
+     * WARNING: this is not accepted as a valid type for this ValueObject
+     */
+    public const TYPE_UNDEFINED = '';
+
+    /**
      * A list of available types
      */
     public const AVAILABLE_TYPES = [

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -176,6 +176,22 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @Then product :productReference persisted type should be :productType
+     *
+     * @param string $productReference
+     * @param string $productTypeName
+     */
+    public function assertPersistedProductType(string $productReference, string $productTypeName): void
+    {
+        if ('empty' === $productTypeName) {
+            $productTypeName = '';
+        }
+        $productId = $this->getSharedStorage()->get($productReference);
+        $product = new Product($productId);
+        Assert::assertEquals($productTypeName, $product->product_type);
+    }
+
+    /**
      * @Then I should get error that product :fieldName is invalid
      *
      * @param string $fieldName

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -183,8 +183,8 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
      */
     public function assertPersistedProductType(string $productReference, string $productTypeName): void
     {
-        if ('empty' === $productTypeName) {
-            $productTypeName = '';
+        if ('undefined' === $productTypeName) {
+            $productTypeName = ProductType::TYPE_UNDEFINED;
         }
         $productId = $this->getSharedStorage()->get($productReference);
         $product = new Product($productId);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -192,6 +192,22 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @Then product :productReference dynamic type should be :productType
+     *
+     * @param string $productReference
+     * @param string $productTypeName
+     */
+    public function assertDynamicProductType(string $productReference, string $productTypeName): void
+    {
+        if ('empty' === $productTypeName) {
+            $productTypeName = '';
+        }
+        $productId = $this->getSharedStorage()->get($productReference);
+        $product = new Product($productId);
+        Assert::assertEquals($productTypeName, $product->getDynamicProductType());
+    }
+
+    /**
      * @Then I should get error that product :fieldName is invalid
      *
      * @param string $fieldName

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -199,8 +199,8 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
      */
     public function assertDynamicProductType(string $productReference, string $productTypeName): void
     {
-        if ('empty' === $productTypeName) {
-            $productTypeName = '';
+        if ('undefined' === $productTypeName) {
+            $productTypeName = ProductType::TYPE_UNDEFINED;
         }
         $productId = $this->getSharedStorage()->get($productReference);
         $product = new Product($productId);

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -106,6 +106,18 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @Then there is a product :productReference with name :productName
+     *
+     * @param string $productReference
+     * @param string $productName
+     */
+    public function storeProductReferenceByName(string $productReference, string $productName): void
+    {
+        $productId = $this->getProductIdByName($productName);
+        $this->getSharedStorage()->set($productReference, $productId);
+    }
+
+    /**
      * @param string $productName
      *
      * @return int

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -724,6 +724,7 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
             $this->products[$containedProductName]->id,
             $containedQuantity
         );
+        Pack::resetStaticCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -37,7 +37,7 @@ Feature: Legacy products have consistent product type through dynamic checking (
       | whiteM    | 150      | Size:M;Color:White |
       | whiteL    | 150      | Size:L;Color:White |
     Then product "product_with_combinations" type should be combinations
-    And product "product_with_combinations" persisted type should be empty
+    And product "product_with_combinations" persisted type should be combinations
     And product "product_with_combinations" dynamic type should be combinations
 
   Scenario: I create a virtual product, its product type should be virtual

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -48,7 +48,7 @@ Feature: Legacy products have consistent product type through dynamic checking (
     And product "virtual_product" dynamic type should be standard
     Given product "Virtual Product" is virtual
     Then product "virtual_product" type should be virtual
-    And product "virtual_product" persisted type should be undefined
+    And product "virtual_product" persisted type should be virtual
     And product "virtual_product" dynamic type should be virtual
 
   Scenario: I create a pack product, its product type should be pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -24,14 +24,14 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Given there is a product in the catalog named "Standard Product" with a price of 15.0 and 100 items in stock
     Then there is a product "standard_product" with name "Standard Product"
     And product "standard_product" type should be standard
-    And product "standard_product" persisted type should be empty
+    And product "standard_product" persisted type should be undefined
     And product "standard_product" dynamic type should be standard
 
   Scenario: I create a product and add combinations using legacy methods, its product type should be combinations
     Given there is a product in the catalog named "Product With Combinations" with a price of 15.0 and 100 items in stock
     Then there is a product "product_with_combinations" with name "Product With Combinations"
     And product "product_with_combinations" type should be standard
-    And product "product_with_combinations" persisted type should be empty
+    And product "product_with_combinations" persisted type should be undefined
     And product "Product With Combinations" has combinations with following details:
       | reference | quantity | attributes         |
       | whiteM    | 150      | Size:M;Color:White |
@@ -44,11 +44,11 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Given there is a product in the catalog named "Virtual Product" with a price of 15.0 and 100 items in stock
     Then there is a product "virtual_product" with name "Virtual Product"
     And product "virtual_product" type should be standard
-    And product "virtual_product" persisted type should be empty
+    And product "virtual_product" persisted type should be undefined
     And product "virtual_product" dynamic type should be standard
     Given product "Virtual Product" is virtual
     Then product "virtual_product" type should be virtual
-    And product "virtual_product" persisted type should be empty
+    And product "virtual_product" persisted type should be undefined
     And product "virtual_product" dynamic type should be virtual
 
   Scenario: I create a pack product, its product type should be pack
@@ -56,10 +56,10 @@ Feature: Legacy products have consistent product type through dynamic checking (
     And there is a product in the catalog named "Product in pack" with a price of 15.0 and 100 items in stock
     Then there is a product "pack_product" with name "Pack Product"
     And product "pack_product" type should be standard
-    And product "pack_product" persisted type should be empty
+    And product "pack_product" persisted type should be undefined
     And product "pack_product" dynamic type should be standard
     Given product "Pack Product" is a pack containing 10 items of product "Product in pack"
     Then product "Pack Product" is considered as a pack
     And product "pack_product" type should be pack
-    And product "pack_product" persisted type should be empty
+    And product "pack_product" persisted type should be pack
     And product "pack_product" dynamic type should be pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -25,6 +25,7 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Then there is a product "standard_product" with name "Standard Product"
     And product "standard_product" type should be standard
     And product "standard_product" persisted type should be empty
+    And product "standard_product" dynamic type should be standard
 
   Scenario: I create a product and add combinations using legacy methods, its product type should be combinations
     Given there is a product in the catalog named "Product With Combinations" with a price of 15.0 and 100 items in stock
@@ -37,15 +38,18 @@ Feature: Legacy products have consistent product type through dynamic checking (
       | whiteL    | 150      | Size:L;Color:White |
     Then product "product_with_combinations" type should be combinations
     And product "product_with_combinations" persisted type should be empty
+    And product "product_with_combinations" dynamic type should be combinations
 
   Scenario: I create a virtual product, its product type should be virtual
     Given there is a product in the catalog named "Virtual Product" with a price of 15.0 and 100 items in stock
     Then there is a product "virtual_product" with name "Virtual Product"
     And product "virtual_product" type should be standard
     And product "virtual_product" persisted type should be empty
+    And product "virtual_product" dynamic type should be standard
     Given product "Virtual Product" is virtual
     Then product "virtual_product" type should be virtual
     And product "virtual_product" persisted type should be empty
+    And product "virtual_product" dynamic type should be virtual
 
   Scenario: I create a pack product, its product type should be pack
     Given there is a product in the catalog named "Pack Product" with a price of 15.0 and 100 items in stock
@@ -53,7 +57,9 @@ Feature: Legacy products have consistent product type through dynamic checking (
     Then there is a product "pack_product" with name "Pack Product"
     And product "pack_product" type should be standard
     And product "pack_product" persisted type should be empty
+    And product "pack_product" dynamic type should be standard
     Given product "Pack Product" is a pack containing 10 items of product "Product in pack"
     Then product "Pack Product" is considered as a pack
     And product "pack_product" type should be pack
     And product "pack_product" persisted type should be empty
+    And product "pack_product" dynamic type should be pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -1,0 +1,59 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags legacy-product-type
+@reset-database-before-feature
+@clear-cache-before-feature
+@clear-cache-after-feature
+@legacy-product-type
+Feature: Legacy products have consistent product type through dynamic checking (BO)
+  As a BO user
+  I need to be sure that "legacy" products (created with page v1) have a correct product type (used for v2)
+
+  Background:
+    Given language with iso code "en" is the default one
+    And the current currency is "USD"
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+
+  Scenario: I create a standard product using legacy methods, its product type should be standard
+    Given there is a product in the catalog named "Standard Product" with a price of 15.0 and 100 items in stock
+    Then there is a product "standard_product" with name "Standard Product"
+    And product "standard_product" type should be standard
+    And product "standard_product" persisted type should be empty
+
+  Scenario: I create a product and add combinations using legacy methods, its product type should be combinations
+    Given there is a product in the catalog named "Product With Combinations" with a price of 15.0 and 100 items in stock
+    Then there is a product "product_with_combinations" with name "Product With Combinations"
+    And product "product_with_combinations" type should be standard
+    And product "product_with_combinations" persisted type should be empty
+    And product "Product With Combinations" has combinations with following details:
+      | reference | quantity | attributes         |
+      | whiteM    | 150      | Size:M;Color:White |
+      | whiteL    | 150      | Size:L;Color:White |
+    Then product "product_with_combinations" type should be combinations
+    And product "product_with_combinations" persisted type should be empty
+
+  Scenario: I create a virtual product, its product type should be virtual
+    Given there is a product in the catalog named "Virtual Product" with a price of 15.0 and 100 items in stock
+    Then there is a product "virtual_product" with name "Virtual Product"
+    And product "virtual_product" type should be standard
+    And product "virtual_product" persisted type should be empty
+    Given product "Virtual Product" is virtual
+    Then product "virtual_product" type should be virtual
+    And product "virtual_product" persisted type should be empty
+
+  Scenario: I create a pack product, its product type should be pack
+    Given there is a product in the catalog named "Pack Product" with a price of 15.0 and 100 items in stock
+    And there is a product in the catalog named "Product in pack" with a price of 15.0 and 100 items in stock
+    Then there is a product "pack_product" with name "Pack Product"
+    And product "pack_product" type should be standard
+    And product "pack_product" persisted type should be empty
+    Given product "Pack Product" is a pack containing 10 items of product "Product in pack"
+    Then product "Pack Product" is considered as a pack
+    And product "pack_product" type should be pack
+    And product "pack_product" persisted type should be empty

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -219,11 +219,13 @@ default:
         product:
             paths:
                 - %paths.base%/Features/Scenario/Product
-                - %paths.base%/Features/Scenario/Product/Combination
-                - %paths.base%/Features/Scenario/Product/SpecificPrice
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductTypeFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A new field `Product::product_type` was added during the product page migration, to improve the compatibility with former page the empty (undefined) value is allowed and has a dynamic fallback And modifications made via legacy codes can now update the new field appropriately
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23943)
<!-- Reviewable:end -->
