### PR TITLE
Fix unbounded dependency version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
     "symfony/polyfill-apcu": "^1.0",
     "symfony/polyfill-php73": "^1.10",
     "symfony/swiftmailer-bundle": "^3.1",
-    "symfony/symfony": ">=3.4.37",
+    "symfony/symfony": "^3.4.37",
     "tecnickcom/tcpdf": "^6.2.12",
     "tijsverkoyen/css-to-inline-styles": "^2.2",
     "twig/twig": "^1.38"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26b0d4f0c511a6fb6f9afe2d6fef1e91",
+    "content-hash": "9352849e367647c0df35b06c413b14f5",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix error reported by composer "require.symfony/symfony : unbound version constraints (>=3.4.37) should be avoided"
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Nothing to test


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23971)
<!-- Reviewable:end -->
