### PR TITLE
Fix Preview order - Invoice details is missing the address mail of the customer - BO Orders list

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -84,10 +84,11 @@
                 <strong>{{ 'Invoice details'|trans({}, 'Admin.Orderscustomers.Feature') }}:</strong>
               </p>
 
-
               {% for line in orderPreview.invoiceAddressFormatted|split("\n") %}
                 <p{% if not loop.last %} class="mb-0"{% endif %}>{{ line }}</p>
               {% endfor %}
+
+              <p class="mb-0">{{ orderPreview.invoiceDetails.email }}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds the customer email to view of "Preview Order"
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #24482 
| How to test?      | Go to BO > Orders > Orders list page , Click on 'arrow_down' to preview any order, see the address mail is not missing the invoice details
| Possible impacts? | I don't see any.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24486)
<!-- Reviewable:end -->
