### PR TITLE
[POC] extend symfony FormBuilder with methods addBefore & addAfter

### DIFF
--- a/src/PrestaShopBundle/Form/FormBuilder.php
+++ b/src/PrestaShopBundle/Form/FormBuilder.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form;
+
+use RuntimeException;
+
+final class FormBuilder extends \Symfony\Component\Form\FormBuilder implements FormBuilderInterface
+{
+    public function addBefore(string $targetFieldName, $child, $type = null, array $options = []): FormBuilderInterface
+    {
+        $this->assertFieldExists($targetFieldName);
+
+        foreach ($this->all() as $formBuilder) {
+            $this->add($formBuilder);
+
+            if ($formBuilder->getName() === $targetFieldName) {
+                $this->add($child, $type, $options);
+            }
+        }
+
+        return $this;
+    }
+
+    public function addAfter(string $targetFieldName, $child, $type = null, array $options = []): FormBuilderInterface
+    {
+        $this->assertFieldExists($targetFieldName);
+
+        foreach ($this->all() as $formBuilder) {
+            if ($formBuilder->getName() === $targetFieldName) {
+                $this->add($child, $type, $options);
+            }
+
+            $this->add($formBuilder);
+        }
+
+        return $this;
+    }
+
+    private function assertFieldExists(string $name): void
+    {
+        if ($this->has($name)) {
+            return;
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Form field "%s" does not exist in "%s" form',
+                $name,
+                $this->getName()
+            )
+        );
+    }
+}

--- a/src/PrestaShopBundle/Form/FormBuilder.php
+++ b/src/PrestaShopBundle/Form/FormBuilder.php
@@ -34,11 +34,12 @@ final class FormBuilder extends \Symfony\Component\Form\FormBuilder implements F
     public function addBefore(string $targetFieldName, $child, $type = null, array $options = []): FormBuilderInterface
     {
         $this->assertFieldExists($targetFieldName);
+        $childFormBuilders = $this->removeAllChild();
 
-        foreach ($this->all() as $formBuilder) {
-            $this->add($formBuilder);
+        foreach ($childFormBuilders as $childFormBuilder) {
+            $this->add($childFormBuilder);
 
-            if ($formBuilder->getName() === $targetFieldName) {
+            if ($childFormBuilder->getName() === $targetFieldName) {
                 $this->add($child, $type, $options);
             }
         }
@@ -49,16 +50,28 @@ final class FormBuilder extends \Symfony\Component\Form\FormBuilder implements F
     public function addAfter(string $targetFieldName, $child, $type = null, array $options = []): FormBuilderInterface
     {
         $this->assertFieldExists($targetFieldName);
+        $childFormBuilders = $this->removeAllChild();
 
-        foreach ($this->all() as $formBuilder) {
-            if ($formBuilder->getName() === $targetFieldName) {
+        foreach ($childFormBuilders as $childFormBuilder) {
+            if ($childFormBuilder->getName() === $targetFieldName) {
                 $this->add($child, $type, $options);
             }
 
-            $this->add($formBuilder);
+            $this->add($childFormBuilder);
         }
 
         return $this;
+    }
+
+    private function removeAllChild(): array
+    {
+        $childFormBuilders = [];
+        foreach ($this->all() as $formBuilder) {
+            $this->remove($formBuilder->getName());
+            $childFormBuilders[] = $formBuilder;
+        }
+
+        return $childFormBuilders;
     }
 
     private function assertFieldExists(string $name): void

--- a/src/PrestaShopBundle/Form/FormBuilderInterface.php
+++ b/src/PrestaShopBundle/Form/FormBuilderInterface.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form;
+
+interface FormBuilderInterface extends \Symfony\Component\Form\FormBuilderInterface
+{
+    /**
+     * @param string $targetFieldName
+     * @param FormBuilderInterface|string $child
+     * @param string|null $type
+     * @param array<string, mixed> $options
+     *
+     * @return FormBuilderInterface
+     */
+    public function addBefore(string $targetFieldName, $child, $type = null, array $options = []): FormBuilderInterface;
+
+    /**
+     * @param string $targetFieldName
+     * @param FormBuilderInterface|string $child
+     * @param string|null $type
+     * @param array<string, mixed> $options
+     *
+     * @return FormBuilderInterface
+     */
+    public function addAfter(string $targetFieldName, $child, $type = null, array $options = []): FormBuilderInterface;
+}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | POC. Introduce methods addBefore & addAfter in FormBuilder, these would save a lot of time for module developers. 
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | 
| How to test?      | Will define later if this pr reaches that state (its only a playground now)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24337)
<!-- Reviewable:end -->
