### PR TITLE
Improve complexity of `CategoryController::getCanonicalURL` and Add doc to the parent function

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1743,10 +1743,10 @@ class FrontControllerCore extends Controller
 
     /**
      * Generate the canonical URL of the current page
-     * 
+     *
      * Mainly used for ProductController and CategoryController
      * but can be implemented by other classes inheriting from FrontController
-     * 
+     *
      * @return string|void
      */
     public function getCanonicalURL()

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1741,6 +1741,14 @@ class FrontControllerCore extends Controller
         ];
     }
 
+    /**
+     * Generate the canonical URL of the current page
+     * 
+     * Mainly used for ProductController and CategoryController
+     * but can be implemented by other classes inheriting from FrontController
+     * 
+     * @return string|void
+     */
     public function getCanonicalURL()
     {
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -86,7 +86,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     /**
      * {@inheritdoc}
-     * 
+     *
      * @return string
      */
     public function getCanonicalURL(): string

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -83,7 +83,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             ));
         }
     }
-
+    
+    /**
+     * {@inheritdoc}
+     * 
+     * @return string
+     */
     public function getCanonicalURL(): string
     {
         $product = $this->context->smarty->getTemplateVars('product');

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -86,8 +86,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
     public function getCanonicalURL(): string
     {

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -83,7 +83,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             ));
         }
     }
-    
+
     /**
      * {@inheritdoc}
      * 

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -50,8 +50,6 @@ class CategoryControllerCore extends ProductListingFrontController
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
     public function getCanonicalURL()
     {

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -50,7 +50,7 @@ class CategoryControllerCore extends ProductListingFrontController
 
     /**
      * {@inheritdoc}
-     * 
+     *
      * @return string
      */
     public function getCanonicalURL(): string

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -48,24 +48,29 @@ class CategoryControllerCore extends ProductListingFrontController
         }
     }
 
-    public function getCanonicalURL()
+    /**
+     * {@inheritdoc}
+     * 
+     * @return string
+     */
+    public function getCanonicalURL(): string
     {
         $canonicalUrl = $this->context->link->getCategoryLink($this->category);
         $parsedUrl = parse_url($canonicalUrl);
+        $params = [];
+        $page = (int) Tools::getValue('page');
+
         if (isset($parsedUrl['query'])) {
             parse_str($parsedUrl['query'], $params);
-        } else {
-            $params = [];
         }
-        $page = (int) Tools::getValue('page');
+
         if ($page > 1) {
             $params['page'] = $page;
         } else {
             unset($params['page']);
         }
-        $canonicalUrl = http_build_url($parsedUrl, ['query' => http_build_query($params)]);
 
-        return $canonicalUrl;
+        return http_build_url($parsedUrl, ['query' => http_build_query($params)]);
     }
 
     /**

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -53,7 +53,7 @@ class CategoryControllerCore extends ProductListingFrontController
      *
      * @return string
      */
-    public function getCanonicalURL(): string
+    public function getCanonicalURL()
     {
         $canonicalUrl = $this->context->link->getCategoryLink($this->category);
         $parsedUrl = parse_url($canonicalUrl);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improved complexity of CategoryController::getCanonicalURL() and added documentation to the parent function in FrontController + added documentation to ProductController::getCanonicalURL()
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  no
| How to test?      | Go to a product page and a category page and the canonical URLs are generated in the same way


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24080)
<!-- Reviewable:end -->
