### PR TITLE
Open confirm modal only when eligible for feature flag form

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
@@ -49,6 +49,7 @@ $(() => {
     }
 
     let oneFlagIsEnabled = false;
+
     for (let i = 0; i < formData.length; i += 1) {
       if ((formData[i].name !== 'form[_token]') && (formData[i].value !== '0') && (initialFormData[i].value === '0')) {
         oneFlagIsEnabled = true;

--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
@@ -33,6 +33,7 @@ $(() => {
   const $form = $('#feature-flag-form');
   const $formInputs = $('#feature-flag-form input');
   const initialState = $form.serialize();
+  const initialFormData = $form.serializeArray();
 
   $formInputs.change(() => {
     if (initialState === $form.serialize()) {
@@ -53,7 +54,7 @@ $(() => {
     }
 
     for (let i = 0; i < formData.length; i += 1) {
-      if ((formData[i].name !== 'form[_token]') && (formData[i].value !== '0')) {
+      if ((formData[i].name !== 'form[_token]') && (formData[i].value !== '0') && (initialFormData[i].value === '0')) {
         oneFlagIsEnabled = true;
         break;
       }

--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
@@ -36,23 +36,19 @@ $(() => {
   const initialFormData = $form.serializeArray();
 
   $formInputs.change(() => {
-    if (initialState === $form.serialize()) {
-      $submitButton.prop('disabled', true);
-    } else {
-      $submitButton.prop('disabled', false);
-    }
+    $submitButton.prop('disabled', initialState === $form.serialize());
   });
 
   $submitButton.on('click', (event) => {
     event.preventDefault();
 
     const formData = $form.serializeArray();
-    let oneFlagIsEnabled = false;
 
     if (initialState === $form.serialize()) {
       return;
     }
 
+    let oneFlagIsEnabled = false;
     for (let i = 0; i < formData.length; i += 1) {
       if ((formData[i].name !== 'form[_token]') && (formData[i].value !== '0') && (initialFormData[i].value === '0')) {
         oneFlagIsEnabled = true;

--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
@@ -30,9 +30,21 @@ const {$} = window;
 $(() => {
   const $submitButton = $('#submit-btn-feature-flag');
   const $form = $('#feature-flag-form');
+  const initialState = $form.serialize();
 
   $submitButton.on('click', (event) => {
     event.preventDefault();
+
+    const formData = $form.serializeArray();
+    let oneFlagIsEnabled = false;
+    const noFieldModifiedInTheForm = (initialState === $form.serialize());
+
+    for (let i = 0; i < formData.length; i += 1) {
+      if ((formData[i].name !== 'form[_token]') && (formData[i].value !== '0')) {
+        oneFlagIsEnabled = true;
+        break;
+      }
+    }
 
     const modal = new ConfirmModal(
       {
@@ -46,6 +58,11 @@ $(() => {
         $form.submit();
       },
     );
-    modal.show();
+
+    if (oneFlagIsEnabled && !noFieldModifiedInTheForm) {
+      modal.show();
+    } else {
+      $form.submit();
+    }
   });
 });

--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.js
@@ -29,15 +29,28 @@ const {$} = window;
 
 $(() => {
   const $submitButton = $('#submit-btn-feature-flag');
+  $submitButton.prop('disabled', true);
   const $form = $('#feature-flag-form');
+  const $formInputs = $('#feature-flag-form input');
   const initialState = $form.serialize();
+
+  $formInputs.change(() => {
+    if (initialState === $form.serialize()) {
+      $submitButton.prop('disabled', true);
+    } else {
+      $submitButton.prop('disabled', false);
+    }
+  });
 
   $submitButton.on('click', (event) => {
     event.preventDefault();
 
     const formData = $form.serializeArray();
     let oneFlagIsEnabled = false;
-    const noFieldModifiedInTheForm = (initialState === $form.serialize());
+
+    if (initialState === $form.serialize()) {
+      return;
+    }
 
     for (let i = 0; i < formData.length; i += 1) {
       if ((formData[i].name !== 'form[_token]') && (formData[i].value !== '0')) {
@@ -59,7 +72,7 @@ $(() => {
       },
     );
 
-    if (oneFlagIsEnabled && !noFieldModifiedInTheForm) {
+    if (oneFlagIsEnabled) {
       modal.show();
     } else {
       $form.submit();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | See below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/24267
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/24267
| Possible impacts? | I modified the Feature flag form JS

### Description

In this PR, I modify the behavior of the JavaScript that controls the Confirmation Modal for the Back Office feature flag page.

I monitor two things in the form:
- has any input been modified? if no I dont enable the SAVE button
- for all the inputs (token input excluded), is the value different from 0? if no I don't open the modal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24052)
<!-- Reviewable:end -->
