### PR TITLE
Remove old selected_filters route 

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -133,19 +133,6 @@ class DispatcherCore
                 'tags' => ['regexp' => '[a-zA-Z0-9-\pL]*'],
             ],
         ],
-        /* Must be after the product and category rules in order to avoid conflict */
-        'layered_rule' => [
-            'controller' => 'category',
-            'rule' => '{id}-{rewrite}{/:selected_filters}',
-            'keywords' => [
-                'id' => ['regexp' => '[0-9]+', 'param' => 'id_category'],
-                /* Selected filters is used by the module blocklayered */
-                'selected_filters' => ['regexp' => '.*', 'param' => 'selected_filters'],
-                'rewrite' => ['regexp' => self::REWRITE_PATTERN],
-                'meta_keywords' => ['regexp' => '[_a-zA-Z0-9-\pL]*'],
-                'meta_title' => ['regexp' => '[_a-zA-Z0-9-\pL]*'],
-            ],
-        ],
     ];
 
     /**

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -449,9 +449,6 @@ class LinkCore
             throw new \InvalidArgumentException('Invalid category parameter');
         }
 
-        // Selected filters is used by the module ps_facetedsearch
-        $selectedFilters = null === $selectedFilters ? '' : $selectedFilters;
-
         $rule = 'category_rule';
 
         if (!$alias) {

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -452,12 +452,7 @@ class LinkCore
         // Selected filters is used by the module ps_facetedsearch
         $selectedFilters = null === $selectedFilters ? '' : $selectedFilters;
 
-        if (empty($selectedFilters)) {
-            $rule = 'category_rule';
-        } else {
-            $rule = 'layered_rule';
-            $params['selected_filters'] = $selectedFilters;
-        }
+        $rule = 'category_rule';
 
         if (!$alias) {
             $category = $this->getCategoryObject($category, $idLang);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove selected_filters in routes : this route was created for [blocklayered](https://github.com/prestashop/blocklayered) module and this module was compatible with 1.6 and less only. This route cause a bug if you add a `/anything` at the end of the category url (cf issue)
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23632
| How to test?      | Add `/anything` to a category url in front, it should display a not found page as expected (see issue). Please verify [ps_facetedsearch](https://github.com/PrestaShop/ps_facetedsearch) works well with this PR.
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24509)
<!-- Reviewable:end -->
