### PR TITLE
Make color required for order state forms

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -61,7 +61,7 @@ class OrderReturnStateType extends TranslatorAwareType
                 ],
             ])
             ->add('color', ColorPickerType::class, [
-                'required' => false,
+                'required' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -130,7 +130,7 @@ class OrderStateType extends TranslatorAwareType
                 ],
             ])
             ->add('color', ColorPickerType::class, [
-                'required' => false,
+                'required' => true,
             ])
             ->add('loggable', CheckboxType::class, [
                 'required' => false,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make color required for order state forms
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/20441
| How to test?      | Please follow https://github.com/PrestaShop/PrestaShop/issues/20441 steps
| Possible impacts? | Only the 2 forms mentioned in the GitHub issues have been modified.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24184)
<!-- Reviewable:end -->
