### PR TITLE
Fix: Notice: Trying to access array offset on value of type null 

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -279,6 +279,10 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function __construct($name = null, Context $context = null)
     {
+        if ($this->ps_versions_compliancy === null) {
+            $this->ps_versions_compliancy = [];
+        }
+
         if (isset($this->ps_versions_compliancy) && !isset($this->ps_versions_compliancy['min'])) {
             $this->ps_versions_compliancy['min'] = '1.4.0.0';
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See 1st commit desc for stacktrace. I do not know the reason (seems like some module is downloaded incomplete or so), but I can reproduce the issue repeatably on our Gitlab server. Also, I think Sanity tests fail for the same reason.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass (several times at least :) )
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23955)
<!-- Reviewable:end -->
