### PR TITLE
Migrate make into composer script

### DIFF
--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -56,7 +56,7 @@ jobs:
         run: composer install --prefer-dist
 
       - name: Build assets
-        run: make assets
+        run: composer build-assets
 
       - name: Install PrestaShop
         run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
                 run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
 
             -   name: Build assets
-                run: make assets
+                run: composer build-assets
 
             -   name: Install PrestaShop
                 run: php install-dev/index_cli.php --language=en --country=fr --domain=localhost --db_server=127.0.0.1 --db_password=password --db_name=prestashop --db_create=1 --name=prestashop.unit.test --email=demo@prestashop.com --password=prestashop_demo

--- a/.github/workflows/sanity-72.yml
+++ b/.github/workflows/sanity-72.yml
@@ -62,8 +62,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: Composer install and build assets
-        run: make
+      - name: Composer Install
+        run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+
+      - name: Build assets
+        run: composer build-assets
 
       - run: |
           sudo chown www-data:www-data -R ${{ github.workspace }} && \

--- a/.github/workflows/sanity-73.yml
+++ b/.github/workflows/sanity-73.yml
@@ -62,8 +62,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: Composer install and build assets
-        run: make
+      - name: Composer Install
+        run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+
+      - name: Build assets
+        run: composer build-assets
 
       - run: |
           sudo chown www-data:www-data -R ${{ github.workspace }} && \

--- a/.github/workflows/sanity-74.yml
+++ b/.github/workflows/sanity-74.yml
@@ -62,8 +62,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: Composer install and build assets
-        run: make
+      - name: Composer Install
+        run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+
+      - name: Build assets
+        run: composer build-assets
 
       - run: |
           sudo chown www-data:www-data -R ${{ github.workspace }} && \

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -63,8 +63,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: Composer install and build assets
-        run: make
+      - name: Composer Install
+        run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+
+      - name: Build assets
+        run: composer build-assets
 
       - run: |
           sudo chown www-data:www-data -R ${{ github.workspace }} && \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-install: composer assets
-
-composer:
-	composer install
-
-assets:
-	./tools/assets/build.sh

--- a/composer.json
+++ b/composer.json
@@ -216,7 +216,7 @@
     "integration-behaviour-tests": [
       "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
     ],
-    "build-assets": "@sh tools/assets/build.sh",
+    "build-assets": "sh tools/assets/build.sh",
     "create-release": "@php tools/build/CreateRelease.php",
     "git-hook-install": "@php .github/contrib/install.php",
     "git-hook-uninstall": "@php .github/contrib/uninstall.php"

--- a/composer.json
+++ b/composer.json
@@ -175,7 +175,7 @@
       "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
     ],
     "create-test-db": [
-      "@php ./tests-legacy/create-test-db.php"
+      "@php tests-legacy/create-test-db.php"
     ],
     "test-all": [
       "@composer phpunit-admin",
@@ -188,33 +188,33 @@
     ],
     "phpunit-legacy": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests-legacy/phpunit.xml"
     ],
     "phpunit-endpoints": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
     ],
     "unit-tests": [
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests/Unit/phpunit.xml"
     ],
     "integration-tests": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests/Integration/phpunit.xml"
     ],
     "phpunit-admin": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-admin.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests-legacy/phpunit-admin.xml"
     ],
     "phpunit-sf": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/sf-tests.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests-legacy/sf-tests.xml"
     ],
     "phpunit-controllers": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/old-controllers.xml"
+      "@php -d date.timezone=UTC vendor/bin/phpunit -c tests-legacy/old-controllers.xml"
     ],
     "integration-behaviour-tests": [
-      "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
+      "@php -d date.timezone=UTC vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
     ],
     "build-assets": "sh tools/assets/build.sh",
     "create-release": "@php tools/build/CreateRelease.php",

--- a/composer.json
+++ b/composer.json
@@ -216,7 +216,7 @@
     "integration-behaviour-tests": [
       "@php -d date.timezone=UTC vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
     ],
-    "build-assets": "sh tools/assets/build.sh",
+    "build-assets": "bash tools/assets/build.sh",
     "create-release": "@php tools/build/CreateRelease.php",
     "git-hook-install": "@php .github/contrib/install.php",
     "git-hook-uninstall": "@php .github/contrib/uninstall.php"

--- a/composer.json
+++ b/composer.json
@@ -216,6 +216,7 @@
     "integration-behaviour-tests": [
       "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
     ],
+    "build-assets": "@sh tools/assets/build.sh",
     "create-release": "@php tools/build/CreateRelease.php",
     "git-hook-install": "@php .github/contrib/install.php",
     "git-hook-uninstall": "@php .github/contrib/uninstall.php"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migrate make into composer script. Also solves https://github.com/PrestaShop/PrestaShop/pull/23964#discussion_r610664149
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | GH CI must pass
| Possible impacts? | Developers using `make assets` must use `composer build-assets` now


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23982)
<!-- Reviewable:end -->
