### PR TITLE
Delete parameters.yml after migration to php

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -63,7 +63,7 @@ $exportPhpConfigFile = function ($config, $destination) use ($filesystem) {
 if (!file_exists($phpParametersFilepath) && file_exists($yamlParametersFilepath)) {
     $parameters = Yaml::parseFile($yamlParametersFilepath);
     if ($exportPhpConfigFile($parameters, $phpParametersFilepath)) {
-        $filesystem->dumpFile($yamlParametersFilepath, 'parameters:' . "\n");
+        $filesystem->remove($yamlParametersFilepath);
     }
 }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -238,17 +238,17 @@ class Install extends AbstractInstall
 
             return false;
         } else {
-            return $this->emptyYamlParameters();
+            return $this->unlinkYamlParameters();
         }
     }
 
     /**
      * Prevent availability of YAML parameters.
      */
-    protected function emptyYamlParameters()
+    protected function unlinkYamlParameters()
     {
-        if (!file_put_contents(_PS_ROOT_DIR_ . '/app/config/parameters.yml', 'parameters:')) {
-            $this->setError($this->translator->trans('Cannot write app/config/parameters.yml file', [], 'Install'));
+        if (!unlink(_PS_ROOT_DIR_ . '/app/config/parameters.yml')) {
+            $this->setError($this->translator->trans('Cannot unlink app/config/parameters.yml file', [], 'Install'));
 
             return false;
         }

--- a/src/PrestaShopBundle/Install/Upgrade.php
+++ b/src/PrestaShopBundle/Install/Upgrade.php
@@ -1231,7 +1231,7 @@ namespace PrestaShopBundle\Install {
                 $settings_content .= '//@deprecated 1.7';
 
                 file_put_contents($root_dir . '/' . self::SETTINGS_FILE, $settings_content);
-                file_put_contents($root_dir . '/app/config/parameters.yml', 'parameters:');
+                unlink($root_dir . '/app/config/parameters.yml');
             }
 
             if ($event !== null) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | emptying the yml file after migration is wrong, as the configuration can be loaded in theory, but without any meaningful data
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass
| Possible impacts? | no, not expected to be used by anything else than PrestaShop code


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23952)
<!-- Reviewable:end -->
