### PR TITLE
Add an unit test for refreshCaCertFile

### DIFF
--- a/tests/Unit/Adapter/ToolsTest.php
+++ b/tests/Unit/Adapter/ToolsTest.php
@@ -58,4 +58,14 @@ class ToolsTest extends TestCase
         yield ['0.0000000', '10', 6, '10.000000'];
         yield ['0.0', '0.00000002', 2, '0.00'];
     }
+
+    /**
+     * Test for refreshCaCertFile : delete de Ca Cert file, refresh and test if the file is created
+     */
+    public function testRefreshCaCertFile(): void
+    {
+        @unlink(_PS_CACHE_CA_CERT_FILE_);
+        (new Tools())->refreshCaCertFile();
+        self::assertEquals(1, file_exists(_PS_CACHE_CA_CERT_FILE_));
+    }
 }


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Add a test for refreshCaCertFile : delete the file, launch the refresh and test if the file exists
| Type?             |  improvement 
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  no ticket
| How to test?      | Launch unit test phpunit -c tests/Unit/phpunit.xml tests/Unit/Adapter/ToolsTest.php
| Possible impacts? | none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24212)
<!-- Reviewable:end -->
