### PR TITLE
Support shop logo in svg

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -58,6 +58,11 @@ class ImageManagerCore
     ];
 
     /**
+     * @var array - a list of svg mime types
+     */
+    protected const SVG_MIMETYPES = ['image/svg+xml', 'image/svg'];
+
+    /**
      * Generate a cached thumbnail for object lists (eg. carrier, order statuses...etc).
      *
      * @param string $image Real image filename
@@ -719,4 +724,9 @@ class ImageManagerCore
 
         return $mimeType;
     }
+    
+    public static function isSvgMimeType(string $mimeType): bool
+    {
+        return in_array($mimeType, self::SVG_MIMETYPES);
+    }    
 }

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -691,6 +691,7 @@ class ImageManagerCore
             'image/jpeg' => ['jpg', 'jpeg'],
             'image/png' => ['png'],
             'image/webp' => ['webp'],
+            'image/svg+xml' => ['svg'],
         ];
         $extension = substr($fileName, strrpos($fileName, '.') + 1);
 

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -724,9 +724,9 @@ class ImageManagerCore
 
         return $mimeType;
     }
-    
+
     public static function isSvgMimeType(string $mimeType): bool
     {
         return in_array($mimeType, self::SVG_MIMETYPES);
-    }    
+    }
 }

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -48,6 +48,15 @@ class ImageManagerCore
         'image/svg',
     ];
 
+    public const EXTENSIONS_SUPPORTED = [
+        'gif',
+        'jpg',
+        'jpeg',
+        'jpe',
+        'png',
+        'webp',
+    ];
+
     /**
      * Generate a cached thumbnail for object lists (eg. carrier, order statuses...etc).
      *

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -44,15 +44,8 @@ class ImageManagerCore
         'image/png',
         'image/x-png',
         'image/webp',
-    ];
-
-    public const EXTENSIONS_SUPPORTED = [
-        'gif',
-        'jpg',
-        'jpeg',
-        'jpe',
-        'png',
-        'webp',
+        'image/svg+xml',
+        'image/svg',
     ];
 
     /**

--- a/src/Core/Domain/Shop/Command/UploadLogosCommand.php
+++ b/src/Core/Domain/Shop/Command/UploadLogosCommand.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\FileUploadException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\DTO\ShopLogoSettings;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedFaviconExtensionException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedLogoImageExtensionException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedMailAndInvoiceImageExtensionException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -90,12 +91,12 @@ class UploadLogosCommand
     /**
      * @param UploadedFile $uploadedInvoiceLogo
      *
-     * @throws NotSupportedLogoImageExtensionException
+     * @throws NotSupportedMailAndInvoiceImageExtensionException
      * @throws FileUploadException
      */
     public function setUploadedInvoiceLogo(UploadedFile $uploadedInvoiceLogo)
     {
-        $this->assertIsValidLogoImageExtension($uploadedInvoiceLogo);
+        $this->assertIsValidMailAndInvoiceImageExtension($uploadedInvoiceLogo);
         $this->assertNativeFileValidationDoesNotFail($uploadedInvoiceLogo);
 
         $this->uploadedInvoiceLogo = $uploadedInvoiceLogo;
@@ -112,12 +113,12 @@ class UploadLogosCommand
     /**
      * @param UploadedFile $uploadedMailLogo
      *
-     * @throws NotSupportedLogoImageExtensionException
+     * @throws NotSupportedMailAndInvoiceImageExtensionException
      * @throws FileUploadException
      */
     public function setUploadedMailLogo(UploadedFile $uploadedMailLogo)
     {
-        $this->assertIsValidLogoImageExtension($uploadedMailLogo);
+        $this->assertIsValidMailAndInvoiceImageExtension($uploadedMailLogo);
         $this->assertNativeFileValidationDoesNotFail($uploadedMailLogo);
 
         $this->uploadedMailLogo = $uploadedMailLogo;
@@ -161,6 +162,23 @@ class UploadLogosCommand
                 'Not supported "%s" image logo extension. Supported extensions are "%s"',
                 $extension,
                 implode(',', ShopLogoSettings::AVAILABLE_LOGO_IMAGE_EXTENSIONS
+            )));
+        }
+    }
+
+    /**
+     * @param UploadedFile $uploadedFile
+     *
+     * @throws NotSupportedMailAndInvoiceImageExtensionException
+     */
+    private function assertIsValidMailAndInvoiceImageExtension(UploadedFile $uploadedFile): void
+    {
+        $extension = $uploadedFile->getClientOriginalExtension();
+        if (!in_array($extension, ShopLogoSettings::AVAILABLE_MAIL_AND_INVOICE_LOGO_IMAGE_EXTENSIONS, true)) {
+            throw new NotSupportedMailAndInvoiceImageExtensionException(sprintf(
+                'Not supported "%s" image logo extension. Supported extensions are "%s"',
+                $extension,
+                implode(',', ShopLogoSettings::AVAILABLE_MAIL_AND_INVOICE_LOGO_IMAGE_EXTENSIONS
             )));
         }
     }

--- a/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
+++ b/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
@@ -57,7 +57,7 @@ class ShopLogoSettings
     /**
      * Gets the list of available extensions with dot attached to the front of the extension
      *
-     * @param string optional configuration key
+     * @param string $fieldName optional configuration key
      *
      * @return array<int, string>
      */

--- a/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
+++ b/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
@@ -45,6 +45,11 @@ class ShopLogoSettings
     public const AVAILABLE_LOGO_IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp', 'svg'];
 
     /**
+     * @var array<int, string> List of available image mime types for mail and invoice
+     */
+    public const AVAILABLE_MAIL_AND_INVOICE_LOGO_IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp'];
+
+    /**
      * @var string - a type used for icon images for shop logo
      */
     public const AVAILABLE_ICON_IMAGE_EXTENSION = 'ico';
@@ -52,12 +57,16 @@ class ShopLogoSettings
     /**
      * Gets the list of available extensions with dot attached to the front of the extension
      *
+     * @param string optional configuration key
+     *
      * @return array<int, string>
      */
-    public function getLogoImageExtensionsWithDot()
+    public function getLogoImageExtensionsWithDot($fieldName = '')
     {
         $mimeTypes = [];
-        foreach (self::AVAILABLE_LOGO_IMAGE_EXTENSIONS as $imageExtension) {
+        $availableExtensions = (in_array($fieldName, ['PS_LOGO_MAIL', 'PS_LOGO_INVOICE'])) ? ShopLogoSettings::AVAILABLE_MAIL_AND_INVOICE_LOGO_IMAGE_EXTENSIONS : ShopLogoSettings::AVAILABLE_LOGO_IMAGE_EXTENSIONS;
+
+        foreach ($availableExtensions as $imageExtension) {
             $mimeTypes[] = '.' . $imageExtension;
         }
 

--- a/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
+++ b/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
@@ -42,7 +42,7 @@ class ShopLogoSettings
     /**
      * @var array<int, string> List of available image mime types
      */
-    public const AVAILABLE_LOGO_IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp'];
+    public const AVAILABLE_LOGO_IMAGE_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp', 'svg'];
 
     /**
      * @var string - a type used for icon images for shop logo

--- a/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
+++ b/src/Core/Domain/Shop/DTO/ShopLogoSettings.php
@@ -61,7 +61,7 @@ class ShopLogoSettings
      *
      * @return array<int, string>
      */
-    public function getLogoImageExtensionsWithDot($fieldName = '')
+    public function getLogoImageExtensionsWithDot(string $fieldName = '')
     {
         $mimeTypes = [];
         $availableExtensions = (in_array($fieldName, ['PS_LOGO_MAIL', 'PS_LOGO_INVOICE'])) ? ShopLogoSettings::AVAILABLE_MAIL_AND_INVOICE_LOGO_IMAGE_EXTENSIONS : ShopLogoSettings::AVAILABLE_LOGO_IMAGE_EXTENSIONS;

--- a/src/Core/Domain/Shop/Exception/NotSupportedMailAndInvoiceImageExtensionException.php
+++ b/src/Core/Domain/Shop/Exception/NotSupportedMailAndInvoiceImageExtensionException.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Shop\Exception;
 
 class NotSupportedMailAndInvoiceImageExtensionException extends ShopException

--- a/src/Core/Domain/Shop/Exception/NotSupportedMailAndInvoiceImageExtensionException.php
+++ b/src/Core/Domain/Shop/Exception/NotSupportedMailAndInvoiceImageExtensionException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Shop\Exception;
+
+class NotSupportedMailAndInvoiceImageExtensionException extends ShopException
+{
+}

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -173,7 +173,7 @@ class LogoUploader
 
     public function isSvgMimeType(string $mimeType): bool
     {
-        return (bool) in_array($mimeType, self::SVG_MIMETYPES);
+        return in_array($mimeType, self::SVG_MIMETYPES);
     }
 
     private function updateInMultiShopContext(&$idShop, &$idShopGroup, $fieldName)

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -157,7 +157,7 @@ class LogoUploader
             if (!count($this->errors) && @filemtime(_PS_IMG_DIR_ . Configuration::get($fieldName)) && $deleteOldLogo) {
                 if (Shop::isFeatureActive()) {
                     $this->updateInMultiShopContext($idShop, $idShopGroup, $fieldName);
-                } elseif ($deleteOldLogo) {
+                } else {
                     @unlink(_PS_IMG_DIR_ . Configuration::get($fieldName));
                 }
             }

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -49,11 +49,6 @@ class LogoUploader
      */
     private $errors = [];
 
-    /**
-     * @var array - a list of svg mime types
-     */
-    protected const SVG_MIMETYPES = ['image/svg+xml', 'image/svg'];
-
     public function __construct(Shop $shop)
     {
         $this->shop = $shop;
@@ -117,7 +112,7 @@ class LogoUploader
                 throw new PrestaShopException(sprintf('%Upload of temporary file to %s has failed.', $tmpName));
             }
 
-            if ($this->isSvgMimeType($files[$fieldName]['type'])) {
+            if (ImageManager::isSvgMimeType($files[$fieldName]['type'])) {
                 $fileExtension = '.svg';
             } else {
                 $fileExtension = ($fieldName == 'PS_STORES_ICON') ? '.gif' : '.jpg';
@@ -129,7 +124,7 @@ class LogoUploader
                     throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop icon %s.', $logoName));
                 }
             } else {
-                if ($this->isSvgMimeType($files[$fieldName]['type'])) {
+                if (ImageManager::isSvgMimeType($files[$fieldName]['type'])) {
                     if (!copy($tmpName, _PS_IMG_DIR_ . $logoName)) {
                         throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop logo %s.', $logoName));
                     }
@@ -143,7 +138,7 @@ class LogoUploader
 
             // on updating PS_LOGO if the new file is an svg, keep old logo for mail and invoice
             $deleteOldLogo = true;
-            if ($fieldName == 'PS_LOGO' && $this->isSvgMimeType($files[$fieldName]['type'])) {
+            if ($fieldName == 'PS_LOGO' && ImageManager::isSvgMimeType($files[$fieldName]['type'])) {
                 if (empty(Configuration::get('PS_LOGO_MAIL'))) {
                     Configuration::updateValue('PS_LOGO_MAIL', Configuration::get('PS_LOGO'));
                     $deleteOldLogo = false;
@@ -170,11 +165,6 @@ class LogoUploader
         }
 
         return false;
-    }
-
-    public function isSvgMimeType(string $mimeType): bool
-    {
-        return in_array($mimeType, self::SVG_MIMETYPES);
     }
 
     private function updateInMultiShopContext(&$idShop, &$idShopGroup, $fieldName)

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -136,21 +136,26 @@ class LogoUploader
             $idShop = $this->shop->id;
             $idShopGroup = null;
 
-            // on updating PS_LOGO if the new file is an svg, keep old logo for mail and invoice
-            $deleteOldLogo = true;
+            // on updating PS_LOGO if the new file is an svg, copy old logo for mail and invoice
             if ($fieldName == 'PS_LOGO' && ImageManager::isSvgMimeType($files[$fieldName]['type'])) {
                 if (empty(Configuration::get('PS_LOGO_MAIL'))) {
-                    Configuration::updateValue('PS_LOGO_MAIL', Configuration::get('PS_LOGO'));
-                    $deleteOldLogo = false;
+                    $newLogoMail = $this->getLogoName('logo_mail', '.' . pathinfo(_PS_IMG_DIR_ . Configuration::get($fieldName), \PATHINFO_EXTENSION));
+                    // copy old logo file for mail
+                    if (@copy(_PS_IMG_DIR_ . Configuration::get($fieldName), _PS_IMG_DIR_ . $newLogoMail)) {
+                        Configuration::updateValue('PS_LOGO_MAIL', $newLogoMail);
+                    }
                 }
                 if (empty(Configuration::get('PS_LOGO_INVOICE'))) {
-                    Configuration::updateValue('PS_LOGO_INVOICE', Configuration::get('PS_LOGO'));
-                    $deleteOldLogo = false;
+                    $newLogoInvoice = $this->getLogoName('logo_invoice', '.' . pathinfo(Configuration::get($fieldName), \PATHINFO_EXTENSION));
+                    // copy old logo file for invoice
+                    if (@copy(_PS_IMG_DIR_ . Configuration::get($fieldName), _PS_IMG_DIR_ . $newLogoInvoice)) {
+                        Configuration::updateValue('PS_LOGO_INVOICE', $newLogoInvoice);
+                    }
                 }
             }
 
             // manage deleting old logo
-            if (!count($this->errors) && @filemtime(_PS_IMG_DIR_ . Configuration::get($fieldName)) && $deleteOldLogo) {
+            if (!count($this->errors) && @filemtime(_PS_IMG_DIR_ . Configuration::get($fieldName))) {
                 if (Shop::isFeatureActive()) {
                     $this->updateInMultiShopContext($idShop, $idShopGroup, $fieldName);
                 } else {

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -49,6 +49,11 @@ class LogoUploader
      */
     private $errors = [];
 
+    /**
+     * @var array - a list of svg mime types
+     */
+    protected const SVG_MIMETYPES = ['image/svg+xml', 'image/svg'];
+
     public function __construct(Shop $shop)
     {
         $this->shop = $shop;
@@ -112,7 +117,7 @@ class LogoUploader
             }
 
             $fileExtension = ($fieldName == 'PS_STORES_ICON') ? '.gif' : '.jpg';
-            if (in_array($files[$fieldName]['type'], ['image/svg+xml', 'image/svg'])) {
+            if ($this->isSvgMimeType($files[$fieldName]['type'])) {
                 $fileExtension = '.svg';
             }
             $logoName = $this->getLogoName($logoPrefix, $fileExtension);
@@ -122,7 +127,7 @@ class LogoUploader
                     throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop icon %s.', $logoName));
                 }
             } else {
-                if (in_array($files[$fieldName]['type'], ['image/svg+xml', 'image/svg'])) {
+                if ($this->isSvgMimeType($files[$fieldName]['type'])) {
                     if (!copy($tmpName, _PS_IMG_DIR_ . $logoName)) {
                         throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop logo %s.', $logoName));
                     }
@@ -149,6 +154,11 @@ class LogoUploader
         }
 
         return false;
+    }
+
+    public function isSvgMimeType(string $mimeType): bool
+    {
+        return (bool) in_array($mimeType, self::SVG_MIMETYPES);
     }
 
     private function updateInMultiShopContext(&$idShop, &$idShopGroup, $fieldName)

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -117,9 +117,10 @@ class LogoUploader
                 throw new PrestaShopException(sprintf('%Upload of temporary file to %s has failed.', $tmpName));
             }
 
-            $fileExtension = ($fieldName == 'PS_STORES_ICON') ? '.gif' : '.jpg';
             if ($this->isSvgMimeType($files[$fieldName]['type'])) {
                 $fileExtension = '.svg';
+            } else {
+                $fileExtension = ($fieldName == 'PS_STORES_ICON') ? '.gif' : '.jpg';
             }
             $logoName = $this->getLogoName($logoPrefix, $fileExtension);
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -602,7 +602,7 @@ class ThemeController extends AbstractAdminController
         );
 
         $mailAndInvoiceImageFormatError = $this->trans(
-            'Image format not recognized, allowed format(s) is(are): .%s',
+            'Image format not recognized, allowed formats are: %s',
             'Admin.Notifications.Error',
             [$availableMailAndInvoiceFormatsImploded]
         );

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Meta\QueryResult\LayoutCustomizationPage;
 use PrestaShop\PrestaShop\Core\Domain\Shop\DTO\ShopLogoSettings;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedFaviconExtensionException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedLogoImageExtensionException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedMailAndInvoiceImageExtensionException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Query\GetLogosPaths;
 use PrestaShop\PrestaShop\Core\Domain\Shop\QueryResult\LogosPaths;
 use PrestaShop\PrestaShop\Core\Domain\Theme\Command\AdaptThemeToRTLLanguagesCommand;
@@ -591,12 +592,19 @@ class ThemeController extends AbstractAdminController
     private function getLogoUploadErrorMessages(DomainException $exception)
     {
         $availableLogoFormatsImploded = implode(', .', ShopLogoSettings::AVAILABLE_LOGO_IMAGE_EXTENSIONS);
+        $availableMailAndInvoiceFormatsImploded = implode(', .', ShopLogoSettings::AVAILABLE_MAIL_AND_INVOICE_LOGO_IMAGE_EXTENSIONS);
         $availableIconFormat = ShopLogoSettings::AVAILABLE_ICON_IMAGE_EXTENSION;
 
         $logoImageFormatError = $this->trans(
             'Image format not recognized, allowed format(s) is(are): .%s',
             'Admin.Notifications.Error',
             [$availableLogoFormatsImploded]
+        );
+
+        $mailAndInvoiceImageFormatError = $this->trans(
+            'Image format not recognized, allowed format(s) is(are): .%s',
+            'Admin.Notifications.Error',
+            [$availableMailAndInvoiceFormatsImploded]
         );
 
         $iconFormatError = $this->trans(
@@ -607,6 +615,7 @@ class ThemeController extends AbstractAdminController
 
         return [
             NotSupportedLogoImageExtensionException::class => $logoImageFormatError,
+            NotSupportedMailAndInvoiceImageExtensionException::class => $mailAndInvoiceImageFormatError,
             NotSupportedFaviconExtensionException::class => $iconFormatError,
             FileUploadException::class => [
                 UPLOAD_ERR_INI_SIZE => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Theme/ShopLogosType.php
@@ -81,25 +81,23 @@ class ShopLogosType extends AbstractType
     {
         $shopLogoSettings = new ShopLogoSettings();
 
-        $availableLogoFileTypes = implode(',', $shopLogoSettings->getLogoImageExtensionsWithDot());
-
         $builder
             ->add('header_logo', FileType::class, [
                 'required' => false,
                 'attr' => [
-                    'accept' => $availableLogoFileTypes,
+                    'accept' => implode(',', $shopLogoSettings->getLogoImageExtensionsWithDot()),
                 ],
             ])
             ->add('mail_logo', FileType::class, [
                 'required' => false,
                 'attr' => [
-                    'accept' => $availableLogoFileTypes,
+                    'accept' => implode(',', $shopLogoSettings->getLogoImageExtensionsWithDot('PS_LOGO_MAIL')),
                 ],
             ])
             ->add('invoice_logo', FileType::class, [
                 'required' => false,
                 'attr' => [
-                    'accept' => $availableLogoFileTypes,
+                    'accept' => implode(',', $shopLogoSettings->getLogoImageExtensionsWithDot('PS_LOGO_INVOICE')),
                 ],
             ])
             ->add('favicon', FileType::class, [

--- a/tests/Unit/Core/Domain/Shop/Command/UploadLogosCommandTest.php
+++ b/tests/Unit/Core/Domain/Shop/Command/UploadLogosCommandTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\Exception\FileUploadException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Command\UploadLogosCommand;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedLogoImageExtensionException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\NotSupportedMailAndInvoiceImageExtensionException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadLogosCommandTest extends TestCase
@@ -55,6 +56,26 @@ class UploadLogosCommandTest extends TestCase
         $uploadLogosCommand = new UploadLogosCommand();
         $uploadedFile = new UploadedFile(__FILE__, basename(__FILE__));
         $uploadLogosCommand->setUploadedHeaderLogo($uploadedFile);
+    }
+
+    public function testSetUploadedMailLogoNotValidHeaderLogoImage(): void
+    {
+        $this->expectException(NotSupportedMailAndInvoiceImageExtensionException::class);
+        $this->expectExceptionMessage('Not supported "php" image logo extension. Supported extensions are "gif,jpg,jpeg,jpe,png,webp"');
+
+        $uploadLogosCommand = new UploadLogosCommand();
+        $uploadedFile = new UploadedFile(__FILE__, basename(__FILE__));
+        $uploadLogosCommand->setUploadedMailLogo($uploadedFile);
+    }
+
+    public function testSetUploadedInvoiceLogoNotValidHeaderLogoImage(): void
+    {
+        $this->expectException(NotSupportedMailAndInvoiceImageExtensionException::class);
+        $this->expectExceptionMessage('Not supported "php" image logo extension. Supported extensions are "gif,jpg,jpeg,jpe,png,webp"');
+
+        $uploadLogosCommand = new UploadLogosCommand();
+        $uploadedFile = new UploadedFile(__FILE__, basename(__FILE__));
+        $uploadLogosCommand->setUploadedInvoiceLogo($uploadedFile);
     }
 
     public function testSetUploadedHeaderLogoNativeFileValidationDoesFail(): void
@@ -85,9 +106,59 @@ class UploadLogosCommandTest extends TestCase
     }
 
     /**
+     * @dataProvider dataProviderSetUploadedMailAndInvoiceLogo
+     *
+     * @param string $path
+     */
+    public function testSetUploadedMailLogo(string $path): void
+    {
+        $uploadLogosCommand = new UploadLogosCommand();
+        $uploadedFile = new UploadedFile($path, basename($path));
+        $uploadLogosCommand->setUploadedMailLogo($uploadedFile);
+
+        self::assertSame(
+            $uploadedFile,
+            $uploadLogosCommand->getUploadedMailLogo()
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderSetUploadedMailAndInvoiceLogo
+     *
+     * @param string $path
+     */
+    public function testSetUploadedInvoiceLogo(string $path): void
+    {
+        $uploadLogosCommand = new UploadLogosCommand();
+        $uploadedFile = new UploadedFile($path, basename($path));
+        $uploadLogosCommand->setUploadedInvoiceLogo($uploadedFile);
+
+        self::assertSame(
+            $uploadedFile,
+            $uploadLogosCommand->getUploadedInvoiceLogo()
+        );
+    }
+
+    /**
      * @return array<int, array<int, string>>
      */
     public function dataProviderSetUploadedHeaderLogo(): array
+    {
+        return [
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.gif'],
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.jpe'],
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.jpg'],
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.jpeg'],
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.png'],
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.webp'],
+            [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.svg'],
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public function dataProviderSetUploadedMailAndInvoiceLogo(): array
     {
         return [
             [_PS_ROOT_DIR_ . '/tests/Unit/Resources/assets/img/logo.gif'],

--- a/tests/Unit/Core/Domain/Shop/Command/UploadLogosCommandTest.php
+++ b/tests/Unit/Core/Domain/Shop/Command/UploadLogosCommandTest.php
@@ -50,7 +50,7 @@ class UploadLogosCommandTest extends TestCase
     public function testSetUploadedHeaderLogoNotValidHeaderLogoImage(): void
     {
         $this->expectException(NotSupportedLogoImageExtensionException::class);
-        $this->expectExceptionMessage('Not supported "php" image logo extension. Supported extensions are "gif,jpg,jpeg,jpe,png,webp"');
+        $this->expectExceptionMessage('Not supported "php" image logo extension. Supported extensions are "gif,jpg,jpeg,jpe,png,webp,svg"');
 
         $uploadLogosCommand = new UploadLogosCommand();
         $uploadedFile = new UploadedFile(__FILE__, basename(__FILE__));

--- a/tests/Unit/Core/Domain/Shop/DTO/ShopLogoSettingsTest.php
+++ b/tests/Unit/Core/Domain/Shop/DTO/ShopLogoSettingsTest.php
@@ -38,7 +38,7 @@ class ShopLogoSettingsTest extends TestCase
         $shopLogoSettings = new ShopLogoSettings();
 
         self::assertSame(
-            ['.gif', '.jpg', '.jpeg', '.jpe', '.png', '.webp'],
+            ['.gif', '.jpg', '.jpeg', '.jpe', '.png', '.webp', '.svg'],
             $shopLogoSettings->getLogoImageExtensionsWithDot()
         );
     }

--- a/tests/Unit/Resources/assets/img/logo.svg
+++ b/tests/Unit/Resources/assets/img/logo.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="620" height="472" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <path id="b" d="m0 0h77v210h-77z" stroke="#000" stroke-width="2"/>
+  <path id="a" d="m0 0h77v60h-77z" stroke="#000" stroke-width="2"/>
+ </defs>
+ <path d="m0 0h620v472h-620z" fill="#fff"/>
+ <g transform="translate(2 1)">
+  <use fill="#fff" xlink:href="#b"/>
+  <use x="77" fill="#ff0" xlink:href="#b"/>
+  <use x="154" fill="#0ff" xlink:href="#b"/>
+  <use x="231" fill="#0f0" xlink:href="#b"/>
+  <use x="308" fill="#f0f" xlink:href="#b"/>
+  <use x="385" fill="red" xlink:href="#b"/>
+  <use x="462" fill="#00f" xlink:href="#b"/>
+  <use x="539" xlink:href="#b"/>
+ </g>
+ <g transform="translate(2 230)">
+  <use fill="red" xlink:href="#a"/>
+  <use x="77" fill="red" xlink:href="#a"/>
+  <use x="154" fill="#fff" xlink:href="#a"/>
+  <use x="231" fill="#fff" xlink:href="#a"/>
+  <use x="308" fill="red" xlink:href="#a"/>
+  <use x="385" fill="red" xlink:href="#a"/>
+  <use x="462" fill="#fff" xlink:href="#a"/>
+  <use x="539" fill="#fff" xlink:href="#a"/>
+ </g>
+ <g transform="translate(2 312)">
+  <use fill="#0f0" xlink:href="#a"/>
+  <use x="77" fill="#0f0" xlink:href="#a"/>
+  <use x="154" fill="#0f0" xlink:href="#a"/>
+  <use x="231" fill="#0f0" xlink:href="#a"/>
+  <use x="308" fill="#fff" xlink:href="#a"/>
+  <use x="385" fill="#fff" xlink:href="#a"/>
+  <use x="462" fill="#fff" xlink:href="#a"/>
+  <use x="539" fill="#fff" xlink:href="#a"/>
+ </g>
+ <g transform="translate(2 392)">
+  <use fill="#00f" xlink:href="#a"/>
+  <use x="77" fill="#fff" xlink:href="#a"/>
+  <use x="154" fill="#00f" xlink:href="#a"/>
+  <use x="231" fill="#fff" xlink:href="#a"/>
+  <use x="308" fill="#00f" xlink:href="#a"/>
+  <use x="385" fill="#fff" xlink:href="#a"/>
+  <use x="462" fill="#00f" xlink:href="#a"/>
+  <use x="539" fill="#fff" xlink:href="#a"/>
+ </g>
+ <text font-family="DejaVu Sans" stroke-width="4" x="310" y="174.47" font-size="180" text-anchor="middle">TEST</text>
+</svg>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop 
| Description?  | support shop logo in svg
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/17673
| How to test?  |  add a svg logo

It's a non sense to resize a svg file, it's vector graphic, the file is simply copied.
Svg is badly supported in email readers and not supported in pdf, so if the user upload an svg file for the shop logo the old logo is set for email and invoice in pdf.
The old logo should be in a supported format (jpg, gif, ...)

Just a point:
Il the same jpg/png logo is used in header and mail/invoice this PR add a this behavior :
- The user upload a svg logo in the header
- Then the old  jpg/png logo is set to email/invoice if none has been set

By consequence, if you upload a new jpg/png logo in header replacing svg logo, the mail/invoice will not be affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/21627)
<!-- Reviewable:end -->
