### PR TITLE
BO: #24130 use `defaultCategory` instead of `window.defaultCategory` - Approach 2

### DIFF
--- a/admin-dev/themes/new-theme/.eslintrc.js
+++ b/admin-dev/themes/new-theme/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
   rules: {
     'class-methods-use-this': 0,
     'func-names': 0,
+    'no-undef':0,
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/admin-dev/themes/new-theme/.eslintrc.js
+++ b/admin-dev/themes/new-theme/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
   rules: {
     'class-methods-use-this': 0,
     'func-names': 0,
-    'no-undef':0,
+    'no-undef': 0,
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/admin-dev/themes/new-theme/js/product-page/nested-categories.js
+++ b/admin-dev/themes/new-theme/js/product-page/nested-categories.js
@@ -25,7 +25,7 @@ export default function () {
         if (category.is(':checked') === false && defaultcat.is(':checked') === true) {
           category.trigger('click');
         }
-        window.defaultCategory.check(categoryId);
+        defaultCategory.check(categoryId);
       });
     },
     removeDefaultIfNeeded() {
@@ -54,7 +54,7 @@ export default function () {
         } else if (category.is(':checked') === false && defaultcat.is(':checked') === true) {
           const newCategory = findClosestCheckedCategory(category);
 
-          window.defaultCategory.check(newCategory.val());
+          defaultCategory.check(newCategory.val());
           window.productCategoriesTags.checkDefaultCategory(newCategory.val());
         }
       });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | This PR tries to access `defautCategory`object, which lives inside `default` theme, from inside the `new-theme`. This object was first taken from the window global. (This PR is the second approach, please to also see first approach in ticket page)
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |no
| Deprecations?     |no
| Fixed ticket?     | Fixes #24130
| How to test?      | Go to product page in BO using the javascript console. When changing the default category in product details page, no ReferenceError is thrown and default category is saved in database.
| Possible impacts? | Disallowing Undeclared Variables (no-undef) may lower the current code quality level.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24200)
<!-- Reviewable:end -->
