### PR TITLE
Improve multistore dropdown behavior

### DIFF
--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -32,7 +32,6 @@ use Feature;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
-use PrestaShopBundle\Entity\Shop as ShopEntity;
 use PrestaShopBundle\Exception\NotImplementedException;
 use Shop;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -395,38 +394,5 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
             !empty($shopGroupId) ? $shopGroupId->getValue() : null,
             !empty($shopId) ? $shopId->getValue() : null
         );
-    }
-
-    /**
-     * Tests if a configuration value is overriden for a given shop, not only on the shop itself
-     * but also on parent shop group: when a shop inherits an overridden configuration value from his shop group
-     * the value is considered to be customized for this shop
-     *
-     * @param string $configurationKey
-     * @param ShopEntity $shop
-     *
-     * @return bool
-     */
-    public function isCustomizedForThisShop(string $configurationKey, ShopEntity $shop): bool
-    {
-        // check if given configuration is overridden for the parent shop group
-        $shopGroupConstraint = new ShopConstraint(
-            null,
-            $shop->getShopGroup()->getId(),
-            true // it must be strict, otherwise the method will also check for configuration settings in "all shop" context
-        );
-
-        if ($this->has($configurationKey, $shopGroupConstraint)) {
-            return true;
-        }
-
-        // check if given configuration is overridden for the shop
-        $shopConstraint = new ShopConstraint(
-            $shop->getId(),
-            $shop->getShopGroup()->getId(),
-            true
-        );
-
-        return $this->has($configurationKey, $shopConstraint);
     }
 }

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -32,6 +32,7 @@ use Feature;
 use Language;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\Entity\Shop as ShopEntity;
 use PrestaShopBundle\Exception\NotImplementedException;
 use Shop;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -394,5 +395,38 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
             !empty($shopGroupId) ? $shopGroupId->getValue() : null,
             !empty($shopId) ? $shopId->getValue() : null
         );
+    }
+
+    /**
+     * Tests if a configuration value is overriden for a given shop, not only on the shop itself
+     * but also on parent shop group: when a shop inherits an overridden configuration value from his shop group
+     * the value is considered to be customized for this shop
+     *
+     * @param string $configurationKey
+     * @param ShopEntity $shop
+     *
+     * @return bool
+     */
+    public function isCustomizedForThisShop(string $configurationKey, ShopEntity $shop): bool
+    {
+        // check if given configuration is overridden for the parent shop group
+        $shopGroupConstraint = new ShopConstraint(
+            null,
+            $shop->getShopGroup()->getId(),
+            true // it must be strict, otherwise the method will also check for configuration settings in "all shop" context
+        );
+
+        if ($this->has($configurationKey, $shopGroupConstraint)) {
+            return true;
+        }
+
+        // check if given configuration is overriden for the shop
+        $shopConstraint = new ShopConstraint(
+            $shop->getId(),
+            $shop->getShopGroup()->getId(),
+            true
+        );
+
+        return $this->has($configurationKey, $shopConstraint);
     }
 }

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -420,7 +420,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
             return true;
         }
 
-        // check if given configuration is overriden for the shop
+        // check if given configuration is overridden for the shop
         $shopConstraint = new ShopConstraint(
             $shop->getId(),
             $shop->getShopGroup()->getId(),

--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -122,7 +122,7 @@ class MultistoreController extends FrameworkBundleAdminController
                 unset($groupList[$key]);
             }
             foreach ($group->getShops() as $shop) {
-                if ($shop->isConfigurationKeyOverridden($configuration, $configurationKey)) {
+                if ($configuration->isCustomizedForThisShop($configurationKey, $shop)) {
                     $shouldDisplayDropdown = true;
                     break;
                 }

--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -116,13 +116,15 @@ class MultistoreController extends FrameworkBundleAdminController
     public function configurationDropdown(ShopConfigurationInterface $configuration, string $configurationKey): Response
     {
         $groupList = $this->entityManager->getRepository(ShopGroup::class)->findBy(['active' => true]);
+        $shopCustomizationChecker = $this->get('prestashop.multistore.customized_configuration_checker');
         $shouldDisplayDropdown = false;
+
         foreach ($groupList as $key => $group) {
             if (count($group->getShops()) === 0) {
                 unset($groupList[$key]);
             }
             foreach ($group->getShops() as $shop) {
-                if ($configuration->isCustomizedForThisShop($configurationKey, $shop)) {
+                if ($shopCustomizationChecker->isConfigurationCustomizedForThisShop($configurationKey, $shop)) {
                     $shouldDisplayDropdown = true;
                     break;
                 }
@@ -136,7 +138,7 @@ class MultistoreController extends FrameworkBundleAdminController
 
         return $this->render('@PrestaShop/Admin/Multistore/dropdown.html.twig', [
             'groupList' => $groupList,
-            'shopConfiguration' => $configuration,
+            'shopCustomizationChecker' => $shopCustomizationChecker,
             'configurationKey' => $configurationKey,
         ]);
     }

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -301,7 +301,7 @@ class Shop
     }
 
     /**
-     * Checks if a configuration value is overridden for this shop
+     * Checks if a configuration value is overridden for this shop or his shop group
      *
      * @param ShopConfigurationInterface $configuration
      * @param string $configurationKey
@@ -313,7 +313,7 @@ class Shop
         $shopConstraint = new ShopConstraint(
             $this->getId(),
             $this->getShopGroup()->getId(),
-            true
+            false
         );
 
         return $configuration->has($configurationKey, $shopConstraint);

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -310,10 +310,20 @@ class Shop
      */
     public function isConfigurationKeyOverridden(ShopConfigurationInterface $configuration, string $configurationKey): bool
     {
+        $shopGroupConstraint = new ShopConstraint(
+            null,
+            $this->getShopGroup()->getId(),
+            true // it must be strict, otherwise the method will also check for configuration settings in all shop context
+        );
+
+        if ($configuration->has($configurationKey, $shopGroupConstraint)) {
+            return true;
+        }
+
         $shopConstraint = new ShopConstraint(
             $this->getId(),
             $this->getShopGroup()->getId(),
-            false
+            true
         );
 
         return $configuration->has($configurationKey, $shopConstraint);

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -301,7 +301,7 @@ class Shop
     }
 
     /**
-     * Checks if a configuration value is overridden for this shop or his shop group
+     * Checks if a configuration value is overridden for this shop or its shop group
      *
      * @param ShopConfigurationInterface $configuration
      * @param string $configurationKey

--- a/src/PrestaShopBundle/Entity/Shop.php
+++ b/src/PrestaShopBundle/Entity/Shop.php
@@ -28,8 +28,6 @@ namespace PrestaShopBundle\Entity;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Shop.
@@ -298,34 +296,5 @@ class Shop
         }
 
         return false;
-    }
-
-    /**
-     * Checks if a configuration value is overridden for this shop or its shop group
-     *
-     * @param ShopConfigurationInterface $configuration
-     * @param string $configurationKey
-     *
-     * @return bool
-     */
-    public function isConfigurationKeyOverridden(ShopConfigurationInterface $configuration, string $configurationKey): bool
-    {
-        $shopGroupConstraint = new ShopConstraint(
-            null,
-            $this->getShopGroup()->getId(),
-            true // it must be strict, otherwise the method will also check for configuration settings in all shop context
-        );
-
-        if ($configuration->has($configurationKey, $shopGroupConstraint)) {
-            return true;
-        }
-
-        $shopConstraint = new ShopConstraint(
-            $this->getId(),
-            $this->getShopGroup()->getId(),
-            true
-        );
-
-        return $configuration->has($configurationKey, $shopConstraint);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -103,3 +103,8 @@ services:
             - "@=service('prestashop.core.foundation.version').getVersion()"
         calls:
             - [ "setSslVerification", ["%prestashop.addons.api_client.verify_ssl%"]]
+
+    prestashop.multistore.customized_configuration_checker:
+        class: PrestaShopBundle\Service\Multistore\CustomizedConfigurationChecker
+        arguments:
+            - "@prestashop.adapter.legacy.configuration"

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -19,7 +19,7 @@
               {% for shop in group.shops %}
                 <li class="multistore-dropdown-shop">
                   <a class="multistore-dropdown-shop-name{% if shop.hasMainUrl() == false %} multistore-dropdown-no-url">{{ shop.name }}</a>{% else %}" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>{% endif %}
-                  {% if shopConfiguration.isCustomizedForThisShop(configurationKey, shop) == true %}
+                  {% if shopCustomizationChecker.isConfigurationCustomizedForThisShop(configurationKey, shop) == true %}
                     <p class="multistore-dropdown-shop-status multistore-dropdown-shop-status-locked">
                       <i class="material-icons">https</i>
                       {{ 'Customized'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -19,7 +19,7 @@
               {% for shop in group.shops %}
                 <li class="multistore-dropdown-shop">
                   <a class="multistore-dropdown-shop-name{% if shop.hasMainUrl() == false %} multistore-dropdown-no-url">{{ shop.name }}</a>{% else %}" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>{% endif %}
-                  {% if shop.isConfigurationKeyOverridden(shopConfiguration, configurationKey) == true %}
+                  {% if shopConfiguration.isCustomizedForThisShop(configurationKey, shop) == true %}
                     <p class="multistore-dropdown-shop-status multistore-dropdown-shop-status-locked">
                       <i class="material-icons">https</i>
                       {{ 'Customized'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Service/Multistore/CustomizedConfigurationChecker.php
+++ b/src/PrestaShopBundle/Service/Multistore/CustomizedConfigurationChecker.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Service\Multistore;
+
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShopBundle\Entity\Shop;
+
+class CustomizedConfigurationChecker
+{
+    /**
+     * @var ShopConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var Shop
+     */
+    private $shop;
+
+    public function __construct(ShopConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Tests if a configuration value is overriden for a given shop, not only on the shop itself
+     * but also on parent shop group: when a shop inherits an overridden configuration value from his shop group
+     * the value is considered to be customized for this shop
+     *
+     * @param string $configurationKey
+     * @param Shop $shop
+     *
+     * @return bool
+     */
+    public function isConfigurationCustomizedForThisShop(string $configurationKey, Shop $shop): bool
+    {
+        // check if given configuration is overridden for the parent shop group
+        $shopGroupConstraint = new ShopConstraint(
+            null,
+            $shop->getShopGroup()->getId(),
+            true // it must be strict, otherwise the method will also check for configuration settings in "all shop" context
+        );
+
+        if ($this->configuration->has($configurationKey, $shopGroupConstraint)) {
+            return true;
+        }
+
+        // check if given configuration is overridden for the shop
+        $shopConstraint = new ShopConstraint(
+            $shop->getId(),
+            $shop->getShopGroup()->getId(),
+            true
+        );
+
+        return $this->configuration->has($configurationKey, $shopConstraint);
+    }
+}

--- a/src/PrestaShopBundle/Service/Multistore/CustomizedConfigurationChecker.php
+++ b/src/PrestaShopBundle/Service/Multistore/CustomizedConfigurationChecker.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Service\Multistore;
 
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;

--- a/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\PrestaShopBundle\Service\Multistore;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup;
+use PrestaShopBundle\Service\Multistore\CustomizedConfigurationChecker;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class CustomizedConfigurationCheckerTest extends TestCase
+{
+    public function testIsConfigurationCustomizedForThisShop(): void
+    {
+        $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(true));
+        $res = $customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal());
+        $this->assertTrue($res);
+
+        $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(false));
+        $res = $customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal());
+        $this->assertFalse($res);
+    }
+
+    /**
+     * @return ObjectProphecy
+     */
+    private function mockShopConfiguration(bool $hasConfig): MockObject
+    {
+        $shopConfigurationMock = $this->createMock(ShopConfigurationInterface::class);
+        $shopConfigurationMock->method('has')->willReturn($hasConfig);
+
+        return $shopConfigurationMock;
+    }
+
+    private function prophesizeShopEntity(): ObjectProphecy
+    {
+        $shopMock = $this->prophesize(Shop::class);
+        $shopGroupMock = $this->prophesize(ShopGroup::class);
+        $shopGroupMock->getId()->willReturn(3); // id not important
+        $shopMock->getShopGroup()->willReturn($shopGroupMock->reveal());
+        $shopMock->getId()->willReturn(3); // id not important
+
+        return $shopMock;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
@@ -42,8 +42,7 @@ class CustomizedConfigurationCheckerTest extends TestCase
             $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
 
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(false));
-        $res = $customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal());
-        $this->assertFalse($res);
+        $this->assertFalse($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
     }
 
     /**

--- a/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
@@ -39,8 +39,7 @@ class CustomizedConfigurationCheckerTest extends TestCase
     public function testIsConfigurationCustomizedForThisShop(): void
     {
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(true));
-        $res = $customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal());
-        $this->assertTrue($res);
+            $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
 
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(false));
         $res = $customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal());

--- a/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
@@ -39,7 +39,7 @@ class CustomizedConfigurationCheckerTest extends TestCase
     public function testIsConfigurationCustomizedForThisShop(): void
     {
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(true));
-            $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
+        $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
 
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(false));
         $this->assertFalse($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));

--- a/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
@@ -48,7 +48,9 @@ class CustomizedConfigurationCheckerTest extends TestCase
     }
 
     /**
-     * @return ObjectProphecy
+     * @param bool $hasConfig
+     *
+     * @return MockObject
      */
     private function mockShopConfiguration(bool $hasConfig): MockObject
     {
@@ -58,6 +60,9 @@ class CustomizedConfigurationCheckerTest extends TestCase
         return $shopConfigurationMock;
     }
 
+    /**
+     * @return ObjectProphecy
+     */
     private function prophesizeShopEntity(): ObjectProphecy
     {
         $shopMock = $this->prophesize(Shop::class);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes the multistore dropdown display condition as well as the inherited/customized assignation.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #24041
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

Before this PR the `isConfigurationKeyOverridden` would return true only if the customization happened on the shop itself, but we realized the configuration should also be considered overridden when it's the parent shop group that has been customized.

Also, I couldn't rely on setting the "strict" parameter to false, because then a configuration modified in all shop context would be considered customized too.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24042)
<!-- Reviewable:end -->
