### PR TITLE
Add multistore all shops context and message for Order States SF pages

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -418,7 +418,8 @@ class OrderStateController extends FrameworkBundleAdminController
     protected function isMultistoreAllShopsContextForced(): bool
     {
         return $this->get('prestashop.adapter.multistore_feature')->isUsed()
-            && $this->get('prestashop.adapter.shop.context')->isShopContext();
+            && ($this->get('prestashop.adapter.shop.context')->isShopContext()
+                || $this->get('prestashop.adapter.shop.context')->isGroupShopContext());
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -72,6 +72,11 @@ class OrderStateController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'orderStatesGrid' => $this->presentGrid($orderStatesGrid),
             'orderReturnStatesGrid' => $this->presentGrid($orderReturnStatesGrid),
+            'multistoreForcedContextInfoTip' => $this->trans(
+                'Note that this page is available in all shops context only, this is why your context has just switched.',
+                'Admin.Notifications.Info'
+            ),
+            'displayAllShopsContextForced' => $this->isMultistoreAllShopsContextForced(),
         ]);
     }
 
@@ -139,6 +144,8 @@ class OrderStateController extends FrameworkBundleAdminController
                         'id' => $language['iso_code'],
                         'value' => sprintf('%s - %s', $language['iso_code'], $language['name']), ];
                 }, $this->get('prestashop.adapter.legacy.context')->getLanguages()),
+            'multistoreForcedContextInfoTip' => $this->getMultistoreAllShopsContextForcedMessage(),
+            'displayAllShopsContextForced' => $this->isMultistoreAllShopsContextForced(),
         ]);
     }
 
@@ -184,6 +191,8 @@ class OrderStateController extends FrameworkBundleAdminController
                         'id' => $language['iso_code'],
                         'value' => sprintf('%s - %s', $language['iso_code'], $language['name']), ];
                 }, $this->get('prestashop.adapter.legacy.context')->getLanguages()),
+            'multistoreForcedContextInfoTip' => $this->getMultistoreAllShopsContextForcedMessage(),
+            'displayAllShopsContextForced' => $this->isMultistoreAllShopsContextForced(),
         ]);
     }
 
@@ -216,6 +225,8 @@ class OrderStateController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/create.html.twig', [
             'orderReturnStateForm' => $orderReturnStateForm->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'multistoreForcedContextInfoTip' => $this->getMultistoreAllShopsContextForcedMessage(),
+            'displayAllShopsContextForced' => $this->isMultistoreAllShopsContextForced(),
         ]);
     }
 
@@ -254,6 +265,8 @@ class OrderStateController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'editableOrderReturnState' => $this->getQueryBus()->handle(new GetOrderReturnStateForEditing((int) $orderReturnStateId)),
             'contextLangId' => $this->getContextLangId(),
+            'multistoreForcedContextInfoTip' => $this->getMultistoreAllShopsContextForcedMessage(),
+            'displayAllShopsContextForced' => $this->isMultistoreAllShopsContextForced(),
         ]);
     }
 
@@ -397,5 +410,25 @@ class OrderStateController extends FrameworkBundleAdminController
                 ]
             ),
         ];
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isMultistoreAllShopsContextForced(): bool
+    {
+        return $this->get('prestashop.adapter.multistore_feature')->isUsed()
+            && $this->get('prestashop.adapter.shop.context')->isShopContext();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMultistoreAllShopsContextForcedMessage(): string
+    {
+        return $this->trans(
+            'Note that this feature is available in all shops context only. It will be added to all your stores.',
+            'Admin.Notifications.Info'
+        );
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/create.html.twig
@@ -29,6 +29,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block content %}
+  {% if displayAllShopsContextForced %}{{ ps.infotip(multistoreForcedContextInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/edit.html.twig
@@ -31,6 +31,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block content %}
+  {% if displayAllShopsContextForced %}{{ ps.infotip(multistoreForcedContextInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/create.html.twig
@@ -29,6 +29,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block content %}
+  {% if displayAllShopsContextForced %}{{ ps.infotip(multistoreForcedContextInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/edit.html.twig
@@ -31,6 +31,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block content %}
+  {% if displayAllShopsContextForced %}{{ ps.infotip(multistoreForcedContextInfoTip, true) }}{% endif %}
   <div class="row justify-content-center">
     <div class="col">
       {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/index.html.twig
@@ -42,6 +42,8 @@
 
 {% block content %}
 
+  {% if displayAllShopsContextForced %}{{ ps.infotip(multistoreForcedContextInfoTip, true) }}{% endif %}
+  
   {% block order_states_listing %}
     <div class="row">
       <div class="col-12">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I reuse the components introduced in https://github.com/PrestaShop/PrestaShop/pull/24128/ on Order State BO pages. These pages are hidden for now, you need the URL to navigate to them.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/19495<br> Fixes https://github.com/PrestaShop/PrestaShop/issues/19496<br> Fixes https://github.com/PrestaShop/PrestaShop/issues/19497
| How to test?      | See below
| Possible impacts? | PR modifies the Symfony controller for BO pages "order states" and "return states". These pages are hidden.

## How to test

1. Enable Multistore mode
2. Select "single shop context"
3. Navigate to each of the hidden pages in the list below and verify that the context is forced to "all shops" (look at the header) and that the information messages are displayed (messages specified in https://github.com/PrestaShop/PrestaShop/issues/19495 https://github.com/PrestaShop/PrestaShop/issues/19496 https://github.com/PrestaShop/PrestaShop/issues/19497)

You can also test with group context by using another step 2:

2. Select "group shop context"

### URL for hidden BO pages

List /admin-dev/index.php/configure/shop/order-states/?_token=ABCD

Add an order State
/admin-dev/index.php/configure/shop/order-states/new?_token=ABCD
Edit an order State
/admin-dev/index.php/configure/shop/order-states/12/edit?_token=ABCD

Add an order return status
/admin-dev/index.php/configure/shop/order-return-states/new?_token=ABCD
Edit an order return status
/admin-dev/index.php/configure/shop/order-return-states/3/edit?_token=ABCD

## Screenshots


![Capture d’écran 2021-04-23 à 14 16 13](https://user-images.githubusercontent.com/3830050/115870803-0ee9d600-a440-11eb-9788-f1b8fa8133b4.png)
![Capture d’écran 2021-04-23 à 14 16 21](https://user-images.githubusercontent.com/3830050/115870814-114c3000-a440-11eb-8f38-9067bd00d670.png)
![Capture d’écran 2021-04-23 à 14 16 31](https://user-images.githubusercontent.com/3830050/115870821-14dfb700-a440-11eb-986f-be2998cbfc87.png)
![Capture d’écran 2021-04-23 à 14 17 02](https://user-images.githubusercontent.com/3830050/115870830-17421100-a440-11eb-90cb-a96de634018e.png)
![Capture d’écran 2021-04-23 à 14 17 15](https://user-images.githubusercontent.com/3830050/115870837-1a3d0180-a440-11eb-80d0-928c99dac059.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24180)
<!-- Reviewable:end -->
