### PR TITLE
Fix ThemeExporterTest test path

### DIFF
--- a/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php
+++ b/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php
@@ -92,9 +92,7 @@ class ThemeExporterTest extends TestCase
         );
 
         $this->themeExporter->finder = $this->finderMock;
-        $cacheDir = dirname(__FILE__) . '/' .
-            str_repeat('../', 5) .
-            'app/cache/test';
+        $cacheDir = dirname(__DIR__, 4) . '/' . 'app/cache/test';
         $this->themeExporter->exportDir = $cacheDir . '/export';
         $this->themeExporter->cacheDir = $cacheDir;
     }

--- a/tests/Unit/PrestaShopBundle/Entity/FeatureFlagTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/FeatureFlagTest.php
@@ -39,6 +39,7 @@ class FeatureFlagTest extends TestCase
         $featureFlag = new FeatureFlag('PrestaShop');
 
         // assert nothing, this test aims to validate we can construct the entity
+        $this->assertTrue(true);
     }
 
     public function testFeatureFlagRequiresNotEmptyName()

--- a/tests/Unit/PrestaShopBundle/Entity/FeatureFlagTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/FeatureFlagTest.php
@@ -34,14 +34,6 @@ use PrestaShopBundle\Entity\FeatureFlag;
 
 class FeatureFlagTest extends TestCase
 {
-    public function testConstructFeatureFlag()
-    {
-        $featureFlag = new FeatureFlag('PrestaShop');
-
-        // assert nothing, this test aims to validate we can construct the entity
-        $this->assertTrue(true);
-    }
-
     public function testFeatureFlagRequiresNotEmptyName()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Previously, the path was built using one extra unwanted `../`
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass
| Possible impacts? | no

```
There was 1 error:
1) LegacyTests\PrestaShopBundle\Translation\Exporter\ThemeExporterTest::testCreateZipArchive
is_link(): open_basedir restriction in effect. File(/builds/mvorisek/prestashop_eshop/tests-legacy/PrestaShopBundle/Translation/Exporter/../../../../../app/cache/test/theme) is not within the allowed path(s): (/builds/mvorisek/prestashop_eshop:/tmp)
/builds/mvorisek/prestashop_eshop/vendor/symfony/symfony/src/Symfony/Component/Filesystem/Filesystem.php:171
/builds/mvorisek/prestashop_eshop/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php:205
/builds/mvorisek/prestashop_eshop/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php:128
/builds/mvorisek/prestashop_eshop/src/PrestaShopBundle/Translation/Exporter/ThemeExporter.php:109
/builds/mvorisek/prestashop_eshop/tests-legacy/PrestaShopBundle/Translation/Exporter/ThemeExporterTest.php:104
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23975)
<!-- Reviewable:end -->
