### PR TITLE
Fix OrderState deletion when not in default language context

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -648,17 +648,7 @@ class AdminStatusesControllerCore extends AdminController
             if (!$order_state->isRemovable()) {
                 $this->errors[] = $this->trans('For security reasons, you cannot delete default order statuses.', [], 'Admin.Shopparameters.Notification');
             } else {
-                try {
-                    if (!$order_state->softDelete()) {
-                        throw new PrestaShopException('Error when soft deleting order status');
-                    }
-                } catch (PrestaShopException $e) { // see ObjectModel::softDelete too
-                    $this->errors[] = $this->trans('An error occurred during deletion.', [], 'Admin.Notifications.Error');
-
-                    return $order_state;
-                }
-
-                Tools::redirectAdmin(self::$currentIndex . '&conf=1&token=' . $this->token);
+                return parent::postProcess();
             }
         } elseif (Tools::isSubmit('submitBulkdelete' . $this->table)) {
             if (!$this->access('delete')) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | As the OrderStatus to be delete was constructed with the language of the BO of the employee deleting the order status and not the default language, when calling the `update()` method, the property `name` was empty for the default language, leading to an exception being raised. By letting the parent handling the deletion, the OrderStatus is constructed without language, solving the issue.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23379
| How to test?      | Please see #23379
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24094)
<!-- Reviewable:end -->
