### PR TITLE
Fix bug on cover when you select only one image on dropzone of product page v2

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -49,11 +49,11 @@
         ]"
       >
         <i class="material-icons">add_a_photo</i><br>
-        {{ $t("window.dropImages") }}<br>
-        <a>{{ $t("window.selectFiles") }}</a><br>
+        {{ $t('window.dropImages') }}<br>
+        <a>{{ $t('window.selectFiles') }}</a><br>
         <small>
-          {{ $t("window.recommendedSize") }}<br>
-          {{ $t("window.recommendedFormats") }}
+          {{ $t('window.recommendedSize') }}<br>
+          {{ $t('window.recommendedFormats') }}
         </small>
       </div>
 
@@ -126,7 +126,7 @@
           </div>
         </div>
         <div class="iscover">
-          {{ $t("window.cover") }}
+          {{ $t('window.cover') }}
         </div>
       </div>
     </div>
@@ -537,7 +537,7 @@
 </script>
 
 <style lang="scss" type="text/scss">
-@import "~@scss/config/_settings.scss";
+@import '~@scss/config/_settings.scss';
 
 .product-page #product-images-dropzone {
   &.full {

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -299,6 +299,7 @@
           if (file.is_cover) {
             file.previewElement.classList.add('is-cover');
           }
+
           file.previewElement.addEventListener('click', () => {
             const input = file.previewElement.querySelector(DropzoneMap.checkbox);
             input.checked = !input.checked;
@@ -328,6 +329,10 @@
           file.legends = response.legends;
           // Update dataset so that it can be selected later
           file.previewElement.dataset.id = file.image_id;
+
+          if (file.is_cover) {
+            file.previewElement.classList.add('is-cover');
+          }
         });
       },
       /**
@@ -449,7 +454,11 @@
               const coverElement = document.querySelector(
                 DropzoneMap.coveredPreview,
               );
-              coverElement.classList.remove('is-cover');
+
+              if (coverElement) {
+                coverElement.classList.remove('is-cover');
+              }
+
               savedImageElement.classList.add('is-cover');
 
               this.files = this.files.map((file) => {

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/DropzoneWindow.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/DropzoneWindow.vue
@@ -67,14 +67,14 @@
       @click="$emit('selectAll')"
       v-if="files.length > 0 && selectedFiles.length !== files.length"
     >
-      {{ $t("window.selectAll") }}
+      {{ $t('window.selectAll') }}
     </p>
     <p
       class="dropzone-window-unselect"
       v-if="selectedFiles.length === files.length"
       @click="$emit('unselectAll')"
     >
-      {{ $t("window.unselectAll") }}
+      {{ $t('window.unselectAll') }}
     </p>
 
     <div
@@ -91,7 +91,7 @@
           @change.prevent.stop="coverChanged"
         >
         <i class="md-checkbox-control" />
-        {{ $t("window.useAsCover") }}
+        {{ $t('window.useAsCover') }}
       </label>
     </div>
 
@@ -109,7 +109,7 @@
         for="caption-textarea"
         class="control-label"
       >{{
-        $t("window.caption")
+        $t('window.caption')
       }}</label>
       <div
         class="dropdown"
@@ -161,7 +161,7 @@
         @click="$emit('saveSelectedFile', captionValue, coverData)"
       >
         <span v-if="!loading">
-          {{ $t("window.saveImage") }}
+          {{ $t('window.saveImage') }}
         </span>
         <span
           class="spinner-border spinner-border-sm"
@@ -246,6 +246,7 @@
       window.prestaShopUiKit.initToolTips();
       // We set the intial value of the first item in order to use the computed
       this.captionValue = this.selectedFile.legends;
+      this.coverData = this.selectedFile.is_cover;
     },
     updated() {
       window.prestaShopUiKit.initToolTips();
@@ -279,7 +280,7 @@
 </script>
 
 <style lang="scss" type="text/scss">
-@import "~@scss/config/_settings.scss";
+@import '~@scss/config/_settings.scss';
 
 .product-page {
   .dropzone-window {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | When you select only on image on dropzone, and change caption, and save, the cover is automatically set as false, even if you didn't change it
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on product page v2, select the image set as cover, change caption and save, caption should stay at checked
| Possible impacts? | Product page v2 dropzone behavior


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24129)
<!-- Reviewable:end -->
