### PR TITLE
Fix module activation checkbox in module configuration pages

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl
@@ -29,7 +29,7 @@
 <div class="bootstrap panel">
 	<h3><i class="icon-cogs"></i> {l s='Configuration' d='Admin.Global'}</h3>
 	<input type="checkbox" name="activateModule" value="1"{if $module->isEnabledForShopContext()} checked="checked"{/if}
-		onclick="location.href = '{$current_url|regex_replace:$smarty.capture.default:''}&amp;module_name={$module_name}&amp;enable=' + ($(this).is(':checked') ? '1' : '0');" />
+		onclick="location.href = '{$current_url|regex_replace:$smarty.capture.default:''}&amp;module_name={$module_name}&amp;enable=' + ($(this).prop('checked') ? '1' : '0');" />
 	{l s='Activate module for this shop context: %s.' sprintf=[$shop_context] d='Admin.Modules.Notification'}
 </div>
 {/if}

--- a/admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configuration_bar.tpl
@@ -29,7 +29,7 @@
 <div class="bootstrap panel">
 	<h3><i class="icon-cogs"></i> {l s='Configuration' d='Admin.Global'}</h3>
 	<input type="checkbox" name="activateModule" value="1"{if $module->isEnabledForShopContext()} checked="checked"{/if}
-		onclick="location.href = '{$current_url|regex_replace:$smarty.capture.default:''}&amp;module_name={$module_name}&amp;enable=' + (($(this).attr('checked')) ? 1 : 0);" />
+		onclick="location.href = '{$current_url|regex_replace:$smarty.capture.default:''}&amp;module_name={$module_name}&amp;enable=' + ($(this).is(':checked') ? '1' : '0');" />
 	{l s='Activate module for this shop context: %s.' sprintf=[$shop_context] d='Admin.Modules.Notification'}
 </div>
 {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When the multishop option is activated and at least two shops have been created, a new panel is displayed at the bottom of module configuration pages, containing a checkbox labeled "Activate module for this shop context". Checking/unchecking this checkbox is supposed to enable/disable the current module for the current shop context.<br><br>This does not currently work. Clicking this box reloads the current url, adding an "enable" parameter with a value of 0 or 1 depending on if it is checked or not. Getting the status of the checkbox is achieved via the jquery .attr() method, which since jQuery 1.6 cannot be used for attributes like "checked" or "disabled". As a result "enable" is set to 0 wether the box is checked or not.<br><br>The solution is to use jQuery's .is(':checked') method instead.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24354
| How to test?      | 1. Activate the multistore feature if disabled, in Parameters > General > Enable Multistore <br>2. Access Multistore in Advanced Parameters and create one if only one exists <br>3. Install a module that has a configuration page, like the Contact form module for example <br>4. Access its configuration page from the context of a shop where it's enabled, and then swap to the new shop <br>5. It will show as disabled by default. Check the "Activate module for this shop context" box. <br>6. The page reloads showing the checkbox checked, and the module enabled in this context
| Possible impacts? | Not as far as i'm aware, but i'm currently learning PrestaShop, so some impact could have slipped by me

Hi, all the info is in the table above. Tell me if there's anything wrong/missing.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24353)
<!-- Reviewable:end -->
