### PR TITLE
Backport #23902 with new modal content

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-prices-refresher.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-prices-refresher.js
@@ -106,7 +106,7 @@ export default class OrderPricesRefresher {
       }
 
       if (expectedGivenPrice !== Number(productEditBtn.data('product-price-tax-incl'))) {
-        if (!invoiceId || (invoiceId && currentOrderInvoiceId && invoiceId === currentOrderInvoiceId)) {
+        if (invoiceId === '' || (invoiceId && currentOrderInvoiceId && invoiceId === currentOrderInvoiceId)) {
           unmatchingProductPriceExists = true;
         } else {
           unmatchingInvoicePriceExists = true;

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
@@ -259,7 +259,7 @@ export default class OrderProductAdd {
       invoiceId,
     );
 
-    if (productPriceMatch !== null) {
+    if (productPriceMatch === 'invoice') {
       const modalEditPrice = new ConfirmModal(
         {
           id: 'modal-confirm-new-price',

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
@@ -259,7 +259,7 @@ export default class OrderProductAdd {
       invoiceId,
     );
 
-    if (!productPriceMatch) {
+    if (productPriceMatch !== null) {
       const modalEditPrice = new ConfirmModal(
         {
           id: 'modal-confirm-new-price',

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
@@ -190,13 +190,13 @@ export default class OrderProductEdit {
       this.orderDetailId,
     );
 
-    if (productPriceMatch) {
+    if (productPriceMatch === null) {
       this.editProduct($(event.currentTarget).data('orderId'), this.orderDetailId);
 
       return;
     }
 
-    const dataSelector = Number(orderInvoiceId) === 0 ? this.priceTaxExcludedInput : this.productEditInvoiceSelect;
+    const dataSelector = productPriceMatch === 'product' ? this.priceTaxExcludedInput : this.productEditInvoiceSelect;
 
     const modalEditPrice = new ConfirmModal(
       {

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
@@ -190,7 +190,7 @@ export default class OrderProductEdit {
       this.orderDetailId,
     );
 
-    if (productPriceMatch || Number(orderInvoiceId) === 0) {
+    if (productPriceMatch) {
       this.editProduct($(event.currentTarget).data('orderId'), this.orderDetailId);
 
       return;

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
@@ -190,7 +190,7 @@ export default class OrderProductEdit {
       this.orderDetailId,
     );
 
-    if (productPriceMatch) {
+    if (productPriceMatch || Number(orderInvoiceId) === 0) {
       this.editProduct($(event.currentTarget).data('orderId'), this.orderDetailId);
 
       return;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig
@@ -32,7 +32,7 @@
         'data-modal-edit-price-title': 'Edit the price'|trans({}, 'Admin.Orderscustomers.Feature'),
         'data-modal-edit-price-apply': 'Edit'|trans({}, 'Admin.Actions'),
         'data-modal-edit-price-cancel': 'Cancel'|trans({}, 'Admin.Actions'),
-        'data-modal-edit-price-body': 'Are you sure you want to edit this product price? It will be applied to all invoices of this order.'|trans({}, 'Admin.Orderscustomers.Notification'),
+        'data-modal-edit-price-body': 'Are you sure you want to edit this product price? It will be applied to all identical products in this order.'|trans({}, 'Admin.Orderscustomers.Notification'),
       }})
     }}
     {{ form_row(editProductRowForm.price_tax_included) }}
@@ -49,7 +49,7 @@
       {{ form_row(editProductRowForm.invoice, {
         'attr': {
           'data-modal-edit-price-title': 'Edit the price'|trans({}, 'Admin.Orderscustomers.Feature'),
-          'data-modal-edit-price-apply': 'Update'|trans({}, 'Admin.Actions'),
+          'data-modal-edit-price-apply': 'Edit'|trans({}, 'Admin.Actions'),
           'data-modal-edit-price-cancel': 'Cancel'|trans({}, 'Admin.Actions'),
           'data-modal-edit-price-body': 'Are you sure you want to edit this product price? It will be applied to all invoices of this order.'|trans({}, 'Admin.Orderscustomers.Notification'),
         }})


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR is mostly a cherry pick of #23902 with only a modal content that will be different when 2 same products are found in the same invoice (or no invoice) of an order.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23734 & Fixes #24191
| How to test?      | Please see #23734 & #24191
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24253)
<!-- Reviewable:end -->
