### PR TITLE
Improve CartPresenter performance, and allow Order to retrieve default_image

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -34,9 +34,9 @@ use Country;
 use Hook;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
-use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
@@ -104,9 +104,9 @@ class CartPresenter implements PresenterInterface
     /**
      * @param array $rawProduct
      *
-     * @return ProductLazyArray|ProductList
+     * @return ProductLazyArray|ProductListingLazyArray
      */
-    public function presentProduct(array $rawProduct)
+    private function presentProduct(array $rawProduct)
     {
         $assembledProduct = $this->getProductAssembler()->assembleProduct($rawProduct);
         $rawProduct = array_merge($assembledProduct, $rawProduct);

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -35,6 +35,8 @@ use Hook;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
@@ -71,6 +73,16 @@ class CartPresenter implements PresenterInterface
      */
     private $taxConfiguration;
 
+    /**
+     * @var ProductPresentationSettings
+     */
+    protected $settings;
+
+    /**
+     * @var ProductAssembler
+     */
+    protected $productAssembler;
+
     public function __construct()
     {
         $context = Context::getContext();
@@ -92,23 +104,12 @@ class CartPresenter implements PresenterInterface
     /**
      * @param array $rawProduct
      *
-     * @return \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray|\PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingLazyArray
+     * @return ProductLazyArray|ProductList
      */
-    private function presentProduct(array $rawProduct)
+    public function presentProduct(array $rawProduct)
     {
-        $assembler = new ProductAssembler(Context::getContext());
-        $assembledProduct = $assembler->assembleProduct($rawProduct);
+        $assembledProduct = $this->getProductAssembler()->assembleProduct($rawProduct);
         $rawProduct = array_merge($assembledProduct, $rawProduct);
-
-        $settings = new ProductPresentationSettings();
-
-        $settings->catalog_mode = Configuration::isCatalogMode();
-        $settings->catalog_mode_with_prices = (int) Configuration::get('PS_CATALOG_MODE_WITH_PRICES');
-        $settings->include_taxes = $this->includeTaxes();
-        $settings->allow_add_variant_to_cart_from_listing = (int) Configuration::get('PS_ATTRIBUTE_CATEGORY_DISPLAY');
-        $settings->stock_management_enabled = Configuration::get('PS_STOCK_MANAGEMENT');
-        $settings->showPrices = Configuration::showPrices();
-        $settings->showLabelOOSListingPages = (bool) Configuration::get('PS_SHOW_LABEL_OOS_LISTING_PAGES');
 
         if (isset($rawProduct['attributes']) && is_string($rawProduct['attributes'])) {
             $rawProduct['attributes'] = $this->getAttributesArrayFromString($rawProduct['attributes']);
@@ -179,7 +180,7 @@ class CartPresenter implements PresenterInterface
         );
 
         return $presenter->present(
-            $settings,
+            $this->getSettings(),
             $rawProduct,
             Context::getContext()->language
         );
@@ -678,5 +679,31 @@ class CartPresenter implements PresenterInterface
         }
 
         return $attributesArray;
+    }
+
+    protected function getSettings(): ProductPresentationSettings
+    {
+        if ($this->settings === null) {
+            $this->settings = new ProductPresentationSettings();
+
+            $this->settings->catalog_mode = Configuration::isCatalogMode();
+            $this->settings->catalog_mode_with_prices = (int) Configuration::get('PS_CATALOG_MODE_WITH_PRICES');
+            $this->settings->include_taxes = $this->includeTaxes();
+            $this->settings->allow_add_variant_to_cart_from_listing = (int) Configuration::get('PS_ATTRIBUTE_CATEGORY_DISPLAY');
+            $this->settings->stock_management_enabled = Configuration::get('PS_STOCK_MANAGEMENT');
+            $this->settings->showPrices = Configuration::showPrices();
+            $this->settings->showLabelOOSListingPages = (bool) Configuration::get('PS_SHOW_LABEL_OOS_LISTING_PAGES');
+        }
+
+        return $this->settings;
+    }
+
+    protected function getProductAssembler(): ProductAssembler
+    {
+        if ($this->productAssembler === null) {
+            $this->productAssembler = new ProductAssembler(Context::getContext());
+        }
+
+        return $this->productAssembler;
     }
 }

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -202,14 +202,17 @@ class OrderLazyArray extends AbstractLazyArray
 
             foreach ($cartProducts['products'] as $cartProduct) {
                 if (($cartProduct['id_product'] === $orderProduct['id_product'])
-                    && ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute'])) {
+                    && ($cartProduct['id_product_attribute'] === $orderProduct['id_product_attribute'])
+                ) {
                     if (isset($cartProduct['attributes'])) {
                         $orderProduct['attributes'] = $cartProduct['attributes'];
                     } else {
                         $orderProduct['attributes'] = [];
                     }
                     $orderProduct['cover'] = $cartProduct['cover'];
+                    $orderProduct['default_image'] = $cartProduct['default_image'];
                     $orderProduct['unit_price_full'] = $cartProduct['unit_price_full'];
+                    break;
                 }
             }
 

--- a/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-product-line.tpl
@@ -25,8 +25,8 @@
 {block name='cart_summary_product_line'}
   <div class="media-left">
     <a href="{$product.url}" title="{$product.name}">
-      {if $product.cover}
-        <img class="media-object" src="{$product.cover.small.url}" alt="{$product.name}" loading="lazy">
+      {if $product.default_image}
+        <img class="media-object" src="{$product.default_image.small.url}" alt="{$product.name}" loading="lazy">
       {else}
         <img src="{$urls.no_picture_image.bySize.small_default.url}" loading="lazy" />
       {/if}

--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -39,8 +39,8 @@
         <div class="order-line row">
           <div class="col-sm-2 col-xs-3">
             <span class="image">
-              {if !empty($product.cover)}
-                <img src="{$product.cover.medium.url}" loading="lazy" />
+              {if !empty($product.default_image)}
+                <img src="{$product.default_image.medium.url}" loading="lazy" />
               {else}
                 <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
               {/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | From this [comment](https://github.com/PrestaShop/PrestaShop/pull/24248#issuecomment-830167910). OrderPresenter now also returns default_image in products, and correctly find the right image depending on the attribute & product id. Also refactor to don't rebuild some classes on each product loop.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21775
| How to test?      | Follow this [comment](https://github.com/PrestaShop/PrestaShop/pull/24248#issuecomment-830167910) and ticket
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24430)
<!-- Reviewable:end -->
