### PR TITLE
BO SpecificPriceRule - Fix Multi Shop filter on conditions

### DIFF
--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -216,7 +216,7 @@ class SpecificPriceRuleCore extends ObjectModel
     public function getAffectedProducts($products = false)
     {
         $conditions_group = $this->getConditions();
-        $current_shop_id = Context::getContext()->shop->id;
+        $shop_id = $this->id_shop ?: Context::getContext()->shop->id;
 
         $result = [];
 
@@ -227,7 +227,7 @@ class SpecificPriceRuleCore extends ObjectModel
                 $query->select('p.`id_product`')
                     ->from('product', 'p')
                     ->leftJoin('product_shop', 'ps', 'p.`id_product` = ps.`id_product`')
-                    ->where('ps.id_shop = ' . (int) $current_shop_id);
+                    ->where('ps.id_shop = ' . (int) $shop_id);
 
                 $attributes_join_added = false;
 
@@ -286,7 +286,7 @@ class SpecificPriceRuleCore extends ObjectModel
                         ->select('NULL as `id_product_attribute`')
                         ->from('product', 'p')
                         ->leftJoin('product_shop', 'ps', 'p.`id_product` = ps.`id_product`')
-                        ->where('ps.id_shop = ' . (int) $current_shop_id);
+                        ->where('ps.id_shop = ' . (int) $shop_id);
                     $query->where('p.`id_product` IN (' . implode(', ', array_map('intval', $products)) . ')');
                     $result = Db::getInstance()->executeS($query);
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See #24490.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24490.
| How to test?      | See #24490.
| Possible impacts? | None.

#### Describe the bug

When creating a catalog specific price rule **_using conditions_**, the rule is not working as expected if user choosed the second shop on a multi store installation of Prestashop.

#### Additional information

The problem happens because `getAffectedProducts` method uses `Context::getContext()->shop->id` instead of the selected `$this->id_shop`. (`$this->id_shop` contains the shop selected by the user)

![image](https://user-images.githubusercontent.com/915273/118426573-a667df00-b6f5-11eb-9d69-4a4470a6e8a6.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24491)
<!-- Reviewable:end -->
