### PR TITLE
Fixed wording domains in multistore dropdown template

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -6,7 +6,7 @@
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton4">
       <div class="multistore-dropdown-search-container">
         <i class="material-icons">search</i>
-        <input type="text" class="form-control multistore-dropdown-search js-multistore-dropdown-search" placeholder="Search shop name" data-no-results="{{ "No results found for"|trans({}, 'Admin.Shop') }}" data-searching="{{ "Searching for"|trans({}, 'Admin.Shop') }}">
+        <input type="text" class="form-control multistore-dropdown-search js-multistore-dropdown-search" placeholder="Search shop name" data-no-results="{{ "No results found for"|trans({}, 'Admin.Global') }}" data-searching="{{ "Searching for"|trans({}, 'Admin.Global') }}">
       </div>
 
       <div class="multistore-dropdown-content js-multistore-scrollbar">
@@ -22,10 +22,10 @@
                   {% if shop.isConfigurationKeyOverridden(shopConfiguration, configurationKey) == true %}
                     <p class="multistore-dropdown-shop-status multistore-dropdown-shop-status-locked">
                       <i class="material-icons">https</i>
-                      {{ "Customized"|trans({}, 'Admin.Shop') }}
+                      {{ "Customized"|trans({}, 'Admin.Global') }}
                   {% else %}
                     <p class="multistore-dropdown-shop-status">
-                      {{ "Inherited"|trans({}, 'Admin.Shop') }}
+                      {{ "Inherited"|trans({}, 'Admin.Global') }}
                   {% endif %}
                     </p>
                 </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -6,7 +6,7 @@
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton4">
       <div class="multistore-dropdown-search-container">
         <i class="material-icons">search</i>
-        <input type="text" class="form-control multistore-dropdown-search js-multistore-dropdown-search" placeholder="Search shop name" data-no-results="{{ "No results found for"|trans({}, 'Admin.Global') }}" data-searching="{{ "Searching for"|trans({}, 'Admin.Global') }}">
+        <input type="text" class="form-control multistore-dropdown-search js-multistore-dropdown-search" placeholder="Search shop name" data-no-results="{{ 'No results found for'|trans({}, 'Admin.Global') }}" data-searching="{{ 'Searching for'|trans({}, 'Admin.Global') }}">
       </div>
 
       <div class="multistore-dropdown-content js-multistore-scrollbar">

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -25,7 +25,7 @@
                       {{ "Customized"|trans({}, 'Admin.Global') }}
                   {% else %}
                     <p class="multistore-dropdown-shop-status">
-                      {{ "Inherited"|trans({}, 'Admin.Global') }}
+                      {{ 'Inherited'|trans({}, 'Admin.Global') }}
                   {% endif %}
                     </p>
                 </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -22,7 +22,7 @@
                   {% if shop.isConfigurationKeyOverridden(shopConfiguration, configurationKey) == true %}
                     <p class="multistore-dropdown-shop-status multistore-dropdown-shop-status-locked">
                       <i class="material-icons">https</i>
-                      {{ "Customized"|trans({}, 'Admin.Global') }}
+                      {{ 'Customized'|trans({}, 'Admin.Global') }}
                   {% else %}
                     <p class="multistore-dropdown-shop-status">
                       {{ 'Inherited'|trans({}, 'Admin.Global') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes wrong domains for wordings in multishop dropdown's twig template.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | none
| How to test?      | only wording check is needed, no QA, CI must be green
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24028)
<!-- Reviewable:end -->
