### PR TITLE
Fix getting CLDR data when creating a new currency

### DIFF
--- a/src/Core/Localization/CLDR/Currency.php
+++ b/src/Core/Localization/CLDR/Currency.php
@@ -152,7 +152,7 @@ final class Currency implements CurrencyInterface
      *
      * @param string $type Possible value: "default" ("$") and "narrow" ("US$")
      *
-     * @return string The currency's symbol
+     * @return string|null The currency's symbol
      *
      * @throws LocalizationException When an invalid symbol type is passed
      */
@@ -166,6 +166,6 @@ final class Currency implements CurrencyInterface
             return $this->symbols[$type];
         }
 
-        return $this->symbols[CurrencyInterface::SYMBOL_TYPE_DEFAULT];
+        return $this->symbols[CurrencyInterface::SYMBOL_TYPE_DEFAULT] ?? null;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | When a CLDR currency has no symbol defined and we call the method `getSymbol()`, we try to access a property as an array even if it's null. This was ok until PHP 7.3 but since PHP 7.4, it throws an exception. This PR fixes it by checking that the property contains the value we're looking for before trying to return it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23434
| How to test?      | Please see #23434
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24274)
<!-- Reviewable:end -->
