### PR TITLE
Remove unused table ps_order_slip_detail_tax from install

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2796,15 +2796,6 @@ CREATE TABLE `PREFIX_smarty_cache` (
   KEY `modified` (`modified`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
-CREATE TABLE IF NOT EXISTS `PREFIX_order_slip_detail_tax` (
-  `id_order_slip_detail` int(11) unsigned NOT NULL,
-  `id_tax` int(11) unsigned NOT NULL,
-  `unit_amount` decimal(16, 6) NOT NULL DEFAULT '0.000000',
-  `total_amount` decimal(16, 6) NOT NULL DEFAULT '0.000000',
-  KEY (`id_order_slip_detail`),
-  KEY `id_tax` (`id_tax`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
-
 CREATE TABLE IF NOT EXISTS `PREFIX_mail` (
   `id_mail` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `recipient` varchar(126) NOT NULL,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This table is not used anywhere in the core
| Type?             | improvement
| Category?         | IN
| BC breaks?        | yes - The table is no longer created on install
| Deprecations?     | no
| Fixed ticket?     | Fixes #22914
| How to test?      | Validated by automatic tests
| Possible impacts? | Unknown


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24118)
<!-- Reviewable:end -->
