### PR TITLE
[FO] Update order_conf_product_list.tpl on customization text HTML display

### DIFF
--- a/mails/_partials/order_conf_product_list.tpl
+++ b/mails/_partials/order_conf_product_list.tpl
@@ -47,7 +47,7 @@
 						{if count($product['customization']) == 1}
 							<br>
 							{foreach $product['customization'] as $customization}
-								{$customization['customization_text']}
+								{$customization['customization_text'] nofilter}
 							{/foreach}
 						{/if}
 
@@ -107,7 +107,7 @@
   					<td width="5">&nbsp;</td>
   					<td>
   						<font size="2" face="Open-sans, sans-serif" color="#555454">
-  							{$customization['customization_text']}
+  							{$customization['customization_text'] nofilter}
   						</font>
   					</td>
   					<td width="5">&nbsp;</td>
@@ -121,7 +121,7 @@
   					<td align="right">
   						<font size="2" face="Open-sans, sans-serif" color="#555454">
   							{if count($product['customization']) > 1}
-  								{$customization['customization_quantity']}
+  								{$customization['customization_quantity'] nofilter}
   							{/if}
   						</font>
   					</td>


### PR DESCRIPTION
Customization text is HTML and is not parsed correctly on the order confirmation emails. 

It is diplayed like below:
<strong>Dimension</strong>:Weight 12.5 kg <br/>

Adding nofilter, the issue is solved and the customization text is parsed correctly.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x / 1.7.7.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto / critical
| Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24181)
<!-- Reviewable:end -->
