### PR TITLE
Fix performance issue on Smarty template caching

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3567,7 +3567,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return string
      */
-    public function getDefaultCompileId()
+    public function getDefaultCompileId(): string
     {
         return Context::getContext()->shop->theme->getName();
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2442,7 +2442,7 @@ abstract class ModuleCore implements ModuleInterface
                 Tools::enableCache();
             }
             if ($compile_id === null) {
-                $compile_id = Context::getContext()->shop->theme->getName();
+                $compile_id = $this->getDefaultCompileId();
             }
 
             $result = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->fetch();
@@ -2472,7 +2472,7 @@ abstract class ModuleCore implements ModuleInterface
             Tools::enableCache();
         }
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         $template = $this->context->smarty->createTemplate(
@@ -2499,7 +2499,7 @@ abstract class ModuleCore implements ModuleInterface
     protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
     {
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         if (!isset($this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id])) {
@@ -2508,9 +2508,6 @@ abstract class ModuleCore implements ModuleInterface
                 !file_exists($template)
             ) {
                 $template = $this->getTemplatePath($template);
-            }
-            if ($compile_id === null) {
-                $compile_id = Context::getContext()->shop->theme->getName();
             }
 
             $this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id] = $this->context->smarty->createTemplate(
@@ -2565,7 +2562,7 @@ abstract class ModuleCore implements ModuleInterface
             $template = $this->getTemplatePath($template);
         }
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         $is_cached = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->isCached($template, $cache_id, $compile_id);
@@ -2590,7 +2587,7 @@ abstract class ModuleCore implements ModuleInterface
             $ps_smarty_clear_cache = Configuration::get('PS_SMARTY_CLEAR_CACHE');
         }
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         if (static::$_batch_mode) {
@@ -3563,6 +3560,16 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         $this->getContainer()->get('prestashop.adapter.cache.clearer.symfony_cache_clearer')->clear();
+    }
+
+    /**
+     * Returns shop theme name from context as a default compile Id.
+     *
+     * @return string
+     */
+    public function getDefaultCompileId()
+    {
+        return Context::getContext()->shop->theme->getName();
     }
 }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2498,6 +2498,10 @@ abstract class ModuleCore implements ModuleInterface
      */
     protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
     {
+        if ($compile_id === null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
+        }
+
         if (!isset($this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id])) {
             if (false === strpos($template, 'module:') &&
                 !file_exists(_PS_ROOT_DIR_ . '/' . $template) &&

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2441,6 +2441,9 @@ abstract class ModuleCore implements ModuleInterface
             if ($cache_id !== null) {
                 Tools::enableCache();
             }
+            if ($compile_id === null) {
+                $compile_id = Context::getContext()->shop->theme->getName();
+            }
 
             $result = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->fetch();
 
@@ -2502,6 +2505,9 @@ abstract class ModuleCore implements ModuleInterface
             ) {
                 $template = $this->getTemplatePath($template);
             }
+            if ($compile_id === null) {
+                $compile_id = Context::getContext()->shop->theme->getName();
+            }
 
             $this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id] = $this->context->smarty->createTemplate(
                 $template,
@@ -2554,6 +2560,9 @@ abstract class ModuleCore implements ModuleInterface
         if (false === strpos($template, 'module:') && !file_exists(_PS_ROOT_DIR_ . '/' . $template)) {
             $template = $this->getTemplatePath($template);
         }
+        if ($compile_id === null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
+        }
 
         $is_cached = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->isCached($template, $cache_id, $compile_id);
         Tools::restoreCacheSettings();
@@ -2575,6 +2584,9 @@ abstract class ModuleCore implements ModuleInterface
         static $ps_smarty_clear_cache = null;
         if ($ps_smarty_clear_cache === null) {
             $ps_smarty_clear_cache = Configuration::get('PS_SMARTY_CLEAR_CACHE');
+        }
+        if ($compile_id === null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
         }
 
         if (static::$_batch_mode) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | From 1.7.7.0 version Module class function isCached fails to check if tpl is cached. This PR fixes that.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24235.
| How to test?      | In order to test if it is fixed you need to check if function isCached works properly or try to reproduce issue. How to reproduce issue is described in issue ticket.
| Possible impacts? | Smarty cache compile / fetch / clear

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24241)
<!-- Reviewable:end -->
