### PR TITLE
Remove host when generating logo url for pdf

### DIFF
--- a/pdf/header.tpl
+++ b/pdf/header.tpl
@@ -28,7 +28,7 @@
 <tr>
 	<td style="width: 50%">
 		{if $logo_path}
-			<img src="{$logo_path}" style="width:{$width_logo}px; height:{$height_logo}px;" />
+      <img src="{$logo_path|regex_replace:"/http(s?):\/\/(.+?)\//": "/"}" style="width:{$width_logo}px; height:{$height_logo}px;" />
 		{/if}
 	</td>
 	<td style="width: 50%; text-align: right;">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When running prestashop in container with an exposed port, prestashop can't download the logo to generate invoice.
| Type?             | bug fix / Critical
| Category?         | FO  or WS ?
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22581
| How to test?      | SEtup prestashop with container thought a non 80 port, and try to make works the invoice logo. With this PR, it works..
| Possible impacts? | No impact


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24496)
<!-- Reviewable:end -->
