### PR TITLE
Partially restore feature search in Back Office

### DIFF
--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -57,7 +57,7 @@ $(function() {
             {foreach $features key=key item=feature}
                 {foreach $feature key=k item=val name=feature_list}
                     <tr>
-                        <td><a href="{$val.link}"{if $smarty.foreach.feature_list.first}><strong>{$key}</strong>{/if}</a></td>
+                        <td><a href="{$val.link}">{if $smarty.foreach.feature_list.first}><strong>{$key}</strong>{/if}</a></td>
                     </tr>
                 {/foreach}
             {/foreach}

--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -58,7 +58,6 @@ $(function() {
                 {foreach $feature key=k item=val name=feature_list}
                     <tr>
                         <td><a href="{$val.link}"{if $smarty.foreach.feature_list.first}><strong>{$key}</strong>{/if}</a></td>
-                        <td><a href="{$val.link}">{$val.value}</a></td>
                     </tr>
                 {/foreach}
             {/foreach}

--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -57,7 +57,7 @@ $(function() {
             {foreach $features key=key item=feature}
                 {foreach $feature key=k item=val name=feature_list}
                     <tr>
-                        <td><a href="{$val.link}">{if $smarty.foreach.feature_list.first}><strong>{$key}</strong>{/if}</a></td>
+                        <td><a href="{$val.link}"><strong>{$key}</strong></a></td>
                     </tr>
                 {/foreach}
             {/foreach}

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -265,7 +265,7 @@ class AdminSearchControllerCore extends AdminController
         $this->_list['features'] = [];
 
         $result = Db::getInstance()->executeS(
-            'SELECT class_name, name
+            'SELECT class_name, name, route_name
             FROM ' . _DB_PREFIX_ . 'tab t
             INNER JOIN ' . _DB_PREFIX_ . 'tab_lang tl ON (t.id_tab = tl.id_tab AND tl.id_lang = ' . (int) $this->context->employee->id_lang . ')
             WHERE active = 1'
@@ -275,7 +275,11 @@ class AdminSearchControllerCore extends AdminController
                 false !== stripos($row['name'], $this->query)
                 && Access::isGranted('ROLE_MOD_TAB_' . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)
             ) {
-                $this->_list['features'][$row['name']][] = ['link' => Context::getContext()->link->getAdminLink($row['class_name']), 'value' => Tools::safeOutput($value)];
+                $sfRouteParams = (!empty($row['route_name'])) ? ['route' => $row['route_name']] : [];
+                $this->_list['features'][$row['name']][] = [
+                    'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams),
+                    'value' => Tools::safeOutput($value)
+                ];
             }
         }
     }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -277,7 +277,7 @@ class AdminSearchControllerCore extends AdminController
             ) {
                 $sfRouteParams = (!empty($row['route_name'])) ? ['route' => $row['route_name']] : [];
                 $this->_list['features'][$row['name']][] = [
-                    'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams)
+                    'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams),
                 ];
             }
         }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -264,43 +264,18 @@ class AdminSearchControllerCore extends AdminController
     {
         $this->_list['features'] = [];
 
-        global $_LANGADM;
-        if ($_LANGADM === null) {
-            return;
-        }
-
-        $tabs = [];
-        $key_match = [];
         $result = Db::getInstance()->executeS(
-            '
-		SELECT class_name, name
-		FROM ' . _DB_PREFIX_ . 'tab t
-		INNER JOIN ' . _DB_PREFIX_ . 'tab_lang tl ON (t.id_tab = tl.id_tab AND tl.id_lang = ' . (int) $this->context->employee->id_lang . ')
-		WHERE active = 1' . (defined('_PS_HOST_MODE_') ? ' AND t.`hide_host_mode` = 0' : '')
+            'SELECT class_name, name
+            FROM ' . _DB_PREFIX_ . 'tab t
+            INNER JOIN ' . _DB_PREFIX_ . 'tab_lang tl ON (t.id_tab = tl.id_tab AND tl.id_lang = ' . (int) $this->context->employee->id_lang . ')
+            WHERE active = 1'
         );
         foreach ($result as $row) {
-            if (Access::isGranted('ROLE_MOD_TAB_' . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)) {
-                $tabs[strtolower($row['class_name'])] = $row['name'];
-                $key_match[strtolower($row['class_name'])] = $row['class_name'];
-            }
-        }
-
-        $this->_list['features'] = [];
-        foreach ($_LANGADM as $key => $value) {
-            if (stripos($value, $this->query) !== false) {
-                $value = stripslashes($value);
-                $key = strtolower(substr($key, 0, -32));
-                if (in_array($key, ['AdminTab', 'index'])) {
-                    continue;
-                }
-                // if class name doesn't exists, just ignore it
-                if (!isset($tabs[$key])) {
-                    continue;
-                }
-                if (!isset($this->_list['features'][$tabs[$key]])) {
-                    $this->_list['features'][$tabs[$key]] = [];
-                }
-                $this->_list['features'][$tabs[$key]][] = ['link' => Context::getContext()->link->getAdminLink($key_match[$key]), 'value' => Tools::safeOutput($value)];
+            if (
+                false !== stripos($row['name'], $this->query)
+                && Access::isGranted('ROLE_MOD_TAB_' . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)
+            ) {
+                $this->_list['features'][$row['name']][] = ['link' => Context::getContext()->link->getAdminLink($row['class_name']), 'value' => Tools::safeOutput($value)];
             }
         }
     }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -277,8 +277,7 @@ class AdminSearchControllerCore extends AdminController
             ) {
                 $sfRouteParams = (!empty($row['route_name'])) ? ['route' => $row['route_name']] : [];
                 $this->_list['features'][$row['name']][] = [
-                    'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams),
-                    'value' => Tools::safeOutput($value)
+                    'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams)
                 ];
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This change partially restores the "feature" search in the Back Office
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to #14546 (doesn't fix it completely though)
| How to test?      | Search for anything that appears in the menu. You should find it in the search results. Clicking on an item brings you to the page.
| Possible impacts? | Nothing else

## What's changed

The original feature search relied on PrestaShop 1.5's translation dictionaries. Originally, each page had its own dictionary, so by searching inside wordings we were able to find features (i.e. _fields_) from a specific page. To the dismay of some users (see linked issue), this feature became de-facto disabled the moment these dictionaries were removed (I'm guessing since 1.7.0).

This change partially re-enables this feature by adding menu items matching the search terms to the search pool:

![Screenshot](https://user-images.githubusercontent.com/1009343/117481174-e21ae000-af62-11eb-9d10-95a0d13c6c59.png)

Right now it's not possible to search in fields as it was before. The previous search relied on a hack that can no longer be exploited. To perform search within the forms we'd have to implement a way to interpret Form types to pull out form fields, then index their labels. Not impossible, but significantly harder than before.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24398)
<!-- Reviewable:end -->
