### PR TITLE
WIP Fix error output when vendor dir/config is missing for CLI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,6 +67,9 @@ jobs:
       -   name: Composer Install
           run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
 
+      -   name: PrestaShop Configuration
+          run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml
+
       -   name: Run Lint Yaml on `src`
           run: php bin/console lint:yaml src
 
@@ -105,6 +108,9 @@ jobs:
 
       -   name: Composer Install
           run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+
+      -   name: PrestaShop Configuration
+          run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml
 
       -   name: Run Lint Twig
           run: php bin/console lint:twig src/PrestaShopBundle/Resources/views/

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -48,11 +48,14 @@ ini_set('default_charset', 'utf-8');
 /* in dev mode - check if composer was executed */
 if (is_dir(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'admin-dev') && (!is_dir(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'vendor') ||
         !file_exists(_PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php'))) {
-    die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
+    (new PrestaShopException('Missing vendor data, run "composer install" first'))->displayMessage();
 }
 
 /* No settings file? goto installer... */
 if (!file_exists(_PS_ROOT_DIR_ . '/app/config/parameters.yml') && !file_exists(_PS_ROOT_DIR_ . '/app/config/parameters.php')) {
+    if (Tools::isPHPCLI()) {
+        (new PrestaShopException('Missing "/app/config/parameters.yml" configuration'))->displayMessage();
+    }
     Tools::redirectToInstall();
 }
 
@@ -67,12 +70,10 @@ if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
     Windows::improveFilesytemPerformances();
 }
 
-if (defined('_PS_CREATION_DATE_')) {
-    $creationDate = _PS_CREATION_DATE_;
-    if (empty($creationDate)) {
-        Tools::redirectToInstall();
+if (!defined('_PS_CREATION_DATE_') || empty(_PS_CREATION_DATE_)) {
+    if (Tools::isPHPCLI()) {
+        (new PrestaShopException('Missing "_PS_CREATION_DATE_" constant'))->displayMessage();
     }
-} else {
     Tools::redirectToInstall();
 }
 


### PR DESCRIPTION
Finish after https://github.com/PrestaShop/PrestaShop/pull/22823 is merged

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix error output when vendor dir/config is missing for CLI
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | Run `vendor/bin/behat -c tests/Integration/Behaviour/behat.yml` right after fresh `git clone https://github.com/PrestaShop/PrestaShop.git && composer install`. Previously, there was zero output without which was very hard to debug. Now error is displayed instead of redirect (which can not work in CLI) which helps the developer to understand a missing configuration file.
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/23985)
<!-- Reviewable:end -->
