### PR TITLE
Bug fix for number of decimals in product price

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4960,7 +4960,7 @@ class ProductCore extends ObjectModel
             (int) $row['id_product'],
             false,
             $id_product_attribute,
-            (self::$_taxCalculationMethod == PS_TAX_EXC ? 2 : 6),
+            (self::$_taxCalculationMethod == PS_TAX_EXC ? Context::getContext()->getComputingPrecision() : 6),
             null,
             false,
             true,

--- a/src/Core/Localization/Number/Formatter.php
+++ b/src/Core/Localization/Number/Formatter.php
@@ -121,7 +121,7 @@ class Formatter
 
         // Assemble the final number
         $formattedNumber = $majorDigits;
-        if ($minorDigits) {
+        if (strlen($minorDigits)) {
             $formattedNumber .= self::DECIMAL_SEPARATOR_PLACEHOLDER . $minorDigits;
         }
 

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_int($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
+            is_int(intval($currency->getDecimalPrecision())) ? intval($currency->getDecimalPrecision()) : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            $this->getMinFractionDigits($positivePattern),
+            is_int($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            ctype_digit($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            is_numeric($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_int((int)$currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            (int)$currency->getDecimalPrecision() ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_int(intval($currency->getDecimalPrecision())) ? intval($currency->getDecimalPrecision()) : $this->getMinFractionDigits($positivePattern),
+            is_int((int)$currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            (int)$currency->getDecimalPrecision() ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            ctype_digit($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_numeric($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            is_numeric($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -294,7 +294,7 @@ class FactoryTest extends TestCase
                 $expected,
                 $specification->toArray()
             );
-            $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+            self::assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
         }
     }
 

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -27,10 +27,10 @@
 namespace LegacyTests\Unit\Core\Localization\Specification;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Localization\Currency;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\Locale;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleData;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\NumberSymbolsData;
+use PrestaShop\PrestaShop\Core\Localization\Currency;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Factory as FactorySpecification;
 
 class FactoryTest extends TestCase
@@ -221,85 +221,50 @@ class FactoryTest extends TestCase
      * Given an integer to specify max fraction digits
      * Then calling buildPriceSpecification() should return an NumberSpecification
      *
-     * @dataProvider getPriceData
+     * @dataProvider getPriceDataWithPrecisions
      */
     public function testBuildPriceSpecificationWithPrecisionFallback(array $data, array $expected): void
+    {
+        $currencyPrecision = $data[4]['currencyPrecision'];
+        $maxFractionDigits = $data[4]['maxFractionDigits'];
+        $expectedMinFractionDigits = $data[4]['expectedMinFractionDigits'];
+
+        $specification = $this->factory->buildPriceSpecification(
+            $data[0],
+            $this->createLocale(
+                ...$data
+            ),
+            new Currency(
+                null,
+                null,
+                'EUR',
+                '978',
+                [
+                    $data[0] => '€',
+                ],
+                $currencyPrecision,
+                [
+                    $data[0] => 'Euro',
+                ]
+            ),
+            3,
+            true,
+            $maxFractionDigits
+        );
+        $expected['maxFractionDigits'] = $maxFractionDigits;
+        $expected['minFractionDigits'] = $expectedMinFractionDigits;
+        self::assertEquals(
+            $expected,
+            $specification->toArray()
+        );
+        self::assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+    }
+
+    public function getPriceDataWithPrecisions()
     {
         // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
         // see PrestaShop\PrestaShop\Core\Localization\Specification\Number
         // The dataProvider provides minFractionDigits === 2
-        $precisions = [
-            [
-                'currencyPrecision' => 6,
-                'maxFractionDigits' => 3,
-                'expectedMinFractionDigits' => 3,
-            ], //minFractionDigits will be equal to 3
-            [
-                'currencyPrecision' => 6,
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 6,
-            ], //minFractionDigits will be equal to 6
-            [
-                'currencyPrecision' => 1,
-                'maxFractionDigits' => 3,
-                'expectedMinFractionDigits' => 1,
-            ], //minFractionDigits will be equal to 1
-            [
-                'currencyPrecision' => '4',
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 4,
-            ], //minFractionDigits will be equal to 4 because precision is numeric
-            [
-                'currencyPrecision' => null,
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 2,
-            ], //minFractionDigits will be equal to 2
-            [
-                'currencyPrecision' => [],
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 2,
-            ], //minFractionDigits will be equal to 2
-        ];
-
-        foreach ($precisions as $expectedPrecisions) {
-            $currencyPrecision = $expectedPrecisions['currencyPrecision'];
-            $maxFractionDigits = $expectedPrecisions['maxFractionDigits'];
-            $expectedMinFractionDigits = $expectedPrecisions['expectedMinFractionDigits'];
-
-            $specification = $this->factory->buildPriceSpecification(
-                $data[0],
-                $this->createLocale(
-                    ...$data
-                ),
-                new Currency(
-                    null,
-                    null,
-                    'EUR',
-                    '978',
-                    [
-                        $data[0] => '€',
-                    ],
-                    $currencyPrecision,
-                    [
-                        $data[0] => 'Euro',
-                    ]
-                ),
-                3,
-                true,
-                $maxFractionDigits
-            );
-            $expected['maxFractionDigits'] = $maxFractionDigits;
-            $expected['minFractionDigits'] = $expectedMinFractionDigits;
-            self::assertEquals(
-                $expected,
-                $specification->toArray()
-            );
-            self::assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
-        }
-    }
-
-    public function getPriceData()
-    {
         return [
             [
                 [
@@ -307,6 +272,11 @@ class FactoryTest extends TestCase
                     '¤ #,##0.00;¤ -#,##0.00',
                     '#,##0%',
                     '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 3,
+                    ],
                 ],
                 [
                     'positivePattern' => '¤ #,##0.00',
@@ -339,6 +309,381 @@ class FactoryTest extends TestCase
                     '#,##0.00 ¤',
                     '#,##0 %',
                     '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 3,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 6,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 6,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 1,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 1,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 1,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 1,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => '4',
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 4,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => '4',
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 4,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => null,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => null,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => [],
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => [],
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
                 ],
                 [
                     'positivePattern' => '#,##0.00 ¤',

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -223,7 +223,7 @@ class FactoryTest extends TestCase
      *
      * @dataProvider getPriceData
      */
-    public function testBuildPriceSpecificationWithPrecisionFallback($data, $expected)
+    public function testBuildPriceSpecificationWithPrecisionFallback(array $data, array $expected): void
     {
         // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
         // see PrestaShop\PrestaShop\Core\Localization\Specification\Number

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -214,6 +214,90 @@ class FactoryTest extends TestCase
         $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
     }
 
+    /**
+     * Given a valid CLDR locale
+     * Given a Max Fractions digits to display in a number's decimal
+     * Given a boolean to define if we should group digits in a number's integer part
+     * Given an integer to specify max fraction digits
+     * Then calling buildPriceSpecification() should return an NumberSpecification
+     *
+     * @dataProvider getPriceData
+     */
+    public function testBuildPriceSpecificationWithPrecisionFallback($data, $expected)
+    {
+        // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
+        // see PrestaShop\PrestaShop\Core\Localization\Specification\Number
+        // The dataProvider provides minFractionDigits === 2
+        $precisions = [
+            [
+                'currencyPrecision' => 6,
+                'maxFractionDigits' => 3,
+                'expectedMinFractionDigits' => 3,
+            ], //minFractionDigits will be equal to 3
+            [
+                'currencyPrecision' => 6,
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 6,
+            ], //minFractionDigits will be equal to 6
+            [
+                'currencyPrecision' => 1,
+                'maxFractionDigits' => 3,
+                'expectedMinFractionDigits' => 1,
+            ], //minFractionDigits will be equal to 1
+            [
+                'currencyPrecision' => '4',
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+            [
+                'currencyPrecision' => null,
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+            [
+                'currencyPrecision' => [],
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+        ];
+
+        foreach ($precisions as $expectedPrecisions) {
+            $currencyPrecision = $expectedPrecisions['currencyPrecision'];
+            $maxFractionDigits = $expectedPrecisions['maxFractionDigits'];
+            $expectedMinFractionDigits = $expectedPrecisions['expectedMinFractionDigits'];
+
+            $specification = $this->factory->buildPriceSpecification(
+                $data[0],
+                $this->createLocale(
+                    ...$data
+                ),
+                new Currency(
+                    null,
+                    null,
+                    'EUR',
+                    '978',
+                    [
+                        $data[0] => '€',
+                    ],
+                    $currencyPrecision,
+                    [
+                        $data[0] => 'Euro',
+                    ]
+                ),
+                3,
+                true,
+                $maxFractionDigits
+            );
+            $expected['maxFractionDigits'] = $maxFractionDigits;
+            $expected['minFractionDigits'] = $expectedMinFractionDigits;
+            $this->assertEquals(
+                $expected,
+                $specification->toArray()
+            );
+            $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+        }
+    }
+
     public function getPriceData()
     {
         return [

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -247,8 +247,8 @@ class FactoryTest extends TestCase
             [
                 'currencyPrecision' => '4',
                 'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 2,
-            ], //minFractionDigits will be equal to 2
+                'expectedMinFractionDigits' => 4,
+            ], //minFractionDigits will be equal to 4 because precision is numeric
             [
                 'currencyPrecision' => null,
                 'maxFractionDigits' => 6,

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -290,7 +290,7 @@ class FactoryTest extends TestCase
             );
             $expected['maxFractionDigits'] = $maxFractionDigits;
             $expected['minFractionDigits'] = $expectedMinFractionDigits;
-            $this->assertEquals(
+            self::assertEquals(
                 $expected,
                 $specification->toArray()
             );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Decimals feature does not work.By default it's set to two, and it's stuck to 2 and it does not change according to the configuration in backoffice International->Localization->Currencies->edit for a currency->Decimals. So, this pull request fixes this issue. Actually the problem has two parts. One which is fixed in Product.php is that the number of Decimals is fixed to two, and another issue is that the extra 0 won't be added to match the number of decimals chosen in configuration which is fixed in Factory.php file.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23868
| How to test?      | Change decimals in backoffice and check the product price in front office
| Possible impacts? | I really got the root cause, exactly the points where the problem comes from


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24320)
<!-- Reviewable:end -->
