### PR TITLE
Multistore header on product pages

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -83,6 +83,7 @@ twig:
     globals:
         webpack_server: false
         multistore_field_prefix: !php/const:PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX
+        multistore_controller: '@prestashop.core.admin.multistore'
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -83,7 +83,6 @@ twig:
     globals:
         webpack_server: false
         multistore_field_prefix: !php/const:PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX
-        multistore_controller: '@prestashop.core.admin.multistore'
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -118,3 +118,10 @@ services:
       class: 'PrestaShopBundle\Twig\Extension\NumberExtension'
       tags:
         - { name: twig.extension }
+
+    prestashop.twig.extension.multistore_header_extension:
+      class: 'PrestaShopBundle\Twig\Extension\MultistoreHeaderExtension'
+      arguments:
+        - '@prestashop.core.admin.multistore'
+      tags:
+        - { name: twig.extension }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig
@@ -25,6 +25,9 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
+  <div class="header-toolbar d-print-none">
+    {{ multistore_controller.header(false).getContent()|raw }}
+  </div>
     <div class="col-md-12">
         <div class="alert alert-danger" role="alert">
             <p class="alert-text">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig
@@ -26,7 +26,7 @@
 
 {% block content %}
   <div class="header-toolbar d-print-none">
-    {{ multistore_controller.header(false).getContent()|raw }}
+    {{ multistoreHeader()|raw }}
   </div>
     <div class="col-md-12">
         <div class="alert alert-danger" role="alert">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/disabled_form_alert.html.twig
@@ -26,7 +26,7 @@
 
 {% block content %}
   <div class="header-toolbar d-print-none">
-    {{ multistoreHeader()|raw }}
+    {{ multistoreHeader() }}
   </div>
     <div class="col-md-12">
         <div class="alert alert-danger" role="alert">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -31,7 +31,7 @@
 {% block content %}
   {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
   <div class="header-toolbar d-print-none">
-    {{ multistoreHeader()|raw }}
+    {{ multistoreHeader() }}
   </div>
   <form name="form" id="form" method="post" class="form-horizontal product-page row justify-content-md-center" novalidate="novalidate">
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -29,9 +29,10 @@
 {% endblock %}
 
 {% block content %}
-
   {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
-
+  <div class="header-toolbar d-print-none">
+    {{ multistore_controller.header(false).getContent()|raw }}
+  </div>
   <form name="form" id="form" method="post" class="form-horizontal product-page row justify-content-md-center" novalidate="novalidate">
 
     {% if not editable %} <fieldset disabled id="field-disabled"> {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -31,7 +31,7 @@
 {% block content %}
   {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': id_product }) %}
   <div class="header-toolbar d-print-none">
-    {{ multistore_controller.header(false).getContent()|raw }}
+    {{ multistoreHeader()|raw }}
   </div>
   <form name="form" id="form" method="post" class="form-horizontal product-page row justify-content-md-center" novalidate="novalidate">
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -41,7 +41,7 @@
   {% set extraModulesHooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
 
   <div class="header-toolbar d-print-none">
-    {{ multistoreHeader()|raw }}
+    {{ multistoreHeader() }}
   </div>
 
   {{ form_start(productForm, {'attr': {

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -40,6 +40,10 @@
   {% set productId = productForm.vars.product_id %}
   {% set extraModulesHooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
 
+  <div class="header-toolbar d-print-none">
+    {{ multistore_controller.header(false).getContent()|raw }}
+  </div>
+
   {{ form_start(productForm, {'attr': {
     'class': 'form-horizontal product-page product-page-v2 row justify-content-md-center', 'novalidate': 'novalidate',
     'data-product-id': productId,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -41,7 +41,7 @@
   {% set extraModulesHooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
 
   <div class="header-toolbar d-print-none">
-    {{ multistore_controller.header(false).getContent()|raw }}
+    {{ multistoreHeader()|raw }}
   </div>
 
   {{ form_start(productForm, {'attr': {

--- a/src/PrestaShopBundle/Twig/Extension/MultistoreHeaderExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/MultistoreHeaderExtension.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Twig\Extension;
+
+use PrestaShopBundle\Controller\Admin\MultistoreController;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Class MultistoreHeaderExtension provides helper function to get the multistore header's html in a template
+ */
+class MultistoreHeaderExtension extends AbstractExtension
+{
+    /**
+     * @var MultistoreController
+     */
+    private $multistoreController;
+
+    /**
+     * MultistoreHeaderExtension constructor.
+     *
+     * @param MultistoreController $multistoreController
+     */
+    public function __construct(MultistoreController $multistoreController)
+    {
+        $this->multistoreController = $multistoreController;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [new TwigFunction('multistoreHeader', [$this, 'getMultistoreHeader'])];
+    }
+
+    /**
+     * @param bool $lockedToAllShopContext
+     *
+     * @return string
+     */
+    public function getMultistoreHeader($lockedToAllShopContext = false): string
+    {
+        return $this->multistoreController->header($lockedToAllShopContext)->getContent();
+    }
+}

--- a/src/PrestaShopBundle/Twig/Extension/MultistoreHeaderExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/MultistoreHeaderExtension.php
@@ -57,7 +57,18 @@ class MultistoreHeaderExtension extends AbstractExtension
      */
     public function getFunctions(): array
     {
-        return [new TwigFunction('multistoreHeader', [$this, 'getMultistoreHeader'])];
+        return [new TwigFunction(
+            'multistoreHeader',
+            [
+                $this,
+                'getMultistoreHeader',
+            ],
+            [
+                'is_safe' => [
+                    'html',
+                ],
+            ]
+        )];
     }
 
     /**
@@ -65,7 +76,7 @@ class MultistoreHeaderExtension extends AbstractExtension
      *
      * @return string
      */
-    public function getMultistoreHeader($lockedToAllShopContext = false): string
+    public function getMultistoreHeader(bool $lockedToAllShopContext = false): string
     {
         return $this->multistoreController->header($lockedToAllShopContext)->getContent();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR brings the multistore header to the product creation/edition page (both on current and experimental pages)
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23937
| How to test?      | See issue #23937
| Possible impacts? | 

This PR makes the multistore controller, which is a controller as a service, callable from twig globally.
Then It calls the multistore header where it's needed, adding the missing HTML header container that exists on other migrated pages.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24469)
<!-- Reviewable:end -->
