### PR TITLE
Fix for $id_lang variable in the Order::getHistory

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -511,7 +511,7 @@ class OrderCore extends ObjectModel
      *
      * @return array History entries ordered by date DESC
      */
-    public function getHistory($id_lang, $id_order_state = false, $no_hidden = false, $filters = 0)
+    public function getHistory($id_lang = 0, $id_order_state = false, $no_hidden = false, $filters = 0)
     {
         if (!$id_order_state) {
             $id_order_state = 0;
@@ -546,7 +546,7 @@ class OrderCore extends ObjectModel
             FROM `' . _DB_PREFIX_ . 'orders` o
             LEFT JOIN `' . _DB_PREFIX_ . 'order_history` oh ON o.`id_order` = oh.`id_order`
             LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON os.`id_order_state` = oh.`id_order_state`
-            LEFT JOIN `' . _DB_PREFIX_ . 'order_state_lang` osl ON (os.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = ' . (int) ($id_lang) . ')
+            LEFT JOIN `' . _DB_PREFIX_ . 'order_state_lang` osl ON (os.`id_order_state` = osl.`id_order_state` AND osl.`id_lang` = ' . ($id_lang) . ')
             LEFT JOIN `' . _DB_PREFIX_ . 'employee` e ON e.`id_employee` = oh.`id_employee`
             WHERE oh.id_order = ' . (int) $this->id . '
             ' . ($no_hidden ? ' AND os.hidden = 0' : '') . '


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | $id_lang was as required param, so I think it could have default value = 0, and then the checks on line 543 will work properly. Also, on line 549, *(int)* should be removed for $id_lang as we could receive a string or an int value.
| Type?             |  improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Seems no
| How to test?      | Just use Order::getHistory method without id_lang as params
| Possible impacts? | Order::getHistory usage :)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24362)
<!-- Reviewable:end -->
