### PR TITLE
Fix Gift + discount cartRule calculation in cart summary

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -5163,6 +5163,7 @@ class CartCore extends ObjectModel
     protected function splitGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = true;
+        $this->_products = null;
 
         return $this;
     }
@@ -5173,6 +5174,7 @@ class CartCore extends ObjectModel
     protected function mergeGiftsProductsQuantity()
     {
         $this->shouldSplitGiftProductsQuantity = false;
+        $this->_products = null;
 
         return $this;
     }
@@ -5180,6 +5182,7 @@ class CartCore extends ObjectModel
     protected function excludeGiftsDiscountFromTotal()
     {
         $this->shouldExcludeGiftsDiscount = true;
+        $this->_products = null;
 
         return $this;
     }
@@ -5187,6 +5190,7 @@ class CartCore extends ObjectModel
     protected function includeGiftsDiscountInTotal()
     {
         $this->shouldExcludeGiftsDiscount = false;
+        $this->_products = null;
 
         return $this;
     }

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1176,7 +1176,12 @@ class CartRuleCore extends ObjectModel
                 // Do not give a reduction on free products!
                 $order_total = $order_package_products_total;
                 foreach ($context->cart->getCartRules(CartRule::FILTER_ACTION_GIFT, false) as $cart_rule) {
-                    $order_total -= Tools::ps_round($cart_rule['obj']->getContextualValue($use_tax, $context, CartRule::FILTER_ACTION_GIFT, $package), Context::getContext()->getComputingPrecision());
+                    $freeProductsPrice = Tools::ps_round($cart_rule['obj']->getContextualValue($use_tax, $context, CartRule::FILTER_ACTION_GIFT, $package), Context::getContext()->getComputingPrecision());
+                    if (isset($basePriceForPercentReduction) && $order_total === $basePriceForPercentReduction) {
+                        // Gifts haven't been excluded yet, we need to do it
+                        $basePriceForPercentReduction -= $freeProductsPrice;
+                    }
+                    $order_total -= $freeProductsPrice;
                 }
 
                 // Remove products that are on special

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -35,6 +35,22 @@ Feature: Cart calculation with cart rules giving gift
     # Test known not to be reliable on previous
     # Then my cart total using previous calculation method should be 60.4924 tax included
 
+  Scenario: 3 products in cart, one cart rule offering a gift and a global 10% discount
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
+    Given there is a cart rule named "cartrule13" that applies a percent discount of 10.0% with priority 13, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule13" has a discount code "foo13"
+    Given cart rule "cartrule13" offers a gift product "product4"
+    When I add 3 items of product "product1" in my cart
+    When I use the discount "cartrule13"
+    Then I should have 4 products in my cart
+    Then my cart total should be 60.487 tax included
+    Then shipping handling fees are set to 7.0
+    Then the current cart should have the following contextual reductions:
+      | cartrule13        |  41.514  |
+
   Scenario: 1 product in my cart, one cart rule offering the same product and a global 50% discount
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -51,6 +51,28 @@ Feature: Cart calculation with cart rules giving gift
     Then the current cart should have the following contextual reductions:
       | cartrule13        |  41.514  |
 
+  Scenario: 2 products in cart including one with specific price, one cart rule offering a gift and a global 10% discount
+    but does not apply to already discounted products
+
+    Given I have an empty default cart
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    Given there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    And product "product1" has a specific price named "discount" with a discount of 20.00 percent
+    Given there is a product in the catalog named "product2" with a price of 11.00 and 1000 items in stock
+    Given there is a product in the catalog named "product4" with a price of 35.567 and 1000 items in stock
+    Given there is a cart rule named "cartrule13" that applies a percent discount of 10.0% with priority 13, quantity of 1000 and quantity per user 1000
+    Given cart rule "cartrule13" has a discount code "foo13"
+    Given cart rule "cartrule13" offers a gift product "product4"
+    Given cart rule "cartrule13" does not apply to already discounted products
+    When I add 1 items of product "product1" in my cart
+    And I add 1 items of product "product2" in my cart
+    When I use the discount "cartrule13"
+    Then I should have 3 products in my cart
+    Then my cart total should be 32.8 tax included
+    Then shipping handling fees are set to 7.0
+    Then the current cart should have the following contextual reductions:
+      | cartrule13        |  36.67  |
+
   Scenario: 1 product in my cart, one cart rule offering the same product and a global 50% discount
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When getting cartRules from the cart, when a cartRule has both a free gift & a discount, the free gift was not deducted when applying the discount. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22948
| How to test?      | Please see #22948
| Possible impacts? | This PR is related to the CartRules so I guess maybe it can have an impact on discounts calculation


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24088)
<!-- Reviewable:end -->
