### PR TITLE
Use default string if no translation was loaded

### DIFF
--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -198,6 +198,7 @@ class TranslateCore
         }
 
         if (!isset($translationsMerged[$name][$iso])) {
+            $translationsMerged[$name][$iso] = false;
             $filesByPriority = [
                 // PrestaShop 1.5 translations
                 _PS_MODULE_DIR_ . $name . '/translations/' . $iso . '.php',
@@ -211,9 +212,9 @@ class TranslateCore
                 if (file_exists($file)) {
                     include_once $file;
                     $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
+                    $translationsMerged[$name][$iso] = true;
                 }
             }
-            $translationsMerged[$name][$iso] = true;
         }
 
         $string = preg_replace("/\\\*'/", "\'", $originalString);
@@ -232,7 +233,9 @@ class TranslateCore
                 $defaultKeyFile = strtolower('<{' . $name . '}prestashop>' . $file) . '_' . $key;
             }
 
-            if (isset($currentKeyFile) && !empty($_MODULES[$currentKeyFile])) {
+            if($translationsMerged[$name][$iso] === false){
+                $ret = stripslashes($string);
+            } elseif (isset($currentKeyFile) && !empty($_MODULES[$currentKeyFile])) {
                 $ret = stripslashes($_MODULES[$currentKeyFile]);
             } elseif (isset($defaultKeyFile) && !empty($_MODULES[$defaultKeyFile])) {
                 $ret = stripslashes($_MODULES[$defaultKeyFile]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | this fix will record if a translation file was found and loaded for the selected language and return the default string if is was not.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #13392 (#24277)
| How to test?      | consider a module with a translation file in translation/de.php.  We load a string with $module->l('String','file','de-DE'); as a result global $MODULES has been populated with the translation from "String". Now we want to get $module->l('String','file','en-US'); Erroneously we receive the German translation at this point
| Possible impacts? | none so far

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24189)
<!-- Reviewable:end -->
