### PR TITLE
Remove support for legacy Core translation dictionaries in Back Office

### DIFF
--- a/admin-dev/functions.php
+++ b/admin-dev/functions.php
@@ -239,25 +239,6 @@ function checkPSVersion()
 }
 
 /**
- * @deprecated 1.5.4.1 Use Translate::getAdminTranslation($string) instead
- * @param string $string
- * @return string
- */
-function translate($string)
-{
-    Tools::displayAsDeprecated();
-
-    global $_LANGADM;
-    if (!is_array($_LANGADM)) {
-        return str_replace('"', '&quot;', $string);
-    }
-    $key = md5(str_replace('\'', '\\\'', $string));
-    $str = (array_key_exists('index'.$key, $_LANGADM)) ? $_LANGADM['index'.$key] : ((array_key_exists('index'.$key, $_LANGADM)) ? $_LANGADM['index'.$key] : $string);
-
-    return str_replace('"', '&quot;', stripslashes($str));
-}
-
-/**
  * Returns a new Tab object
  *
  * @param string $tab class name

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -66,6 +66,8 @@ class TranslateCore
     /**
      * Get a translation for an admin controller.
      *
+     * @deprecated Use Context::getContext()->getTranslator()->trans()
+     *
      * @param $string
      * @param string $class
      * @param bool $addslashes
@@ -75,23 +77,12 @@ class TranslateCore
      */
     public static function getAdminTranslation($string, $class = 'AdminTab', $addslashes = false, $htmlentities = true, $sprintf = null)
     {
-        static $modulesTabs = null;
+        @trigger_error(__FUNCTION__ . 'is deprecated. Use Context::getContext()->getTranslator()->trans() instead.', E_USER_DEPRECATED);
 
-        // @todo remove global keyword in translations files and use static
-        global $_LANGADM;
+        static $modulesTabs = null;
 
         if ($modulesTabs === null) {
             $modulesTabs = Tab::getModuleTabList();
-        }
-
-        if ($_LANGADM == null) {
-            $iso = Context::getContext()->language->iso_code;
-            if (empty($iso)) {
-                $iso = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
-            }
-            if (file_exists(_PS_TRANSLATIONS_DIR_ . $iso . '/admin.php')) {
-                include_once _PS_TRANSLATIONS_DIR_ . $iso . '/admin.php';
-            }
         }
 
         if (isset($modulesTabs[strtolower($class)])) {
@@ -102,13 +93,7 @@ class TranslateCore
             }
         }
 
-        $string = preg_replace("/\\\*'/", "\'", $string);
-        $key = md5($string);
-        if (isset($_LANGADM[$class . $key])) {
-            $str = $_LANGADM[$class . $key];
-        } else {
-            $str = Translate::getGenericAdminTranslation($string, $key, $_LANGADM);
-        }
+        $str = Context::getContext()->getTranslator()->trans($string);
 
         if ($htmlentities) {
             $str = htmlspecialchars($str, ENT_QUOTES, 'utf-8');
@@ -123,36 +108,7 @@ class TranslateCore
             $str = Translate::checkAndReplaceArgs($str, $sprintf);
         }
 
-        return $addslashes ? addslashes($str) : stripslashes($str);
-    }
-
-    /**
-     * Return the translation for a string if it exists for the base AdminController or for helpers.
-     *
-     * @param $string string to translate
-     * @param null $key md5 key if already calculated (optional)
-     * @param array $langArray Global array of admin translations
-     *
-     * @return string translation
-     */
-    public static function getGenericAdminTranslation($string, $key, &$langArray)
-    {
-        $string = preg_replace("/\\\*'/", "\'", $string);
-        if (null === $key) {
-            $key = md5($string);
-        }
-
-        if (isset($langArray['AdminController' . $key])) {
-            $str = $langArray['AdminController' . $key];
-        } elseif (isset($langArray['Helper' . $key])) {
-            $str = $langArray['Helper' . $key];
-        } elseif (isset($langArray['AdminTab' . $key])) {
-            $str = $langArray['AdminTab' . $key];
-        } else {
-            $str = $string;
-        }
-
-        return $str;
+        return $addslashes ? addslashes($str) : $str;
     }
 
     /**
@@ -180,7 +136,7 @@ class TranslateCore
         $fallback = true,
         $escape = true
     ) {
-        global $_MODULES, $_MODULE, $_LANGADM;
+        global $_MODULES, $_MODULE;
 
         static $langCache = [];
         // $_MODULES is a cache of translations for all module.
@@ -240,9 +196,6 @@ class TranslateCore
                 $ret = stripslashes($_MODULES[$currentKey]);
             } elseif (!empty($_MODULES[$defaultKey])) {
                 $ret = stripslashes($_MODULES[$defaultKey]);
-            } elseif (!empty($_LANGADM)) {
-                // if translation was not found in module, look for it in AdminController or Helpers
-                $ret = stripslashes(Translate::getGenericAdminTranslation($string, $key, $_LANGADM));
             } else {
                 $ret = stripslashes($string);
             }

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -79,20 +79,6 @@ class TranslateCore
     {
         @trigger_error(__FUNCTION__ . 'is deprecated. Use Context::getContext()->getTranslator()->trans() instead.', E_USER_DEPRECATED);
 
-        static $modulesTabs = null;
-
-        if ($modulesTabs === null) {
-            $modulesTabs = Tab::getModuleTabList();
-        }
-
-        if (isset($modulesTabs[strtolower($class)])) {
-            $classNameController = $class . 'controller';
-            // if the class is extended by a module, use modules/[module_name]/xx.php lang file
-            if (class_exists($classNameController) && Module::getModuleNameFromClass($classNameController)) {
-                return Translate::getModuleTranslation(Module::$classInModule[$classNameController], $string, $classNameController, $sprintf, $addslashes);
-            }
-        }
-
         $str = Context::getContext()->getTranslator()->trans($string);
 
         if ($htmlentities) {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2747,7 +2747,7 @@ class AdminControllerCore extends Controller
     }
 
     /**
-     * Non-static method which uses AdminController::translate().
+     * Translates a wording
      *
      * @deprecated Use $this->trans instead
      *
@@ -2762,22 +2762,7 @@ class AdminControllerCore extends Controller
     {
         @trigger_error(__FUNCTION__ . 'is deprecated. Use AdminController::trans instead.', E_USER_DEPRECATED);
 
-        $translated = $this->translator->trans($string);
-
-        if ($translated !== $string) {
-            return $translated;
-        }
-
-        // fallback for legacy modules
-
-        if ($class === null || $class == 'AdminTab') {
-            $class = substr(get_class($this), 0, -10);
-        } elseif (strtolower(substr($class, -10)) == 'controller') {
-            /* classname has changed, from AdminXXX to AdminXXXController, so we remove 10 characters and we keep same keys */
-            $class = substr($class, 0, -10);
-        }
-
-        return Translate::getAdminTranslation($string, $class, $addslashes, $htmlentities);
+        return $this->translator->trans($string);
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2749,7 +2749,7 @@ class AdminControllerCore extends Controller
     /**
      * Non-static method which uses AdminController::translate().
      *
-     * @deprecated use Context::getContext()->getTranslator()->trans($id, $parameters, $domain, $locale); instead
+     * @deprecated Use $this->trans instead
      *
      * @param string $string Term or expression in english
      * @param string|null $class Name of the class
@@ -2760,10 +2760,15 @@ class AdminControllerCore extends Controller
      */
     protected function l($string, $class = null, $addslashes = false, $htmlentities = true)
     {
+        @trigger_error(__FUNCTION__ . 'is deprecated. Use AdminController::trans instead.', E_USER_DEPRECATED);
+
         $translated = $this->translator->trans($string);
+
         if ($translated !== $string) {
             return $translated;
         }
+
+        // fallback for legacy modules
 
         if ($class === null || $class == 'AdminTab') {
             $class = substr(get_class($this), 0, -10);

--- a/classes/controller/ModuleAdminController.php
+++ b/classes/controller/ModuleAdminController.php
@@ -95,4 +95,30 @@ abstract class ModuleAdminControllerCore extends AdminController
             $templatePath,
         ];
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Use $this->trans instead
+     */
+    protected function l($string, $class = null, $addslashes = false, $htmlentities = true)
+    {
+        $translated = parent::l($string, $class, $addslashes, $htmlentities);
+
+        if ($translated === $string) {
+            // legacy fallback
+
+            if ($class === null || $class == 'AdminTab') {
+                $class = get_class($this);
+            }
+
+            $translated = Translate::getModuleTranslation($this->module->name, $string, $class, null, $addslashes);
+        }
+
+        if ($htmlentities) {
+            $translated = htmlspecialchars($translated, ENT_QUOTES, 'utf-8');
+        }
+
+        return $translated;
+    }
 }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1119,7 +1119,7 @@ abstract class ModuleCore implements ModuleInterface
     /**
      * This function is used to determine the module name
      * of an AdminTab which belongs to a module, in order to keep translation
-     * related to a module in its directory (instead of $_LANGADM).
+     * related to a module in its directory.
      *
      * @param string $current_class Name of Module class
      *

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1272,7 +1272,7 @@ abstract class ModuleCore implements ModuleInterface
         // Find translations
         global $_MODULES;
         $file = _PS_MODULE_DIR_ . $module . '/' . Context::getContext()->language->iso_code . '.php';
-        if (Tools::file_exists_cache($file) && include_once ($file)) {
+        if (Tools::file_exists_cache($file) && include_once($file)) {
             if (isset($_MODULE) && is_array($_MODULE)) {
                 $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
             }
@@ -1371,7 +1371,7 @@ abstract class ModuleCore implements ModuleInterface
                 // If no errors in Xml, no need instand and no need new config.xml file, we load only translations
                 if (!count($module_errors) && (int) $xml_module->need_instance == 0) {
                     $file = _PS_MODULE_DIR_ . $module . '/' . Context::getContext()->language->iso_code . '.php';
-                    if (Tools::file_exists_cache($file) && include_once ($file)) {
+                    if (Tools::file_exists_cache($file) && include_once($file)) {
                         if (isset($_MODULE) && is_array($_MODULE)) {
                             $_MODULES = !empty($_MODULES) ? array_merge($_MODULES, $_MODULE) : $_MODULE;
                         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed support for 1.5-1.6 style core translation dictionary files in Back Office
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | N/A
| How to test?      | Read "How to test" below
| Possible impacts? | To be completed

## What's changed

This change removes support for old Core Back Office (aka "Admin") translation dictionary files from 1.5 and 1.6.

Before 1.7, the Core's BO translations were located in `translations/<iso>/admin.php` and loaded into a global variable `$_LANGADM` ([see doc](http://doc.prestashop.com/display/PS15/Translations+in+PrestaShop+1.5)). Since these translation dictionaries no longer exist, there is no point in keeping the system supporting them anymore.

I had to rework a buggy legacy fallback from `AdminController::l()` which is still used by some modules like Gamification. It made no sense to leave it in `AdminController` because only modules need it, so I moved it into `ModuleAdminController`, which is the class modules extend to create BO controllers. The original method now redirects directly to `trans()`. Another advantage of moving the fallback into `ModuleAdminController` is that we don't need to perform weird heuristics anymore to find out which module the controller belongs to.

## Breaking or risky changes

- `translate()` (deprecated in 1.5.4.1) has been removed.
- The global variable `$_LANGADM` has been removed.
- `Translate::getAdminTranslation()` now redirects to `Context::getContext()->getTranslator()->trans()` and it no longer attempts to translate using module translations.
- `Translate::getGenericAdminTranslation()` has been removed
- `Translate::getModuleTranslation()` no longer falls back to admin translations
- `AdminController::l()` no longer falls back to admin / legacy module translations (this is done in `ModuleAdminController` now)
- `Module::getModuleNameFromClass()` no longer produces side effects (i.e. it no longer loads the module's translations)

## Deprecations

- `Translate::getAdminTranslation()` --> Use `Context::getContext()->getTranslator()->trans()`

## How to test

This change potentially affects legacy admin controllers and modules that include their own translations, like gamification for example.

- Test a legacy core admin controller in a language different than English. Wordings should be translated.
- Test a module that uses the legacy translation system, like psgdpr or gamification, in a language different than English. 	 
  - Wordings that it uses in other pages or on its own controllers should be translated (eg the gamification menu).

⚠️ Note that while the gamification module does use `ModuleAdminController::l()`, its translations aren't up to date, so many wordings are left untranslated (also some wordings are using the wrong domain, I'll create a PR to fix that).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24401)
<!-- Reviewable:end -->
