### PR TITLE
Increase minimum size of the Quantity field in Partial Refund

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -514,11 +514,11 @@
       }
 
       .input-group {
-        min-width: 90px;
+        min-width: 100px;
         max-width: 110px;
 
         .form-control {
-          min-width: 30px;
+          min-width: 44px;
           max-width: 76px;
           height: 35px;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | When performing a partial refund of a product with quantity > 9, the size of the quantity to refund field is reduced and it seems that the field is not editable. This PR aims to fix this issue by increasing the minimum size of the input.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24033
| How to test?      | Please see #24033
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24266)
<!-- Reviewable:end -->
