### PR TITLE
Add info block background to order page

### DIFF
--- a/admin-dev/themes/new-theme/scss/config/_settings.scss
+++ b/admin-dev/themes/new-theme/scss/config/_settings.scss
@@ -15,6 +15,7 @@ $background-info: #dcf4f9;
 $purple: #34219e;
 $bright-status-text: #383838;
 $local-font: true;
+$info-block-background: #f8f8f8;
 
 // Multishop
 $multishop-header-default-color: #383c43;

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -99,8 +99,6 @@
   margin-top: 8px;
 }
 
-$order-block-background-color: #f8f8f8 !default;
-
 .info-block {
   padding-top: 18px;
   padding-right: 18px;
@@ -142,7 +140,7 @@ $order-block-background-color: #f8f8f8 !default;
 
 .messages-block {
   padding: 3rem 0;
-  background-color: $order-block-background-color;
+  background-color: $info-block-background;
   $private-message-color: #7a8a8f;
 
   .employee-icon {

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -106,6 +106,7 @@ $order-block-background-color: #f8f8f8 !default;
   padding-right: 18px;
   padding-bottom: 16px;
   padding-left: 18px;
+  background-color: $info-block-background;
 
   & &-col {
     > .row {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Order page had info blocks with a gray background before, it should get back!
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #23115.
| How to test?      | Go on order page, and see if blocks get the grey background (see issue for more)
| Possible impacts? | Order page layout

# BC Break explanations
We removed a default var from the order file, and created a new more generic var inside variables files meaning that if a template inherit $order-block-background-color it won't exist anymore (but I doubt backoffice theme has been customized that much)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24283)
<!-- Reviewable:end -->
