### PR TITLE
Make multistore dropdown appear in group shop context 

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -110,10 +110,11 @@ class MultistoreController extends FrameworkBundleAdminController
     /**
      * @param ShopConfigurationInterface $configuration
      * @param string $configurationKey
+     * @param int|null $groupId
      *
      * @return Response
      */
-    public function configurationDropdown(ShopConfigurationInterface $configuration, string $configurationKey): Response
+    public function configurationDropdown(ShopConfigurationInterface $configuration, string $configurationKey, int $groupId = null): Response
     {
         $groupList = $this->entityManager->getRepository(ShopGroup::class)->findBy(['active' => true]);
         $shopCustomizationChecker = $this->get('prestashop.multistore.customized_configuration_checker');
@@ -124,7 +125,7 @@ class MultistoreController extends FrameworkBundleAdminController
                 unset($groupList[$key]);
             }
             foreach ($group->getShops() as $shop) {
-                if ($shopCustomizationChecker->isConfigurationCustomizedForThisShop($configurationKey, $shop)) {
+                if ($shopCustomizationChecker->isConfigurationCustomizedForThisShop($configurationKey, $shop) && $group->getId() === $groupId) {
                     $shouldDisplayDropdown = true;
                     break;
                 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -43,7 +43,7 @@
               {% for shop in group.shops %}
                 <li class="multistore-dropdown-shop">
                   <a class="multistore-dropdown-shop-name{% if shop.hasMainUrl() == false %} multistore-dropdown-no-url">{{ shop.name }}</a>{% else %}" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>{% endif %}
-                  {% if shopCustomizationChecker.isConfigurationCustomizedForThisShop(configurationKey, shop) == true %}
+                  {% if shopCustomizationChecker.isConfigurationCustomizedForThisShop(configurationKey, shop, isGroupShopContext) == true %}
                     <p class="multistore-dropdown-shop-status multistore-dropdown-shop-status-locked">
                       <i class="material-icons">https</i>
                       {{ 'Customized'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
+++ b/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
@@ -168,8 +168,7 @@ class MultistoreCheckboxEnabler
         if ($this->multiStoreContext->isAllShopContext() || $this->multiStoreContext->isGroupShopContext()) {
             $options['multistore_dropdown'] = $this->multistoreController->configurationDropdown(
                 $this->configuration,
-                $options['attr']['multistore_configuration_key'],
-                $this->multiStoreContext->isGroupShopContext() ? $this->multiStoreContext->getContextShopGroup()->id : null
+                $options['attr']['multistore_configuration_key']
             )->getContent();
         }
 

--- a/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
+++ b/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
@@ -165,10 +165,11 @@ class MultistoreCheckboxEnabler
         $options['attr']['disabled'] = !$this->multiStoreContext->isAllShopContext() && !$isOverriddenInCurrentContext;
 
         // add multistore dropdown in field option
-        if ($this->multiStoreContext->isAllShopContext()) {
+        if ($this->multiStoreContext->isAllShopContext() || $this->multiStoreContext->isGroupShopContext()) {
             $options['multistore_dropdown'] = $this->multistoreController->configurationDropdown(
                 $this->configuration,
-                $options['attr']['multistore_configuration_key']
+                $options['attr']['multistore_configuration_key'],
+                $this->multiStoreContext->isGroupShopContext() ? $this->multiStoreContext->getContextShopGroup()->id : null
             )->getContent();
         }
 

--- a/src/PrestaShopBundle/Service/Multistore/CustomizedConfigurationChecker.php
+++ b/src/PrestaShopBundle/Service/Multistore/CustomizedConfigurationChecker.php
@@ -56,20 +56,24 @@ class CustomizedConfigurationChecker
      *
      * @param string $configurationKey
      * @param Shop $shop
+     * @param bool $isGroupShopContext
      *
      * @return bool
      */
-    public function isConfigurationCustomizedForThisShop(string $configurationKey, Shop $shop): bool
+    public function isConfigurationCustomizedForThisShop(string $configurationKey, Shop $shop, bool $isGroupShopContext): bool
     {
-        // check if given configuration is overridden for the parent shop group
-        $shopGroupConstraint = new ShopConstraint(
-            null,
-            $shop->getShopGroup()->getId(),
-            true // it must be strict, otherwise the method will also check for configuration settings in "all shop" context
-        );
+        // we don't check group shop customization if we are already in group shop context
+        if (!$isGroupShopContext) {
+            // check if given configuration is overridden for the parent group shop
+            $shopGroupConstraint = new ShopConstraint(
+                null,
+                $shop->getShopGroup()->getId(),
+                true // it must be strict, otherwise the method will also check for configuration settings in "all shop" context
+            );
 
-        if ($this->configuration->has($configurationKey, $shopGroupConstraint)) {
-            return true;
+            if ($this->configuration->has($configurationKey, $shopGroupConstraint)) {
+                return true;
+            }
         }
 
         // check if given configuration is overridden for the shop

--- a/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
@@ -102,6 +102,7 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
         // the added multistore checkbox must have the correct `multistore_configuration_key` attribute
         $multistoreFirstFieldCheckboxOptions = $form->get(MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'first_field')->getConfig()->getOptions();
         $this->assertEquals('TEST_CONFIGURATION_KEY', $multistoreFirstFieldCheckboxOptions['attr']['multistore_configuration_key']);
+        $this->assertArrayHasKey('multistore_dropdown', $multistoreFirstFieldCheckboxOptions);
     }
 
     /**
@@ -154,16 +155,18 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
 
     /**
      * @param bool $isAllShopContext
+     * @param bool $isGroupShopContext
      *
      * @return MockObject
      */
-    private function createMultistoreContextMock(bool $isAllShopContext = false): MockObject
+    private function createMultistoreContextMock(bool $isAllShopContext = false, bool $isGroupShopContext = true): MockObject
     {
         $shopGroupObject = new stdClass();
         $shopGroupObject->id = 2;
         $stub = $this->createMock(ShopContext::class);
         $stub->method('getContextShopId')->willReturn(1);
         $stub->method('isAllShopContext')->willReturn($isAllShopContext);
+        $stub->method('isGroupShopContext')->willReturn($isGroupShopContext);
         $stub->method('getContextShopGroup')->willReturn($shopGroupObject);
 
         return $stub;

--- a/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Multistore/CustomizedConfigurationCheckerTest.php
@@ -39,10 +39,12 @@ class CustomizedConfigurationCheckerTest extends TestCase
     public function testIsConfigurationCustomizedForThisShop(): void
     {
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(true));
-        $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
+        $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal(), true));
+        $this->assertTrue($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal(), false));
 
         $customizedConfigurationChecker = new CustomizedConfigurationChecker($this->mockShopConfiguration(false));
-        $this->assertFalse($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal()));
+        $this->assertFalse($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal(), true));
+        $this->assertFalse($customizedConfigurationChecker->isConfigurationCustomizedForThisShop('FAKE_CONFIG_KEY', $this->prophesizeShopEntity()->reveal(), false));
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The multistore dropdown should appear in group shop context, this PR fixes this.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24066
| How to test?      | The test procedure is described in the issue.
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24108)
<!-- Reviewable:end -->
