### PR TITLE
Fix thumbnail regeneration for files other than jpg

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -164,8 +164,7 @@ class ImageRetriever
         $urls = [];
         $image_types = ImageType::getImagesTypes($type, true);
 
-        $extPath = $imageFolderPath . DIRECTORY_SEPARATOR . 'fileType';
-        $ext = @file_get_contents($extPath) ?: 'jpg';
+        $ext = 'jpg';
 
         $mainImagePath = implode(DIRECTORY_SEPARATOR, [
             $imageFolderPath,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When importing an image, Prestashop saves it always with id_image as name and the extension `.jpg` regardless of the format (e.g. `123.jpg`). It also saves a file named `fileType` along the image file. When `ImageRetriever::getImage()` attemps to resize the file, it will not look for `123.jpg`, but instead for a file with the extension saved in `fileType` (e.g. `123.png`). This latter does not exists, and the thumbnail generation fails.<br>There are two possible fixes:<br> - Always save the images with the correct extension<br> - Always look for a file `id_image.jpg` and ignore `fileType`<br> Since all the rest of Prestashop assumes that images have always an extension `.jpg` (e.g. in URL rewriting), the first option, would need a very heavy lifting.<br> I opted for the second, even though it perpetuates the principle that every image has a `jpg` extension, and that I personally strongly dislike.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #18769.
| How to test?      | - Go in the image directory of an image with type png<br> - Delete all thumbnails, but not the file `fileType`<br> - Display the product in the FO<br> Without the fix, the thumbnail do not regenerate. With the fix it works.
| Possible impacts? | This should have no impact other than the fix.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24116)
<!-- Reviewable:end -->
