### PR TITLE
Add images to combinations list

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/combinations-grid-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/combinations-grid-renderer.js
@@ -98,8 +98,9 @@ export default class CombinationsGridRenderer {
       $impactOnPriceInput.data('initial-value', combination.impactOnPrice);
       $(ProductMap.combinations.tableRow.editButton(rowIndex), $row).data('id', combination.id);
       $(ProductMap.combinations.tableRow.deleteButton(rowIndex), $row).data('id', combination.id);
-      $(ProductMap.combinations.tableRow.combinationImg, $row).attr('src', combination.imageUrl);
-      $(ProductMap.combinations.tableRow.combinationImg, $row).attr('alt', combination.name);
+      $(ProductMap.combinations.tableRow.combinationImg, $row)
+        .attr('src', combination.imageUrl)
+        .attr('alt', combination.name);
 
       if (combination.isDefault) {
         $(ProductMap.combinations.tableRow.isDefaultInput(rowIndex), $row).prop('checked', true);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/combinations-grid-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/combinations-grid-renderer.js
@@ -99,6 +99,7 @@ export default class CombinationsGridRenderer {
       $(ProductMap.combinations.tableRow.editButton(rowIndex), $row).data('id', combination.id);
       $(ProductMap.combinations.tableRow.deleteButton(rowIndex), $row).data('id', combination.id);
       $(ProductMap.combinations.tableRow.combinationImg, $row).attr('src', combination.imageUrl);
+      $(ProductMap.combinations.tableRow.combinationImg, $row).attr('alt', combination.name);
 
       if (combination.isDefault) {
         $(ProductMap.combinations.tableRow.isDefaultInput(rowIndex), $row).prop('checked', true);

--- a/admin-dev/themes/new-theme/js/pages/product/edit/combinations-grid-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/combinations-grid-renderer.js
@@ -98,13 +98,13 @@ export default class CombinationsGridRenderer {
       $impactOnPriceInput.data('initial-value', combination.impactOnPrice);
       $(ProductMap.combinations.tableRow.editButton(rowIndex), $row).data('id', combination.id);
       $(ProductMap.combinations.tableRow.deleteButton(rowIndex), $row).data('id', combination.id);
+      $(ProductMap.combinations.tableRow.combinationImg, $row).attr('src', combination.imageUrl);
 
       if (combination.isDefault) {
         $(ProductMap.combinations.tableRow.isDefaultInput(rowIndex), $row).prop('checked', true);
       }
 
       this.$combinationsTableBody.append($row);
-
       rowIndex += 1;
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.js
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.js
@@ -105,6 +105,7 @@ export default {
     editionForm: 'form[name="combination_form"]',
     editCombinationButtons: '.edit-combination-item',
     tableRow: {
+      combinationImg: '.combination-image',
       combinationCheckbox: (rowIndex) => `${combinationListId}_combinations_${rowIndex}_is_selected`,
       combinationIdInput: (rowIndex) => `${combinationListId}_combinations_${rowIndex}_combination_id`,
       combinationNameInput: (rowIndex) => `${combinationListId}_combinations_${rowIndex}_name`,

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1391,7 +1391,7 @@ class LinkCore
      *
      * @return string
      */
-    public function getBaseLink($idShop = null, $ssl = null, $relativeProtocol = false)
+    public function getBaseShopUrl($idShop = null, $ssl = null, $relativeProtocol = false)
     {
         if (null === $ssl) {
             $ssl = (Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE'));
@@ -1409,7 +1409,25 @@ class LinkCore
             $base = (($ssl && $this->ssl_enable) ? 'https://' . $shop->domain_ssl : 'http://' . $shop->domain);
         }
 
-        return $base . $shop->getBaseURI();
+        return $base;
+    }
+
+    /**
+     * @param int|null $idShop
+     * @param bool|null $ssl
+     * @param bool $relativeProtocol
+     *
+     * @return string
+     */
+    public function getBaseLink($idShop = null, $ssl = null, $relativeProtocol = false)
+    {
+        if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && $idShop !== null) {
+            $shop = new Shop($idShop);
+        } else {
+            $shop = Context::getContext()->shop;
+        }
+
+        return $this->getBaseShopUrl($idShop, $ssl, $relativeProtocol) . $shop->getBaseURI();
     }
 
     /**

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1391,7 +1391,7 @@ class LinkCore
      *
      * @return string
      */
-    public function getBaseShopUrl($idShop = null, $ssl = null, $relativeProtocol = false)
+    public function getBaseLink($idShop = null, $ssl = null, $relativeProtocol = false)
     {
         if (null === $ssl) {
             $ssl = (Configuration::get('PS_SSL_ENABLED') && Configuration::get('PS_SSL_ENABLED_EVERYWHERE'));
@@ -1409,25 +1409,7 @@ class LinkCore
             $base = (($ssl && $this->ssl_enable) ? 'https://' . $shop->domain_ssl : 'http://' . $shop->domain);
         }
 
-        return $base;
-    }
-
-    /**
-     * @param int|null $idShop
-     * @param bool|null $ssl
-     * @param bool $relativeProtocol
-     *
-     * @return string
-     */
-    public function getBaseLink($idShop = null, $ssl = null, $relativeProtocol = false)
-    {
-        if (Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE') && $idShop !== null) {
-            $shop = new Shop($idShop);
-        } else {
-            $shop = Context::getContext()->shop;
-        }
-
-        return $this->getBaseShopUrl($idShop, $ssl, $relativeProtocol) . $shop->getBaseURI();
+        return $base . $shop->getBaseURI();
     }
 
     /**

--- a/src/Adapter/Image/ImageValidator.php
+++ b/src/Adapter/Image/ImageValidator.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageFileNotFoundExcepti
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
-use Tools;
 
 /**
  * Responsible for validating image before upload
@@ -47,11 +46,11 @@ class ImageValidator
     private $maxUploadSize;
 
     /**
-     * @param int|null $maxUploadSize
+     * @param int $maxUploadSize
      */
-    public function __construct(?int $maxUploadSize = null)
+    public function __construct(int $maxUploadSize)
     {
-        $this->maxUploadSize = $maxUploadSize ?: Tools::getMaxUploadSize();
+        $this->maxUploadSize = $maxUploadSize;
     }
 
     /**

--- a/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationImagesUpdater;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\RemoveAllCombinationImagesHandlerInterface;
+
+class RemoveAllCombinationImagesHandler implements RemoveAllCombinationImagesHandlerInterface
+{
+    /**
+     * @var CombinationImagesUpdater
+     */
+    private $combinationImagesUpdater;
+
+    /**
+     * @param CombinationImagesUpdater $combinationImagesUpdater
+     */
+    public function __construct(CombinationImagesUpdater $combinationImagesUpdater)
+    {
+        $this->combinationImagesUpdater = $combinationImagesUpdater;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(RemoveAllCombinationImagesCommand $command): void
+    {
+        $this->combinationImagesUpdater->deleteAllImages($command->getCombinationId());
+    }
+}

--- a/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\RemoveA
 /**
  * Handles @see RemoveAllCombinationImagesCommand using adapter udpater service
  */
-class RemoveAllCombinationImagesHandler implements RemoveAllCombinationImagesHandlerInterface
+final class RemoveAllCombinationImagesHandler implements RemoveAllCombinationImagesHandlerInterface
 {
     /**
      * @var CombinationImagesUpdater

--- a/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
@@ -55,6 +55,6 @@ final class RemoveAllCombinationImagesHandler implements RemoveAllCombinationIma
      */
     public function handle(RemoveAllCombinationImagesCommand $command): void
     {
-        $this->combinationImagesUpdater->deleteAllImages($command->getCombinationId());
+        $this->combinationImagesUpdater->deleteAllImageAssociations($command->getCombinationId());
     }
 }

--- a/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandler.php
@@ -32,6 +32,9 @@ use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationImagesUp
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\RemoveAllCombinationImagesHandlerInterface;
 
+/**
+ * Handles @see RemoveAllCombinationImagesCommand using adapter udpater service
+ */
 class RemoveAllCombinationImagesHandler implements RemoveAllCombinationImagesHandlerInterface
 {
     /**

--- a/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
@@ -32,6 +32,9 @@ use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationImagesUp
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\SetCombinationImagesHandlerInterface;
 
+/**
+ * Handles @see SetCombinationImagesCommand using adapter udpater service
+ */
 class SetCombinationImagesHandler implements SetCombinationImagesHandlerInterface
 {
     /**

--- a/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\SetComb
 /**
  * Handles @see SetCombinationImagesCommand using adapter udpater service
  */
-class SetCombinationImagesHandler implements SetCombinationImagesHandlerInterface
+final class SetCombinationImagesHandler implements SetCombinationImagesHandlerInterface
 {
     /**
      * @var CombinationImagesUpdater

--- a/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationImagesUpdater;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\SetCombinationImagesHandlerInterface;
+
+class SetCombinationImagesHandler implements SetCombinationImagesHandlerInterface
+{
+    /**
+     * @var CombinationImagesUpdater
+     */
+    private $combinationImagesUpdater;
+
+    /**
+     * @param CombinationImagesUpdater $combinationImagesUpdater
+     */
+    public function __construct(CombinationImagesUpdater $combinationImagesUpdater)
+    {
+        $this->combinationImagesUpdater = $combinationImagesUpdater;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(SetCombinationImagesCommand $command): void
+    {
+        $this->combinationImagesUpdater->setImages($command->getCombinationId(), $command->getImageIds());
+    }
+}

--- a/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/SetCombinationImagesHandler.php
@@ -55,6 +55,6 @@ final class SetCombinationImagesHandler implements SetCombinationImagesHandlerIn
      */
     public function handle(SetCombinationImagesCommand $command): void
     {
-        $this->combinationImagesUpdater->setImages($command->getCombinationId(), $command->getImageIds());
+        $this->combinationImagesUpdater->associateImages($command->getCombinationId(), $command->getImageIds());
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -242,7 +242,7 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
     private function getImages(Combination $combination): array
     {
         $combinationId = (int) $combination->id;
-        $combinationImageIds = $this->productImageRepository->getImagesIdsForCombinations([]);
+        $combinationImageIds = $this->productImageRepository->getImagesIdsForCombinations([$combinationId]);
         if (empty($combinationImageIds[$combinationId])) {
             return [];
         }

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -32,6 +32,7 @@ use Combination;
 use DateTime;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
@@ -44,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\Combinatio
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationPrices;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationStock;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
@@ -76,6 +78,11 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
     private $productRepository;
 
     /**
+     * @var ProductImageRepository
+     */
+    private $productImageRepository;
+
+    /**
      * @var int
      */
     private $contextLanguageId;
@@ -100,6 +107,7 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
      * @param StockAvailableRepository $stockAvailableRepository
      * @param AttributeRepository $attributeRepository
      * @param ProductRepository $productRepository
+     * @param ProductImageRepository $productImageRepository
      * @param NumberExtractor $numberExtractor
      * @param TaxComputer $taxComputer
      * @param int $contextLanguageId
@@ -110,6 +118,7 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
         StockAvailableRepository $stockAvailableRepository,
         AttributeRepository $attributeRepository,
         ProductRepository $productRepository,
+        ProductImageRepository $productImageRepository,
         NumberExtractor $numberExtractor,
         TaxComputer $taxComputer,
         int $contextLanguageId,
@@ -119,6 +128,7 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
         $this->stockAvailableRepository = $stockAvailableRepository;
         $this->attributeRepository = $attributeRepository;
         $this->productRepository = $productRepository;
+        $this->productImageRepository = $productImageRepository;
         $this->numberExtractor = $numberExtractor;
         $this->taxComputer = $taxComputer;
         $this->contextLanguageId = $contextLanguageId;
@@ -137,7 +147,8 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
             $this->getCombinationName($query->getCombinationId()),
             $this->getDetails($combination),
             $this->getPrices($combination, $product),
-            $this->getStock($combination)
+            $this->getStock($combination),
+            $this->getImages($combination)
         );
     }
 
@@ -221,5 +232,22 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
             $stockAvailable->location,
             DateTimeUtil::NULL_DATE === $combination->available_date ? null : new DateTime($combination->available_date)
         );
+    }
+
+    /**
+     * @param Combination $combination
+     *
+     * @return int[]
+     */
+    private function getImages(Combination $combination): array
+    {
+        $combinationImageIds = $this->productImageRepository->getImagesIdsForCombinations([(int) $combination->id]);
+        if (empty($combinationImageIds[(int) $combination->id])) {
+            return [];
+        }
+
+        return array_map(function (ImageId $imageId) {
+            return $imageId->getValue();
+        }, $combinationImageIds[(int) $combination->id]);
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -241,13 +241,14 @@ final class GetCombinationForEditingHandler implements GetCombinationForEditingH
      */
     private function getImages(Combination $combination): array
     {
-        $combinationImageIds = $this->productImageRepository->getImagesIdsForCombinations([(int) $combination->id]);
-        if (empty($combinationImageIds[(int) $combination->id])) {
+        $combinationId = (int) $combination->id;
+        $combinationImageIds = $this->productImageRepository->getImagesIdsForCombinations([]);
+        if (empty($combinationImageIds[$combinationId])) {
             return [];
         }
 
         return array_map(function (ImageId $imageId) {
             return $imageId->getValue();
-        }, $combinationImageIds[(int) $combination->id]);
+        }, $combinationImageIds[$combinationId]);
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -33,7 +33,6 @@ use PDO;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Product\AbstractProductHandler;
-use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
@@ -46,23 +45,12 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\Combinatio
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductCombinationFilters;
-use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
 
 /**
  * Handles @see GetEditableCombinationsList using legacy object model
  */
 final class GetEditableCombinationsListHandler extends AbstractProductHandler implements GetEditableCombinationsListHandlerInterface
 {
-    /**
-     * @var CombinationRepository
-     */
-    private $combinationRepository;
-
-    /**
-     * @var NumberExtractor
-     */
-    private $numberExtractor;
-
     /**
      * @var StockAvailableRepository
      */
@@ -94,8 +82,6 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
     private $cachedImageIds = [];
 
     /**
-     * @param CombinationRepository $combinationRepository
-     * @param NumberExtractor $numberExtractor
      * @param StockAvailableRepository $stockAvailableRepository
      * @param DoctrineQueryBuilderInterface $combinationQueryBuilder
      * @param AttributeRepository $attributeRepository
@@ -103,16 +89,12 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
      * @param ProductImagePathFactory $productImagePathFactory
      */
     public function __construct(
-        CombinationRepository $combinationRepository,
-        NumberExtractor $numberExtractor,
         StockAvailableRepository $stockAvailableRepository,
         DoctrineQueryBuilderInterface $combinationQueryBuilder,
         AttributeRepository $attributeRepository,
         ProductImageRepository $productImageRepository,
         ProductImagePathFactory $productImagePathFactory
     ) {
-        $this->combinationRepository = $combinationRepository;
-        $this->numberExtractor = $numberExtractor;
         $this->stockAvailableRepository = $stockAvailableRepository;
         $this->combinationQueryBuilder = $combinationQueryBuilder;
         $this->attributeRepository = $attributeRepository;
@@ -186,7 +168,10 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
                 );
             }
 
-            $imageId = $this->getImageId($combinationId, $imageIdsByCombinationIds);
+            $imageId = null;
+            if (!empty($imageIdsByCombinationIds[$combinationId])) {
+                $imageId = $imageIdsByCombinationIds[$combinationId][0];
+            }
 
             $impactOnPrice = new DecimalNumber($combination['price']);
             $combinationsForEditing[] = new EditableCombinationForListing(

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -41,7 +41,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\Combinatio
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationListForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\EditableCombinationForListing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
-use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductCombinationFilters;
 
@@ -74,11 +73,6 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
      * @var ProductImagePathFactory
      */
     private $productImagePathFactory;
-
-    /**
-     * @var array<int, ImageId>
-     */
-    private $cachedImageIds = [];
 
     /**
      * @param StockAvailableRepository $stockAvailableRepository
@@ -169,7 +163,7 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
 
             $imageId = null;
             if (!empty($imageIdsByCombinationIds[$combinationId])) {
-                $imageId = $imageIdsByCombinationIds[$combinationId][0];
+                $imageId = reset($imageIdsByCombinationIds[$combinationId]);
             }
 
             $impactOnPrice = new DecimalNumber($combination['price']);

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler;
 
-use Image;
 use PDO;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
@@ -187,33 +186,6 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
         }
 
         return new CombinationListForEditing($totalCombinationsCount, $combinationsForEditing);
-    }
-
-    /**
-     * Fetches image by combination id and caches it in class property
-     * (All combinations are only reusing product images, so there is no point retrieving same image over and over again)
-     *
-     * @param int $combinationId
-     * @param array<int, int[]> $imageIdsByCombinationIds
-     *
-     * @return ImageId|null
-     */
-    private function getImageId(int $combinationId, array $imageIdsByCombinationIds): ?ImageId
-    {
-        if (!isset($imageIdsByCombinationIds[$combinationId][0])) {
-            return null;
-        }
-
-        $imageIdValue = $imageIdsByCombinationIds[$combinationId][0];
-
-        if (isset($this->cachedImageIds[$imageIdValue])) {
-            return $this->cachedImageIds[$imageIdValue];
-        }
-
-        $imageId = new ImageId($imageIdValue);
-        $this->cachedImageIds[$imageIdValue] = $imageId;
-
-        return $imageId;
     }
 
     /**

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\Combinatio
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationListForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\EditableCombinationForListing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductCombinationFilters;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
@@ -221,7 +222,7 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
             return $cachedImages[$imageId];
         }
 
-        $image = new Image($imageId);
+        $image = $this->productImageRepository->get(new ImageId($imageId));
         $cachedImages[$imageId] = $image;
 
         return $image;

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler;
 
 use Image;
-use Language;
 use PDO;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
@@ -167,8 +166,6 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
     ): CombinationListForEditing {
         $combinationsForEditing = [];
 
-        $langIso = Language::getIsoById($langId);
-
         foreach ($combinations as $combination) {
             $combinationId = (int) $combination['id_product_attribute'];
             $combinationAttributesInformation = [];
@@ -193,7 +190,7 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
                 (bool) $combination['default_on'],
                 $impactOnPrice,
                 (int) $this->stockAvailableRepository->getForCombination(new CombinationId($combinationId))->quantity,
-                $this->getImagePath((int) $imageData['id_image'], $langIso)
+                $this->getImagePath((int) $imageData['id_image'])
             );
         }
 
@@ -202,17 +199,16 @@ final class GetEditableCombinationsListHandler extends AbstractProductHandler im
 
     /**
      * @param int $imageId
-     * @param string $langIso
      *
      * @return string
      */
-    private function getImagePath(int $imageId, string $langIso): string
+    private function getImagePath(int $imageId): ?string
     {
         $image = new Image($imageId);
         $type = '-small_default.jpg';
 
         if (empty($image->getImgPath())) {
-            return $this->productImgDir . sprintf('%s-default%s', $langIso, $type);
+            return null;
         }
 
         return sprintf('%s%s%s', $this->productImgDir, $image->getImgPath(), $type);

--- a/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
@@ -34,6 +34,9 @@ use Doctrine\DBAL\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 
+/**
+ * Updates images associated to combination
+ */
 class CombinationImagesUpdater
 {
     /**

--- a/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+
+class CombinationImagesUpdater
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix
+    ) {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+    }
+
+    /**
+     * @param CombinationId $combinationId
+     *
+     * @throws DBALException
+     * @throws InvalidArgumentException
+     */
+    public function deleteAllImages(CombinationId $combinationId): void
+    {
+        $this->connection->delete(
+            $this->dbPrefix . 'product_attribute_image',
+            ['id_product_attribute' => $combinationId->getValue()]
+        );
+    }
+
+    /**
+     * @param CombinationId $combinationId
+     * @param ImageId[] $imageIds
+     *
+     * @throws DBALException
+     * @throws InvalidArgumentException
+     */
+    public function setImages(CombinationId $combinationId, array $imageIds): void
+    {
+        // First delete all images
+        $this->deleteAllImages($combinationId);
+
+        // Then create all new ones
+        foreach ($imageIds as $imageId) {
+            $insertedValues = [
+                'id_product_attribute' => $combinationId->getValue(),
+                'id_image' => $imageId->getValue(),
+            ];
+            $this->connection->insert($this->dbPrefix . 'product_attribute_image', $insertedValues);
+        }
+    }
+}

--- a/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationImagesUpdater.php
@@ -63,7 +63,7 @@ class CombinationImagesUpdater
      * @throws DBALException
      * @throws InvalidArgumentException
      */
-    public function deleteAllImages(CombinationId $combinationId): void
+    public function deleteAllImageAssociations(CombinationId $combinationId): void
     {
         $this->connection->delete(
             $this->dbPrefix . 'product_attribute_image',
@@ -78,10 +78,10 @@ class CombinationImagesUpdater
      * @throws DBALException
      * @throws InvalidArgumentException
      */
-    public function setImages(CombinationId $combinationId, array $imageIds): void
+    public function associateImages(CombinationId $combinationId, array $imageIds): void
     {
         // First delete all images
-        $this->deleteAllImages($combinationId);
+        $this->deleteAllImageAssociations($combinationId);
 
         // Then create all new ones
         foreach ($imageIds as $imageId) {

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -51,11 +51,6 @@ class ProductImagePathFactory
     /**
      * @var string
      */
-    private $basePath;
-
-    /**
-     * @var string
-     */
     private $pathToBaseDir;
 
     /**

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -38,6 +38,8 @@ class ProductImagePathFactory
     public const IMAGE_TYPE_HOME_DEFAULT = 'home_default';
     public const IMAGE_TYPE_CART_DEFAULT = 'cart_default';
 
+    public const DEFAULT_IMAGE_FORMAT = 'jpg';
+
     /**
      * @var string
      */
@@ -75,7 +77,7 @@ class ProductImagePathFactory
      *
      * @return string
      */
-    public function getPath(ImageId $imageId, string $extension = 'jpg'): string
+    public function getPath(ImageId $imageId, string $extension = self::DEFAULT_IMAGE_FORMAT): string
     {
         $path = $this->getBaseImagePathWithoutExtension($imageId);
 
@@ -89,7 +91,7 @@ class ProductImagePathFactory
      *
      * @return string
      */
-    public function getPathByType(ImageId $imageId, string $type, string $extension = 'jpg'): string
+    public function getPathByType(ImageId $imageId, string $type, string $extension = self::DEFAULT_IMAGE_FORMAT): string
     {
         $path = $this->getBaseImagePathWithoutExtension($imageId);
 
@@ -98,7 +100,7 @@ class ProductImagePathFactory
 
     /**
      * @param string $type
-     * @param string|null $langIso
+     * @param string|null $langIso if null, will use $contextLangIsoCode by default
      *
      * @return string
      */
@@ -141,7 +143,7 @@ class ProductImagePathFactory
     {
         $path = implode('/', str_split((string) $imageId->getValue()));
 
-        return sprintf('%s%s', $this->pathToBaseDir, $path);
+        return $this->pathToBaseDir . $path;
     }
 
     /**

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -137,11 +137,21 @@ class ProductImagePathFactory
      *
      * @return string
      */
-    private function getBaseImagePathWithoutExtension(ImageId $imageId): string
+    public function getImageFolder(ImageId $imageId): string
     {
         $id = $imageId->getValue();
-        $path = implode('/', str_split((string) $id)) . '/' . $id;
+        $path = implode('/', str_split((string) $id));
 
         return sprintf('%s%s', $this->pathToBaseDir, $path);
+    }
+
+    /**
+     * @param ImageId $imageId
+     *
+     * @return string
+     */
+    private function getBaseImagePathWithoutExtension(ImageId $imageId): string
+    {
+        return $this->getImageFolder($imageId) . '/' . $imageId->getValue();
     }
 }

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -139,8 +139,7 @@ class ProductImagePathFactory
      */
     public function getImageFolder(ImageId $imageId): string
     {
-        $id = $imageId->getValue();
-        $path = implode('/', str_split((string) $id));
+        $path = implode('/', str_split((string) $imageId->getValue()));
 
         return sprintf('%s%s', $this->pathToBaseDir, $path);
     }

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Image;
 
-use Image;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 
 class ProductImagePathFactory
 {
@@ -37,11 +37,6 @@ class ProductImagePathFactory
     public const IMAGE_TYPE_LARGE_DEFAULT = 'large_default';
     public const IMAGE_TYPE_HOME_DEFAULT = 'home_default';
     public const IMAGE_TYPE_CART_DEFAULT = 'cart_default';
-
-    /**
-     * @var bool
-     */
-    private $isLegacyImageMode;
 
     /**
      * @var string
@@ -59,18 +54,15 @@ class ProductImagePathFactory
     private $contextLangIsoCode;
 
     /**
-     * @param bool $isLegacyImageMode
      * @param string $pathToBaseDir
      * @param string $temporaryImgDir
      * @param string $contextLangIsoCode
      */
     public function __construct(
-        bool $isLegacyImageMode,
         string $pathToBaseDir,
         string $temporaryImgDir,
         string $contextLangIsoCode
     ) {
-        $this->isLegacyImageMode = $isLegacyImageMode;
         // make sure one trailing slash is always there
         $this->temporaryImgDir = rtrim($temporaryImgDir, '/') . '/';
         $this->pathToBaseDir = rtrim($pathToBaseDir, '/') . '/';
@@ -78,28 +70,30 @@ class ProductImagePathFactory
     }
 
     /**
-     * @param Image $image
+     * @param ImageId $imageId
+     * @param string $extension
      *
      * @return string
      */
-    public function getPath(Image $image): string
+    public function getPath(ImageId $imageId, string $extension = 'jpg'): string
     {
-        $path = $this->getBaseImagePathWithoutExtension($image);
+        $path = $this->getBaseImagePathWithoutExtension($imageId);
 
-        return sprintf('%s.%s', $path, $image->image_format);
+        return sprintf('%s.%s', $path, $extension);
     }
 
     /**
-     * @param Image $image
+     * @param ImageId $imageId
      * @param string $type
+     * @param string $extension
      *
      * @return string
      */
-    public function getPathByType(Image $image, string $type): string
+    public function getPathByType(ImageId $imageId, string $type, string $extension = 'jpg'): string
     {
-        $path = $this->getBaseImagePathWithoutExtension($image);
+        $path = $this->getBaseImagePathWithoutExtension($imageId);
 
-        return sprintf('%s-%s.%s', $path, $type, $image->image_format);
+        return sprintf('%s-%s.%s', $path, $type, $extension);
     }
 
     /**
@@ -139,17 +133,14 @@ class ProductImagePathFactory
     }
 
     /**
-     * @param Image $image
+     * @param ImageId $imageId
      *
      * @return string
      */
-    private function getBaseImagePathWithoutExtension(Image $image): string
+    private function getBaseImagePathWithoutExtension(ImageId $imageId): string
     {
-        if ($this->isLegacyImageMode) {
-            $path = $image->id_product . '-' . $image->id;
-        } else {
-            $path = ltrim($image->getImgPath(), '/');
-        }
+        $id = $imageId->getValue();
+        $path = implode('/', str_split((string) $id)) . '/' . $id;
 
         return sprintf('%s%s', $this->pathToBaseDir, $path);
     }

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -66,23 +66,23 @@ class ProductImagePathFactory
     /**
      * @param bool $isLegacyImageMode
      * @param string $basePath
-     * @param string $relativeImagesPath
+     * @param string $relativeImagesDir
      * @param string $temporaryImgDir
      * @param string $contextLangIsoCode
      */
     public function __construct(
         bool $isLegacyImageMode,
         string $basePath,
-        string $relativeImagesPath,
+        string $relativeImagesDir,
         string $temporaryImgDir,
         string $contextLangIsoCode
     ) {
         $this->isLegacyImageMode = $isLegacyImageMode;
-        $this->temporaryImgDir = $temporaryImgDir;
         // make sure one trailing slash is always there
-        $this->pathToBaseDir = rtrim($basePath, '/') . '/' . rtrim($relativeImagesPath, '/') . '/';
+        $this->temporaryImgDir = rtrim($temporaryImgDir, '/') . '/';
+        $this->basePath = rtrim($basePath, '/') . '/';
+        $this->pathToBaseDir = $this->basePath . rtrim(ltrim($relativeImagesDir, '/'), '/') . '/';
         $this->contextLangIsoCode = $contextLangIsoCode;
-        $this->basePath = $basePath;
     }
 
     /**
@@ -166,7 +166,7 @@ class ProductImagePathFactory
         if ($this->isLegacyImageMode) {
             $path = $image->id_product . '-' . $image->id;
         } else {
-            $path = $image->getImgPath();
+            $path = ltrim($image->getImgPath(), '/');
         }
 
         return sprintf('%s%s', $this->pathToBaseDir, $path);

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -65,34 +65,21 @@ class ProductImagePathFactory
 
     /**
      * @param bool $isLegacyImageMode
-     * @param string $basePath
-     * @param string $relativeImagesDir
+     * @param string $pathToBaseDir
      * @param string $temporaryImgDir
      * @param string $contextLangIsoCode
      */
     public function __construct(
         bool $isLegacyImageMode,
-        string $basePath,
-        string $relativeImagesDir,
+        string $pathToBaseDir,
         string $temporaryImgDir,
         string $contextLangIsoCode
     ) {
         $this->isLegacyImageMode = $isLegacyImageMode;
         // make sure one trailing slash is always there
         $this->temporaryImgDir = rtrim($temporaryImgDir, '/') . '/';
-        $this->basePath = rtrim($basePath, '/') . '/';
-        $this->pathToBaseDir = $this->basePath . rtrim(ltrim($relativeImagesDir, '/'), '/') . '/';
+        $this->pathToBaseDir = rtrim($pathToBaseDir, '/') . '/';
         $this->contextLangIsoCode = $contextLangIsoCode;
-    }
-
-    /**
-     * @param string $relativePath
-     *
-     * @return string
-     */
-    public function buildFullPath(string $relativePath): string
-    {
-        return $this->basePath . ltrim($relativePath, '/');
     }
 
     /**

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -87,7 +87,7 @@ class ProductImagePathFactory
      *
      * @return string
      */
-    public function getBaseImagePath(Image $image): string
+    public function getPath(Image $image): string
     {
         $path = $this->getBaseImagePathWithoutExtension($image);
 

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -51,7 +51,12 @@ class ProductImagePathFactory
     /**
      * @var string
      */
-    private $productImageDir;
+    private $basePath;
+
+    /**
+     * @var string
+     */
+    private $pathToBaseDir;
 
     /**
      * @var string
@@ -60,20 +65,24 @@ class ProductImagePathFactory
 
     /**
      * @param bool $isLegacyImageMode
-     * @param string $productImageDir
+     * @param string $basePath
+     * @param string $relativeImagesPath
      * @param string $temporaryImgDir
      * @param string $contextLangIsoCode
      */
     public function __construct(
         bool $isLegacyImageMode,
-        string $productImageDir,
+        string $basePath,
+        string $relativeImagesPath,
         string $temporaryImgDir,
         string $contextLangIsoCode
     ) {
         $this->isLegacyImageMode = $isLegacyImageMode;
         $this->temporaryImgDir = $temporaryImgDir;
-        $this->productImageDir = $productImageDir;
+        // make sure one trailing slash is always there
+        $this->pathToBaseDir = rtrim($basePath, '/') . '/' . rtrim($relativeImagesPath, '/') . '/';
         $this->contextLangIsoCode = $contextLangIsoCode;
+        $this->basePath = $basePath;
     }
 
     /**
@@ -113,7 +122,7 @@ class ProductImagePathFactory
             $langIso = $this->contextLangIsoCode;
         }
 
-        return sprintf('%s%s-%s-%s.jpg', $this->productImageDir, $langIso, 'default', $type);
+        return sprintf('%s%s-%s-%s.jpg', $this->pathToBaseDir, $langIso, 'default', $type);
     }
 
     /**
@@ -150,6 +159,6 @@ class ProductImagePathFactory
             $path = $image->getImgPath();
         }
 
-        return sprintf('%s%s', $this->productImageDir, $path);
+        return sprintf('%s%s', $this->pathToBaseDir, $path);
     }
 }

--- a/src/Adapter/Product/Image/ProductImagePathFactory.php
+++ b/src/Adapter/Product/Image/ProductImagePathFactory.php
@@ -86,13 +86,23 @@ class ProductImagePathFactory
     }
 
     /**
+     * @param string $relativePath
+     *
+     * @return string
+     */
+    public function buildFullPath(string $relativePath): string
+    {
+        return $this->basePath . ltrim($relativePath, '/');
+    }
+
+    /**
      * @param Image $image
      *
      * @return string
      */
-    public function getBasePath(Image $image): string
+    public function getBaseImagePath(Image $image): string
     {
-        $path = $this->getBaseImagePath($image);
+        $path = $this->getBaseImagePathWithoutExtension($image);
 
         return sprintf('%s.%s', $path, $image->image_format);
     }
@@ -105,7 +115,7 @@ class ProductImagePathFactory
      */
     public function getPathByType(Image $image, string $type): string
     {
-        $path = $this->getBaseImagePath($image);
+        $path = $this->getBaseImagePathWithoutExtension($image);
 
         return sprintf('%s-%s.%s', $path, $type, $image->image_format);
     }
@@ -151,7 +161,7 @@ class ProductImagePathFactory
      *
      * @return string
      */
-    private function getBaseImagePath(Image $image): string
+    private function getBaseImagePathWithoutExtension(Image $image): string
     {
         if ($this->isLegacyImageMode) {
             $path = $image->id_product . '-' . $image->id;

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -71,7 +71,7 @@ class ProductImageRepository extends AbstractObjectModelRepository
     public function __construct(
         Connection $connection,
         string $dbPrefix,
-        ProductImageValidator $productImageValidator,
+        ProductImageValidator $productImageValidator
     ) {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -234,7 +234,7 @@ class ProductImageRepository extends AbstractObjectModelRepository
      *
      * @param int[] $combinationIds
      *
-     * @return array<int, int[]> [(int) id_combination => [(int) id_image]]
+     * @return array<int, ImageId[]> [(int) id_combination => [ImageId]]
      */
     public function getImagesIdsForCombinations(array $combinationIds): array
     {
@@ -258,9 +258,15 @@ class ProductImageRepository extends AbstractObjectModelRepository
             return [];
         }
 
+        // Temporary ImageId pool to avoid creating duplicates
+        $imageIds = [];
         $imagesIdsByCombinationIds = [];
         foreach ($results as $result) {
-            $imagesIdsByCombinationIds[(int) $result['id_product_attribute']][] = (int) $result['id_image'];
+            $id = (int) $result['id_image'];
+            if (!isset($imageIds[$id])) {
+                $imageIds[$id] = new ImageId($id);
+            }
+            $imagesIdsByCombinationIds[(int) $result['id_product_attribute']][] = $imageIds[$id];
         }
 
         return $imagesIdsByCombinationIds;

--- a/src/Adapter/Product/Image/Repository/ProductImageRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageRepository.php
@@ -64,26 +64,18 @@ class ProductImageRepository extends AbstractObjectModelRepository
     private $productImageValidator;
 
     /**
-     * @var int
-     */
-    private $contextShopId;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param ProductImageValidator $productImageValidator
-     * @param int $contextShopId
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
         ProductImageValidator $productImageValidator,
-        int $contextShopId
     ) {
         $this->connection = $connection;
         $this->dbPrefix = $dbPrefix;
         $this->productImageValidator = $productImageValidator;
-        $this->contextShopId = $contextShopId;
     }
 
     /**
@@ -246,21 +238,15 @@ class ProductImageRepository extends AbstractObjectModelRepository
      */
     public function getImagesIdsForCombinations(array $combinationIds): array
     {
+        //@todo: multishop not handled
         $qb = $this->connection->createQueryBuilder();
         $qb->select('pai.id_product_attribute, pai.id_image')
             ->from($this->dbPrefix . 'product_attribute_image', 'pai')
             ->leftJoin(
                 'pai',
-                $this->dbPrefix . 'image_shop', 'ims',
-                'pai.id_image = ims.id_image'
-            )
-            ->leftJoin(
-                'pai',
                 $this->dbPrefix . 'image', 'i',
                 'i.id_image = pai.id_image'
             )
-            ->where('ims.id_shop = :shopId')
-            ->setParameter('shopId', $this->contextShopId)
             ->andWhere($qb->expr()->in('pai.id_product_attribute', ':combinationIds'))
             ->setParameter('combinationIds', $combinationIds, Connection::PARAM_INT_ARRAY)
             ->orderBy('i.position', 'asc')

--- a/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
+++ b/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
@@ -121,7 +121,7 @@ class ProductImageUploader extends AbstractImageUploader
     public function upload(Image $image, string $filePath): string
     {
         $this->createDestinationDirectory($image);
-        $destinationPath = $this->productImagePathFactory->getBaseImagePath($image);
+        $destinationPath = $this->productImagePathFactory->getPath($image);
         $this->uploadFromTemp($filePath, $destinationPath);
         $this->imageGenerator->generateImagesByTypes($destinationPath, $this->productImageRepository->getProductImageTypes());
 
@@ -142,7 +142,7 @@ class ProductImageUploader extends AbstractImageUploader
      */
     public function remove(Image $image): void
     {
-        $destinationPath = $this->productImagePathFactory->getBaseImagePath($image);
+        $destinationPath = $this->productImagePathFactory->getPath($image);
         $this->deleteCachedImages($image);
         $this->deleteGeneratedImages($destinationPath, $this->productImageRepository->getProductImageTypes());
     }

--- a/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
+++ b/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Image\Exception\CannotUnlinkImageException;
 use PrestaShop\PrestaShop\Core\Image\Exception\ImageOptimizationException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -151,15 +152,18 @@ class ProductImageUploader extends AbstractImageUploader
     private function createDestinationDirectory(ImageId $imageId, int $productId): void
     {
         $imageFolder = $this->productImagePathFactory->getImageFolder($imageId);
-        $this->fileSystem->mkdir($imageFolder, PsFileSystem::DEFAULT_MODE_FOLDER);
         if (is_dir($imageFolder)) {
             return;
         }
 
-        throw new ImageUploadException(sprintf(
-            'Error occurred when trying to create directory for product #%d image',
-            $productId
-        ));
+        try {
+            $this->fileSystem->mkdir($imageFolder, PsFileSystem::DEFAULT_MODE_FOLDER);
+        } catch (IOException $e) {
+            throw new ImageUploadException(sprintf(
+                'Error occurred when trying to create directory for product #%d image',
+                $productId
+            ));
+        }
     }
 
     /**

--- a/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
+++ b/src/Adapter/Product/Image/Uploader/ProductImageUploader.php
@@ -121,7 +121,7 @@ class ProductImageUploader extends AbstractImageUploader
     public function upload(Image $image, string $filePath): string
     {
         $this->createDestinationDirectory($image);
-        $destinationPath = $this->productImagePathFactory->getBasePath($image);
+        $destinationPath = $this->productImagePathFactory->getBaseImagePath($image);
         $this->uploadFromTemp($filePath, $destinationPath);
         $this->imageGenerator->generateImagesByTypes($destinationPath, $this->productImageRepository->getProductImageTypes());
 
@@ -142,7 +142,7 @@ class ProductImageUploader extends AbstractImageUploader
      */
     public function remove(Image $image): void
     {
-        $destinationPath = $this->productImagePathFactory->getBasePath($image);
+        $destinationPath = $this->productImagePathFactory->getBaseImagePath($image);
         $this->deleteCachedImages($image);
         $this->deleteGeneratedImages($destinationPath, $this->productImageRepository->getProductImageTypes());
     }

--- a/src/Adapter/Shop/Url/ProductImageFolderProvider.php
+++ b/src/Adapter/Shop/Url/ProductImageFolderProvider.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shop\Url;
+
+use Link;
+use PrestaShop\PrestaShop\Core\Shop\Url\UrlProviderInterface;
+
+class ProductImageFolderProvider implements UrlProviderInterface
+{
+    /**
+     * @var Link
+     */
+    private $link;
+
+    /**
+     * @var string
+     */
+    private $imagesRelativeFolder;
+
+    /**
+     * @param Link $link
+     * @param string $imagesRelativeFolder
+     */
+    public function __construct(
+        Link $link,
+        string $imagesRelativeFolder
+    ) {
+        $this->link = $link;
+        $this->imagesRelativeFolder = $imagesRelativeFolder;
+    }
+
+    /**
+     * Create a link to product images base folder.
+     *
+     * @param int|null $productId
+     * @param string|null $rewrite
+     *
+     * @return string
+     */
+    public function getUrl(?int $productId = null, ?string $rewrite = null): string
+    {
+        return $this->link->getBaseShopUrl() . $this->imagesRelativeFolder;
+    }
+}

--- a/src/Core/Domain/Product/Combination/Command/RemoveAllCombinationImagesCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/RemoveAllCombinationImagesCommand.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+
+class RemoveAllCombinationImagesCommand
+{
+    /**
+     * @var CombinationId
+     */
+    private $combinationId;
+
+    /**
+     * @param int $combinationId
+     */
+    public function __construct(int $combinationId)
+    {
+        $this->combinationId = new CombinationId($combinationId);
+    }
+
+    /**
+     * @return CombinationId
+     */
+    public function getCombinationId(): CombinationId
+    {
+        return $this->combinationId;
+    }
+}

--- a/src/Core/Domain/Product/Combination/Command/SetCombinationImagesCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/SetCombinationImagesCommand.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+
+class SetCombinationImagesCommand
+{
+    /**
+     * @var CombinationId
+     */
+    private $combinationId;
+
+    /**
+     * @var ImageId[]
+     */
+    private $imageIds;
+
+    /**
+     * @param int $combinationId
+     * @param array $imageIds
+     */
+    public function __construct(int $combinationId, array $imageIds)
+    {
+        $this->combinationId = new CombinationId($combinationId);
+        $this->imageIds = array_map(function (int $imageId) { return new ImageId($imageId); }, $imageIds);
+    }
+
+    /**
+     * @return CombinationId
+     */
+    public function getCombinationId(): CombinationId
+    {
+        return $this->combinationId;
+    }
+
+    /**
+     * @return ImageId[]
+     */
+    public function getImageIds(): array
+    {
+        return $this->imageIds;
+    }
+}

--- a/src/Core/Domain/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandlerInterface.php
+++ b/src/Core/Domain/Product/Combination/CommandHandler/RemoveAllCombinationImagesHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand;
+
+/**
+ * Defines contract to handle @see RemoveAllCombinationImagesCommand
+ */
+interface RemoveAllCombinationImagesHandlerInterface
+{
+    /**
+     * @param RemoveAllCombinationImagesCommand $command
+     */
+    public function handle(RemoveAllCombinationImagesCommand $command): void;
+}

--- a/src/Core/Domain/Product/Combination/CommandHandler/SetCombinationImagesHandlerInterface.php
+++ b/src/Core/Domain/Product/Combination/CommandHandler/SetCombinationImagesHandlerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand;
+
+/**
+ * Defines contract to handle @see SetCombinationImagesCommand
+ */
+interface SetCombinationImagesHandlerInterface
+{
+    /**
+     * @param SetCombinationImagesCommand $command
+     */
+    public function handle(SetCombinationImagesCommand $command): void;
+}

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationForEditing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationForEditing.php
@@ -54,21 +54,29 @@ class CombinationForEditing
     private $stock;
 
     /**
+     * @var int[]
+     */
+    private $imageIds;
+
+    /**
      * @param string $name
      * @param CombinationDetails $options
      * @param CombinationPrices $prices
      * @param CombinationStock $stock
+     * @param int[] $imageIds
      */
     public function __construct(
         string $name,
         CombinationDetails $options,
         CombinationPrices $prices,
-        CombinationStock $stock
+        CombinationStock $stock,
+        array $imageIds
     ) {
         $this->name = $name;
         $this->details = $options;
         $this->stock = $stock;
         $this->prices = $prices;
+        $this->imageIds = $imageIds;
     }
 
     /**
@@ -101,5 +109,13 @@ class CombinationForEditing
     public function getStock(): CombinationStock
     {
         return $this->stock;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getImageIds(): array
+    {
+        return $this->imageIds;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -73,7 +73,7 @@ class EditableCombinationForListing
     /**
      * @var string|null
      */
-    private $relativeImagePath;
+    private $imageUrl;
 
     /**
      * @param int $combinationId
@@ -83,7 +83,7 @@ class EditableCombinationForListing
      * @param bool $default
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
-     * @param string|null $relativeImagePath
+     * @param string|null $imageUrl
      */
     public function __construct(
         int $combinationId,
@@ -93,7 +93,7 @@ class EditableCombinationForListing
         bool $default,
         DecimalNumber $impactOnPrice,
         int $quantity,
-        ?string $relativeImagePath = null
+        ?string $imageUrl = null
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -102,7 +102,7 @@ class EditableCombinationForListing
         $this->default = $default;
         $this->impactOnPrice = $impactOnPrice;
         $this->quantity = $quantity;
-        $this->relativeImagePath = $relativeImagePath;
+        $this->imageUrl = $imageUrl;
     }
 
     /**
@@ -164,8 +164,8 @@ class EditableCombinationForListing
     /**
      * @return string|null
      */
-    public function getRelativeImagePath(): ?string
+    public function getImageUrl(): ?string
     {
-        return $this->relativeImagePath;
+        return $this->imageUrl;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -71,6 +71,11 @@ class EditableCombinationForListing
     private $quantity;
 
     /**
+     * @var string|null
+     */
+    private $imagePath;
+
+    /**
      * @param int $combinationId
      * @param string $combinationName
      * @param string $reference
@@ -78,6 +83,7 @@ class EditableCombinationForListing
      * @param bool $default
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
+     * @param string|null $imagePath
      */
     public function __construct(
         int $combinationId,
@@ -86,7 +92,8 @@ class EditableCombinationForListing
         array $attributesInformation,
         bool $default,
         DecimalNumber $impactOnPrice,
-        int $quantity
+        int $quantity,
+        ?string $imagePath = null
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -95,6 +102,7 @@ class EditableCombinationForListing
         $this->default = $default;
         $this->impactOnPrice = $impactOnPrice;
         $this->quantity = $quantity;
+        $this->imagePath = $imagePath;
     }
 
     /**
@@ -151,5 +159,13 @@ class EditableCombinationForListing
     public function getQuantity(): int
     {
         return $this->quantity;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getImagePath(): ?string
+    {
+        return $this->imagePath;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -73,7 +73,7 @@ class EditableCombinationForListing
     /**
      * @var string|null
      */
-    private $imagePath;
+    private $relativeImagePath;
 
     /**
      * @param int $combinationId
@@ -83,7 +83,7 @@ class EditableCombinationForListing
      * @param bool $default
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
-     * @param string|null $imagePath
+     * @param string|null $relativeImagePath
      */
     public function __construct(
         int $combinationId,
@@ -93,7 +93,7 @@ class EditableCombinationForListing
         bool $default,
         DecimalNumber $impactOnPrice,
         int $quantity,
-        ?string $imagePath = null
+        ?string $relativeImagePath = null
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -102,7 +102,7 @@ class EditableCombinationForListing
         $this->default = $default;
         $this->impactOnPrice = $impactOnPrice;
         $this->quantity = $quantity;
-        $this->imagePath = $imagePath;
+        $this->relativeImagePath = $relativeImagePath;
     }
 
     /**
@@ -164,8 +164,8 @@ class EditableCombinationForListing
     /**
      * @return string|null
      */
-    public function getImagePath(): ?string
+    public function getRelativeImagePath(): ?string
     {
-        return $this->imagePath;
+        return $this->relativeImagePath;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -71,7 +71,7 @@ class EditableCombinationForListing
     private $quantity;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $imagePath;
 
@@ -83,7 +83,7 @@ class EditableCombinationForListing
      * @param bool $default
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
-     * @param string $imagePath
+     * @param string|null $imagePath
      */
     public function __construct(
         int $combinationId,
@@ -93,7 +93,7 @@ class EditableCombinationForListing
         bool $default,
         DecimalNumber $impactOnPrice,
         int $quantity,
-        string $imagePath
+        ?string $imagePath = null
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -162,9 +162,9 @@ class EditableCombinationForListing
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getImagePath(): string
+    public function getImagePath(): ?string
     {
         return $this->imagePath;
     }

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -71,7 +71,7 @@ class EditableCombinationForListing
     private $quantity;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $imagePath;
 
@@ -83,7 +83,7 @@ class EditableCombinationForListing
      * @param bool $default
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
-     * @param string|null $imagePath
+     * @param string $imagePath
      */
     public function __construct(
         int $combinationId,
@@ -93,7 +93,7 @@ class EditableCombinationForListing
         bool $default,
         DecimalNumber $impactOnPrice,
         int $quantity,
-        ?string $imagePath = null
+        string $imagePath
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -162,9 +162,9 @@ class EditableCombinationForListing
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getImagePath(): ?string
+    public function getImagePath(): string
     {
         return $this->imagePath;
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -246,6 +246,8 @@ class CombinationController extends FrameworkBundleAdminController
             'combinations' => [],
             'total' => $combinationListForEditing->getTotalCombinationsCount(),
         ];
+
+        $fallbackImageUrl = $this->getFallbackImageUrl();
         foreach ($combinationListForEditing->getCombinations() as $combination) {
             $data['combinations'][] = [
                 'id' => $combination->getCombinationId(),
@@ -255,7 +257,7 @@ class CombinationController extends FrameworkBundleAdminController
                 'impactOnPrice' => (string) $combination->getImpactOnPrice(),
                 'quantity' => $combination->getQuantity(),
                 'isDefault' => $combination->isDefault(),
-                'imageUrl' => $this->formatImageUrl($combination->getImageUrl()),
+                'imageUrl' => $combination->getImageUrl() ?: $fallbackImageUrl,
             ];
         }
 
@@ -263,19 +265,13 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param string|null $imageUrl
-     *
      * @return string
      */
-    private function formatImageUrl(?string $imageUrl): string
+    private function getFallbackImageUrl(): string
     {
-        if (!$imageUrl) {
-            $imageUrlFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
+        $imageUrlFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
 
-            return $imageUrlFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
-        }
-
-        return $imageUrl;
+        return $imageUrlFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -255,7 +255,7 @@ class CombinationController extends FrameworkBundleAdminController
                 'impactOnPrice' => (string) $combination->getImpactOnPrice(),
                 'quantity' => $combination->getQuantity(),
                 'isDefault' => $combination->isDefault(),
-                'imageUrl' => $this->formatImageUrl($combination->getRelativeImagePath()),
+                'imageUrl' => $this->formatImageUrl($combination->getImageUrl()),
             ];
         }
 
@@ -263,19 +263,19 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param string|null $relativeImgPath
+     * @param string|null $imageUrl
      *
      * @return string
      */
-    private function formatImageUrl(?string $relativeImgPath): string
+    private function formatImageUrl(?string $imageUrl): string
     {
-        $imageUrlFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
+        if (!$imageUrl) {
+            $imageUrlFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
 
-        if (!$relativeImgPath) {
             return $imageUrlFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
         }
 
-        return $imageUrlFactory->buildFullPath($relativeImgPath);
+        return $imageUrl;
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -28,8 +28,8 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog\Product;
 
 use Exception;
-use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Query\GetProductAttributeGroups;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\QueryResult\AttributeGroup;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetEditableCombinationsList;
@@ -269,13 +269,9 @@ class CombinationController extends FrameworkBundleAdminController
      */
     private function formatImageUrl(?string $imgPath): string
     {
-        $contextLink = $this->getContext()->link;
-
         if (!$imgPath) {
-            $imageRetriever = new ImageRetriever($contextLink);
-            $defaultImg = $imageRetriever->getNoPictureImage($this->getContext()->language);
-
-            return $defaultImg['small']['url'];
+            $imagePathFactory = $this->get('prestashop.adapter.product.image.product_image_path_factory');
+            $imgPath = $imagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
         }
 
         return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -255,11 +255,22 @@ class CombinationController extends FrameworkBundleAdminController
                 'impactOnPrice' => (string) $combination->getImpactOnPrice(),
                 'quantity' => $combination->getQuantity(),
                 'isDefault' => $combination->isDefault(),
-                'imagePath' => $combination->getImagePath() ? $combination->getImagePath() . '-small_default.jpg' : null,
+                // @todo; no image thumbnail instead of null
+                'imageUrl' => $combination->getImagePath() ? $this->formatImageUrl($combination->getImagePath()) : null,
             ];
         }
 
         return $data;
+    }
+
+    /**
+     * @param string $imgPath
+     *
+     * @return string
+     */
+    private function formatImageUrl(string $imgPath): string
+    {
+        return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/') . '-small_default.jpg';
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -270,8 +270,9 @@ class CombinationController extends FrameworkBundleAdminController
     private function formatImageUrl(?string $imgPath): string
     {
         if (!$imgPath) {
-            $imagePathFactory = $this->get('prestashop.adapter.product.image.product_image_path_factory');
-            $imgPath = $imagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
+            $imagePathFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
+
+            return $imagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
         }
 
         return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog\Product;
 
 use Exception;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Query\GetProductAttributeGroups;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\QueryResult\AttributeGroup;
@@ -262,12 +263,21 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param string $imgPath
+     * @param string|null $imgPath
      *
      * @return string
      */
-    private function formatImageUrl(string $imgPath): string
+    private function formatImageUrl(?string $imgPath): string
     {
+        $contextLink = $this->getContext()->link;
+
+        if (!$imgPath) {
+            $imageRetriever = new ImageRetriever($contextLink);
+            $defaultImg = $imageRetriever->getNoPictureImage($this->getContext()->language);
+
+            return $defaultImg['small']['url'];
+        }
+
         return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/');
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -251,12 +251,10 @@ class CombinationController extends FrameworkBundleAdminController
                 'isSelected' => false,
                 'name' => $combination->getCombinationName(),
                 'reference' => $combination->getReference(),
-                //@todo: don't forget image path when implemented in the query
                 'impactOnPrice' => (string) $combination->getImpactOnPrice(),
                 'quantity' => $combination->getQuantity(),
                 'isDefault' => $combination->isDefault(),
-                // @todo; no image thumbnail instead of null
-                'imageUrl' => $combination->getImagePath() ? $this->formatImageUrl($combination->getImagePath()) : null,
+                'imageUrl' => $this->formatImageUrl($combination->getImagePath()),
             ];
         }
 
@@ -270,7 +268,7 @@ class CombinationController extends FrameworkBundleAdminController
      */
     private function formatImageUrl(string $imgPath): string
     {
-        return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/') . '-small_default.jpg';
+        return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -255,6 +255,7 @@ class CombinationController extends FrameworkBundleAdminController
                 'impactOnPrice' => (string) $combination->getImpactOnPrice(),
                 'quantity' => $combination->getQuantity(),
                 'isDefault' => $combination->isDefault(),
+                'imagePath' => $combination->getImagePath() ? $combination->getImagePath() . '-small_default.jpg' : null,
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -255,7 +255,7 @@ class CombinationController extends FrameworkBundleAdminController
                 'impactOnPrice' => (string) $combination->getImpactOnPrice(),
                 'quantity' => $combination->getQuantity(),
                 'isDefault' => $combination->isDefault(),
-                'imageUrl' => $this->formatImageUrl($combination->getImagePath()),
+                'imageUrl' => $this->formatImageUrl($combination->getRelativeImagePath()),
             ];
         }
 
@@ -263,19 +263,19 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @param string|null $imgPath
+     * @param string|null $relativeImgPath
      *
      * @return string
      */
-    private function formatImageUrl(?string $imgPath): string
+    private function formatImageUrl(?string $relativeImgPath): string
     {
-        if (!$imgPath) {
-            $imagePathFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
+        $imageUrlFactory = $this->get('prestashop.adapter.product.image.product_image_url_factory');
 
-            return $imagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
+        if (!$relativeImgPath) {
+            return $imageUrlFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
         }
 
-        return $this->getContext()->link->getAdminBaseLink() . ltrim($imgPath, '/');
+        return $imageUrlFactory->buildFullPath($relativeImgPath);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
@@ -36,3 +36,5 @@ services:
 
     prestashop.adapter.image.image_validator:
         class: 'PrestaShop\PrestaShop\Adapter\Image\ImageValidator'
+        arguments:
+            - '@=service("prestashop.core.configuration.upload_size_configuration").getMaxUploadSizeInBytes()'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -53,8 +53,6 @@ services:
     prestashop.adapter.product.combination.query_handler.get_editable_combinations_list_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler\GetEditableCombinationsListHandler
         arguments:
-            - '@prestashop.adapter.product.combination.repository.combination_repository'
-            - '@prestashop.core.util.number.number_extractor'
             - '@prestashop.adapter.product.stock.repository.stock_available_repository'
             - '@prestashop.core.grid.query_builder.product_combination'
             - '@prestashop.adapter.attribute.repository.attribute_repository'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -58,7 +58,7 @@ services:
             - '@prestashop.core.grid.query_builder.product_combination'
             - '@prestashop.adapter.attribute.repository.attribute_repository'
             - '@prestashop.adapter.product.image.repository.product_image_repository'
-            - '@prestashop.adapter.product.image.product_image_path_factory'
+            - '@prestashop.adapter.product.image.product_image_url_factory'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetEditableCombinationsList

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -41,6 +41,7 @@ services:
             - '@prestashop.adapter.product.stock.repository.stock_available_repository'
             - '@prestashop.adapter.attribute.repository.attribute_repository'
             - '@prestashop.adapter.product.repository.product_repository'
+            - '@prestashop.adapter.product.image.repository.product_image_repository'
             - '@prestashop.core.util.number.number_extractor'
             - '@prestashop.adapter.tax.tax_computer'
             - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
@@ -99,6 +100,12 @@ services:
             - '@prestashop.adapter.product.repository.product_repository'
             - '@prestashop.adapter.product.combination.repository.combination_repository'
 
+    prestashop.adapter.product.combination.update.combination_images_updater:
+        class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationImagesUpdater
+        arguments:
+            - '@doctrine.dbal.default_connection'
+            - '%database_prefix%'
+
     prestashop.adapter.product.combination.command_handler.update_combination_from_listing_handler:
         class: PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationFromListingHandler
         arguments:
@@ -137,3 +144,19 @@ services:
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllAssociatedCombinationSuppliersCommand
+
+    prestashop.adapter.product.combination.command_handler.set_combination_images_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\SetCombinationImagesHandler
+        arguments:
+            - '@prestashop.adapter.product.combination.update.combination_images_updater'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand
+
+    prestashop.adapter.product.combination.command_handler.remove_all_combination_images_handler:
+        class: PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\RemoveAllCombinationImagesHandler
+        arguments:
+            - '@prestashop.adapter.product.combination.update.combination_images_updater'
+        tags:
+            - name: tactician.handler
+              command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -58,8 +58,7 @@ services:
             - '@prestashop.core.grid.query_builder.product_combination'
             - '@prestashop.adapter.attribute.repository.attribute_repository'
             - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
-#            @todo; originally _PS_THEME_PROD_DIR_ was used, but it points to same dir and its not visible in tests. Can i use PROD_IMG_DIR?
-            - !php/const _PS_PROD_IMG_DIR_
+            - '@prestashop.adapter.product.image.product_image_path_factory'
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetEditableCombinationsList

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -58,7 +58,8 @@ services:
             - '@prestashop.core.grid.query_builder.product_combination'
             - '@prestashop.adapter.attribute.repository.attribute_repository'
             - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
-            - !php/const _THEME_PROD_DIR_
+#            @todo; originally _PS_THEME_PROD_DIR_ was used, but it points to same dir and its not visible in tests. Can i use PROD_IMG_DIR?
+            - !php/const _PS_PROD_IMG_DIR_
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetEditableCombinationsList

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -57,6 +57,8 @@ services:
             - '@prestashop.adapter.product.stock.repository.stock_available_repository'
             - '@prestashop.core.grid.query_builder.product_combination'
             - '@prestashop.adapter.attribute.repository.attribute_repository'
+            - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+            - !php/const _THEME_PROD_DIR_
         tags:
             - name: tactician.handler
               command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetEditableCombinationsList

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -57,7 +57,7 @@ services:
             - '@prestashop.adapter.product.stock.repository.stock_available_repository'
             - '@prestashop.core.grid.query_builder.product_combination'
             - '@prestashop.adapter.attribute.repository.attribute_repository'
-            - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+            - '@prestashop.adapter.product.image.repository.product_image_repository'
             - '@prestashop.adapter.product.image.product_image_path_factory'
         tags:
             - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -84,11 +84,8 @@ services:
     prestashop.adapter.product.image.uploader.product_image_uploader:
         class: 'PrestaShop\PrestaShop\Adapter\Product\Image\Uploader\ProductImageUploader'
         arguments:
-            - '@prestashop.core.configuration.upload_size_configuration'
             - '@prestashop.adapter.product.image.product_image_path_factory'
             - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
             - "@prestashop.adapter.image.image_generator"
             - "@prestashop.core.hook.dispatcher"
-            - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
             - '@prestashop.adapter.product.image.repository.product_image_repository'
-

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -57,7 +57,6 @@ services:
             - '@doctrine.dbal.default_connection'
             - '%database_prefix%'
             - '@prestashop.adapter.product.image.validate.product_image_validator'
-            - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
 
     prestashop.adapter.product.image.update.product_image_updater:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\Update\ProductImageUpdater

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -77,7 +77,7 @@ services:
     prestashop.adapter.product.image.product_image_url_factory:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
-            - !php/const _PS_PROD_IMG_
+            - '@=service("prestashop.adapter.shop.url.product_image_folder_provider").getUrl()'
             - !php/const _PS_TMP_IMG_DIR_
             - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -72,8 +72,7 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
             - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
-            - ''
-            - !php/const _PS_PROD_IMG_
+            - !php/const _PS_PROD_IMG_DIR_
             - !php/const _PS_TMP_IMG_DIR_
             - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 
@@ -81,7 +80,6 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
             - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
-            - '@=service("prestashop.adapter.legacy.context").getContext().link.getAdminBaseLink()'
             - !php/const _PS_PROD_IMG_
             - !php/const _PS_TMP_IMG_DIR_
             - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -70,7 +70,6 @@ services:
     prestashop.adapter.product.image.product_image_path_factory:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
-            - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
             - !php/const _PS_PROD_IMG_DIR_
             - !php/const _PS_TMP_IMG_DIR_
             - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
@@ -78,7 +77,6 @@ services:
     prestashop.adapter.product.image.product_image_url_factory:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
-            - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
             - !php/const _PS_PROD_IMG_
             - !php/const _PS_TMP_IMG_DIR_
             - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -71,7 +71,9 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
             - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
+            - !php/const _PS_PROD_IMG_DIR_
             - !php/const _PS_TMP_IMG_DIR_
+            - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 
     prestashop.adapter.product.image.uploader.product_image_uploader:
         class: 'PrestaShop\PrestaShop\Adapter\Product\Image\Uploader\ProductImageUploader'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -57,6 +57,7 @@ services:
             - '@doctrine.dbal.default_connection'
             - '%database_prefix%'
             - '@prestashop.adapter.product.image.validate.product_image_validator'
+            - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
 
     prestashop.adapter.product.image.update.product_image_updater:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\Update\ProductImageUpdater

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -71,7 +71,17 @@ services:
         class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
         arguments:
             - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
-            - !php/const _PS_PROD_IMG_DIR_
+            - ''
+            - !php/const _PS_PROD_IMG_
+            - !php/const _PS_TMP_IMG_DIR_
+            - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
+
+    prestashop.adapter.product.image.product_image_url_factory:
+        class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
+        arguments:
+            - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_LEGACY_IMAGES')"
+            - '@=service("prestashop.adapter.legacy.context").getContext().link.getAdminBaseLink()'
+            - !php/const _PS_PROD_IMG_
             - !php/const _PS_TMP_IMG_DIR_
             - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
@@ -48,3 +48,9 @@ services:
     tags:
       - name: 'tactician.handler'
         command: PrestaShop\PrestaShop\Core\Domain\Shop\Query\SearchShops
+
+  prestashop.adapter.shop.url.product_image_folder_provider:
+      class: 'PrestaShop\PrestaShop\Adapter\Shop\Url\ProductImageFolderProvider'
+      arguments:
+          - "@=service('prestashop.adapter.legacy.context').getContext().link"
+          - !php/const _PS_PROD_IMG_

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
@@ -53,4 +53,4 @@ services:
       class: 'PrestaShop\PrestaShop\Adapter\Shop\Url\ProductImageFolderProvider'
       arguments:
           - "@=service('prestashop.adapter.legacy.context').getContext().link"
-          - !php/const _PS_PROD_IMG_
+          - 'img/p'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/combinations_form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/combinations_form_theme.html.twig
@@ -31,10 +31,13 @@
 {%- endblock -%}
 
 {%- block combination_item_row -%}
-  <tr>
+  <tr id="combination-list-row-{{ form.vars.name }}">
     <td>
       {{ form_widget(form.is_selected) }}
       {{ form_widget(form.combination_id) }}
+    </td>
+    <td>
+      <img class="combination-image" src="" alt="">
     </td>
     <td>
       {{ form_widget(form.name) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/combinations_form_theme.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Form/combinations_form_theme.html.twig
@@ -77,6 +77,7 @@
       <th scope="col">
         {{ ps.sortable_column_header('ID'|trans({}, 'Admin.Global'), 'id_product_attribute') }}
       </th>
+      <th scope="col"></th>
       <th scope="col">
         {{ 'Combination'|trans({}, 'Admin.Global') }}
       </th>

--- a/tests/Integration/Adapter/Shop/Url/TestProductImageFolderProvider.php
+++ b/tests/Integration/Adapter/Shop/Url/TestProductImageFolderProvider.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\Shop\Url;
+
+use PrestaShop\PrestaShop\Core\Shop\Url\UrlProviderInterface;
+
+/**
+ * Test class used to replace ProductImageFolderProvider in test environment
+ */
+class TestProductImageFolderProvider implements UrlProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getUrl()
+    {
+        return 'http://myshop.com/img/p';
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
@@ -264,7 +264,7 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
             $expectedCombination = $expectedDataRows[$key];
 
             // @todo: assert combination images when we implement combination image association commands
-            Assert::assertNull($editableCombinationForListing->getRelativeImagePath(), 'Unexpected combination image');
+            Assert::assertNull($editableCombinationForListing->getImageUrl(), 'Unexpected combination image');
 
             Assert::assertSame(
                 $expectedCombination['combination name'],

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
@@ -263,9 +263,6 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
         foreach ($listCombinations as $key => $editableCombinationForListing) {
             $expectedCombination = $expectedDataRows[$key];
 
-            // @todo: assert combination images when we implement combination image association commands
-            Assert::assertNull($editableCombinationForListing->getImageUrl(), 'Unexpected combination image');
-
             Assert::assertSame(
                 $expectedCombination['combination name'],
                 $editableCombinationForListing->getCombinationName(),
@@ -298,6 +295,30 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
                 count($editableCombinationForListing->getAttributesInformation()),
                 'Unexpected attributes count in combination'
             );
+
+            if (empty($expectedCombination['image url'])) {
+                Assert::assertNull($editableCombinationForListing->getImageUrl(), 'Unexpected combination image');
+            } else {
+                // Get image reference which is integrated in image url
+                $imageUrl = $expectedCombination['image url'];
+                preg_match('_\{(.+)\}_', $imageUrl, $matches);
+                $imageReference = $matches[1];
+                $imageId = $this->getSharedStorage()->get($imageReference);
+
+                // Now rebuild the image folder with image id appended
+                $imageFolder = implode('/', str_split((string) $imageId)) . '/' . $imageId;
+                $realImageUrl = str_replace(
+                    '{' . $imageReference . '}',
+                    $imageFolder,
+                    $imageUrl
+                );
+
+                Assert::assertEquals(
+                    $realImageUrl,
+                    $editableCombinationForListing->getImageUrl(),
+                    'Unexpected combination image url'
+                );
+            }
 
             $this->assertAttributesInfo($expectedAttributesInfo, $editableCombinationForListing->getAttributesInformation());
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
@@ -263,6 +263,9 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
         foreach ($listCombinations as $key => $editableCombinationForListing) {
             $expectedCombination = $expectedDataRows[$key];
 
+            // @todo: assert combination images when we implement combination image association commands
+            Assert::assertNull($editableCombinationForListing->getImagePath(), 'Unexpected combination image');
+
             Assert::assertSame(
                 $expectedCombination['combination name'],
                 $editableCombinationForListing->getCombinationName(),

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
@@ -264,7 +264,7 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
             $expectedCombination = $expectedDataRows[$key];
 
             // @todo: assert combination images when we implement combination image association commands
-            Assert::assertNull($editableCombinationForListing->getImagePath(), 'Unexpected combination image');
+            Assert::assertNull($editableCombinationForListing->getRelativeImagePath(), 'Unexpected combination image');
 
             Assert::assertSame(
                 $expectedCombination['combination name'],

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationImagesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationImagesFeatureContext.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
+
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\RemoveAllCombinationImagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetCombinationImagesCommand;
+use RuntimeException;
+
+class UpdateCombinationImagesFeatureContext extends AbstractCombinationFeatureContext
+{
+    /**
+     * @When I associate :imageReferences to combination :combinationReference
+     *
+     * @param array $imageReferences
+     * @param string $combinationReference
+     */
+    public function associateCombinationImages(array $imageReferences, string $combinationReference): void
+    {
+        $imageIds = array_map(function (string $imageReference) {
+            return (int) $this->getSharedStorage()->get($imageReference);
+        }, $imageReferences);
+
+        $this->getCommandBus()->handle(new SetCombinationImagesCommand(
+            (int) $this->getSharedStorage()->get($combinationReference),
+            $imageIds
+        ));
+    }
+
+    /**
+     * @When I remove all images associated to combination :combinationReference
+     *
+     * @param string $combinationReference
+     */
+    public function removeCombinationImages(string $combinationReference): void
+    {
+        $this->getCommandBus()->handle(new RemoveAllCombinationImagesCommand(
+            (int) $this->getSharedStorage()->get($combinationReference)
+        ));
+    }
+
+    /**
+     * @Then combination :combinationReference should have following images :imageReferences
+     *
+     * @param string $combinationReference
+     * @param string[] $imageReferences
+     */
+    public function assertCombinationImages(string $combinationReference, array $imageReferences): void
+    {
+        $images = $this->getCombinationForEditing($combinationReference)->getImageIds();
+        Assert::assertEquals(count($images), count($imageReferences));
+        foreach ($imageReferences as $imageReference) {
+            $imageId = $this->getSharedStorage()->get($imageReference);
+            if (!in_array($imageId, $images)) {
+                throw new RuntimeException(sprintf(
+                    'Could not find image %s for combination %s',
+                    $imageId,
+                    $combinationReference
+                ));
+            }
+        }
+    }
+
+    /**
+     * @Then combination :combinationReference should have no images
+     *
+     * @param string $combinationReference
+     */
+    public function assertNoImages(string $combinationReference): void
+    {
+        $images = $this->getCombinationForEditing($combinationReference)->getImageIds();
+        Assert::assertEmpty($images);
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -54,7 +54,7 @@ Feature: Associate combination image from Back Office (BO)
       | type        | combinations      |
     And product product1 type should be combinations
     And I generate combinations for product product1 using following attributes:
-      | Size  | [S,M]              |
+      | Size  | [S,M]         |
       | Color | [White,Black] |
     And product "product1" should have following combinations:
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | image url |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -57,13 +57,21 @@ Feature: Associate combination image from Back Office (BO)
       | Size  | [S,M]              |
       | Color | [White,Black] |
     And product "product1" should have following combinations:
-      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
-      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
-      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
-      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
-      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | image url |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |           |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |           |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |           |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |           |
     And combination "product1SWhite" should have no images
     When I associate "[image1, image2]" to combination "product1SWhite"
     Then combination "product1SWhite" should have following images "[image1, image2]"
+    When I associate "[image3, image4]" to combination "product1MBlack"
+    Then combination "product1MBlack" should have following images "[image3, image4]"
+    And product "product1" should have following combinations:
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | image url                         |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | /img/p/{image1}-small_default.jpg |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |                                   |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |                                   |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | /img/p/{image3}-small_default.jpg |
     When I remove all images associated to combination "product1SWhite"
     And combination "product1SWhite" should have no images

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -68,10 +68,10 @@ Feature: Associate combination image from Back Office (BO)
     When I associate "[image3, image4]" to combination "product1MBlack"
     Then combination "product1MBlack" should have following images "[image3, image4]"
     And product "product1" should have following combinations:
-      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | image url                         |
-      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | /img/p/{image1}-small_default.jpg |
-      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |                                   |
-      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |                                   |
-      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | /img/p/{image3}-small_default.jpg |
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                          |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{image1}-small_default.jpg |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |                                                    |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |                                                    |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{image3}-small_default.jpg |
     When I remove all images associated to combination "product1SWhite"
     And combination "product1SWhite" should have no images

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -1,0 +1,69 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-images
+@reset-database-before-feature
+@clear-cache-before-feature
+@reset-img-after-feature
+@product-combination
+@update-combination-images
+Feature: Associate combination image from Back Office (BO)
+  As an employee I need to be able to associate combination images
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And following image types should be applicable to products:
+      | reference     | name           | width | height |
+      | cartDefault   | cart_default   | 125   | 125    |
+      | homeDefault   | home_default   | 250   | 250    |
+      | largeDefault  | large_default  | 800   | 800    |
+      | mediumDefault | medium_default | 452   | 452    |
+      | smallDefault  | small_default  | 98    | 98     |
+    And I add product "product1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And product "product1" type should be standard
+    And product "product1" should have no images
+    And I add new image "image1" named "app_icon.png" to product "product1"
+    And I add new image "image2" named "logo.jpg" to product "product1"
+    And I add new image "image3" named "app_icon.png" to product "product1"
+    And I add new image "image4" named "logo.jpg" to product "product1"
+    And product "product1" should have following images:
+      | image reference | is cover | legend[en-US] | position |
+      | image1          | true     |               | 1        |
+      | image2          | false    |               | 2        |
+      | image3          | false    |               | 3        |
+      | image4          | false    |               | 4        |
+    And images "[image1, image2, image3, image4]" should have following types generated:
+      | name           | width | height |
+      | cart_default   | 125   | 125    |
+      | home_default   | 250   | 250    |
+      | large_default  | 800   | 800    |
+      | medium_default | 452   | 452    |
+      | small_default  | 98    | 98     |
+
+  Scenario: I associate images to a combination
+    Given I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I generate combinations for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black] |
+    And product "product1" should have following combinations:
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And combination "product1SWhite" should have no images
+    When I associate "[image1, image2]" to combination "product1SWhite"
+    Then combination "product1SWhite" should have following images "[image1, image2]"
+    When I remove all images associated to combination "product1SWhite"
+    And combination "product1SWhite" should have no images

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -271,6 +271,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationPricesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPriceContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext

--- a/tests/Resources/config/services.yml
+++ b/tests/Resources/config/services.yml
@@ -8,6 +8,9 @@ services:
     prestashop.adapter.image.uploader.category_cover_image_uploader:
         class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\CategoryCoverImageUploader'
 
+    prestashop.adapter.shop.url.product_image_folder_provider:
+        class: 'Tests\Integration\Adapter\Shop\Url\TestProductImageFolderProvider'
+
     # Advanced form type
     test.integration.prestashop_bundle.form.advanced_form_type:
         class: 'Tests\Integration\PrestaShopBundle\Form\AdvancedFormType'

--- a/tests/Unit/Adapter/Image/ImageValidatorTest.php
+++ b/tests/Unit/Adapter/Image/ImageValidatorTest.php
@@ -31,6 +31,7 @@ namespace Tests\Unit\Adapter\Image;
 use Generator;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Image\ImageValidator;
+use PrestaShop\PrestaShop\Core\Configuration\IniConfiguration;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageFileNotFoundException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
@@ -46,7 +47,8 @@ class ImageValidatorTest extends TestCase
     public function setUp()
     {
         require_once __DIR__ . '/../../bootstrap.php';
-        $this->imageValidator = new ImageValidator();
+        $iniConfiguration = new IniConfiguration();
+        $this->imageValidator = new ImageValidator($iniConfiguration->getUploadMaxSizeInBytes());
     }
 
     /**

--- a/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
+++ b/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Image;
+
+use Generator;
+use Image;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
+
+class ProductImagePathFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider getArgumentsForSmokeTest
+     *
+     * @param bool $isLegacyImageMode
+     * @param string $basePath
+     * @param string $relativeImagesPath
+     * @param string $temporaryImgDir
+     * @param string $contextLangIsoCode
+     */
+    public function testConstructImagePathFactory(
+        bool $isLegacyImageMode,
+        string $basePath,
+        string $relativeImagesPath,
+        string $temporaryImgDir,
+        string $contextLangIsoCode
+    ): void {
+        $imagePathFactory = new ProductImagePathFactory(
+            $isLegacyImageMode,
+            $basePath,
+            $relativeImagesPath,
+            $temporaryImgDir,
+            $contextLangIsoCode
+        );
+        Assert::assertInstanceOf(ProductImagePathFactory::class, $imagePathFactory);
+    }
+
+    /**
+     * @dataProvider getDataForFullPathBuilding
+     *
+     * @param string $basePath
+     * @param string $relativePath
+     * @param string $expected
+     */
+    public function testBuildsFullPath(string $basePath, string $relativePath, string $expected): void
+    {
+        $imagePathFactory = $this->buildImagePathFactory($basePath);
+        $actual = $imagePathFactory->buildFullPath($relativePath);
+
+        Assert::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @dataProvider getDataForBaseImagePathBuilding
+     *
+     * @param string $basePath
+     * @param Image $image
+     * @param string $expected
+     */
+    public function testGetBaseImagePath(string $basePath, Image $image, string $expected): void
+    {
+        $imagePathFactory = $this->buildImagePathFactory($basePath);
+
+        Assert::assertEquals($expected, $imagePathFactory->getBaseImagePath($image));
+    }
+
+    /**
+     * @dataProvider getDataForPathByType
+     *
+     * @param string $basePath
+     * @param Image $image
+     * @param string $type
+     * @param string $expected
+     */
+    public function testGetPathByType(string $basePath, Image $image, string $type, string $expected): void
+    {
+        $imagePathFactory = $this->buildImagePathFactory($basePath);
+
+        Assert::assertEquals($expected, $imagePathFactory->getPathByType($image, $type));
+    }
+
+    /**
+     * @dataProvider getDataforNoImagePath
+     *
+     * @param string $basePath
+     * @param string $type
+     * @param string|null $langIso
+     * @param string $expected
+     */
+    public function testGetNoImagePath(string $basePath, string $type, ?string $langIso, string $expected): void
+    {
+        $imagePathFactory = $this->buildImagePathFactory($basePath);
+
+        Assert::assertEquals($expected, $imagePathFactory->getNoImagePath($type, $langIso));
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getArgumentsForSmokeTest(): Generator
+    {
+        yield [false, 'localhost/', '/img/p/', 'img/tmp', 'en'];
+        yield [true, '', '/img', 'img/tmp', 'en'];
+        yield [true, '', '/img', 'img/tmp', 'lt'];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getDataForFullPathBuilding(): Generator
+    {
+        yield ['localhost', '/img/p/20.jpg', 'localhost/img/p/20.jpg'];
+        yield ['localhost/', '/img/p/20.jpg', 'localhost/img/p/20.jpg'];
+        yield ['localhost', 'img/p/20.jpg', 'localhost/img/p/20.jpg'];
+        yield ['/var/www/html/prestashop/', 'img/p/20.jpg', '/var/www/html/prestashop/img/p/20.jpg'];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getDataForBaseImagePathBuilding(): Generator
+    {
+        $img1 = $this->mockImage(10, 'jpg', '/1/0/10');
+        $img2 = $this->mockImage(11, 'jpg', '/1/1/11');
+        $img3 = $this->mockImage(2504, 'png', '/2/5/0/4/2504');
+
+        yield ['localhost', $img1, 'localhost/img/p/1/0/10.jpg'];
+        yield ['localhost', $img2, 'localhost/img/p/1/1/11.jpg'];
+        yield ['localhost', $img3, 'localhost/img/p/2/5/0/4/2504.png'];
+        yield ['/var/www/presta/', $img3, '/var/www/presta/img/p/2/5/0/4/2504.png'];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getDataForPathByType(): Generator
+    {
+        $img1 = $this->mockImage(10, 'jpg', '/1/0/10');
+        $img2 = $this->mockImage(11, 'jpg', '/1/1/11');
+        $img3 = $this->mockImage(2504, 'png', '/2/5/0/4/2504');
+
+        yield ['localhost', $img1, 'small_default', 'localhost/img/p/1/0/10-small_default.jpg'];
+        yield ['localhost', $img2, 'medium_default', 'localhost/img/p/1/1/11-medium_default.jpg'];
+        yield ['localhost', $img3, 'large_default', 'localhost/img/p/2/5/0/4/2504-large_default.png'];
+        yield ['/var/www/presta/', $img3, 'cart_default', '/var/www/presta/img/p/2/5/0/4/2504-cart_default.png'];
+    }
+
+    public function getDataForNoImagePath(): Generator
+    {
+        yield ['localhost', 'small_default', null, 'localhost/img/p/en-default-small_default.jpg'];
+        yield ['localhost', 'medium_default', 'lt', 'localhost/img/p/lt-default-medium_default.jpg'];
+        yield ['/var/www/presta/', 'large_default', 'fr', '/var/www/presta/img/p/fr-default-large_default.jpg'];
+    }
+
+    /**
+     * @param int $id
+     * @param string $format
+     * @param string $imgPathWillReturn
+     *
+     * @return Image
+     */
+    private function mockImage(int $id, string $format, string $imgPathWillReturn): Image
+    {
+        $imageMock =
+            $this->getMockBuilder(Image::class)
+                ->setMethods(['getImgPath'])
+                ->getMock()
+        ;
+        $imageMock->method('getImgPath')->willReturn($imgPathWillReturn);
+        $imageMock->id = $id;
+        $imageMock->image_format = $format;
+
+        return $imageMock;
+    }
+
+    /**
+     * @param string $basePath
+     *
+     * @return ProductImagePathFactory
+     */
+    private function buildImagePathFactory(string $basePath): ProductImagePathFactory
+    {
+        return new ProductImagePathFactory(
+            false,
+            $basePath,
+            '/img/p',
+            '/img/tmp/',
+            'en'
+        );
+    }
+}

--- a/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
+++ b/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
@@ -65,11 +65,11 @@ class ProductImagePathFactoryTest extends TestCase
      * @param Image $image
      * @param string $expected
      */
-    public function testGetBaseImagePath(string $pathToBaseDir, Image $image, string $expected): void
+    public function testGetPath(string $pathToBaseDir, Image $image, string $expected): void
     {
         $imagePathFactory = $this->buildImagePathFactory($pathToBaseDir);
 
-        Assert::assertEquals($expected, $imagePathFactory->getBaseImagePath($image));
+        Assert::assertEquals($expected, $imagePathFactory->getPath($image));
     }
 
     /**

--- a/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
+++ b/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
@@ -138,10 +138,11 @@ class ProductImagePathFactoryTest extends TestCase
      */
     public function getDataForPathByType(): Generator
     {
-        yield ['/img/p/', new ImageId(10), 'small_default', '/img/p/1/0/10-small_default.jpg'];
-        yield ['/img/p', new ImageId(11), 'medium_default', '/img/p/1/1/11-medium_default.jpg'];
-        yield ['img/p/', new ImageId(2504), 'large_default', 'img/p/2/5/0/4/2504-large_default.jpg'];
-        yield ['/img/p/', new ImageId(2504), 'cart_default', '/img/p/2/5/0/4/2504-cart_default.jpg'];
+        yield ['/img/p/', new ImageId(10), ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT, '/img/p/1/0/10-small_default.jpg'];
+        yield ['/img/p', new ImageId(11), ProductImagePathFactory::IMAGE_TYPE_MEDIUM_DEFAULT, '/img/p/1/1/11-medium_default.jpg'];
+        yield ['img/p/', new ImageId(2504), ProductImagePathFactory::IMAGE_TYPE_LARGE_DEFAULT, 'img/p/2/5/0/4/2504-large_default.jpg'];
+        yield ['/img/p/', new ImageId(2504), ProductImagePathFactory::IMAGE_TYPE_CART_DEFAULT, '/img/p/2/5/0/4/2504-cart_default.jpg'];
+        yield ['/img/p/', new ImageId(2504), ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT, '/img/p/2/5/0/4/2504-home_default.jpg'];
     }
 
     public function getDataForImageFolder(): Generator

--- a/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
+++ b/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
@@ -39,22 +39,19 @@ class ProductImagePathFactoryTest extends TestCase
      * @dataProvider getArgumentsForSmokeTest
      *
      * @param bool $isLegacyImageMode
-     * @param string $basePath
-     * @param string $relativeImagesPath
+     * @param string $pathToBaseDir
      * @param string $temporaryImgDir
      * @param string $contextLangIsoCode
      */
     public function testConstructImagePathFactory(
         bool $isLegacyImageMode,
-        string $basePath,
-        string $relativeImagesPath,
+        string $pathToBaseDir,
         string $temporaryImgDir,
         string $contextLangIsoCode
     ): void {
         $imagePathFactory = new ProductImagePathFactory(
             $isLegacyImageMode,
-            $basePath,
-            $relativeImagesPath,
+            $pathToBaseDir,
             $temporaryImgDir,
             $contextLangIsoCode
         );
@@ -62,30 +59,15 @@ class ProductImagePathFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider getDataForFullPathBuilding
-     *
-     * @param string $basePath
-     * @param string $relativePath
-     * @param string $expected
-     */
-    public function testBuildsFullPath(string $basePath, string $relativePath, string $expected): void
-    {
-        $imagePathFactory = $this->buildImagePathFactory($basePath);
-        $actual = $imagePathFactory->buildFullPath($relativePath);
-
-        Assert::assertEquals($expected, $actual);
-    }
-
-    /**
      * @dataProvider getDataForBaseImagePathBuilding
      *
-     * @param string $basePath
+     * @param string $pathToBaseDir
      * @param Image $image
      * @param string $expected
      */
-    public function testGetBaseImagePath(string $basePath, Image $image, string $expected): void
+    public function testGetBaseImagePath(string $pathToBaseDir, Image $image, string $expected): void
     {
-        $imagePathFactory = $this->buildImagePathFactory($basePath);
+        $imagePathFactory = $this->buildImagePathFactory($pathToBaseDir);
 
         Assert::assertEquals($expected, $imagePathFactory->getBaseImagePath($image));
     }
@@ -93,29 +75,29 @@ class ProductImagePathFactoryTest extends TestCase
     /**
      * @dataProvider getDataForPathByType
      *
-     * @param string $basePath
+     * @param string $pathToBaseDir
      * @param Image $image
      * @param string $type
      * @param string $expected
      */
-    public function testGetPathByType(string $basePath, Image $image, string $type, string $expected): void
+    public function testGetPathByType(string $pathToBaseDir, Image $image, string $type, string $expected): void
     {
-        $imagePathFactory = $this->buildImagePathFactory($basePath);
+        $imagePathFactory = $this->buildImagePathFactory($pathToBaseDir);
 
         Assert::assertEquals($expected, $imagePathFactory->getPathByType($image, $type));
     }
 
     /**
-     * @dataProvider getDataforNoImagePath
+     * @dataProvider getDataForNoImagePath
      *
-     * @param string $basePath
+     * @param string $pathToBaseDir
      * @param string $type
      * @param string|null $langIso
      * @param string $expected
      */
-    public function testGetNoImagePath(string $basePath, string $type, ?string $langIso, string $expected): void
+    public function testGetNoImagePath(string $pathToBaseDir, string $type, ?string $langIso, string $expected): void
     {
-        $imagePathFactory = $this->buildImagePathFactory($basePath);
+        $imagePathFactory = $this->buildImagePathFactory($pathToBaseDir);
 
         Assert::assertEquals($expected, $imagePathFactory->getNoImagePath($type, $langIso));
     }
@@ -125,20 +107,9 @@ class ProductImagePathFactoryTest extends TestCase
      */
     public function getArgumentsForSmokeTest(): Generator
     {
-        yield [false, 'localhost/', '/img/p/', 'img/tmp', 'en'];
-        yield [true, '', '/img', 'img/tmp', 'en'];
-        yield [true, '', '/img', 'img/tmp', 'lt'];
-    }
-
-    /**
-     * @return Generator
-     */
-    public function getDataForFullPathBuilding(): Generator
-    {
-        yield ['localhost', '/img/p/20.jpg', 'localhost/img/p/20.jpg'];
-        yield ['localhost/', '/img/p/20.jpg', 'localhost/img/p/20.jpg'];
-        yield ['localhost', 'img/p/20.jpg', 'localhost/img/p/20.jpg'];
-        yield ['/var/www/html/prestashop/', 'img/p/20.jpg', '/var/www/html/prestashop/img/p/20.jpg'];
+        yield [false, '/img/p/', 'img/tmp', 'en'];
+        yield [true, '/img', 'img/tmp', 'en'];
+        yield [true, '/img', 'img/tmp', 'lt'];
     }
 
     /**
@@ -150,10 +121,10 @@ class ProductImagePathFactoryTest extends TestCase
         $img2 = $this->mockImage(11, 'jpg', '/1/1/11');
         $img3 = $this->mockImage(2504, 'png', '/2/5/0/4/2504');
 
-        yield ['localhost', $img1, 'localhost/img/p/1/0/10.jpg'];
-        yield ['localhost', $img2, 'localhost/img/p/1/1/11.jpg'];
-        yield ['localhost', $img3, 'localhost/img/p/2/5/0/4/2504.png'];
-        yield ['/var/www/presta/', $img3, '/var/www/presta/img/p/2/5/0/4/2504.png'];
+        yield ['/img/p', $img1, '/img/p/1/0/10.jpg'];
+        yield ['whatever/img/p', $img2, 'whatever/img/p/1/1/11.jpg'];
+        yield ['img/p/', $img3, 'img/p/2/5/0/4/2504.png'];
+        yield ['/', $img3, '/2/5/0/4/2504.png'];
     }
 
     /**
@@ -165,17 +136,17 @@ class ProductImagePathFactoryTest extends TestCase
         $img2 = $this->mockImage(11, 'jpg', '/1/1/11');
         $img3 = $this->mockImage(2504, 'png', '/2/5/0/4/2504');
 
-        yield ['localhost', $img1, 'small_default', 'localhost/img/p/1/0/10-small_default.jpg'];
-        yield ['localhost', $img2, 'medium_default', 'localhost/img/p/1/1/11-medium_default.jpg'];
-        yield ['localhost', $img3, 'large_default', 'localhost/img/p/2/5/0/4/2504-large_default.png'];
-        yield ['/var/www/presta/', $img3, 'cart_default', '/var/www/presta/img/p/2/5/0/4/2504-cart_default.png'];
+        yield ['/img/p/', $img1, 'small_default', '/img/p/1/0/10-small_default.jpg'];
+        yield ['/img/p', $img2, 'medium_default', '/img/p/1/1/11-medium_default.jpg'];
+        yield ['img/p/', $img3, 'large_default', 'img/p/2/5/0/4/2504-large_default.png'];
+        yield ['/img/p/', $img3, 'cart_default', '/img/p/2/5/0/4/2504-cart_default.png'];
     }
 
     public function getDataForNoImagePath(): Generator
     {
-        yield ['localhost', 'small_default', null, 'localhost/img/p/en-default-small_default.jpg'];
-        yield ['localhost', 'medium_default', 'lt', 'localhost/img/p/lt-default-medium_default.jpg'];
-        yield ['/var/www/presta/', 'large_default', 'fr', '/var/www/presta/img/p/fr-default-large_default.jpg'];
+        yield ['/img/p', 'small_default', null, '/img/p/en-default-small_default.jpg'];
+        yield ['/img/p', 'medium_default', 'lt', '/img/p/lt-default-medium_default.jpg'];
+        yield ['/img/p', 'large_default', 'fr', '/img/p/fr-default-large_default.jpg'];
     }
 
     /**
@@ -190,8 +161,7 @@ class ProductImagePathFactoryTest extends TestCase
         $imageMock =
             $this->getMockBuilder(Image::class)
                 ->setMethods(['getImgPath'])
-                ->getMock()
-        ;
+                ->getMock();
         $imageMock->method('getImgPath')->willReturn($imgPathWillReturn);
         $imageMock->id = $id;
         $imageMock->image_format = $format;
@@ -200,16 +170,15 @@ class ProductImagePathFactoryTest extends TestCase
     }
 
     /**
-     * @param string $basePath
+     * @param string $pathToBaseDir
      *
      * @return ProductImagePathFactory
      */
-    private function buildImagePathFactory(string $basePath): ProductImagePathFactory
+    private function buildImagePathFactory(string $pathToBaseDir): ProductImagePathFactory
     {
         return new ProductImagePathFactory(
             false,
-            $basePath,
-            '/img/p',
+            $pathToBaseDir,
             '/img/tmp/',
             'en'
         );

--- a/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
+++ b/tests/Unit/Adapter/Product/Image/ProductImagePathFactoryTest.php
@@ -85,6 +85,20 @@ class ProductImagePathFactoryTest extends TestCase
     }
 
     /**
+     * @dataProvider getDataForImageFolder
+     *
+     * @param string $pathToBaseDir
+     * @param ImageId $imageId
+     * @param string $expected
+     */
+    public function testGetImageFolder(string $pathToBaseDir, ImageId $imageId, string $expected): void
+    {
+        $imagePathFactory = $this->buildImagePathFactory($pathToBaseDir);
+
+        Assert::assertEquals($expected, $imagePathFactory->getImageFolder($imageId));
+    }
+
+    /**
      * @dataProvider getDataForNoImagePath
      *
      * @param string $pathToBaseDir
@@ -128,6 +142,14 @@ class ProductImagePathFactoryTest extends TestCase
         yield ['/img/p', new ImageId(11), 'medium_default', '/img/p/1/1/11-medium_default.jpg'];
         yield ['img/p/', new ImageId(2504), 'large_default', 'img/p/2/5/0/4/2504-large_default.jpg'];
         yield ['/img/p/', new ImageId(2504), 'cart_default', '/img/p/2/5/0/4/2504-cart_default.jpg'];
+    }
+
+    public function getDataForImageFolder(): Generator
+    {
+        yield ['/img/p/', new ImageId(10), '/img/p/1/0'];
+        yield ['/img/p', new ImageId(11), '/img/p/1/1'];
+        yield ['img/p/', new ImageId(2504), 'img/p/2/5/0/4'];
+        yield ['/img/p/', new ImageId(2504), '/img/p/2/5/0/4'];
     }
 
     public function getDataForNoImagePath(): Generator

--- a/tests/Unit/Adapter/Shop/Url/ProductImageFolderProviderTest.php
+++ b/tests/Unit/Adapter/Shop/Url/ProductImageFolderProviderTest.php
@@ -26,42 +26,38 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Adapter\Shop\Url;
+namespace Tests\Unit\Adapter\Shop\Url;
 
+use Generator;
 use Link;
-use PrestaShop\PrestaShop\Core\Shop\Url\UrlProviderInterface;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductImageFolderProvider;
 
-class ProductImageFolderProvider implements UrlProviderInterface
+class ProductImageFolderProviderTest extends TestCase
 {
     /**
-     * @var Link
+     * @dataProvider getTestData
+     *
+     * @param string $baseUrl
+     * @param string $relativeImagePath
+     * @param string $expectedUrl
      */
-    private $link;
-
-    /**
-     * @var string
-     */
-    private $imagesRelativeFolder;
-
-    /**
-     * @param Link $link
-     * @param string $imagesRelativeFolder
-     */
-    public function __construct(
-        Link $link,
-        string $imagesRelativeFolder
-    ) {
-        $this->link = $link;
-        $this->imagesRelativeFolder = $imagesRelativeFolder;
+    public function testGetUrl(string $baseUrl, string $relativeImagePath, string $expectedUrl): void
+    {
+        $linkMock = $this->createMock(Link::class);
+        $linkMock->method('getBaseLink')
+            ->willReturn($baseUrl)
+        ;
+        $provider = new ProductImageFolderProvider($linkMock, $relativeImagePath);
+        $generatedUrl = $provider->getUrl();
+        $this->assertEquals($expectedUrl, $generatedUrl);
     }
 
-    /**
-     * Create a link to product images base folder.
-     *
-     * @return string
-     */
-    public function getUrl(): string
+    public function getTestData(): Generator
     {
-        return rtrim($this->link->getBaseLink(), '/') . '/' . rtrim($this->imagesRelativeFolder, '/');
+        yield ['http://superurl', 'img/p', 'http://superurl/img/p'];
+        yield ['http://superurl/', 'img/p', 'http://superurl/img/p'];
+        yield ['http://superurl', 'img/p/', 'http://superurl/img/p'];
+        yield ['http://superurl/', 'img/p/', 'http://superurl/img/p'];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProviderTest.php
@@ -255,7 +255,8 @@ class CombinationFormDataProviderTest extends TestCase
             $combination['name'] ?? static::DEFAULT_NAME,
             $this->createDetails($combination),
             $this->createPrices($combination),
-            $this->createStock($combination)
+            $this->createStock($combination),
+            $combination['image_ids'] ?? []
         );
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add images to combination list in product edit v2 page. No styling is done, only php part. (see screenshot how it looks bellow). Notice :warning:  - legacy page used to show images for every combination, even if that combination doesn't have associated image (I feel like it was more like a bug ?) - now if combination doesn't have image, it shows default "no_image" image instead.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of #20648
| How to test?      | see images in combinations list of product page v2
| Possible impacts? | need to double check ImagePathFactory related code (like Product image upload command). Because done some refacto there.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24013)
<!-- Reviewable:end -->
Screenshots:
![Screenshot from 2021-04-13 10-08-53](https://user-images.githubusercontent.com/31609858/114511220-4c7c8100-9c40-11eb-94ea-f0350eeda446.png)
