### PR TITLE
Fix obvious bugs in product page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.js
@@ -67,15 +67,13 @@ $(() => {
   const $redirectTargetInput = $(ProductMap.redirectOption.targetInput);
   new RedirectOptionManager($redirectTypeInput, $redirectTargetInput);
 
+  // Product type has strong impact on the page rendering so when it is modified it must be submitted right away
+  new ProductTypeManager($(ProductMap.productTypeSelector), $productForm);
+
   // Form has no productId data means that we are in creation mode
   if (!productId) {
     return;
   }
-
-  // On creation product type can be modified as you wish, but once it is created it has strong impacts, so we must
-  // force submit because it influences the available features in the form, and it also perform cleaning on non relevant
-  // associations
-  new ProductTypeManager($(ProductMap.productTypeSelector), $productForm);
 
   // Init Serp component to preview Search engine display
   const translatorInput = window.prestashop.instance.translatableInput;

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-type-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-type-manager.js
@@ -89,6 +89,7 @@ export default class ProductTypeManager {
         closable: false,
       },
       () => {
+        $(ProductMap.productFormSubmitButton).prop('disabled', true);
         this.$productForm.submit();
       },
       () => {

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-type-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-type-manager.js
@@ -39,6 +39,7 @@ export default class ProductTypeManager {
   constructor($typeSelector, $productForm) {
     this.$typeSelector = $typeSelector;
     this.$productForm = $productForm;
+    this.productId = parseInt($productForm.data('productId'), 10);
     this.initialType = $typeSelector.val();
 
     this.$typeSelector.on('change', (event) => this.confirmTypeSubmit(event));
@@ -51,22 +52,25 @@ export default class ProductTypeManager {
    */
   confirmTypeSubmit() {
     let confirmMessage = this.$typeSelector.data('confirm-message');
-    let confirmWarning;
+    let confirmWarning = '';
 
-    switch (this.initialType) {
-      case ProductMap.productType.COMBINATIONS:
-        confirmWarning = this.$typeSelector.data('combinations-warning');
-        break;
-      case ProductMap.productType.PACK:
-        confirmWarning = this.$typeSelector.data('pack-warning');
-        break;
-      case ProductMap.productType.VIRTUAL:
-        confirmWarning = this.$typeSelector.data('virtual-warning');
-        break;
-      case ProductMap.productType.STANDARD:
-      default:
-        confirmWarning = '';
-        break;
+    // If no productId we are in creation page so no need for extra warning
+    if (this.productId) {
+      switch (this.initialType) {
+        case ProductMap.productType.COMBINATIONS:
+          confirmWarning = this.$typeSelector.data('combinations-warning');
+          break;
+        case ProductMap.productType.PACK:
+          confirmWarning = this.$typeSelector.data('pack-warning');
+          break;
+        case ProductMap.productType.VIRTUAL:
+          confirmWarning = this.$typeSelector.data('virtual-warning');
+          break;
+        case ProductMap.productType.STANDARD:
+        default:
+          confirmWarning = '';
+          break;
+      }
     }
 
     if (confirmWarning) {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilder.php
@@ -72,11 +72,11 @@ final class VirtualProductFileCommandsBuilder implements ProductCommandsBuilderI
      */
     public function buildAddCommand(ProductId $productId, array $virtualProductFileData): ?AddVirtualProductFileCommand
     {
-        if (!$virtualProductFileData['has_file'] || $virtualProductFileData['virtual_product_file_id']) {
+        if (empty($virtualProductFileData['has_file']) || !empty($virtualProductFileData['virtual_product_file_id'])) {
             return null;
         }
 
-        if (!isset($virtualProductFileData['file'])) {
+        if (empty($virtualProductFileData['file'])) {
             return null;
         }
 
@@ -102,7 +102,7 @@ final class VirtualProductFileCommandsBuilder implements ProductCommandsBuilderI
     {
         $update = false;
 
-        if (!$virtualProductFileData['has_file'] || !$virtualProductFileData['virtual_product_file_id']) {
+        if (empty($virtualProductFileData['has_file']) || empty($virtualProductFileData['virtual_product_file_id'])) {
             return null;
         }
 
@@ -145,7 +145,7 @@ final class VirtualProductFileCommandsBuilder implements ProductCommandsBuilderI
      */
     private function buildDeleteCommand(array $virtualProductFileData): ?DeleteVirtualProductFileCommand
     {
-        if ($virtualProductFileData['has_file'] || !$virtualProductFileData['virtual_product_file_id']) {
+        if (!empty($virtualProductFileData['has_file']) || empty($virtualProductFileData['virtual_product_file_id'])) {
             return null;
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -39,7 +39,10 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryResult\ProductSupplierOptions;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 
 /**
@@ -110,12 +113,16 @@ final class ProductFormDataProvider implements FormDataProviderInterface
      */
     public function getDefaultData()
     {
-        return [
+        return $this->addShortcutData([
             'basic' => [
                 'type' => ProductType::TYPE_STANDARD,
             ],
             'manufacturer' => [
                 'manufacturer_id' => NoManufacturerId::NO_MANUFACTURER_ID,
+            ],
+            'stock' => [
+                'quantity' => 0,
+                'minimal_quantity' => 0,
             ],
             'price' => [
                 'price_tax_excluded' => 0,
@@ -129,9 +136,15 @@ final class ProductFormDataProvider implements FormDataProviderInterface
                 'height' => 0,
                 'depth' => 0,
                 'weight' => 0,
+                'additional_shipping_cost' => 0,
+                'delivery_time_note_type' => DeliveryTimeNoteType::TYPE_DEFAULT,
             ],
-            'activate' => $this->defaultProductActivation,
-        ];
+            'options' => [
+                'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
+                'condition' => ProductCondition::NEW,
+                'activate' => $this->defaultProductActivation,
+            ],
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Extension/DefaultEmptyDataExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/DefaultEmptyDataExtension.php
@@ -59,8 +59,8 @@ class DefaultEmptyDataExtension extends AbstractTypeExtension
                 'default_empty_data' => null,
                 'empty_view_data' => $this->privateEmptyValue,
             ])
-            ->setAllowedTypes('default_empty_data', ['null', 'string', 'int', 'array', 'object', 'bool'])
-            ->setAllowedTypes('empty_view_data', ['null', 'string', 'int', 'array', 'object', 'bool'])
+            ->setAllowedTypes('default_empty_data', ['null', 'string', 'int', 'array', 'object', 'bool', 'float'])
+            ->setAllowedTypes('empty_view_data', ['null', 'string', 'int', 'array', 'object', 'bool', 'float'])
         ;
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Extension/DefaultEmptyDataExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/DefaultEmptyDataExtension.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Extension;
+
+use PrestaShopBundle\Form\DataTransformer\DefaultEmptyDataTransformer;
+use stdClass;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class DefaultEmptyDataExtension extends every form type with additional default_empty_data option.
+ */
+class DefaultEmptyDataExtension extends AbstractTypeExtension
+{
+    /**
+     * @var stdClass
+     */
+    private $privateEmptyValue;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        // We cannot use null as empty value so we create a private object that will allow us to detect that the
+        // empty_view_data option has been explicitly set EVEN if it is null
+        $this->privateEmptyValue = new stdClass();
+
+        $resolver
+            ->setDefaults([
+                'default_empty_data' => null,
+                'empty_view_data' => $this->privateEmptyValue,
+            ])
+            ->setAllowedTypes('default_empty_data', ['null', 'string', 'int', 'array', 'object', 'bool'])
+            ->setAllowedTypes('empty_view_data', ['null', 'string', 'int', 'array', 'object', 'bool'])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+        if (!isset($options['default_empty_data'])) {
+            return;
+        }
+
+        if ($options['empty_view_data'] !== $this->privateEmptyValue) {
+            // This different use case is important because DefaultEmptyDataTransformer has a different behaviour when
+            // the second parameter is provided, especially when you need to force null as the view data
+            $transformer = new DefaultEmptyDataTransformer($options['default_empty_data'], $options['empty_view_data']);
+        } else {
+            $transformer = new DefaultEmptyDataTransformer($options['default_empty_data']);
+        }
+
+        $builder->addModelTransformer($transformer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return FormType::class;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -106,6 +106,7 @@ class CombinationStockType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'default_empty_data' => 0,
+                // Using null here allows to keep the field empty in the page instead of 0
                 'empty_view_data' => null,
             ])
             ->add('low_stock_alert', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -31,7 +31,6 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use PrestaShopBundle\Form\DataTransformer\DefaultEmptyDataTransformer;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -106,6 +105,8 @@ class CombinationStockType extends TranslatorAwareType
                     new Type(['type' => 'numeric']),
                 ],
                 'required' => false,
+                'default_empty_data' => 0,
+                'empty_view_data' => null,
             ])
             ->add('low_stock_alert', SwitchType::class, [
                 'label' => $this->trans(
@@ -132,8 +133,5 @@ class CombinationStockType extends TranslatorAwareType
                 ],
             ])
         ;
-
-        // @todo This model transformer association could be simplified with a FormExtension that would allow default_empty_data option
-        $builder->get('low_stock_threshold')->addModelTransformer(new DefaultEmptyDataTransformer(0, null));
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/OptionsType.php
@@ -79,6 +79,7 @@ class OptionsType extends TranslatorAwareType
         $builder
             ->add('active', SwitchType::class, [
                 'label' => $this->trans('Online', 'Admin.Global'),
+                'required' => false,
             ])
             ->add('visibility', ChoiceType::class, [
                 'choices' => $this->productVisibilityChoiceProvider->getChoices(),
@@ -86,9 +87,11 @@ class OptionsType extends TranslatorAwareType
                     'class' => 'custom-select',
                 ],
                 'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
+                'required' => false,
             ])
             ->add('available_for_order', SwitchType::class, [
                 'label' => $this->trans('Available for order', 'Admin.Catalog.Feature'),
+                'required' => false,
             ])
             ->add('show_price', SwitchType::class, [
                 'label' => $this->trans('Show price', 'Admin.Catalog.Feature'),
@@ -159,7 +162,7 @@ class OptionsType extends TranslatorAwareType
                 'attr' => [
                     'class' => 'custom-select',
                 ],
-                'required' => true,
+                'required' => false,
                 'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductFormType.php
@@ -136,7 +136,9 @@ class ProductFormType extends TranslatorAwareType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $productType = $options['data']['basic']['type'] ?? ProductType::TYPE_STANDARD;
+        // Important to get data from form and not options as it's the most up to date
+        $formData = $form->getData();
+        $productType = $formData['basic']['type'] ?? ProductType::TYPE_STANDARD;
         $formVars = [
             'product_type' => $productType,
             'product_id' => isset($options['product_id']) ? (int) $options['product_id'] : null,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductFormType.php
@@ -154,9 +154,11 @@ class ProductFormType extends TranslatorAwareType
     {
         parent::configureOptions($resolver);
 
+        // We must allow extra fields because when we switch product type some former fields may be present in request
         $resolver->setDefaults([
             'product_id' => null,
             'product_type' => null,
+            'allow_extra_fields' => true,
         ]);
         $resolver->setAllowedTypes('product_id', ['null', 'int']);
         $resolver->setAllowedTypes('product_type', ['null', 'string']);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductSupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ProductSupplierType.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use PrestaShopBundle\Form\DataTransformer\DefaultEmptyDataTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
@@ -106,6 +105,7 @@ class ProductSupplierType extends TranslatorAwareType
                     new NotBlank(),
                     new Type(['type' => 'float']),
                 ],
+                'default_empty_data' => 0.0,
             ])
             ->add('currency_id', ChoiceType::class, [
                 'label' => $this->trans('Currency', 'Admin.Global'),
@@ -115,8 +115,5 @@ class ProductSupplierType extends TranslatorAwareType
                 'choices' => $this->currencyByIdChoiceProvider->getChoices(),
             ])
         ;
-
-        // Used to force default value when empty (especially in the prototype)
-        $builder->get('price_tax_excluded')->addModelTransformer(new DefaultEmptyDataTransformer(0.0));
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/ShortcutsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/ShortcutsType.php
@@ -32,6 +32,7 @@ use PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\PriceShortcutType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Shortcut\StockShortcutType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShortcutsType extends TranslatorAwareType
 {
@@ -54,5 +55,18 @@ class ShortcutsType extends TranslatorAwareType
                 'target_tab_name' => $this->trans('Pricing', 'Admin.Catalog.Feature'),
             ])
         ;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        // We must allow extra fields because when we switch product type some former fields may be present in request
+        $resolver->setDefaults([
+            'allow_extra_fields' => true,
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
@@ -107,6 +107,7 @@ class StockType extends TranslatorAwareType
 
         $builder
             ->add('minimal_quantity', NumberType::class, [
+                'required' => false,
                 'label' => $this->trans('Minimum quantity for sale', 'Admin.Catalog.Feature'),
                 'constraints' => [
                     new NotBlank(),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
@@ -32,7 +32,6 @@ use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use PrestaShopBundle\Form\DataTransformer\DefaultEmptyDataTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -125,6 +124,8 @@ class StockType extends TranslatorAwareType
                     new Type(['type' => 'numeric']),
                 ],
                 'required' => false,
+                'default_empty_data' => 0,
+                'empty_view_data' => null,
             ])
             ->add('low_stock_alert', SwitchType::class, [
                 'required' => false,
@@ -173,7 +174,5 @@ class StockType extends TranslatorAwareType
                 ],
             ])
         ;
-
-        $builder->get('low_stock_threshold')->addModelTransformer(new DefaultEmptyDataTransformer(0, null));
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/StockType.php
@@ -125,6 +125,7 @@ class StockType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'default_empty_data' => 0,
+                // Using null here allows to keep the field empty in the page instead of 0
                 'empty_view_data' => null,
             ])
             ->add('low_stock_alert', SwitchType::class, [

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -22,6 +22,11 @@ services:
       tags:
         - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }
 
+    form.extension.default_empty_data:
+      class: 'PrestaShopBundle\Form\Admin\Extension\DefaultEmptyDataExtension'
+      tags:
+        - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }
+
     form.extension.data_list:
         class: 'PrestaShopBundle\Form\Extension\DataListExtension'
         tags:

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/VirtualProductFileCommandsBuilderTest.php
@@ -160,5 +160,14 @@ class VirtualProductFileCommandsBuilderTest extends AbstractProductCommandBuilde
             ],
             [],
         ];
+
+        yield [
+            [
+                'virtual_product_file' => [
+                    'has_file' => false,
+                ],
+            ],
+            [],
+        ];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -92,6 +92,10 @@ class ProductFormDataProviderTest extends TestCase
             'manufacturer' => [
                 'manufacturer_id' => NoManufacturerId::NO_MANUFACTURER_ID,
             ],
+            'stock' => [
+                'quantity' => 0,
+                'minimal_quantity' => 0,
+            ],
             'price' => [
                 'price_tax_excluded' => 0,
                 'price_tax_included' => 0,
@@ -104,8 +108,24 @@ class ProductFormDataProviderTest extends TestCase
                 'height' => 0,
                 'depth' => 0,
                 'weight' => 0,
+                'additional_shipping_cost' => 0,
+                'delivery_time_note_type' => DeliveryTimeNoteType::TYPE_DEFAULT,
             ],
-            'activate' => false,
+            'options' => [
+                'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
+                'condition' => ProductCondition::NEW,
+                'activate' => false,
+            ],
+            'shortcuts' => [
+                'price' => [
+                    'price_tax_excluded' => 0,
+                    'price_tax_included' => 0,
+                    'tax_rules_group_id' => 42,
+                ],
+                'stock' => [
+                    'quantity' => 0,
+                ],
+            ],
         ];
 
         $defaultData = $provider->getDefaultData();
@@ -121,6 +141,10 @@ class ProductFormDataProviderTest extends TestCase
             'manufacturer' => [
                 'manufacturer_id' => NoManufacturerId::NO_MANUFACTURER_ID,
             ],
+            'stock' => [
+                'quantity' => 0,
+                'minimal_quantity' => 0,
+            ],
             'price' => [
                 'price_tax_excluded' => 0,
                 'price_tax_included' => 0,
@@ -133,8 +157,24 @@ class ProductFormDataProviderTest extends TestCase
                 'height' => 0,
                 'depth' => 0,
                 'weight' => 0,
+                'additional_shipping_cost' => 0,
+                'delivery_time_note_type' => DeliveryTimeNoteType::TYPE_DEFAULT,
             ],
-            'activate' => true,
+            'options' => [
+                'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
+                'condition' => ProductCondition::NEW,
+                'activate' => true,
+            ],
+            'shortcuts' => [
+                'price' => [
+                    'price_tax_excluded' => 0,
+                    'price_tax_included' => 0,
+                    'tax_rules_group_id' => 42,
+                ],
+                'stock' => [
+                    'quantity' => 0,
+                ],
+            ],
         ];
 
         $defaultData = $provider->getDefaultData();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR aims to fix the first obvious and really blocking bugs in the new product page that prevent QA team from correctly testing it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/24258
| How to test?      | See description
| Possible impacts? | See description


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24168)
<!-- Reviewable:end -->

## Bugs fixed, possible impacts

### In edition:
- When saving the form in product not virtual an error related to `virtual_product_file_id` always popped
- When switching to combination type and error related to missing stock form always popped
- When switching types to combination an error indicating that extra fields were present prevented from validating the form and really save the modification

### In creation:
- All fields are correctly prefilled so the only error you should have when creating a new product is the missing default name (if absent of course)
- Now when you switch the type in creation you get a modal to forces you to submit the form to confirm this modification (unlike the edition page no extra warning is displayed as it's not useful for an empty/new product)

### Possible impacts
A new extension manages the empty state of some fields, you should check that these fields have correct behaviour even (especially) when left empty or unmodified with zero values:
- Low stock threshold in product and combination form
-`price_tax_excluded` in Supplier form, when a new product supplier is dynamically added with js action it must be prefilled with `0.0` not empty value
