### PR TITLE
Remove unwanted margins on order page cards

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -46,7 +46,8 @@
     }
   }
 
-  .card,
+  .customer,
+  #orderProductsPanel,
   .product-row .tab-content {
     margin-bottom: 1.875rem;
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | We added margins on order page cards, while themselves contains cards element too, only first level cards needs some margins, so it needs more precise selectors.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #23112.
| How to test?      | Go on the order page, and see if the issue (unwanted margins inside content should have disappeared)
| Possible impacts? | Order page layout


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24282)
<!-- Reviewable:end -->
