### PR TITLE
Fix exception thrown in FO when category not active or doesn't exists

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -50,6 +50,9 @@ class CategoryControllerCore extends ProductListingFrontController
 
     public function getCanonicalURL()
     {
+        if (!Validate::isLoadedObject($this->category)) {
+            return '';
+        }
         $canonicalUrl = $this->context->link->getCategoryLink($this->category);
         $parsedUrl = parse_url($canonicalUrl);
         if (isset($parsedUrl['query'])) {
@@ -130,7 +133,11 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         parent::initContent();
 
-        if ($this->category->checkAccess($this->context->customer->id)) {
+        if (
+            Validate::isLoadedObject($this->category)
+            && $this->category->active
+            && $this->category->checkAccess($this->context->customer->id)
+        ) {
             $this->doProductSearch(
                 'catalog/listing/category',
                 [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since we do not redirect when trying to access an unexisting/disabled category, 2 checks of the category we try to access to were missing leading to an exception being thrown. This PR fixes it.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24145 & #24143
| How to test?      | Please see tickets #24145 & #24143
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24270)
<!-- Reviewable:end -->
