### PR TITLE
Fix cannot change the default category in BO product page

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/default-category.js
+++ b/admin-dev/themes/default/js/bundle/product/default-category.js
@@ -1,7 +1,7 @@
 /**
  * Default category management
  */
-const defaultCategory = (function () {
+window.defaultCategory = (function () {
   const defaultCategoryForm = $('#form_step1_id_category_default');
 
   return {


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | This PR adds `defautCategory`object to the window global object inside `default` theme. The goal is to be able to access `window.defaultCategory` inside the new-theme without having ReferenceError : `window.defaultCategory` is undefined.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |no
| Deprecations?     |no
| Fixed ticket?     | Fixes #24130
| How to test?      | Go to product page in BO using the javascript console. When changing the default category in product details page, no ReferenceError is thrown and default category is saved in database.
| Possible impacts? | I don't see any.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24220)
<!-- Reviewable:end -->
