### PR TITLE
When saving an image as a square png, add always a transparent border

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -272,8 +272,8 @@ class ImageManagerCore
 
         $destImage = imagecreatetruecolor($destinationWidth, $destinationHeight);
 
-        // If image is a PNG and the output is PNG, fill with transparency. Else fill with white background.
-        if ($fileType == 'png' && $type == IMAGETYPE_PNG) {
+        // If the output is PNG, fill with transparency. Else fill with white background.
+        if ($fileType == 'png') {
             imagealphablending($destImage, false);
             imagesavealpha($destImage, true);
             $transparent = imagecolorallocatealpha($destImage, 255, 255, 255, 127);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Transparency of thumbnail images only depends on output file format, not input file format. That means, if we load a product image from a rectangular jpg file, the square thumbnail mast have a transparent border, as if it was a png.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23920.
| How to test?      | Set image settings to *Use PNG for all images* and *Automatic (longest size)*, then import a rectangular image in `jpg` format. The thumbnails must have transparent borders.
| Possible impacts? | Images may have transparent border instead of white border. Invisible for most templates, improvement for others, because now we can use jpg images as source on a template that has non-white image background.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24119)
<!-- Reviewable:end -->
