### PR TITLE
Orders View : Display right price depending configuration

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
@@ -58,27 +58,30 @@ export default class OrderProductAdd {
     this.priceTaxCalculator = new OrderPrices();
     this.orderProductRenderer = new OrderProductRenderer();
     this.orderPricesRefresher = new OrderPricesRefresher();
+    this.isOrderTaxIncluded = $(OrderViewPageMap.addProductTableRow).data('isOrderTaxIncluded');
+    this.taxExcluded = null;
+    this.taxIncluded = null;
   }
 
   setupListener() {
     this.combinationsSelect.on('change', event => {
-      this.priceTaxExcludedInput.val(
-        window.ps_round(
-          $(event.currentTarget)
-            .find(':selected')
-            .data('priceTaxExcluded'),
-          this.currencyPrecision
-        )
+      const taxExcluded = window.ps_round(
+        $(event.currentTarget)
+          .find(':selected')
+          .data('priceTaxExcluded'),
+        this.currencyPrecision
       );
+      this.priceTaxExcludedInput.val(taxExcluded);
+      this.taxExcluded = parseFloat(taxExcluded);
 
-      this.priceTaxIncludedInput.val(
-        window.ps_round(
-          $(event.currentTarget)
-            .find(':selected')
-            .data('priceTaxIncluded'),
-          this.currencyPrecision
-        )
+      const taxIncluded = window.ps_round(
+        $(event.currentTarget)
+          .find(':selected')
+          .data('priceTaxIncluded'),
+        this.currencyPrecision
       );
+      this.priceTaxIncludedInput.val(taxIncluded);
+      this.taxIncluded = parseFloat(taxIncluded);
 
       this.locationText.html(
         $(event.currentTarget)
@@ -105,9 +108,13 @@ export default class OrderProductAdd {
         this.productAddActionBtn.prop('disabled', disableAddActionBtn);
         this.invoiceSelect.prop('disabled', !availableOutOfStock && remainingAvailable < 0);
 
-        const taxIncluded = parseFloat(this.priceTaxIncludedInput.val());
+        this.taxIncluded = parseFloat(this.priceTaxIncludedInput.val());
         this.totalPriceText.html(
-          this.priceTaxCalculator.calculateTotalPrice(newQuantity, taxIncluded, this.currencyPrecision)
+          this.priceTaxCalculator.calculateTotalPrice(
+            newQuantity,
+            this.isOrderTaxIncluded ? this.taxIncluded : this.taxExcluded,
+            this.currencyPrecision
+          )
         );
       }
     });
@@ -118,32 +125,40 @@ export default class OrderProductAdd {
     });
 
     this.priceTaxIncludedInput.on('change keyup', event => {
-      const taxIncluded = parseFloat(event.target.value);
-      const taxExcluded = this.priceTaxCalculator.calculateTaxExcluded(
-        taxIncluded,
+      this.taxIncluded = parseFloat(event.target.value);
+      this.taxExcluded = this.priceTaxCalculator.calculateTaxExcluded(
+        this.taxIncluded,
         this.taxRateInput.val(),
         this.currencyPrecision
       );
       const quantity = parseInt(this.quantityInput.val(), 10);
 
-      this.priceTaxExcludedInput.val(taxExcluded);
+      this.priceTaxExcludedInput.val(this.taxExcluded);
       this.totalPriceText.html(
-        this.priceTaxCalculator.calculateTotalPrice(quantity, taxIncluded, this.currencyPrecision)
+        this.priceTaxCalculator.calculateTotalPrice(
+          quantity,
+          this.isOrderTaxIncluded ? this.taxIncluded : this.taxExcluded,
+          this.currencyPrecision
+        )
       );
     });
 
     this.priceTaxExcludedInput.on('change keyup', event => {
-      const taxExcluded = parseFloat(event.target.value);
-      const taxIncluded = this.priceTaxCalculator.calculateTaxIncluded(
-        taxExcluded,
+      this.taxExcluded = parseFloat(event.target.value);
+      this.taxIncluded = this.priceTaxCalculator.calculateTaxIncluded(
+        this.taxExcluded,
         this.taxRateInput.val(),
         this.currencyPrecision
       );
       const quantity = parseInt(this.quantityInput.val(), 10);
 
-      this.priceTaxIncludedInput.val(taxIncluded);
+      this.priceTaxIncludedInput.val(this.taxIncluded);
       this.totalPriceText.html(
-        this.priceTaxCalculator.calculateTotalPrice(quantity, taxIncluded, this.currencyPrecision)
+        this.priceTaxCalculator.calculateTotalPrice(
+          quantity,
+          this.isOrderTaxIncluded ? this.taxIncluded : this.taxExcluded,
+          this.currencyPrecision
+        )
       );
     });
 
@@ -153,8 +168,15 @@ export default class OrderProductAdd {
 
   setProduct(product) {
     this.productIdInput.val(product.productId).trigger('change');
-    this.priceTaxExcludedInput.val(window.ps_round(product.priceTaxExcl, this.currencyPrecision));
-    this.priceTaxIncludedInput.val(window.ps_round(product.priceTaxIncl, this.currencyPrecision));
+
+    const taxExcluded = window.ps_round(product.priceTaxExcl, this.currencyPrecision);
+    this.priceTaxExcludedInput.val(taxExcluded);
+    this.taxExcluded = parseFloat(taxExcluded);
+
+    const taxIncluded = window.ps_round(product.priceTaxIncl, this.currencyPrecision);
+    this.priceTaxIncludedInput.val(taxIncluded);
+    this.taxIncluded = parseFloat(taxIncluded);
+
     this.taxRateInput.val(product.taxRate);
     this.locationText.html(product.location);
     this.available = product.stock;

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
@@ -155,7 +155,7 @@ export default class OrderProductEdit {
     this.taxRate = product.tax_rate;
     this.initialTotal = this.priceTaxCalculator.calculateTotalPrice(
       product.quantity,
-      product.price_tax_incl,
+      product.isOrderTaxIncluded ? product.price_tax_incl : product.price_tax_excl,
       this.currencyPrecision
     );
     this.quantity = product.quantity;

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-edit.js
@@ -53,6 +53,7 @@ export default class OrderProductEdit {
       const previousQuantity = parseInt(this.quantityInput.data('previousQuantity'), 10);
       const remainingAvailable = availableQuantity - (newQuantity - previousQuantity);
       const availableOutOfStock = this.availableText.data('availableOutOfStock');
+      this.quantity = newQuantity;
       this.availableText.text(remainingAvailable);
       this.availableText.toggleClass('text-danger font-weight-bold', remainingAvailable < 0);
       this.updateTotal();
@@ -66,19 +67,19 @@ export default class OrderProductEdit {
 
     this.priceTaxIncludedInput.on('change keyup', event => {
       this.taxIncluded = parseFloat(event.target.value);
-      const taxExcluded = this.priceTaxCalculator.calculateTaxExcluded(
+      this.taxExcluded = this.priceTaxCalculator.calculateTaxExcluded(
         this.taxIncluded,
         this.taxRate,
         this.currencyPrecision
       );
-      this.priceTaxExcludedInput.val(taxExcluded);
+      this.priceTaxExcludedInput.val(this.taxExcluded);
       this.updateTotal();
     });
 
     this.priceTaxExcludedInput.on('change keyup', event => {
-      const taxExcluded = parseFloat(event.target.value);
+      this.taxExcluded = parseFloat(event.target.value);
       this.taxIncluded = this.priceTaxCalculator.calculateTaxIncluded(
-        taxExcluded,
+        this.taxExcluded,
         this.taxRate,
         this.currencyPrecision
       );
@@ -108,7 +109,7 @@ export default class OrderProductEdit {
   updateTotal() {
     const updatedTotal = this.priceTaxCalculator.calculateTotalPrice(
       this.quantity,
-      this.taxIncluded,
+      this.isOrderTaxIncluded ? this.taxIncluded : this.taxExcluded,
       this.currencyPrecision
     );
     this.priceTotalText.html(updatedTotal);
@@ -158,8 +159,10 @@ export default class OrderProductEdit {
       product.isOrderTaxIncluded ? product.price_tax_incl : product.price_tax_excl,
       this.currencyPrecision
     );
+    this.isOrderTaxIncluded = product.isOrderTaxIncluded;
     this.quantity = product.quantity;
     this.taxIncluded = product.price_tax_incl;
+    this.taxExcluded = product.price_tax_excl;
 
     // Copy product content in cells
     this.productEditImage.html(this.productRow.find(OrderViewPageMap.productEditImage).html());

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
@@ -56,6 +56,7 @@ export default class OrderProductRenderer {
     availableQuantity,
     availableOutOfStock,
     orderInvoiceId,
+    isOrderTaxIncluded,
   ) {
     const $orderEdit = new OrderProductEdit(orderDetailId);
     $orderEdit.displayProduct({
@@ -67,6 +68,7 @@ export default class OrderProductRenderer {
       availableQuantity,
       availableOutOfStock,
       orderInvoiceId,
+      isOrderTaxIncluded,
     });
     $(OrderViewPageMap.productAddActionBtn).addClass('d-none');
     $(OrderViewPageMap.productAddRow).addClass('d-none');

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-view-page.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-view-page.js
@@ -148,6 +148,7 @@ export default class OrderViewPage {
         $btn.data('availableQuantity'),
         $btn.data('availableOutOfStock'),
         $btn.data('orderInvoiceId'),
+        $btn.data('isOrderTaxIncluded')
       );
     });
   }

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -717,15 +717,14 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $wrappingPrice = (float) $order->total_wrapping_tax_excl;
             $shippingPrice = (float) $order->total_shipping_tax_excl;
             $shippingRefundable = max(0, $shipping_refundable_tax_excl);
-            $totalAmount = (float) $order->total_paid_tax_excl;
         } else {
             $productsPrice = (float) $order->total_products_wt;
             $discountsAmount = (float) $order->total_discounts_tax_incl;
             $wrappingPrice = (float) $order->total_wrapping_tax_incl;
             $shippingPrice = (float) $order->total_shipping_tax_incl;
             $shippingRefundable = max(0, $shipping_refundable_tax_incl);
-            $totalAmount = (float) $order->total_paid_tax_incl;
         }
+        $totalAmount = (float) $order->total_paid_tax_incl;
 
         $taxesAmount = $order->total_paid_tax_incl - $order->total_paid_tax_excl;
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<tr id="addProductTableRow" class="add-product d-none">
+<tr id="addProductTableRow" class="add-product d-none" data-is-order-tax-included="{{ orderForViewing.isTaxIncluded }}">
   <td colspan="2" class="pr-2">
     {{ form_row(addProductRowForm.product_id) }}
     {{ form_row(addProductRowForm.tax_rate) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -93,7 +93,8 @@
         data-location="{{ product.location }}"
         data-available-quantity="{{ product.availableQuantity }}"
         data-available-out-of-stock="{{ product.availableOutOfStock }}"
-        data-order-invoice-id="{{ product.orderInvoiceId }}">
+        data-order-invoice-id="{{ product.orderInvoiceId }}"
+        data-is-order-tax-included="{{ isOrderTaxIncluded }}">
         <i class="material-icons">edit</i>
       </button>
       <button

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -94,7 +94,7 @@
         data-available-quantity="{{ product.availableQuantity }}"
         data-available-out-of-stock="{{ product.availableOutOfStock }}"
         data-order-invoice-id="{{ product.orderInvoiceId }}"
-        data-is-order-tax-included="{{ isOrderTaxIncluded }}">
+        data-is-order-tax-included="{{ orderForViewing.isTaxIncluded }}">
         <i class="material-icons">edit</i>
       </button>
       <button

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig
@@ -29,6 +29,7 @@
         'paginationNum': paginationNum,
         'isColumnLocationDisplayed': isColumnLocationDisplayed,
         'isColumnRefundedDisplayed': isColumnRefundedDisplayed,
-        'isAvailableQuantityDisplayed': isAvailableQuantityDisplayed
+        'isAvailableQuantityDisplayed': isAvailableQuantityDisplayed,
+        'isOrderTaxIncluded': orderForViewing.isOrderTaxIncluded
     } %}
 {% endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig
@@ -29,7 +29,6 @@
         'paginationNum': paginationNum,
         'isColumnLocationDisplayed': isColumnLocationDisplayed,
         'isColumnRefundedDisplayed': isColumnRefundedDisplayed,
-        'isAvailableQuantityDisplayed': isAvailableQuantityDisplayed,
-        'isOrderTaxIncluded': orderForViewing.isOrderTaxIncluded
+        'isAvailableQuantityDisplayed': isAvailableQuantityDisplayed
     } %}
 {% endfor %}

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -41,7 +41,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $0.00    |
       | shipping      | $7.00    |
       | taxes         | $1.85    |
-      | total         | $30.80   |
+      | total         | $32.65   |
 
   Scenario: Add amount type discount to order which has no invoices
     Given order "bo_order1" does not have any invoices
@@ -66,7 +66,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $5.19  |
       | shipping      | $7.00  |
       | taxes         | $1.54  |
-      | total         | $25.61 |
+      | total         | $27.15 |
 
   Scenario: Add percent type discount to order which has no invoices
     Given order "bo_order1" does not have any invoices
@@ -91,7 +91,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $11.90 |
       | shipping      | $7.00  |
       | taxes         | $1.13  |
-      | total         | $18.90 |
+      | total         | $20.03 |
 
   # The discount amount was voluntarily computed on whole total (shipping included 32.648) excluded tax and then applied the tax rate
   # This emphasizes the difference compared to performing rounding on each steps which makes a 0.01 difference
@@ -118,7 +118,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $15.40 |
       | shipping      | $7.00  |
       | taxes         | $0.93  |
-      | total         | $15.40 |
+      | total         | $16.33 |
 
   Scenario: Add amount discount matching fifty percent on products only
     Given order "bo_order1" does not have any invoices
@@ -143,7 +143,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $11.90 |
       | shipping      | $7.00  |
       | taxes         | $1.14  |
-      | total         | $18.90 |
+      | total         | $20.04 |
 
   Scenario: Add amount type discount to order and update single invoice
     When I generate invoice for "bo_order1" order
@@ -169,7 +169,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $5.19     |
       | shipping      | $7.00     |
       | taxes         | $1.54     |
-      | total         | $25.61    |
+      | total         | $27.15    |
     And the last invoice for order "bo_order1" should have following prices:
       | products                  | 23.80 |
       | discounts tax excluded    | 5.19  |
@@ -203,7 +203,7 @@ Feature: Add discounts to order from Back Office (BO)
       | discounts     | $11.90 |
       | shipping      | $7.00  |
       | taxes         | $1.13  |
-      | total         | $18.90 |
+      | total         | $20.03 |
     And the last invoice for order "bo_order1" should have following prices:
       | products                  | 23.80 |
       | discounts tax excluded    | 11.90 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Orders View : Display right price depending configuration
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23957
| How to test?      | 1. Create a product A with a price without taxes of € 2,116 (2.56 with taxes).<br>2. Go to Store parameters> Customer settings> Groups and modify the Customers group<br>3. In the section Price display method, change to Tax excluded.<br>4. In the FO, Customer X places an order with product A and checks that the prices with taxes excluded (€ 2.12) and taxes included (€ 2.56) are displayed in the cart.<br>5. In the BO, go to Orders> Orders and see the order with Product A. Here the employee sees the total price with taxes included of the order placed (€ 2.56).<br>6. In the Orders List, in the preview of the order, the price is in tax excluded (like the configuration of Customer Group)<br>7. Enter within the order<br>8. The employee sees the total price taxes excluded wrongly.<br>9. In product lists, the total price for the row of the product is tax excluded (like the configuration of Customer Group)<br>10. In product lists, in summary, the total price is tax included<br>11. In product lists, in edition of row, the last column of total is tax excluded (like the configuration of Customer Group)<br>
 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24324)
<!-- Reviewable:end -->
