### PR TITLE
Enable translation export button only when export choices are made

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/translation-settings/ExportFormFieldToggle.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/ExportFormFieldToggle.js
@@ -35,6 +35,12 @@ const $coreValues = $(TranslationSettingsMap.exportCoreValues).closest('.form-gr
 const $themesValues = $(TranslationSettingsMap.exportThemesValues).closest('.form-group');
 const $modulesValues = $(TranslationSettingsMap.exportModulesValues).closest('.form-group');
 
+const $coreCheckboxes = $(TranslationSettingsMap.exportCoreValues);
+const $themesSelect = $(TranslationSettingsMap.exportThemesValues);
+const $modulesSelect = $(TranslationSettingsMap.exportModulesValues);
+
+const $exportButton = $(TranslationSettingsMap.exportLanguageButton);
+
 /**
  * Toggles show/hide for the selectors of subtypes (in case of Core type), theme or module when a Type is selected
  *
@@ -46,6 +52,10 @@ export default class ExportFormFieldToggle {
     $coreType.on('change', this.coreTypeChanged.bind(this));
     $themesType.on('change', this.themesTypeChanged.bind(this));
     $modulesType.on('change', this.modulesTypeChanged.bind(this));
+
+    $coreCheckboxes.on('change', this.subChoicesChanged.bind(this));
+    $themesSelect.on('change', this.subChoicesChanged.bind(this));
+    $modulesSelect.on('change', this.subChoicesChanged.bind(this));
 
     this.check($coreType);
   }
@@ -59,6 +69,7 @@ export default class ExportFormFieldToggle {
     this.uncheck($themesType, $modulesType);
     this.show($coreValues);
     this.hide($themesValues, $modulesValues);
+    this.subChoicesChanged();
   }
 
   themesTypeChanged() {
@@ -70,6 +81,7 @@ export default class ExportFormFieldToggle {
     this.uncheck($coreType, $modulesType);
     this.show($themesValues);
     this.hide($coreValues, $modulesValues);
+    this.subChoicesChanged();
   }
 
   modulesTypeChanged() {
@@ -81,6 +93,21 @@ export default class ExportFormFieldToggle {
     this.uncheck($themesType, $coreType);
     this.show($modulesValues);
     this.hide($themesValues, $coreValues);
+    this.subChoicesChanged();
+  }
+
+  subChoicesChanged() {
+    if (
+      ($coreType.prop('checked') && $coreCheckboxes.find(':checked').size() > 0)
+      || ($themesType.prop('checked') && $themesSelect.val() !== null)
+      || ($modulesType.prop('checked') && $modulesSelect.val() !== null)
+    ) {
+      $exportButton.prop('disabled', false);
+
+      return;
+    }
+
+    $exportButton.prop('disabled', true);
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/TranslationSettingsMap.js
@@ -37,4 +37,5 @@ export default {
   exportThemesValues: '#form_themes_selectors_selected_value',
   exportModulesType: '#form_modules_selectors_modules_type',
   exportModulesValues: '#form_modules_selectors_selected_value',
+  exportLanguageButton: '#form-export-language-button',
 };

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportCataloguesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportCataloguesType.php
@@ -110,6 +110,7 @@ class ExportCataloguesType extends TranslatorAwareType
             'label' => null,
             'child_choice' => [
                 'name' => 'selected_value',
+                'empty' => $this->trans('Select a theme', 'Admin.International.Feature'),
                 'choices' => $this->excludeDefaultThemeFromChoices($this->themeChoices),
                 'label' => false,
                 'multiple' => false,
@@ -123,6 +124,7 @@ class ExportCataloguesType extends TranslatorAwareType
             'label' => null,
             'child_choice' => [
                 'name' => 'selected_value',
+                'empty' => $this->trans('Select a module', 'Admin.International.Feature'),
                 'choices' => $this->moduleChoices,
                 'label' => false,
                 'multiple' => false,

--- a/src/PrestaShopBundle/Form/Admin/Type/RadioWithChoiceChildrenType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/RadioWithChoiceChildrenType.php
@@ -47,12 +47,18 @@ class RadioWithChoiceChildrenType extends AbstractType
 
         if (isset($options['child_choice'])) {
             $childChoice = $options['child_choice'];
+            $childChoiceAttr = [];
+            if (isset($childChoice['empty'])) {
+                $childChoice['choices'] = array_merge([$childChoice['empty'] => ''], $childChoice['choices']);
+                $childChoiceAttr[$childChoice['empty']] = ['disabled' => true];
+            }
             $builder->add($childChoice['name'], ChoiceType::class, [
                 'label' => false,
                 'row_attr' => [
                     'class' => 'export-translations-child',
                 ],
                 'choices' => $childChoice['choices'],
+                'choice_attr' => $childChoiceAttr,
                 'expanded' => $childChoice['multiple'], //same value as multiple. We can only have Select or Checkboxes
                 'multiple' => $childChoice['multiple'],
             ]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | With the new implementation of the translation export feature, you cannot select the classic theme when exporting theme translations which can lead to an empty select if the classic theme is the only theme installed. The same issue could happen if no module is installed when exporting module translations. This PR adds a default value to both select and enable/disable the export button according to the value selected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24090
| How to test?      | Please see #24090
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24268)
<!-- Reviewable:end -->
