### PR TITLE
Load Product Page V2 Feature flag at install

### DIFF
--- a/install-dev/data/db_data.sql
+++ b/install-dev/data/db_data.sql
@@ -1,0 +1,8 @@
+SET
+  SESSION sql_mode='';
+SET
+  NAMES 'utf8mb4';
+
+INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
+VALUES
+	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page is a work in progress. It includes new combination management features and other features under development (virtual products, packs, etc.)', 'Admin.Advparameters.Help');

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -70,3 +70,8 @@ UPDATE `PREFIX_product` SET `product_type` = "pack" WHERE `cache_is_pack` = 1;
 UPDATE `PREFIX_product` SET `product_type` = "virtual" WHERE `is_virtual` = 1;
 
 /* PHP:ps_1780_add_feature_flag_tab(); */;
+
+INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
+VALUES
+	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page is a work in progress. It includes new combination management features and other features under development (virtual products, packs, etc.)', 'Admin.Advparameters.Help');
+

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -71,6 +71,21 @@ UPDATE `PREFIX_product` SET `product_type` = "virtual" WHERE `is_virtual` = 1;
 
 /* PHP:ps_1780_add_feature_flag_tab(); */;
 
+/* this table should be created by Doctrine but we need to perform INSERT and the 1.7.8.0.sql script is called
+before Doctrine schema update */
+/* consequently we create the table manually */
+CREATE TABLE IF NOT EXISTS `PREFIX_feature_flag` (
+  `id_feature_flag` INT(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(191) COLLATE utf8mb4_general_ci NOT NULL,
+  `state` TINYINT(1) NOT NULL DEFAULT '0',
+  `label_wording` VARCHAR(191) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `label_domain` VARCHAR(255) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `description_wording` VARCHAR(191) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `description_domain` VARCHAR(255) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id_feature_flag`),
+  UNIQUE KEY `UNIQ_91700F175E237E06` (`name`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 INSERT INTO `PREFIX_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
 VALUES
 	('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page is a work in progress. It includes new combination management features and other features under development (virtual products, packs, etc.)', 'Admin.Advparameters.Help');

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
@@ -65,7 +65,7 @@ class FeatureFlagController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig', [
             'enableSidebar' => true,
             'layoutHeaderToolbarBtn' => [],
-            'layoutTitle' => $this->trans('Experimental Features', 'Admin.Navigation.Menu'),
+            'layoutTitle' => $this->trans('Experimental Features', 'Admin.Advparameters.Feature'),
             'requireBulkActions' => false,
             'showContentHeader' => true,
             'featureFlagsForm' => $featureFlagsForm->createView(),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Load Product Page V2 Feature flag at install using `db_data.sql` feature (see https://github.com/PrestaShop/PrestaShop/blob/develop/src/PrestaShopBundle/Install/Install.php#L508). Load Product Page V2 Feature flag at upgrade using standard 1.7.8 SQL script. Also fixes a wording domain.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23999
| How to test?      | See below
| Possible impacts? | I changed the 1.7.7 -> 1.7.8 SQL upgrade script, the database install script and one page title.

## How to test

1. Install PS using this branch. Verify that when you visit BO page Configure > Advanced Parameters
Experimental Features you can see the Product Page V2 feature flag, that is named `Experimental product page`

2. Install PS 1.7.7 then perform an upgrade to 1.7.8 using this branch. Verify that when you visit BO page Configure > Advanced Parameters
Experimental Features you can see the Product Page V2 feature flag, that is named `Experimental product page`

## Screenshot

<img width="1219" alt="Capture d’écran 2021-04-13 à 22 13 51" src="https://user-images.githubusercontent.com/3830050/114615430-fb9f7380-9ca5-11eb-977e-f01d47497e9a.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24037)
<!-- Reviewable:end -->
