### PR TITLE
Reduce number of GH jobs, run one PHPUnit job per PHP version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,7 @@ name: PHP
 on: [push, pull_request]
 jobs:
   php-cs-fixer:
-    name: PHP Coding Standards Fixer
+    name: PHP CS Fixer
     runs-on: ubuntu-latest
     steps:
       - name: Setup PHP
@@ -62,46 +62,7 @@ jobs:
             run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist
 
   phpunit:
-    name: PHPUnit Tests
-    runs-on: ubuntu-latest
-    strategy:
-        matrix:
-            php: ['7.1', '7.2', '7.3', '7.4']
-        fail-fast: false
-    steps:
-        -   name: Setup PHP
-            uses: shivammathur/setup-php@v2
-            with:
-                php-version: ${{ matrix.php }}
-                extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
-        -   uses: actions/checkout@v2
-
-        -   name: PrestaShop Configuration
-            run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml
-
-        -   name: Get Composer Cache Directory
-            id: composer-cache
-            run: |
-                echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-        -   name: Cache Composer Directory
-            uses: actions/cache@v2
-            with:
-                path: ${{ steps.composer-cache.outputs.dir }}
-                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                restore-keys: |
-                    ${{ runner.os }}-composer-
-
-        -   name: Composer Install
-            run: composer install --ansi --prefer-dist --no-interaction --no-progress
-
-        -   name: Run phpunit
-            run: ./vendor/bin/phpunit -c tests/Unit/phpunit.xml
-            env:
-                SYMFONY_DEPRECATIONS_HELPER: disabled
-
-  phpunit_with_db:
-      name: PHPUnit Tests (With DB)
+      name: PHPUnit
       runs-on: ubuntu-18.04
       strategy:
           matrix:
@@ -113,12 +74,6 @@ jobs:
             with:
                 php-version: ${{ matrix.php }}
                 extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
-        -   name: Setup MySQL
-            uses: mirromutth/mysql-action@v1.1
-            with:
-                mysql version: '5.7'
-                mysql database: 'prestashop'
-                mysql root password: 'password'
 
         -   uses: actions/checkout@v2
 
@@ -140,6 +95,18 @@ jobs:
 
         -   name: Composer Install
             run: composer install --ansi --prefer-dist --no-interaction --no-progress
+
+        -   name: Run phpunit (without DB)
+            run: ./vendor/bin/phpunit -c tests/Unit/phpunit.xml
+            env:
+                SYMFONY_DEPRECATIONS_HELPER: disabled
+
+        -   name: Setup MySQL
+            uses: mirromutth/mysql-action@v1.1
+            with:
+                mysql version: '5.7'
+                mysql database: 'prestashop'
+                mysql root password: 'password'
 
         -   name: Install PrestaShop
             run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -108,6 +108,9 @@ jobs:
                 mysql database: 'prestashop'
                 mysql root password: 'password'
 
+        -   name: Wait for MySQL
+            run: while ! mysqladmin ping -h127.0.0.1 --silent; do sleep 0.2; done && sleep 0.2
+
         -   name: Install PrestaShop
             run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It does not make much sense to run extra job for phpunit tests that does not require DB. They are fast, they require only 5 seconds to complete. This should reduce PRs jobs backlog.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23954)
<!-- Reviewable:end -->
