### PR TITLE
Fix wrong multishop detection in AdminInvoiceController

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
@@ -64,7 +64,7 @@ class OrderInvoiceRepository
         $sql = 'SELECT COUNT(o.id_order) AS nbOrders, o.current_state as id_order_state
             FROM `{table_prefix}order_invoice` oi
             INNER JOIN `{table_prefix}orders` o ON oi.id_order = o.id_order
-            WHERE o.id_shop IN('.implode(',', array_map('intval', $shopIds)).')
+            WHERE o.id_shop IN(' . implode(',', array_map('intval', $shopIds)) . ')
             AND oi.number > 0
             GROUP BY o.current_state';
         $sql = str_replace('{table_prefix}', $this->tablePrefix, $sql);

--- a/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
@@ -63,7 +63,7 @@ class OrderInvoiceRepository
     {
         $sql = 'SELECT COUNT(o.id_order) AS nbOrders, o.current_state as id_order_state
             FROM `{table_prefix}order_invoice` oi
-            LEFT JOIN `{table_prefix}orders` o ON oi.id_order = o.id_order
+            INNER JOIN `{table_prefix}orders` o ON oi.id_order = o.id_order
             WHERE o.id_shop IN('.implode(',', array_map('intval', $shopIds)).')
             AND oi.number > 0
             GROUP BY o.current_state';

--- a/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/OrderInvoiceRepository.php
@@ -61,18 +61,15 @@ class OrderInvoiceRepository
      */
     public function countByOrderState(array $shopIds)
     {
-        $sql = <<<'SQL'
-SELECT COUNT(o.id_order) AS nbOrders, o.current_state as id_order_state
-FROM `{table_prefix}order_invoice` oi
-LEFT JOIN `{table_prefix}orders` o ON oi.id_order = o.id_order
-WHERE o.id_shop IN(:shopIds)
-AND oi.number > 0
-GROUP BY o.current_state
-SQL;
+        $sql = 'SELECT COUNT(o.id_order) AS nbOrders, o.current_state as id_order_state
+            FROM `{table_prefix}order_invoice` oi
+            LEFT JOIN `{table_prefix}orders` o ON oi.id_order = o.id_order
+            WHERE o.id_shop IN('.implode(',', array_map('intval', $shopIds)).')
+            AND oi.number > 0
+            GROUP BY o.current_state';
         $sql = str_replace('{table_prefix}', $this->tablePrefix, $sql);
 
         $statement = $this->connection->prepare($sql);
-        $statement->bindValue('shopIds', implode(',', array_map('intval', $shopIds)));
         $statement->execute();
 
         $result = [];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The actual wrong bindValue of shopIds to imploded string was causing  SQL "IN ()" clause to be always threated as string and not integer array - resulting in wrong invoices listed in backoffice in multiple shop selected / all shops context.
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26137
| How to test?      |  Check "invoices" BO page in "All shops" mode with multiple shops before / after the fix and compare results.

See the actual query below :


![2021-04-20_11-07-00](https://user-images.githubusercontent.com/43071148/115378991-66ced580-a1d1-11eb-97ca-202ed4fa0fbd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24120)
<!-- Reviewable:end -->
