### PR TITLE
Fix upgrade from 1.6.1.24 to 1.7.8.x

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1600,7 +1600,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         }
 
         // Fetch all countries from Intl in specified locale
-        $langCountries = (new self())->getCountries($lang->locale);
+        $langCountries = (new self())->getCountries($lang->getLocale());
         foreach ($translatableCountries as $country) {
             $isoCode = strtolower($country['iso_code']);
             if (empty($langCountries[$isoCode])) {
@@ -1630,7 +1630,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         try {
             $classObject = (new DataLangFactory(_DB_PREFIX_, $translator))
-                ->buildFromClassName($className, $lang->locale);
+                ->buildFromClassName($className, $lang->getLocale());
         } catch (DataLangClassNameNotFoundException $e) {
             return;
         }

--- a/install-dev/upgrade/php/migrate_tabs_17.php
+++ b/install-dev/upgrade/php/migrate_tabs_17.php
@@ -104,6 +104,12 @@ class XmlLoader1700 extends XmlLoader
         if (isset($data['enabled'])) {
             unset($data['enabled']);
         }
+        if (isset($data['wording'])) {
+            unset($data['wording']);
+        }
+        if (isset($data['wording_domain'])) {
+            unset($data['wording_domain']);
+        }
         parent::createEntityTab($identifier, $data, $data_lang);
     }
 }

--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -21,11 +21,11 @@ INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `po
   (NULL, 'actionFrontControllerSetVariables', 'Add variables in JavaScript object and Smarty templates', 'Add variables to javascript object that is available in Front Office. These are also available in smarty templates in modules.your_module_name.', '1'),
   (NULL, 'displayAdminGridTableBefore', 'Display before Grid table', 'This hook adds new blocks before Grid component table.', '1'),
   (NULL, 'displayAdminGridTableAfter', 'Display after Grid table', 'This hook adds new blocks after Grid component table.', '1'),
-  (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons on the create order page dropdown', 'Add buttons on the create order page dropdown', '1')
-  (NULL, 'actionProductFormBuilderModifier', 'Modify product identifiable object form', 'This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself', '1')
-  (NULL, 'actionBeforeUpdateProductFormHandler', 'Modify product identifiable object data before updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1')
-  (NULL, 'actionAfterUpdateProductFormHandler', 'Modify product identifiable object data after updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1')
-  (NULL, 'actionBeforeCreateProductFormHandler', 'Modify product identifiable object data before creating it', 'This hook allows to modify product identifiable object form data before it was created', '1')
+  (NULL, 'displayAdminOrderCreateExtraButtons', 'Add buttons on the create order page dropdown', 'Add buttons on the create order page dropdown', '1'),
+  (NULL, 'actionProductFormBuilderModifier', 'Modify product identifiable object form', 'This hook allows to modify product identifiable object form content by modifying form builder data or FormBuilder itself', '1'),
+  (NULL, 'actionBeforeUpdateProductFormHandler', 'Modify product identifiable object data before updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1'),
+  (NULL, 'actionAfterUpdateProductFormHandler', 'Modify product identifiable object data after updating it', 'This hook allows to modify product identifiable object form data before it was updated', '1'),
+  (NULL, 'actionBeforeCreateProductFormHandler', 'Modify product identifiable object data before creating it', 'This hook allows to modify product identifiable object form data before it was created', '1'),
   (NULL, 'actionAfterCreateProductFormHandler', 'Modify product identifiable object data after creating it', 'This hook allows to modify product identifiable object form data after it was created', '1')
 ;
 

--- a/src/Adapter/EntityTranslation/EntityTranslator.php
+++ b/src/Adapter/EntityTranslation/EntityTranslator.php
@@ -208,7 +208,7 @@ class EntityTranslator implements EntityTranslatorInterface
             );
         }
 
-        return $this->translator->getSourceString($data[$fieldName], $this->dataLang->getDomain());
+        return (string) $this->translator->getSourceString($data[$fieldName], $this->dataLang->getDomain());
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | There were a few changes that prevented the upgrade to complete: <ul><li>`Language::getCountry()` required a string but null could be passed. Using `Language->getLocale()` instead of `Language->locale` solve this issue</li><li>The `Tab` structure changed and 2 new fields (`wording` & `wording_domain`) have been added but are not present yet when migrating the tab in the 1.7.0.0.sql script file. Unsetting those 2 keys from the data array solve this issue</li><li>`$this->translator->getSourceString()` could return an `int` in some cases, breaking the return type and leading to an exception. Casting the returned value to `string` solve the issue</li></ul>
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Try to migrate from 1.6.1.24 to a build of 1.7.8.x, it should work
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24242)
<!-- Reviewable:end -->
