### PR TITLE
Fix Multistore dropdown in current group context

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -155,6 +155,7 @@ class MultistoreController extends FrameworkBundleAdminController
      */
     private function shouldIncludeGroupShop(ShopGroup $group): bool
     {
+        // group shop is only included if we are in all shop context or in group context when this group is the current context
         if (count($group->getShops()) > 0
             && (
                 $this->multistoreContext->isAllShopContext()

--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -125,11 +125,11 @@ class MultistoreController extends FrameworkBundleAdminController
             if ($this->shouldIncludeGroupShop($group)) {
                 $groupList[] = $group;
             }
-            if ($this->multistoreContext->isAllShopContext() || $group->getId() === $this->multistoreContext->getContextShopGroup()->id) {
+            if ($this->multistoreContext->isAllShopContext() || $group->getId() === $this->multistoreContext->getContextShopGroup()->id && !$shouldDisplayDropdown) {
                 foreach ($group->getShops() as $shop) {
                     if ($shopCustomizationChecker->isConfigurationCustomizedForThisShop($configurationKey, $shop, $isGroupShopContext)) {
                         $shouldDisplayDropdown = true;
-                        break 2;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x 
| Description?      | When in a group context, multistore dropdowns should only display the state of fields for the current group, not other groups.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24334
| How to test?      | Detailed steps are available in issue #24334
| Possible impacts? | Multistore dropdown as a whole

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24355)
<!-- Reviewable:end -->
