### PR TITLE
Do not remove modules pushed by API for UI tests

### DIFF
--- a/tests/UI/.docker/prestashop/docker_run.sh
+++ b/tests/UI/.docker/prestashop/docker_run.sh
@@ -89,9 +89,5 @@ fi
 
 chown -hR www-data:www-data /var/www/html
 
-# Can't uninstall all these modules with cli so removing files
-echo "\n* Delete some modules";
-rm -rf modules/ps_checkout modules/ps_metrics modules/ps_accounts modules/ps_eventbus modules/welcome modules/gamification
-
 echo "\n* Almost ! Starting web server now\n";
 exec apache2-foreground


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Revert https://github.com/PrestaShop/PrestaShop/pull/24305/ . After discussion with @PierreRambaud @jolelievre and @Progi1984 we believe that 1) using `rm -rf` is not the right way to uninstall a module and 2) removing these modules make the environment where we run our tests different from the environment that PS users work in, and this is likely to let some bugs undetected which is the opposite of what we aim for
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      |  ~
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24429)
<!-- Reviewable:end -->
