### PR TITLE
Fix upgrade from 1.6.1.24 on certain installation

### DIFF
--- a/install-dev/upgrade/sql/1.7.0.0.sql
+++ b/install-dev/upgrade/sql/1.7.0.0.sql
@@ -117,6 +117,14 @@ CREATE TABLE `PREFIX_authorization_role` (
   UNIQUE KEY (`slug`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;
 
+/* Add missing access entries on certain installation */
+INSERT INTO `PREFIX_access` (`id_profile`, `id_tab`, `view`, `add`, `edit`, `delete`)
+  SELECT 1, `id_tab`, 0, 0 ,0 ,0
+  FROM `PREFIX_tab` WHERE `id_tab` NOT IN (SELECT `id_tab` FROM `PREFIX_access` WHERE `id_profile` = 1);
+INSERT INTO `PREFIX_module_access` (`id_profile`, `id_module`, `view`, `configure`, `uninstall`)
+  SELECT 1, `id_module`, 1, 0, 0
+  FROM `PREFIX_module` WHERE `id_module` NOT IN (SELECT `id_module` FROM `PREFIX_module_access` WHERE `id_profile` = 1);
+
 /* Create a copy without indexes to make ID updates without conflict. */
 CREATE TABLE `PREFIX_access_old` AS SELECT * FROM `PREFIX_access`;
 DROP TABLE `PREFIX_access`;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Before [this PR](https://github.com/PrestaShop/PrestaShop/pull/18451/files), `readdir()` was used leading to an unpredictable order of the file listed. This order had an impact on the entries in the DB and on the `ps_access` & `ps_module_access` in particular. This was not a problem for the 1.6 but after the migration to an 1.7, that lead to unauthorized access on certain pages of the BO. This PR fixes it by adding the missing entries before the migration of the new tab and access structure.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23277 & #9513
| How to test?      | As everyone is not impacted, it can be hard to reproduce but if you are impacted, the way to test is to try an upgrade from 1.6.1.24 to 1.7.7.x with this PR, you should be able to view every page of the BO.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24443)
<!-- Reviewable:end -->
