### PR TITLE
Allow orders with 0 amount

### DIFF
--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -127,7 +127,7 @@
 
   <div id="payment-confirmation" class="js-payment-confirmation">
     <div class="ps-shown-by-js">
-      <button type="submit" class="btn btn-primary center-block{if !$selected_payment_option} disabled{/if}">
+      <button type="submit" class="btn btn-primary center-block{if !$selected_payment_option  && $cart.totals.amount > 0} disabled{/if}">
         {l s='Place order' d='Shop.Theme.Checkout'}
       </button>
       {if $show_final_summary}


### PR DESCRIPTION
When we make an order with discount codes, if the amount is 0 right you can't place the order.

We should be able to place it, this is because no payment method is shown when amount is 0, and in the template, the condition isn't correct.

------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If you try to place an order with a discount code which makes the total amount = 0, the `Order with an obligation to pay` button will be disabled. This is a bug which should be fixed.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9927
| How to test?      | Try to place an order with 0 amount using discount codes, before this PR, the `Order with an obligation to pay` button is disabled, after, it should be enabled to allow placing this order.
| Possible impacts? | I don't know any

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24230)
<!-- Reviewable:end -->
