### PR TITLE
Improve Product getAttributesResume function for MySQL 8

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2693,7 +2693,8 @@ class ProductCore extends ObjectModel
                 FROM `' . _DB_PREFIX_ . 'product_attribute` pa
                 ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
                 WHERE pa.`id_product` = ' . (int) $this->id . '
-                GROUP BY pa.`id_product_attribute`');
+                GROUP BY pa.`id_product_attribute`
+                ORDER BY pa.`id_product_attribute`');
 
         if (!$combinations) {
             return false;
@@ -2711,7 +2712,8 @@ class ProductCore extends ObjectModel
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) $id_lang . ')
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) $id_lang . ')
                 WHERE pac.id_product_attribute IN (' . implode(',', $product_attributes) . ')
-                GROUP BY pac.id_product_attribute');
+                GROUP BY pac.id_product_attribute
+                ORDER BY pac.id_product_attribute');
 
         foreach ($lang as $k => $row) {
             $combinations[$k]['attribute_designation'] = $row['attribute_designation'];


### PR DESCRIPTION
In MySQL 8 implicit and explicit sorting for GROUP BY is removed. This code relies on that sorting, so it should be improved by adding explicit ORDER BY. It does not break backward compatibility.
More about implicit and explicit sorting for GROUP BY removal: https://mysqlserverteam.com/removal-of-implicit-and-explicit-sorting-for-group-by/

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Prestashop 1.7 still uses the getAttributesResume function, we isolated this function on a server with MySQL 8 and found it returning incorrect attributes resume, names of attributes don't match their ID's
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes 
| Fixed ticket?     | Fixes #23973
| How to test?      | Create any test for the getAttributesResume function to find out it's returning incorrect results for MySQL 8.
| Possible impacts? | Probably back office, this function was more in use on Prestashop 1.6, when I can clearly observe the error for combination quantities. On 1.7 I don't see an error there, but it's good to make sure this function works correctly, since there is no backward compatibility break with this improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24089)
<!-- Reviewable:end -->
