### PR TITLE
Display module's multistore compatibility in description

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -85,6 +85,12 @@
   text-align: justify;
 }
 
+.module-readmore-multistore-content {
+  padding: 5px 15px;
+  margin-top: -60px;
+  text-align: justify;
+}
+
 .module-menu-readmore > .tab-content {
   margin-top: 5px;
   color: #000;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3522,7 +3522,7 @@ abstract class ModuleCore implements ModuleInterface
                 self::MULTISTORE_COMPATIBILITY_YES,
             ]
         )) {
-            throw new PrestaShopException(sprintf('Value %s is not a valid module compatibility value', $compatibility));
+            throw new PrestaShopException(sprintf('Value %s is not a valid multistore compatibility value', $compatibility));
         }
 
         $this->multistoreCompatibility = $compatibility;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -205,7 +205,7 @@ abstract class ModuleCore implements ModuleInterface
     /** @var array|null used to cache module ids */
     protected static $cachedModuleNames = null;
 
-    /** @var int Define the multistore compatibility level of the module */
+    /** @var int|null Define the multistore compatibility level of the module */
     public $multistoreCompatibility;
 
     const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
@@ -222,10 +222,10 @@ abstract class ModuleCore implements ModuleInterface
     const CACHE_FILE_TRUSTED_MODULES_LIST = '/config/xml/trusted_modules_list.xml';
     const CACHE_FILE_UNTRUSTED_MODULES_LIST = '/config/xml/untrusted_modules_list.xml';
 
-    const MULTISTORE_COMPATIBILITY_NO = 0;
-    const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = 1;
-    const MULTISTORE_COMPATIBILITY_PARTIAL = 2;
-    const MULTISTORE_COMPATIBILITY_YES = 3;
+    public const MULTISTORE_COMPATIBILITY_NO = 0;
+    public const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = 1;
+    public const MULTISTORE_COMPATIBILITY_PARTIAL = 2;
+    public const MULTISTORE_COMPATIBILITY_YES = 3;
 
     public static $hosted_modules_blacklist = ['autoupgrade'];
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -206,7 +206,7 @@ abstract class ModuleCore implements ModuleInterface
     protected static $cachedModuleNames = null;
 
     /** @var int|null Define the multistore compatibility level of the module */
-    public $multistoreCompatibility;
+    private $multistoreCompatibility;
 
     const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
 
@@ -3504,6 +3504,38 @@ abstract class ModuleCore implements ModuleInterface
     public function saveDashConfig(array $config)
     {
         return false;
+    }
+
+    /**
+     * @param int $compatibility
+     *
+     * @return $this
+     */
+    public function setMultistoreCompatibility(int $compatibility): self
+    {
+        if (!in_array(
+            $compatibility,
+            [
+                self::MULTISTORE_COMPATIBILITY_NO,
+                self::MULTISTORE_COMPATIBILITY_NOT_CONCERNED,
+                self::MULTISTORE_COMPATIBILITY_PARTIAL,
+                self::MULTISTORE_COMPATIBILITY_YES,
+            ]
+        )) {
+            throw new PrestaShopException(sprintf('Value %s is not a valid module compatibility value', $compatibility));
+        }
+
+        $this->multistoreCompatibility = $compatibility;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMultistoreCompatibility(): ?int
+    {
+        return $this->multistoreCompatibility;
     }
 }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3510,9 +3510,9 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * Returns the declared multistore compatibility level
      *
-     * @return int|null
+     * @return int
      */
-    public function getMultistoreCompatibility(): ?int
+    public function getMultistoreCompatibility(): int
     {
         return $this->multistoreCompatibility;
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -205,6 +205,9 @@ abstract class ModuleCore implements ModuleInterface
     /** @var array|null used to cache module ids */
     protected static $cachedModuleNames = null;
 
+    /** @var int Define the multistore compatibility level of the module */
+    public $multistoreCompatibility;
+
     const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
 
     const CACHE_FILE_TAB_MODULES_LIST = '/config/xml/tab_modules_list.xml';
@@ -218,6 +221,11 @@ abstract class ModuleCore implements ModuleInterface
 
     const CACHE_FILE_TRUSTED_MODULES_LIST = '/config/xml/trusted_modules_list.xml';
     const CACHE_FILE_UNTRUSTED_MODULES_LIST = '/config/xml/untrusted_modules_list.xml';
+
+    const MULTISTORE_COMPATIBILITY_NO = 0;
+    const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = 1;
+    const MULTISTORE_COMPATIBILITY_PARTIAL = 2;
+    const MULTISTORE_COMPATIBILITY_YES = 3;
 
     public static $hosted_modules_blacklist = ['autoupgrade'];
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -205,8 +205,8 @@ abstract class ModuleCore implements ModuleInterface
     /** @var array|null used to cache module ids */
     protected static $cachedModuleNames = null;
 
-    /** @var int|null Define the multistore compatibility level of the module */
-    private $multistoreCompatibility;
+    /** @var int Defines the multistore compatibility level of the module */
+    public $multistoreCompatibility = self::MULTISTORE_COMPATIBILITY_UNKNOWN;
 
     const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
 
@@ -222,10 +222,11 @@ abstract class ModuleCore implements ModuleInterface
     const CACHE_FILE_TRUSTED_MODULES_LIST = '/config/xml/trusted_modules_list.xml';
     const CACHE_FILE_UNTRUSTED_MODULES_LIST = '/config/xml/untrusted_modules_list.xml';
 
-    public const MULTISTORE_COMPATIBILITY_NO = 0;
-    public const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = 1;
-    public const MULTISTORE_COMPATIBILITY_PARTIAL = 2;
-    public const MULTISTORE_COMPATIBILITY_YES = 3;
+    public const MULTISTORE_COMPATIBILITY_NO = -20;
+    public const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = -10;
+    public const MULTISTORE_COMPATIBILITY_UNKNOWN = 0;
+    public const MULTISTORE_COMPATIBILITY_PARTIAL = 10;
+    public const MULTISTORE_COMPATIBILITY_YES = 20;
 
     public static $hosted_modules_blacklist = ['autoupgrade'];
 
@@ -3507,30 +3508,8 @@ abstract class ModuleCore implements ModuleInterface
     }
 
     /**
-     * @param int $compatibility
+     * Returns the declared multistore compatibility level
      *
-     * @return $this
-     */
-    public function setMultistoreCompatibility(int $compatibility): self
-    {
-        if (!in_array(
-            $compatibility,
-            [
-                self::MULTISTORE_COMPATIBILITY_NO,
-                self::MULTISTORE_COMPATIBILITY_NOT_CONCERNED,
-                self::MULTISTORE_COMPATIBILITY_PARTIAL,
-                self::MULTISTORE_COMPATIBILITY_YES,
-            ]
-        )) {
-            throw new PrestaShopException(sprintf('Value %s is not a valid multistore compatibility value', $compatibility));
-        }
-
-        $this->multistoreCompatibility = $compatibility;
-
-        return $this;
-    }
-
-    /**
      * @return int|null
      */
     public function getMultistoreCompatibility(): ?int

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Presenter\Module;
 use Currency;
 use Exception;
 use Hook;
+use Module as LegacyModule;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
@@ -67,7 +68,8 @@ class ModulePresenter implements PresenterInterface
         $attributes['starsRate'] = str_replace('.', '', round($attributes['avgRate'] * 2) / 2); // Round to the nearest 0.5
 
         $moduleInstance = $module->getInstance();
-        if ($moduleInstance instanceof Module) {
+
+        if ($moduleInstance instanceof LegacyModule) {
             $attributes['multistoreCompatibility'] = $moduleInstance->getMultistoreCompatibility();
         }
 

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -67,7 +67,7 @@ class ModulePresenter implements PresenterInterface
         $attributes['starsRate'] = str_replace('.', '', round($attributes['avgRate'] * 2) / 2); // Round to the nearest 0.5
 
         $moduleInstance = $module->getInstance();
-        if ($moduleInstance !== null && $moduleInstance->getMultistoreCompatibility() !== null) {
+        if ($moduleInstance !== null) {
             $attributes['multistoreCompatibility'] = $moduleInstance->getMultistoreCompatibility();
         }
 

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -67,7 +67,7 @@ class ModulePresenter implements PresenterInterface
         $attributes['starsRate'] = str_replace('.', '', round($attributes['avgRate'] * 2) / 2); // Round to the nearest 0.5
 
         $moduleInstance = $module->getInstance();
-        if ($moduleInstance !== null) {
+        if ($moduleInstance instanceof Module) {
             $attributes['multistoreCompatibility'] = $moduleInstance->getMultistoreCompatibility();
         }
 

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -67,8 +67,8 @@ class ModulePresenter implements PresenterInterface
         $attributes['starsRate'] = str_replace('.', '', round($attributes['avgRate'] * 2) / 2); // Round to the nearest 0.5
 
         $moduleInstance = $module->getInstance();
-        if ($moduleInstance !== null && $moduleInstance->multistoreCompatibility !== null) {
-            $attributes['multistoreCompatibility'] = $moduleInstance->multistoreCompatibility;
+        if ($moduleInstance !== null && $moduleInstance->getMultistoreCompatibility() !== null) {
+            $attributes['multistoreCompatibility'] = $moduleInstance->getMultistoreCompatibility();
         }
 
         $result = [

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -66,6 +66,11 @@ class ModulePresenter implements PresenterInterface
         $attributes['price'] = $this->getModulePrice($attributes['price']);
         $attributes['starsRate'] = str_replace('.', '', round($attributes['avgRate'] * 2) / 2); // Round to the nearest 0.5
 
+        $moduleInstance = $module->getInstance();
+        if ($moduleInstance !== null && $moduleInstance->multistoreCompatibility !== null) {
+            $attributes['multistoreCompatibility'] = $moduleInstance->multistoreCompatibility;
+        }
+
         $result = [
             'attributes' => $attributes,
             'disk' => $module->disk->all(),

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -121,18 +121,18 @@
             {% if module.attributes.multistoreCompatibility is defined %}
               <div class="module-readmore-multistore-content">
                 <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Notification') }}</h3>
-                {% if module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_YES') %}
+                {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}
                   {{ 'Yes: this module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Notification') }}
                   <ul>
                     <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Notification') }}</li>
                     <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Notification') }}</li>
                     <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Notification') }}</li>
                   </ul>
-                {% elseif module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL') %}
+                {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL')) %}
                   {{ 'Partially: this module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Notification') }}
-                {% elseif module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED') %}
+                {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED')) %}
                   {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Notification') }}
-                {% elseif module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_NO') %}
+                {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NO')) %}
                   {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Notification') }}
                 {% endif %}
               </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -120,20 +120,20 @@
             </p>
             {% if module.attributes.multistoreCompatibility is defined and module.attributes.multistoreCompatibility is not null %}
               <div class="module-readmore-multistore-content">
-                <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Notification') }}</h3>
+                <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Feature') }}</h3>
                 {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}
-                  {{ 'Yes: this module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Notification') }}
+                  {{ 'Yes: this module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Feature') }}
                   <ul>
-                    <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Notification') }}</li>
-                    <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Notification') }}</li>
-                    <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Notification') }}</li>
+                    <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Feature') }}</li>
+                    <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Feature') }}</li>
+                    <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Feature') }}</li>
                   </ul>
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL')) %}
-                  {{ 'Partially: this module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Notification') }}
+                  {{ 'Partially: this module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED')) %}
-                  {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Notification') }}
+                  {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NO')) %}
-                  {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Notification') }}
+                  {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Feature') }}
                 {% endif %}
               </div>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -122,7 +122,7 @@
               <div class="module-readmore-multistore-content">
                 <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Feature') }}</h3>
                 {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}
-                  {{ 'Yes: this module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Feature') }}
+                  {{ 'This module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Feature') }}
                   <ul>
                     <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Feature') }}</li>
                     <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Feature') }}</li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -129,7 +129,7 @@
                     <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Feature') }}</li>
                   </ul>
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL')) %}
-                  {{ 'Partially: this module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Feature') }}
+                  {{ 'This module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED')) %}
                   {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NO')) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -131,7 +131,7 @@
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL')) %}
                   {{ 'This module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED')) %}
-                  {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Feature') }}
+                  {{ 'This module is not compatible with the multistore feature because it would not be useful.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NO')) %}
                   {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Feature') }}
                 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -118,6 +118,25 @@
                 {{ 'No description found for this module :('|trans({}, 'Admin.Modules.Notification') }}
               {% endif %}
             </p>
+            {% if module.attributes.multistoreCompatibility is defined %}
+              <div class="module-readmore-multistore-content">
+                <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Notification') }}</h3>
+                {% if module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_YES') %}
+                  {{ 'Yes: this module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Notification') }}
+                  <ul>
+                    <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Notification') }}</li>
+                    <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Notification') }}</li>
+                    <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Notification') }}</li>
+                  </ul>
+                {% elseif module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL') %}
+                  {{ 'Partially: this module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Notification') }}
+                {% elseif module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED') %}
+                  {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Notification') }}
+                {% elseif module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_NO') %}
+                  {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Notification') }}
+                {% endif %}
+              </div>
+            {% endif %}
           </div>
 
           <div id="additional-{{ name }}" class="tab-pane fade">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -121,18 +121,18 @@
             {% if module.attributes.multistoreCompatibility is defined %}
               <div class="module-readmore-multistore-content">
                 <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Notification') }}</h3>
-                {% if module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_YES') %}
+                {% if module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_YES') %}
                   {{ 'Yes: this module is compatible with the multistore feature. It can be either:'|trans({}, 'Admin.Modules.Notification') }}
                   <ul>
                     <li>{{ 'configured differently from one store to another;'|trans({}, 'Admin.Modules.Notification') }}</li>
                     <li>{{ 'configured quickly in the same way on all stores thanks to the all shops context or to the group of shops;'|trans({}, 'Admin.Modules.Notification') }}</li>
                     <li>{{ 'or even activated for one store and deactivated for another.'|trans({}, 'Admin.Modules.Notification') }}</li>
                   </ul>
-                {% elseif module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL') %}
+                {% elseif module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_PARTIAL') %}
                   {{ 'Partially: this module is partially compatible with the multistore feature. Some of its options might not be available.'|trans({}, 'Admin.Modules.Notification') }}
-                {% elseif module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED') %}
+                {% elseif module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED') %}
                   {{ 'Not concerned: this module is not compatible with the multistore feature because it wouldn\'t be useful.'|trans({}, 'Admin.Modules.Notification') }}
-                {% elseif module.attributes.multistoreCompatibility == constant('\\Module::MULTISTORE_COMPATIBILITY_NO') %}
+                {% elseif module.attributes.multistoreCompatibility === constant('\\Module::MULTISTORE_COMPATIBILITY_NO') %}
                   {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Notification') }}
                 {% endif %}
               </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -118,7 +118,7 @@
                 {{ 'No description found for this module :('|trans({}, 'Admin.Modules.Notification') }}
               {% endif %}
             </p>
-            {% if module.attributes.multistoreCompatibility is defined %}
+            {% if module.attributes.multistoreCompatibility is not null %}
               <div class="module-readmore-multistore-content">
                 <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Notification') }}</h3>
                 {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -118,7 +118,7 @@
                 {{ 'No description found for this module :('|trans({}, 'Admin.Modules.Notification') }}
               {% endif %}
             </p>
-            {% if module.attributes.multistoreCompatibility is defined and module.attributes.multistoreCompatibility is not null %}
+            {% if module.attributes.multistoreCompatibility is defined and module.attributes.multistoreCompatibility is not same as(constant('\\Module::MULTISTORE_COMPATIBILITY_UNKNOWN')) %}
               <div class="module-readmore-multistore-content">
                 <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Feature') }}</h3>
                 {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -133,7 +133,7 @@
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NOT_CONCERNED')) %}
                   {{ 'This module is not compatible with the multistore feature because it would not be useful.'|trans({}, 'Admin.Modules.Feature') }}
                 {% elseif module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_NO')) %}
-                  {{ 'No: this module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Feature') }}
+                  {{ 'This module is not compatible with the multistore feature. It means that its configuration applies for all stores.'|trans({}, 'Admin.Modules.Feature') }}
                 {% endif %}
               </div>
             {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -118,7 +118,7 @@
                 {{ 'No description found for this module :('|trans({}, 'Admin.Modules.Notification') }}
               {% endif %}
             </p>
-            {% if module.attributes.multistoreCompatibility is not null %}
+            {% if module.attributes.multistoreCompatibility is defined and module.attributes.multistoreCompatibility is not null %}
               <div class="module-readmore-multistore-content">
                 <h3>{{ 'Multistore compatibility:'|trans({}, 'Admin.Modules.Notification') }}</h3>
                 {% if module.attributes.multistoreCompatibility is same as(constant('\\Module::MULTISTORE_COMPATIBILITY_YES')) %}

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -92,7 +92,7 @@ class ModuleCoreTest extends TestCase
     /**
      * @dataProvider setMultistoreCompatibilityProvider
      */
-    public function testSetAndGetMultistoreCompatibility(): void
+    public function testGetDefaultMultistoreCompatibility(): void
     {
         $module = new FakeModule();
         $this->assertEquals(FakeModule::MULTISTORE_COMPATIBILITY_UNKNOWN, $module->getMultistoreCompatibility());

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -96,7 +96,7 @@ class ModuleCoreTest extends TestCase
      *
      * @dataProvider setMultistoreCompatibilityProvider
      */
-    public function testSetAndGetMultistoreCompatibility(int $multistoreCompatibility, bool $throwsException)
+    public function testSetAndGetMultistoreCompatibility(int $multistoreCompatibility, bool $throwsException): void
     {
         $module = new FakeModule();
         if ($throwsException) {

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -113,7 +113,7 @@ class ModuleCoreTest extends TestCase
     /**
      * @return array[]
      */
-    public function setMultistoreCompatibilityProvider()
+    public function setMultistoreCompatibilityProvider(): array
     {
         return [
             [FakeModule::MULTISTORE_COMPATIBILITY_NO, false],

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -28,7 +28,6 @@ namespace LegacyTests\Unit\Classes\Module;
 
 use Module;
 use PHPUnit\Framework\TestCase;
-use PrestaShopExceptionCore;
 use Symfony\Component\DomCrawler\Crawler;
 
 class FakeModule extends Module
@@ -91,36 +90,11 @@ class ModuleCoreTest extends TestCase
     }
 
     /**
-     * @param int $multistoreCompatibility
-     * @param bool $throwsException
-     *
      * @dataProvider setMultistoreCompatibilityProvider
      */
-    public function testSetAndGetMultistoreCompatibility(int $multistoreCompatibility, bool $throwsException): void
+    public function testSetAndGetMultistoreCompatibility(): void
     {
         $module = new FakeModule();
-        if ($throwsException) {
-            $this->expectException(PrestaShopExceptionCore::class);
-        }
-
-        $module->setMultistoreCompatibility($multistoreCompatibility);
-
-        if (!$throwsException) {
-            $this->assertEquals($multistoreCompatibility, $module->getMultistoreCompatibility());
-        }
-    }
-
-    /**
-     * @return array[]
-     */
-    public function setMultistoreCompatibilityProvider(): array
-    {
-        return [
-            [FakeModule::MULTISTORE_COMPATIBILITY_NO, false],
-            [FakeModule::MULTISTORE_COMPATIBILITY_NOT_CONCERNED, false],
-            [FakeModule::MULTISTORE_COMPATIBILITY_PARTIAL, false],
-            [FakeModule::MULTISTORE_COMPATIBILITY_YES, false],
-            [7, true],
-        ];
+        $this->assertEquals(FakeModule::MULTISTORE_COMPATIBILITY_UNKNOWN, $module->getMultistoreCompatibility());
     }
 }

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -121,7 +121,6 @@ class ModuleCoreTest extends TestCase
             [FakeModule::MULTISTORE_COMPATIBILITY_PARTIAL, false],
             [FakeModule::MULTISTORE_COMPATIBILITY_YES, false],
             [7, true],
-            [15, true],
         ];
     }
 }

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -90,7 +90,7 @@ class ModuleCoreTest extends TestCase
     }
 
     /**
-     * @dataProvider setMultistoreCompatibilityProvider
+     * @return void
      */
     public function testGetDefaultMultistoreCompatibility(): void
     {

--- a/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
+++ b/tests-legacy/Unit/Classes/Module/ModuleCoreTest.php
@@ -28,6 +28,7 @@ namespace LegacyTests\Unit\Classes\Module;
 
 use Module;
 use PHPUnit\Framework\TestCase;
+use PrestaShopExceptionCore;
 use Symfony\Component\DomCrawler\Crawler;
 
 class FakeModule extends Module
@@ -73,11 +74,11 @@ class ModuleCoreTest extends TestCase
     public function testDisplayErrorShouldReturnMultipleErrors()
     {
         // given
-        $errors = array(
+        $errors = [
             'Error 1',
             'Error 2',
             'Error 3',
-        );
+        ];
 
         $module = new FakeModule();
 
@@ -87,5 +88,40 @@ class ModuleCoreTest extends TestCase
         // then
         $crawler = new Crawler($htmlOutput);
         $this->assertCount(3, $crawler->filter('.module_error li'));
+    }
+
+    /**
+     * @param int $multistoreCompatibility
+     * @param bool $throwsException
+     *
+     * @dataProvider setMultistoreCompatibilityProvider
+     */
+    public function testSetAndGetMultistoreCompatibility(int $multistoreCompatibility, bool $throwsException)
+    {
+        $module = new FakeModule();
+        if ($throwsException) {
+            $this->expectException(PrestaShopExceptionCore::class);
+        }
+
+        $module->setMultistoreCompatibility($multistoreCompatibility);
+
+        if (!$throwsException) {
+            $this->assertEquals($multistoreCompatibility, $module->getMultistoreCompatibility());
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    public function setMultistoreCompatibilityProvider()
+    {
+        return [
+            [FakeModule::MULTISTORE_COMPATIBILITY_NO, false],
+            [FakeModule::MULTISTORE_COMPATIBILITY_NOT_CONCERNED, false],
+            [FakeModule::MULTISTORE_COMPATIBILITY_PARTIAL, false],
+            [FakeModule::MULTISTORE_COMPATIBILITY_YES, false],
+            [7, true],
+            [15, true],
+        ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make multistore compatibility declarative in modules, and display compatibility information in module's description, in BO's module management page.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20382
| How to test?      | See description below 
| Possible impacts? |  you could also check that module's description is still correctly displayed in the popin

## Description
This PR makes modules's multistore compatibility declarative in the module's main class, to do this I implemented the following modifications:

- added a `multistoreCompatibility` property in ModuleCore `classes/module/Module.php`
- added 4 constants in **ModuleCore**, describing the 4 levels of multistore compatibility, these constants are to be used with the `multistoreCompatibility`
- added a setter and a getter for this property
- displayed multistore compatibility information in the module's description, in BO, depending on `multistoreCompatibility` property.

## How to test

- choose a module to test, for example: block reassurance
- in `modules/blockreassurance/blockreassurance.php`, set the `setMultistoreCompatibility` attribute with one of the constant values, ex:<br> `public $setMultistoreCompatibility = self::MULTISTORE_COMPATIBILITY_NOT_CONCERNED;`
- in BO's module manager page, search for "reassurance" module, and click on "read more"
- under the "overview" tab, you should see the related multistore compatibility description

Then you can test it with different constants, available module's multistore compatibility constants are:
- MULTISTORE_COMPATIBILITY_YES
- MULTISTORE_COMPATIBILITY_PARTIAL
- MULTISTORE_COMPATIBILITY_NO
- MULTISTORE_COMPATIBILITY_NOT_CONCERNED

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23968)
<!-- Reviewable:end -->
