### PR TITLE
Add SpeedTrapListener to non-legacy phpunit config, also do not stop phpunit on failure

### DIFF
--- a/tests-legacy/old-controllers.xml
+++ b/tests-legacy/old-controllers.xml
@@ -6,7 +6,6 @@
   convertNoticesToExceptions  = "true"
   convertWarningsToExceptions = "true"
   processIsolation            = "true"
-  stopOnFailure               = "false"
   bootstrap                   =" bootstrap-controllers.php"
 >
   <php>

--- a/tests-legacy/phpunit-endpoints.xml
+++ b/tests-legacy/phpunit-endpoints.xml
@@ -1,5 +1,4 @@
-<phpunit stopOnFailure="true"
-         convertErrorsToExceptions="true"
+<phpunit convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="true"

--- a/tests-legacy/phpunit.xml
+++ b/tests-legacy/phpunit.xml
@@ -1,5 +1,4 @@
 <phpunit bootstrap="bootstrap.php"
-         stopOnFailure="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"

--- a/tests/Integration/phpunit.xml
+++ b/tests/Integration/phpunit.xml
@@ -1,5 +1,4 @@
 <phpunit bootstrap="bootstrap.php"
-         stopOnFailure="true"
          processIsolation="true"
 >
     <!-- process isolation is required since the introduction of GenerateMailTemplatesCommandTest file -->

--- a/tests/Unit/phpunit.xml
+++ b/tests/Unit/phpunit.xml
@@ -1,5 +1,4 @@
 <phpunit bootstrap="bootstrap.php"
-         stopOnFailure="true"
          backupGlobals="true"
 >
   <php>

--- a/tests/Unit/phpunit.xml
+++ b/tests/Unit/phpunit.xml
@@ -5,6 +5,9 @@
   <php>
     <server name="KERNEL_CLASS" value="AppKernel" />
   </php>
+    <listeners>
+        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+    </listeners>
     <testsuites>
         <testsuite name="Unit">
             <directory>.</directory>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `SpeedTrapListener` - help developer which test is slow and should be fixed, do not stop phpunit on failure - show developer always complete testing result to see if one thing break one test, or a whole set, standard practice for CI.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23979)
<!-- Reviewable:end -->
