### PR TITLE
Fix javascript error in console in multistore `create shop` page

### DIFF
--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-// eslint-disable-next-line
 window.Tree = function (element, options) {
   this.$element = $(element);
   this.options = $.extend({}, $.fn.tree.defaults, options);

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -24,7 +24,7 @@
  */
 
 // eslint-disable-next-line
-var Tree = function (element, options) {
+window.Tree = function (element, options) {
   this.$element = $(element);
   this.options = $.extend({}, $.fn.tree.defaults, options);
   this.init();

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-const Tree = function (element, options) {
+var Tree = function (element, options) {
   this.$element = $(element);
   this.options = $.extend({}, $.fn.tree.defaults, options);
   this.init();
@@ -200,7 +200,7 @@ Tree.prototype = {
         },
       );
     } else {
-      $(this).$element.find('label.tree-toggler').each(
+      this.$element.find('label.tree-toggler').each(
         function () {
           $(this).parent().children('.icon-folder-close')
             .removeClass('icon-folder-close')

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -22,6 +22,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+// eslint-disable-next-line
 var Tree = function (element, options) {
   this.$element = $(element);
   this.options = $.extend({}, $.fn.tree.defaults, options);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes an error popping in the console 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24276
| How to test?      | Reproduction steps are detailed in the issue #24276
| Possible impacts? | 


# READ THIS BEFORE REVIEW

The initial bug was that after running autofix on js files, in many places `var` was replaced by `const`, which is normally a good thing. 

The problem with `Tree.js` is the file is loaded at least twice, once with the page, and once in ajax (Tree actually calls himself in ajax, weird I know...). So the variable `Tree` would be declared twice as a const, which would trigger an error.

I talked about it with other core-maintainers and we decided that this temporary patch was sufficient for the 1.7.8, because:

1 / It's not a regression, this weird behavior is only made noticeable now thanx to the autofix that was run on it 
2/ We don't really care about refactoring this code during feature freeze: this page will be migrated, and if we want to refactor this before this page's migration, then it should be done on develop

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24356)
<!-- Reviewable:end -->
