### PR TITLE
Add order_reference to PaymentModule::validateOrder

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -198,6 +198,7 @@ abstract class PaymentModuleCore extends Module
      * @param bool $dont_touch_amount
      * @param string|bool $secure_key
      * @param Shop $shop
+     * @param string|null $order_reference if this parameter is not provided, a random order reference will be generated
      *
      * @return bool
      *
@@ -213,7 +214,8 @@ abstract class PaymentModuleCore extends Module
         $currency_special = null,
         $dont_touch_amount = false,
         $secure_key = false,
-        Shop $shop = null
+        Shop $shop = null,
+        ?string $order_reference = null
     ) {
         if (self::DEBUG_MODE) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Function called', 1, null, 'Cart', (int) $id_cart, true);
@@ -274,9 +276,13 @@ abstract class PaymentModuleCore extends Module
             $order_list = [];
             $order_detail_list = [];
 
-            do {
-                $reference = Order::generateReference();
-            } while (Order::getByReference($reference)->count());
+            if ($order_reference === null) {
+                do {
+                    $reference = Order::generateReference();
+                } while (Order::getByReference($reference)->count());
+            } else {
+                $reference = $order_reference;
+            }
 
             $this->currentOrderReference = $reference;
 


### PR DESCRIPTION
…nce outside from validateOrder

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  With this change it's possible to generate an order ref in a payment gateway before a order is validated. When passed to validateOrder this order_ref if taken to create the order and now new one is generate in validateOrder.
| Type?             |  improvement 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21995.
| How to test?      | Generate an order ref. from a paymenet gateway and pass it to validateOrder
| Possible impacts? | Order validation


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24357)
<!-- Reviewable:end -->
