### PR TITLE
Restore call for organizeTree and protect from failure because category not found

### DIFF
--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -52,9 +52,13 @@ function disableTreeItem(item) {
 }
 
 function organizeTree() {
-	if ($('#id_category').length != 0) {
-		var id = $('#id_category').val();
-		var item = getCategoryById(id).parent().parent();
+	let categoryId = $('#id_category');
+	if (categoryId.length > 0) {
+		const category = getCategoryById(categoryId.val());
+		if (null === category) {
+			return;
+		}
+		let item = category.parent().parent();
 		disableTreeItem(item);
 	}
 }
@@ -215,8 +219,7 @@ Tree.prototype =
 				function(content)
 				{
 					targetTree.html(content);
-          // Function organizeTree() disabled because it no longer has known usage - Crezzur
-					// organizeTree();
+					organizeTree();
 					targetTree.tree('init');
 					targetTree.find("label.tree-toggler").each(
 						function()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Uncomment organizeTree call. CHeck if element searched is found, otherwise return void
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24313
| How to test?      | The descibed here https://github.com/PrestaShop/PrestaShop/pull/23625#issuecomment-826637560 won't trigger an error anymore. The other BO default pages tree will work fine
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24312)
<!-- Reviewable:end -->
