### PR TITLE
Remove touchstart even on TouchSpin on FO

### DIFF
--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -26,6 +26,8 @@ function createSpin() {
     });
   });
 
+  $('.js-touchspin').off('touchstart.touchspin');
+
   CheckUpdateQuantityOperations.switchErrorStat();
 }
 

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -26,7 +26,7 @@ function createSpin() {
     });
   });
 
-  $('.js-touchspin').off('touchstart.touchspin');
+  $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 
   CheckUpdateQuantityOperations.switchErrorStat();
 }

--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -101,6 +101,8 @@ $(document).ready(() => {
       min: 1,
       max: 1000000,
     });
+
+    $('.js-touchspin').off('touchstart.touchspin');
   };
 
   const move = (direction) => {

--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -102,7 +102,7 @@ $(document).ready(() => {
       max: 1000000,
     });
 
-    $('.js-touchspin').off('touchstart.touchspin');
+    $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
   };
 
   const move = (direction) => {

--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -137,7 +137,10 @@ $(document).ready(() => {
       buttonup_class: 'btn btn-touchspin js-touchspin',
       min: parseInt($quantityInput.attr('min'), 10),
       max: 1000000,
+      mousewheel: false,
     });
+
+    $('.js-touchspin').off('touchstart.touchspin');
 
     $quantityInput.focusout(() => {
       if ($quantityInput.val() === '' || $quantityInput.val() < $quantityInput.attr('min')) {

--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -137,10 +137,9 @@ $(document).ready(() => {
       buttonup_class: 'btn btn-touchspin js-touchspin',
       min: parseInt($quantityInput.attr('min'), 10),
       max: 1000000,
-      mousewheel: false,
     });
 
-    $('.js-touchspin').off('touchstart.touchspin');
+    $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 
     $quantityInput.focusout(() => {
       if ($quantityInput.val() === '' || $quantityInput.val() < $quantityInput.attr('min')) {

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -60,6 +60,7 @@ prestashop.themeSelectors = {
   footer: '#footer, .js-footer',
   modalContent: '.js-modal-content',
   modal: '#modal, .js-checkout-modal',
+  touchspin: '.js-touchspin',
   checkout: {
     termsLink: '.js-terms a',
     giftCheckbox: '.js-gift-checkbox',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Touchspin is boring when you start scrolling on it on mobile, it should not work if you drag on it from mobile
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23989.
| How to test?      | Go on product page, listing and cart, go on mobile mode and try to scroll by beginning on the touchspin
| Possible impacts? | Mobile use on FO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24012)
<!-- Reviewable:end -->
