### PR TITLE
Fix order view layout of right column

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -324,7 +324,7 @@
   }
 
   #order-view-page {
-    .table {
+    .table:not(.discountList) {
       display: block;
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -104,7 +104,7 @@
       </tbody>
     </table>
 
-    <div class="row mb-3">
+    <div class="mb-3">
       <div class="col-md-6 text-left d-print-none order-product-pagination">
         <div class="form-group row">
           <label for="paginator_select_page_limit" class="col-form-label ml-3">{{ "Items per page:"|trans({}, 'Admin.Catalog.Feature') }}</label>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Order page table had some problems of spacings
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on order view and add a promo code, you should see that the table is buggy, this PR fix it
| Possible impacts? | Order view layout

# Before
![image](https://user-images.githubusercontent.com/14963751/117795959-ee4aba00-b24e-11eb-988a-5e29cc4c63a2.png)

# After
![image](https://user-images.githubusercontent.com/14963751/117795312-5cdb4800-b24e-11eb-9726-c4199585313d.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24447)
<!-- Reviewable:end -->

