### PR TITLE
Fix escape in ps_1771_update_customer_note()

### DIFF
--- a/install-dev/upgrade/php/ps_1771_update_customer_note.php
+++ b/install-dev/upgrade/php/ps_1771_update_customer_note.php
@@ -38,7 +38,7 @@ function ps_1771_update_customer_note()
     foreach ($notes as $note) {
         $result &= Db::getInstance()->execute(
             'UPDATE ' . _DB_PREFIX_ . 'customer
-            SET note = "' . html_entity_decode($note['note']) . '"
+            SET note = "' . pSQL(html_entity_decode($note['note'])) . '"
             WHERE id_customer = ' . $note['id_customer']
         );
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      |  this PR fixes the issue #23633 by escaping the html_entity_decode($note['note'])) , because it could contain double quotes `"` which would break the SQL query and results in an error
| Type?             | bug fix
| Category?         |BO
| BC breaks?        | no
| Fixed ticket?     | Fixes #23633 
| How to test?      | to test this, try to upgrade from (version < 1.7.7.1) to (version >= 1.7.7.1). In my case, i tested 1.7.6.9 to 1.7.7.3
| Possible impacts? | no possible impacts in my opinion


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24243)
<!-- Reviewable:end -->
