### PR TITLE
Add missing product form hooks

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2875,6 +2875,16 @@
       <title>Modify product identifiable object form</title>
       <description>This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself</description>
     </hook>
+    <hook id="actionBeforeCreateProductFormHandler">
+      <name>actionBeforeCreateProductFormHandler</name>
+      <title>Modify product identifiable object data before creating it</title>
+      <description>This hook allows to modify product identifiable object form data before it was created</description>
+    </hook>
+    <hook id="actionAfterCreateProductFormHandler">
+      <name>actionBeforeCreateProductFormHandler</name>
+      <title>Modify product identifiable object data after creating it</title>
+      <description>This hook allows to modify product identifiable object form data after it was created</description>
+    </hook>
     <hook id="actionBeforeUpdateProductFormHandler">
       <name>actionBeforeUpdateProductFormHandler</name>
       <title>Modify product identifiable object data before updating it</title>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2875,5 +2875,15 @@
       <title>Modify product identifiable object form</title>
       <description>This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself</description>
     </hook>
+    <hook id="actionBeforeUpdateProductFormHandler">
+      <name>actionBeforeUpdateProductFormHandler</name>
+      <title>Modify product identifiable object data before updating it</title>
+      <description>This hook allows to modify product identifiable object form data before it was updated</description>
+    </hook>
+    <hook id="actionAfterUpdateProductFormHandler">
+      <name>actionAfterUpdateProductFormHandler</name>
+      <title>Modify product identifiable object data after updating it</title>
+      <description>This hook allows to modify product identifiable object form data before it was updated</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2870,5 +2870,10 @@
       <title>Display after Grid table</title>
       <description>This hook adds new blocks after Grid component table</description>
     </hook>
+    <hook id="actionProductFormBuilderModifier">
+      <name>actionProductFormBuilderModifier</name>
+      <title>Modify product identifiable object form</title>
+      <description>This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -22,6 +22,7 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayAdminGridTableBefore', 'Display before Grid table', 'This hook adds new blocks before Grid component table.', '1'),
   (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1'),
   (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons on the create order page dropdown', 'Add buttons on the create order page dropdown', '1')
+  (NULL, 'actionProductFormBuilderModifier', 'Modify product identifiable object form', 'This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself', '1')
 ;
 
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -25,6 +25,8 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionProductFormBuilderModifier', 'Modify product identifiable object form', 'This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself', '1')
   (NULL, 'actionBeforeUpdateProductFormHandler', 'Modify product identifiable object data before updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1')
   (NULL, 'actionAfterUpdateProductFormHandler', 'Modify product identifiable object data after updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1')
+  (NULL, 'actionBeforeCreateProductFormHandler', 'Modify product identifiable object data before creating it', 'This hook allows to modify product identifiable object form data before it was created', '1')
+  (NULL, 'actionAfterCreateProductFormHandler', 'Modify product identifiable object data after creating it', 'This hook allows to modify product identifiable object form data after it was created', '1')
 ;
 
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -23,6 +23,8 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1'),
   (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons on the create order page dropdown', 'Add buttons on the create order page dropdown', '1')
   (NULL, 'actionProductFormBuilderModifier', 'Modify product identifiable object form', 'This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself', '1')
+  (NULL, 'actionBeforeUpdateProductFormHandler', 'Modify product identifiable object data before updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1')
+  (NULL, 'actionAfterUpdateProductFormHandler', 'Modify product identifiable object data after updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1')
 ;
 
 ALTER TABLE `PREFIX_employee` ADD `has_enabled_gravatar` TINYINT UNSIGNED DEFAULT 0 NOT NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Adds missing hooks related to new product form. See hooks list bellow
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Install 1.7.8.x version or upgrade from 1.7.7.x & check bellow for further instructions:
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

Added hooks list and how to test:
To test use **ps_qualityassurance** and register each hook with following method content: `dump($params);die;` (test it one by one because it will stop the php script if it works and show you the dumped contents))
1. actionProductFormBuilderModifier - just go to new product page form and you should see the dumped contents (depending if you are in create or edit page you will see different route name)
![Screenshot from 2021-04-27 16-55-08](https://user-images.githubusercontent.com/31609858/116253975-9eadbe00-a779-11eb-9de7-9f2ba7a0bb0e.png)

2. actionBeforeCreateProductFormHandler - this will require going to a "create product" form and creating a new product, once you press SAVE you should see dumped contents 
![Screenshot from 2021-04-27 17-05-03](https://user-images.githubusercontent.com/31609858/116255247-bd608480-a77a-11eb-8929-4ba7461de0d5.png)

3. actionAfterCreateProductFormHandler - follow same procedure as above and you should see such dump (note the main difference is that id is there)
![Screenshot from 2021-04-27 17-06-15](https://user-images.githubusercontent.com/31609858/116255671-23e5a280-a77b-11eb-85ba-d043e67cf6cd.png)

4. actionBeforeUpdateProductFormHandler - same procedure as above except that you need to go to update product page instead of create now. After pressing save you should see this dump
![Screenshot from 2021-04-27 17-11-03](https://user-images.githubusercontent.com/31609858/116256253-b2f2ba80-a77b-11eb-98cf-2d894ef5aff7.png)

5. actionAfterUpdateProductFormHandler - same procedure as above (also in edit page) and after SAVE you should see this dump
![Screenshot from 2021-04-27 17-12-57](https://user-images.githubusercontent.com/31609858/116256459-e1709580-a77b-11eb-8349-a14b672b045c.png)
Only difference with after and before hooks, that if you are testing the "afterUpdate" hook, your changes should be saved when you back to form, whereas with "beforeUpdate" hook, your changes should not be saved. (due to the fact that code is stopped immediately after the dump in the hook)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24213)
<!-- Reviewable:end -->
