### PR TITLE
Fixed an error displayed in the console when changing the order status -  Orders list page 

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/choice-extension.js
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/choice-extension.js
@@ -36,7 +36,7 @@ const {$} = window;
  */
 export default class ChoiceExtension {
   constructor() {
-    this.lock = [];
+    this.locks = [];
   }
 
   extend(grid) {
@@ -90,7 +90,7 @@ export default class ChoiceExtension {
    * @private
    */
   isLocked(url) {
-    return this.lock.includes(url);
+    return this.locks.includes(url);
   }
 
   /**
@@ -99,6 +99,6 @@ export default class ChoiceExtension {
    * @private
    */
   lock(url) {
-    this.lock.push(url);
+    this.locks.push(url);
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Apparenlty, ESLint suggests renaming class methods like `_functionName` to `functionName`, which sometimes creates a bug.  As example, when we already have a class attribute named `functionName`.
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24481
| How to test?      | Go to BO > Orders > Orders list page, open console, try to change the status of any order with the drop-down list, there is no error  `Uncaught type error : this.lock is not a function...`
| Possible impacts? | I don't see any.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24485)
<!-- Reviewable:end -->
