### PR TITLE
Correct logo size of classic theme

### DIFF
--- a/themes/classic/_dev/css/components/header.scss
+++ b/themes/classic/_dev/css/components/header.scss
@@ -7,6 +7,7 @@
 
   .logo {
     max-width: 100%;
+    height: auto;
   }
 
   #_desktop_logo {
@@ -189,6 +190,11 @@
       display: flex;
       align-items: center;
       min-height: 50px;
+
+      img {
+        width: auto;
+        max-height: 2rem;
+      }
 
       > h1 {
         margin: 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Header logo on classic theme was squeezed on desktop and mobile depending on his ratio
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24371.
| How to test?      | Upload a logo, go on FO and see on desktop and mobile if it's right displayed, test some different sizes and ratios
| Possible impacts? | Logo display on FO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24428)
<!-- Reviewable:end -->
