### PR TITLE
Allow all characters when using combination, not only \w

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
@@ -385,8 +385,8 @@ admin_orders_display_customization_image:
     _legacy_controller: AdminOrders
   requirements:
     orderId: \d+
-    name: \w+
-    value: \w+
+    name: .+
+    value: .+
 
 admin_orders_product_prices:
   path: /{orderId}/products/prices


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | We shouldn't allow only a character from a-z, A-Z, 0-9, and _ in the admin_orders_display_customization_image route.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24036
| How to test?      | Try with a customization name `This.!Is.""'a test'`.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24161)
<!-- Reviewable:end -->
