### PR TITLE
Implement Product Page V2 flag behavior

### DIFF
--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -35,7 +35,7 @@
               {if $k != 'back' && $k != 'modules-list'}
                 {* TODO: REFACTOR ALL THIS THINGS *}
                 <a
-                  class="btn btn-primary{if isset($btn.target) && $btn.target} _blank{/if}{if isset($btn.disabled) && $btn.disabled} disabled auto-pointer-events{/if} pointer"{if isset($btn.href)}
+                  class="btn {if isset($btn.class) && $btn.class}{$btn.class|escape}{else}btn-primary{/if}{if isset($btn.target) && $btn.target} _blank{/if}{if isset($btn.disabled) && $btn.disabled} disabled auto-pointer-events{/if} pointer"{if isset($btn.href)}
                   id="page-header-desc-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"
                   href="{$btn.href|escape}"{/if}
                   title="{if isset($btn.help)}{$btn.help}{else}{$btn.desc|escape}{/if}"{if isset($btn.js) && $btn.js}

--- a/src/Core/FeatureFlag/FeatureFlagSettings.php
+++ b/src/Core/FeatureFlag/FeatureFlagSettings.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\FeatureFlag;
+
+class FeatureFlagSettings
+{
+    public const FEATURE_FLAG_PRODUCT_PAGE_V2 = 'product_page_v2';
+}

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductExcep
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Entity\AdminFilter;
@@ -87,8 +88,6 @@ use Tools;
  */
 class ProductController extends FrameworkBundleAdminController
 {
-    public const FEATURE_FLAG_PRODUCT_PAGE_V2 = 'product_page_v2';
-
     /**
      * Used to validate connected user authorizations.
      */
@@ -381,7 +380,7 @@ class ProductController extends FrameworkBundleAdminController
                 'href' => $this->generateUrl('admin_products_v2_create'),
                 'desc' => $this->trans('New product on experimental page', 'Admin.Catalog.Feature'),
                 'icon' => 'add_circle_outline',
-                'class' => 'btn-outline-primary'
+                'class' => 'btn-outline-primary',
             ];
         }
 
@@ -1342,7 +1341,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     private function isProductPageV2Enabled(): bool
     {
-        $productPageV2FeatureFlag = $this->get('prestashop.core.feature_flags.modifier')->getOneFeatureFlagByName(self::FEATURE_FLAG_PRODUCT_PAGE_V2);
+        $productPageV2FeatureFlag = $this->get('prestashop.core.feature_flags.modifier')->getOneFeatureFlagByName(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2);
 
         if (null === $productPageV2FeatureFlag) {
             return false;

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -379,12 +379,9 @@ class ProductController extends FrameworkBundleAdminController
         if ($this->isProductPageV2Enabled()) {
             $toolbarButtons['add_v2'] = [
                 'href' => $this->generateUrl('admin_products_v2_create'),
-                'desc' => $this->trans('New product', 'Admin.Catalog.Feature'),
-                'icon' => 'new_releases',
-                'help' => $this->trans(
-                    'Create a new product on the experimental product page',
-                    'Admin.Catalog.Help'
-                ),
+                'desc' => $this->trans('New product on experimental page', 'Admin.Catalog.Feature'),
+                'icon' => 'add_circle_outline',
+                'class' => 'btn-outline-primary'
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -668,7 +668,7 @@ class ProductController extends FrameworkBundleAdminController
             'editable' => $this->isGranted(PageVoter::UPDATE, self::PRODUCT_OBJECT),
             'drawerModules' => $drawerModules,
             'layoutTitle' => $this->trans('Product', 'Admin.Global'),
-            'productPageV2IsEnabled' => ($this->isProductPageV2Enabled()),
+            'isProductPageV2Enabled' => ($this->isProductPageV2Enabled()),
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -32,10 +32,10 @@ use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\DuplicateFeatureValueAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\InvalidAssociatedFeatureException;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShopBundle\Controller\Admin\ProductController as V1ProductController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\Form\FormInterface;
@@ -214,7 +214,7 @@ class ProductController extends FrameworkBundleAdminController
     private function isProductPageV2Enabled(): bool
     {
         $productPageV2FeatureFlag = $this->get('prestashop.core.feature_flags.modifier')
-            ->getOneFeatureFlagByName(V1ProductController::FEATURE_FLAG_PRODUCT_PAGE_V2);
+            ->getOneFeatureFlagByName(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2);
 
         if (null === $productPageV2FeatureFlag) {
             return false;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -72,8 +72,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function createAction(Request $request): Response
     {
-        $productPageV2IsEnabled = $this->isProductPageV2Enabled();
-        if (!$productPageV2IsEnabled) {
+        if (!$this->isProductPageV2Enabled()) {
             $this->addFlashMessageProductV2IsDisabled();
 
             return $this->redirectToRoute('admin_product_new');
@@ -108,8 +107,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function editAction(Request $request, int $productId): Response
     {
-        $productPageV2IsEnabled = $this->isProductPageV2Enabled();
-        if (!$productPageV2IsEnabled) {
+        if (!$this->isProductPageV2Enabled()) {
             $this->addFlashMessageProductV2IsDisabled();
 
             return $this->redirectToRoute('admin_product_form', ['id' => $productId]);
@@ -226,15 +224,15 @@ class ProductController extends FrameworkBundleAdminController
 
     private function addFlashMessageProductV2IsDisabled(): void
     {
-        $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index'));
-        $urlEnding = '</a>';
-
         $this->addFlash(
             'warning',
             $this->trans(
                 'The experimental product page is not enabled. To enable it, go to the %sExperimental Features%s page.',
                 'Admin.Catalog.Notification',
-                [$urlOpening, $urlEnding]
+                [
+                    sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index')), 
+                    '</a>'
+                ]
             )
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\InvalidAsso
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Controller\Admin\ProductController as V1ProductController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\Form\FormInterface;
@@ -213,7 +214,7 @@ class ProductController extends FrameworkBundleAdminController
     private function isProductPageV2Enabled(): bool
     {
         $productPageV2FeatureFlag = $this->get('prestashop.core.feature_flags.modifier')
-            ->getOneFeatureFlagByName(\PrestaShopBundle\Controller\Admin\ProductController::FEATURE_FLAG_PRODUCT_PAGE_V2);
+            ->getOneFeatureFlagByName(V1ProductController::FEATURE_FLAG_PRODUCT_PAGE_V2);
 
         if (null === $productPageV2FeatureFlag) {
             return false;
@@ -230,8 +231,8 @@ class ProductController extends FrameworkBundleAdminController
                 'The experimental product page is not enabled. To enable it, go to the %sExperimental Features%s page.',
                 'Admin.Catalog.Notification',
                 [
-                    sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index')), 
-                    '</a>'
+                    sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index')),
+                    '</a>',
                 ]
             )
         );

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
@@ -125,6 +125,16 @@
                     }
                 ]) %}
 
+                {% if productPageV2IsEnabled == true %}
+                    {% set buttons_action = buttons_action|merge([
+                        {
+                          "href": product.url_v2|default('#'),
+                          "icon": "mode_edit",
+                          "label": "Edit on experimental page"|trans({}, 'Admin.Catalog.Feature')
+                        }
+                    ]) %}
+                {% endif %}
+
                 {% include '@Product/CatalogPage/Forms/form_edit_dropdown.html.twig' with {
                     'button_id': "product_list_id_" ~ product.id_product ~ "_menu",
                     'default_item': {

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
@@ -106,12 +106,14 @@
       >
         {{ 'Add new product'|trans({}, 'Admin.Catalog.Feature')|raw }}
       </button>
-      <a
-        class="btn btn-outline-secondary ml-3"
-        href="{{ path('admin_products_v2_edit', {'productId': productId}) }}"
-      >
-        {{ 'Edit product V2'|trans({}, 'Admin.Catalog.Feature')|raw }}
-      </a>
+      {% if productPageV2IsEnabled == true %}
+        <a
+          class="btn btn-primary ml-3"
+          href="{{ path('admin_products_v2_edit', {'productId': productId}) }}"
+        >
+          {{ 'Edit on experimental page'|trans({}, 'Admin.Catalog.Feature')|raw }}
+        </a>
+      {% endif %}
 
       <div class="js-spinner spinner hide btn-primary-reverse onclick mr-1 btn"></div>
       <div class="btn-group hide dropdown">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
@@ -106,7 +106,7 @@
       >
         {{ 'Add new product'|trans({}, 'Admin.Catalog.Feature')|raw }}
       </button>
-      {% if productPageV2IsEnabled == true %}
+      {% if isProductPageV2Enabled == true %}
         <a
           class="btn btn-primary ml-3"
           href="{{ path('admin_products_v2_edit', {'productId': productId}) }}"

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -39,7 +39,7 @@
       </a>
       {{ form_widget(productForm.preview) }}
       <a class="btn btn-outline-secondary ml-1" href="{{ path('admin_product_form', {'id': productId}) }}">
-        {{ 'Back to product page'|trans({}, 'Admin.Catalog.Feature')|raw }}
+        {{ 'Back to standard page'|trans({}, 'Admin.Catalog.Feature')|raw }}
       </a>
     {% endif %}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -39,7 +39,7 @@
       </a>
       {{ form_widget(productForm.preview) }}
       <a class="btn btn-outline-secondary ml-1" href="{{ path('admin_product_form', {'id': productId}) }}">
-        {{ 'Edit product V1'|trans({}, 'Admin.Catalog.Feature')|raw }}
+        {{ 'Back to product page'|trans({}, 'Admin.Catalog.Feature')|raw }}
       </a>
     {% endif %}
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/24001
| How to test?      | See below
| Possible impacts? | Product page buttons only

### Description

In this PR I introduce and rename multiple buttons to navigate between Product current pages (= V1) and experimental Product Page (= V2). I added a redirection from V2 page to V1 page when user attempts to reach V2 page although the flag is disabled.

### How to test

1. Install PS using this branch
2. If the Feature Flag for Product Page V2 is not loaded*, load it in database using SQL script
```
INSERT INTO `ps_feature_flag` (`name`, `state`, `label_wording`, `label_domain`, `description_wording`, `description_domain`)
VALUES
   ('product_page_v2', 0, 'Experimental product page', 'Admin.Advparameters.Feature', 'This page is a work in progress. It includes new combination management features and other features under development (virtual products, packs, etc.)', 'Admin.Advparameters.Help');
   ```
3. Visit BO page Configure > Adv Parameters > Experimental Features to enable or disable the flag.
4. Follow the stories written in https://github.com/PrestaShop/PrestaShop/issues/24001

*It should be loaded because https://github.com/PrestaShop/PrestaShop/pull/24037 was merged

### Screenshot

#### Edit button in listing

<img width="300" alt="Capture d’écran 2021-04-13 à 22 28 54" src="https://user-images.githubusercontent.com/3830050/114622262-06f69d00-9cae-11eb-83e9-9534d379572d.png">

<hr>

#### Add new button in listing

![Capture d’écran 2021-04-14 à 16 15 59](https://user-images.githubusercontent.com/3830050/114726307-8ed7b800-9d3d-11eb-9335-51026917eb7f.png)


<hr>

#### Edit button using experimental page in Page V1

![Capture d’écran 2021-04-14 à 16 22 58](https://user-images.githubusercontent.com/3830050/114726525-c3e40a80-9d3d-11eb-93ba-ef78802ab93a.png)


<hr>

#### Back to V1 page in experimental page

![Capture d’écran 2021-04-14 à 16 23 10](https://user-images.githubusercontent.com/3830050/114726510-bfb7ed00-9d3d-11eb-9e74-fcaf75a0992d.png)


<hr>

#### Redirection message

<img width="1216" alt="Capture d’écran 2021-04-13 à 23 01 31" src="https://user-images.githubusercontent.com/3830050/114622381-2c83a680-9cae-11eb-91a9-95ea0c2855cb.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24038)
<!-- Reviewable:end -->
