### PR TITLE
Allow modifying order email product properties

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -439,6 +439,12 @@ abstract class PaymentModuleCore extends Module
                             'customization' => [],
                         ];
 
+	                    Hook::exec('actionGetOrderProductPropertiesBefore', [
+		                    'id_lang' => $this->context->language->id,
+		                    'product' => &$product_var_tpl,
+		                    'context' => $this->context,
+	                    ]);
+
                         if (isset($product['price']) && $product['price']) {
                             $product_var_tpl['unit_price'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code);
                             $product_var_tpl['unit_price_full'] = Tools::getContextLocale($this->context)->formatPrice($product_price, $this->context->currency->iso_code)
@@ -471,6 +477,12 @@ abstract class PaymentModuleCore extends Module
                                 ];
                             }
                         }
+
+	                    Hook::exec('actionGetOrderProductPropertiesAfter', [
+		                    'id_lang' => $this->context->language->id,
+		                    'product' => &$product_var_tpl,
+		                    'context' => $this->context,
+	                    ]);
 
                         $product_var_tpl_list[] = $product_var_tpl;
                         // Check if is not a virtual product for the displaying of shipping

--- a/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
+++ b/src/Adapter/MailTemplate/MailPartialTemplateRenderer.php
@@ -61,6 +61,12 @@ class MailPartialTemplateRenderer
      */
     public function render($partialTemplateName, LanguageInterface $language, array $variables = [], $cleanComments = false)
     {
+        Hook::exec('actionMailPartialTemplateRendererVariables', [
+            'variables' => &$variables,
+            'template' => $partialTemplateName,
+            'language' => $language,
+        ]);
+        
         $potentialPaths = [
             _PS_THEME_DIR_ . 'mails' . DIRECTORY_SEPARATOR . $language->getIsoCode() . DIRECTORY_SEPARATOR . $partialTemplateName,
             _PS_MAIL_DIR_ . $language->getIsoCode() . DIRECTORY_SEPARATOR . $partialTemplateName,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds two hooks that enable developers to modify the product properties available in the order confirmation emails.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | Register the hook and add a custom property to the product. After doing this you can use this property in the `order_conf_product_list` templates for the order confirmation mails.
| Possible impacts? | No idea


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24265)
<!-- Reviewable:end -->
