### PR TITLE
Fix glob result when path is outside open_basedir

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3058,15 +3058,13 @@ exit;
     public static function getDirectoriesWithGlob($path)
     {
         $directoryList = glob($path . '/*', GLOB_ONLYDIR | GLOB_NOSORT);
-        if ($directoryList === false) { // false is returned when path is outside open_basedir
-            return [];
+        if ($directoryList === false) {
+            $directoryList = [];
         }
-        array_walk(
-            $directoryList,
-            function (&$absolutePath, $key) {
-                $absolutePath = substr($absolutePath, strrpos($absolutePath, '/') + 1);
-            }
-        );
+
+        $directoryList = array_map(function ($path) {
+            return substr($path, strrpos($path, '/') + 1);
+        }, $directoryList);
 
         return $directoryList;
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3058,6 +3058,9 @@ exit;
     public static function getDirectoriesWithGlob($path)
     {
         $directoryList = glob($path . '/*', GLOB_ONLYDIR | GLOB_NOSORT);
+        if ($directoryList === false) { // false is returned when path is outside open_basedir
+            return [];
+        }
         array_walk(
             $directoryList,
             function (&$absolutePath, $key) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3059,7 +3059,7 @@ exit;
     {
         $directoryList = glob($path . '/*', GLOB_ONLYDIR | GLOB_NOSORT);
         if ($directoryList === false) {
-            $directoryList = [];
+            return [];
         }
 
         $directoryList = array_map(function ($path) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix glob result when path is outside open_basedir, see failed test case below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass
| Possible impacts? | no

```
There was 1 failure:
1) LegacyTests\Unit\Classes\ToolsCoreTest::testGetDirectories with data set #1 ('/builds/mvorisek/prestashop_e...st.php', false)
Results differ between getDirectoriesWithGlob and getDirectoriesWithReaddir for path /builds/mvorisek/prestashop_eshop/tests-legacy/Unit/Classes/ToolsCoreTest.php
Array () does not match expected type "boolean".
/builds/mvorisek/prestashop_eshop/tests-legacy/Unit/Classes/ToolsCoreTest.php:241
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23969)
<!-- Reviewable:end -->
