### PR TITLE
[WIP] Fix Available carriers for a product should be initially selected

### DIFF
--- a/src/Adapter/Carrier/CarrierDataProvider.php
+++ b/src/Adapter/Carrier/CarrierDataProvider.php
@@ -124,4 +124,40 @@ class CarrierDataProvider
     {
         return Carrier::ALL_CARRIERS;
     }
+
+    /**
+     * Get all carriers in a given language but modified to a format suitable for creation
+     *
+     * @param int $id_lang Language id
+     * @param bool $active Returns only active carriers when true
+     * @param bool $delete
+     * @param bool|int $id_zone
+     * @param string|null $ids_group
+     * @param int $modules_filters Possible values:
+     *                             - PS_CARRIERS_ONLY
+     *                             - CARRIERS_MODULE
+     *                             - CARRIERS_MODULE_NEED_RANGE
+     *                             - PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE
+     *                             - ALL_CARRIERS
+     *
+     * @return array Carriers
+     */
+    public function getCarriersForCreation($id_lang, $active = false, $delete = false, $id_zone = false, $ids_group = null, $modules_filters = Carrier::PS_CARRIERS_ONLY)
+    {
+        $allCarriers = $this->getCarriers(
+            $id_lang,
+            $active,
+            $delete,
+            $id_zone,
+            $ids_group,
+            $modules_filters
+        );
+
+        $allCarriersModified = [];
+        foreach ($allCarriers as $carrier) {
+            $allCarriersModified[] = $carrier['id_reference'];
+        }
+
+        return $allCarriersModified;
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -429,19 +429,14 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $carrierProvider = $this->get('prestashop.adapter.data_provider.carrier');
-        $allCarriers = $carrierProvider->getCarriers(
-            $lang['id_lang'],
-            false,
+        $allCarriersModified = $carrierProvider->getCarriersForCreation(
+            $this->getContext()->language->id,
+            true,
             false,
             false,
             null,
             $carrierProvider->getAllCarriersConstant()
-        );
-
-        $allCarriersModified = [];
-        foreach ($allCarriers as $carrier) {
-            $allCarriersModified[] = $carrier['id_reference'];
-        }
+            );
 
         $product->save();
         $product->addToCategories([$productShopCategory]);

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -428,8 +428,24 @@ class ProductController extends FrameworkBundleAdminController
             $product->link_rewrite[$lang['id_lang']] = '';
         }
 
+        $carrierProvider = $this->get('prestashop.adapter.data_provider.carrier');
+        $allCarriers = $carrierProvider->getCarriers(
+            $lang['id_lang'],
+            false,
+            false,
+            false,
+            null,
+            $carrierProvider->getAllCarriersConstant()
+        );
+
+        $allCarriersModified = [];
+        foreach ($allCarriers as $carrier) {
+            $allCarriersModified[] = $carrier['id_reference'];
+        }
+
         $product->save();
         $product->addToCategories([$productShopCategory]);
+        $product->setCarriers($allCarriersModified);
 
         return $this->redirectToRoute('admin_product_form', ['id' => $product->id]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -180,7 +180,6 @@ class ProductShipping extends CommonAbstractType
                     'multiple' => true,
                     'required' => false,
                     'label' => $this->translator->trans('Available carriers', [], 'Admin.Catalog.Feature'),
-                    'data' => array_values($this->carriersChoices),
                 ]
             )
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -180,6 +180,7 @@ class ProductShipping extends CommonAbstractType
                     'multiple' => true,
                     'required' => false,
                     'label' => $this->translator->trans('Available carriers', [], 'Admin.Catalog.Feature'),
+                    'data' => array_values($this->carriersChoices),
                 ]
             )
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -115,7 +115,6 @@ class ShippingType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Available carriers', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h2',
-                'data' => array_values($this->carrierChoiceProvider->getChoices()),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -115,8 +115,7 @@ class ShippingType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Available carriers', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h2',
-                'alert_message' => $this->trans('If no carrier is selected then all the carriers will be available for customers orders.', 'Admin.Catalog.Notification'),
-                'alert_type' => 'warning',
+                'data' => array_values($this->carrierChoiceProvider->getChoices()),
             ])
         ;
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -143,14 +143,6 @@
 </div>
 
 <div class="col-md-12">
-  <div class="alert alert-warning" role="alert">
-    <p class="alert-text">
-        {{ 'If no carrier is selected then all the carriers will be available for customers orders.'|trans({}, 'Admin.Catalog.Notification')|raw }}
-    </p>
-  </div>
-</div>
-
-<div class="col-md-12">
   <div id="warehouse_combination_collection" class="col-md-12 form-group" data-url="{{ path('admin_warehouse_refresh_product_warehouse_combination_form') }}">
     {% if asm_globally_activated and isNotVirtual and isChecked %}
       {{ include('@PrestaShop/Admin:Product/ProductPage/Forms/form_warehouse_combination.html.twig', { 'warehouses': warehouses, 'form': form }) }}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  develop
| Description?      | By @marionf: By default all available carriers should be checked and displayed in Frontoffice.If a carrier isn't checked, it's not displayed in front-office.This way, we can remove the information message "If no carrier is selected then all the carriers will be available for customers orders."
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #15377
| How to test?      | WIP
| Possible impacts? | I don't see any.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24487)
<!-- Reviewable:end -->
