### PR TITLE
Making the inline tag working for js and css

### DIFF
--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -136,7 +136,7 @@ class JavascriptManagerCore extends AbstractAssetManager
             foreach ($this->list[$position]['inline'] as &$item) {
                 $item['content'] =
                     '/* ---- ' . $item['id'] . ' @ ' . $item['path'] . ' ---- */' . "\r\n" .
-                    file_get_contents($item['path']);
+                    file_get_contents($this->getPathFromUri($item['path']));
             }
         }
     }

--- a/classes/assets/StylesheetManager.php
+++ b/classes/assets/StylesheetManager.php
@@ -157,7 +157,7 @@ class StylesheetManagerCore extends AbstractAssetManager
         foreach ($this->list['inline'] as &$item) {
             $item['content'] =
                 '/* ---- ' . $item['id'] . ' @ ' . $item['path'] . ' ---- */' . "\r\n" .
-                file_get_contents($item['path']);
+                file_get_contents($this->getPathFromUri($item['path']));
         }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This patch will fix issue 13872 and making it possible to use inline tags on js and css registrations.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #13872.
| How to test?      | See bug report for details on how to recreate the issue.
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24155)
<!-- Reviewable:end -->
