### PR TITLE
Typo in head-jsonld.tpl, shop logo link: correction for #23151

### DIFF
--- a/themes/classic/templates/_partials/microdata/head-jsonld.tpl
+++ b/themes/classic/templates/_partials/microdata/head-jsonld.tpl
@@ -57,7 +57,7 @@
       "url" : "{$urls.pages.index}",
       "image": {
         "@type": "ImageObject",
-        "url":"{$urls.shop_domain_url}{$shop.logo}"
+        "url":"{$shop.logo}"
       },
       "potentialAction": {
         "@type": "SearchAction",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x 
| Description?      | Typo detected in #23151 (merged) by mgielecinski , thx to him
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #23151
| How to test?      | Logo url was not good in JSON ld declaration for index page
| Possible impacts? | Error

Simple typo correction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24233)
<!-- Reviewable:end -->
