### PR TITLE
Fix order details product pagination not showing

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
@@ -293,7 +293,7 @@ export default class OrderProductRenderer {
     $(OrderViewPageMap.productsTablePaginationNext).before($linkPaginationTemplate);
 
     // Add appropriate pages
-    for (let i = 1; i < numPages; i += 1) {
+    for (let i = 1; i <= numPages; i += 1) {
       const $linkPagination = $linkPaginationTemplate.clone();
       $linkPagination.find('span').attr('data-page', i);
       $linkPagination.find('span').html(i);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Because of a fix to make the jsLint happy, the loop iterating pages was wrong leading to not showing the page links. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23604
| How to test?      | Please see #23604
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24005)
<!-- Reviewable:end -->
