### PR TITLE
Fix category filter not checked

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -184,7 +184,7 @@ class ProductController extends FrameworkBundleAdminController
         $paginationParameters = $request->attributes->all();
         $paginationParameters['_route'] = 'admin_product_catalog';
         $categoriesForm = $this->createForm(ProductCategories::class);
-        if (!empty($persistedFilterParameters['filter_category'])) {
+        if (!empty($combinedFilterParameters['filter_category'])) {
             $categoriesForm->setData(
                 [
                     'categories' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Because we used persisted filter to know which category is checked **before** we actually persist the filter, we couldn't know which category was checked. This PR fixes the issue by using the combined filters (persisted + sent) to know which category is selected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23847
| How to test?      | Please see #23847
| Possible impacts? | Maybe in some case while playing with category filters on the catalog page?


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24072)
<!-- Reviewable:end -->
