### PR TITLE
Fix quickview image size on FO

### DIFF
--- a/themes/classic/_dev/css/components/quickview.scss
+++ b/themes/classic/_dev/css/components/quickview.scss
@@ -27,7 +27,8 @@
   }
 
   .product-cover img {
-    width: 95%;
+    width: 100%;
+    height: auto;
   }
 
   .images-container {
@@ -38,6 +39,7 @@
     .product-images > li.thumb-container > .thumb {
       width: 100%;
       max-width: 4.938rem;
+      height: auto;
       margin-bottom: 0.8125rem;
       background: $white;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Product images in quickview
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24306.
| How to test?      | Go no FO, click on quickview on a product with 2 images, images should be well displayed (not like in issue)
| Possible impacts? | Quickview FO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24315)
<!-- Reviewable:end -->
