### PR TITLE
Replace price drop flag by on sale

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -455,7 +455,7 @@ class ProductLazyArray extends AbstractLazyArray
         if ($show_price && $this->product['on_sale'] && !$this->settings->catalog_mode) {
             $flags['on-sale'] = [
                 'type' => 'on-sale',
-                'label' => $this->translator->trans('Price drop!', [], 'Shop.Theme.Catalog'),
+                'label' => $this->translator->trans('On sale!', [], 'Shop.Theme.Catalog'),
             ];
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductPrice.php
@@ -217,7 +217,7 @@ class ProductPrice extends CommonAbstractType
                 [
                     'required' => false,
                     'label' => $this->translator->trans(
-                        'Display the "Price drop!" flag on the product page, and on product listings.',
+                        'Display the "On sale!" flag on the product page, and on product listings.',
                         [],
                         'Admin.Catalog.Feature'
                     ),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/PriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/PriceType.php
@@ -120,7 +120,7 @@ class PriceType extends TranslatorAwareType
             ->add('on_sale', CheckboxType::class, [
                 'required' => false,
                 'label' => $this->trans(
-                    'Display the "Price drop!" flag on the product page, and on product listings.',
+                    'Display the "On sale!" flag on the product page, and on product listings.',
                     'Admin.Catalog.Feature'
                 ),
             ])

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -395,7 +395,7 @@ class ProductLazyArrayTest extends TestCase
         ]), [
             'on-sale' => [
                 'type' => 'on-sale',
-                'label' => 'Price drop!',
+                'label' => 'On sale!',
             ],
         ], false];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Replace "price drop" flag by "on sale"
| Type?             | improvement
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Verify the wording in the BO product page > Princing tab, it should be "Display the "On sale!" flag on the product page, and on product listings.". Check the box and verify the flag on the product page and product listing, it should be "On sale!"
| Possible impacts? | nothing


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24150)
<!-- Reviewable:end -->
