### PR TITLE
Fixed Initialization of GCloud Service Key

### DIFF
--- a/.github/workflows/cron_nightly.yml
+++ b/.github/workflows/cron_nightly.yml
@@ -27,7 +27,7 @@ jobs:
             extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
 
       -   name: Initialize GCloud Service Key
-          run: echo $GC_SERVICE_KEY | base64 --decode -i > $HOME/gcloud-service-key.json
+          run: echo $GC_SERVICE_KEY > $HOME/gcloud-service-key.json
 
       -   uses: google-github-actions/setup-gcloud@master
           with:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed Initialization of GCloud Service Key because CI is crashed. The key is store as json and not base64, because travis was unable to insert a full json, we had to use base64, but we no longer have to do it.
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | N/A
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24058)
<!-- Reviewable:end -->
