### PR TITLE
Add multistore info messages

### DIFF
--- a/controllers/admin/AdminStatesController.php
+++ b/controllers/admin/AdminStatesController.php
@@ -134,6 +134,15 @@ class AdminStatesControllerCore extends AdminController
 
     public function renderForm()
     {
+        // display multistore information message if multistore is used
+        if ($this->container->get('prestashop.adapter.multistore_feature')->isUsed()) {
+            $this->informations[] = $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                [],
+                'Admin.Notifications.Info'
+            );
+        }
+
         $this->fields_form = [
             'legend' => [
                 'title' => $this->trans('States', [], 'Admin.International.Feature'),

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
@@ -83,6 +83,11 @@ class BackupController extends FrameworkBundleAdminController
             'downloadFile' => $downloadFile,
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -84,6 +84,11 @@ class PerformanceController extends FrameworkBundleAdminController
             'cachingForm' => $cachingForm->createView(),
             'memcacheForm' => $memcacheForm->createView(),
             'servers' => $this->get('prestashop.adapter.memcache_server.manager')->getServers(),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this page is available in all shops context only, this is why your context has just switched.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -78,6 +78,11 @@ class ProfileController extends FrameworkBundleAdminController
                 'enableSidebar' => true,
                 'layoutTitle' => $this->trans('Profiles', 'Admin.Navigation.Menu'),
                 'grid' => $this->presentGrid($profilesGridFactory->getGrid($filters)),
+                'multistoreInfoTip' => $this->trans(
+                    'Note that this page is available in all shops context only, this is why your context has just switched.',
+                    'Admin.Notifications.Info'
+                ),
+                'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
             ]
         );
     }
@@ -142,6 +147,11 @@ class ProfileController extends FrameworkBundleAdminController
             'layoutTitle' => $this->trans('Add new profile', 'Admin.Advparameters.Feature'),
             'help_link' => $this->generateSidebarLink('AdminProfiles'),
             'enableSidebar' => true,
+            'multistoreInfoTip' => $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -193,6 +193,11 @@ class SqlManagerController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'requestSqlForm' => $sqlRequestForm->createView(),
             'dbTableNames' => $this->getDatabaseTables(),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -132,6 +132,11 @@ class MetaController extends FrameworkBundleAdminController
 
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/create.html.twig', [
             'meta_form' => $metaForm->createView(),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -75,6 +75,11 @@ class LanguageController extends FrameworkBundleAdminController
             'languageGrid' => $this->presentGrid($languageGrid),
             'isHtaccessFileWriter' => $this->get('prestashop.core.util.url.url_file_checker')->isHtaccessFileWritable(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this page is available in all shops context only, this is why your context has just switched.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -185,6 +185,11 @@ class TaxController extends FrameworkBundleAdminController
             'taxForm' => $taxForm->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,
+            'multistoreInfoTip' => $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
@@ -112,6 +112,11 @@ class OrderMessageController extends FrameworkBundleAdminController
             'enableSidebar' => true,
             'layoutTitle' => $this->trans('Add new', 'Admin.Actions'),
             'orderMessageForm' => $form->createView(),
+            'multistoreInfoTip' => $this->trans(
+                'Note that this feature is available in all shops context only. It will be added to all your stores.',
+                'Admin.Notifications.Info'
+            ),
+            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/index.html.twig
@@ -34,6 +34,7 @@
   {% endblock %}
 
   {% block backup_alerts %}
+    {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
     <div class="row">
       <div class="col">
         {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/create.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   <div class="row">
     <div class="col">
       {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   {% block profiles_list_panel %}
     <div class="row">
       <div class="col">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/create.html.twig
@@ -27,6 +27,7 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   {% if requestSqlForm.vars.errors is not empty %}
     <div class="alert alert-danger">
       {% for error in requestSqlForm.vars.errors %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -33,6 +33,7 @@
 {% form_theme cachingForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   {{ form_start(smartyForm, {attr : {class: 'form'}, action: path('admin_performance_smarty_save') }) }}
     <div class="row justify-content-center">
       {% block perfs_form_smarty_cache %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/create.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig', {'metaForm': meta_form}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
@@ -36,6 +36,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   <div class="row">
     <div class="col">
       <div class="alert alert-warning" role="alert">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/OrderMessage/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/OrderMessage/create.html.twig
@@ -26,6 +26,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block content %}
+  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {% include '@PrestaShop/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig' %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds multistore information notice messages on a few BO pages
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19410<br>Fixes #19413<br>Fixes #19414<br>Fixes #19416<br>Fixes #19421<br>Fixes #19422<br>Fixes #19423<br>Fixes #19492<br>Fixes #19494<br>Fixes #19493
| How to test?      | 1/ Enable multistore<br>2/ Create at least a second shop<br>3/ Check that information messages are well displayed on the right pages (there is one issue per page) 
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24032)
<!-- Reviewable:end -->
