### PR TITLE
Fix already selected condition group on safari inside catalog price rules

### DIFF
--- a/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
@@ -304,7 +304,7 @@ $(document).ready(function() {
 				$('#id_attribute_group option[value="{$condition.id_attribute_group}"]').prop('selected', true);
 				$('#id_attribute_{$condition.id_attribute_group} option[value="{$condition.value}"]').prop('selected', true);
 			{elseif $condition.type == 'feature'}
-				$('#id_feature option[value="{$condition.id_feature}"]').attr('selected', true);
+				$('#id_feature option[value="{$condition.id_feature}"]').prop('selected', true);
 				$('#id_feature_{$condition.id_feature} option[value="{$condition.value}"]').prop('selected', true);
 			{else}
 				$('#id_{$condition.type} option[value="{$condition.value}"]').prop('selected', true);

--- a/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
@@ -301,13 +301,13 @@ $(document).ready(function() {
 		new_condition_group();
 		{foreach from=$condition_group item='condition'}
 			{if $condition.type == 'attribute'}
-				$('#id_attribute_group option[value="{$condition.id_attribute_group}"]').attr('selected', true);
-				$('#id_attribute_{$condition.id_attribute_group} option[value="{$condition.value}"]').attr('selected', true);
+				$('#id_attribute_group option[value="{$condition.id_attribute_group}"]').prop('selected', true);
+				$('#id_attribute_{$condition.id_attribute_group} option[value="{$condition.value}"]').prop('selected', true);
 			{elseif $condition.type == 'feature'}
 				$('#id_feature option[value="{$condition.id_feature}"]').attr('selected', true);
-				$('#id_feature_{$condition.id_feature} option[value="{$condition.value}"]').attr('selected', true);
+				$('#id_feature_{$condition.id_feature} option[value="{$condition.value}"]').prop('selected', true);
 			{else}
-				$('#id_{$condition.type} option[value="{$condition.value}"]').attr('selected', true);
+				$('#id_{$condition.type} option[value="{$condition.value}"]').prop('selected', true);
 			{/if}
 			$('#add_condition_{$condition.type}').click();
 		{/foreach}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Catalog price rules was using attr for the selected attribute, it's not working on safari, replacing it by prop is still working
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24147.
| How to test?      | Please see #24147 which is pretty well detailed
| Possible impacts? | Catalog pice rules behavior


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24269)
<!-- Reviewable:end -->
