### PR TITLE
Remove inline-style from form_row of the UIKit and adapt js

### DIFF
--- a/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.js
+++ b/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.js
@@ -96,10 +96,6 @@ export default class CountryStateSelectionToggler {
   }
 
   toggle() {
-    if (this.$countryStateSelector.find('option').length > 0) {
-      this.$stateSelectionBlock.removeClass('d-none');
-    } else {
-      this.$stateSelectionBlock.addClass('d-none');
-    }
+    this.$stateSelectionBlock.toggleClass('d-none', !this.$countryStateSelector.find('option').length > 0);
   }
 }

--- a/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.js
+++ b/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.js
@@ -74,27 +74,32 @@ export default class CountryStateSelectionToggler {
       data: {
         id_country: countryId,
       },
-    }).then((response) => {
-      this.$countryStateSelector.empty();
+    })
+      .then((response) => {
+        this.$countryStateSelector.empty();
 
-      Object.keys(response.states).forEach((value) => {
-        this.$countryStateSelector.append($('<option></option>').attr('value', response.states[value]).text(value));
+        Object.keys(response.states).forEach((value) => {
+          this.$countryStateSelector.append(
+            $('<option></option>')
+              .attr('value', response.states[value])
+              .text(value),
+          );
+        });
+
+        this.toggle();
+      })
+      .catch((response) => {
+        if (typeof response.responseJSON !== 'undefined') {
+          window.showErrorMessage(response.responseJSON.message);
+        }
       });
-
-      this.toggle();
-    }).catch((response) => {
-      if (typeof response.responseJSON !== 'undefined') {
-        window.showErrorMessage(response.responseJSON.message);
-      }
-    });
   }
 
   toggle() {
     if (this.$countryStateSelector.find('option').length > 0) {
-      this.$stateSelectionBlock.fadeIn();
       this.$stateSelectionBlock.removeClass('d-none');
     } else {
-      this.$stateSelectionBlock.fadeOut();
+      this.$stateSelectionBlock.addClass('d-none');
     }
   }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig
@@ -79,7 +79,7 @@
       {% set disabledField = true %}
     {% endif %}
 
-    <div class="{{ block('form_row_class') }}{{ block('widget_type_class') }}{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}"{% if (attr.visible is defined and not attr.visible) %} style="display: none;"{% endif %}>
+    <div class="{{ block('form_row_class') }}{{ block('widget_type_class') }}{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}{% if (attr.visible is defined and not attr.visible) %} d-none{% endif %}">
       {% if attribute(form.parent, multistoreCheckboxName) is defined %}
         {{ form_errors(attribute(form.parent, multistoreCheckboxName)) }}
         {{ form_widget(attribute(form.parent, multistoreCheckboxName)) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | We're using inline-style in form_row of the UIKit, this should be removed to use a bootstrap class
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24376.
| How to test?      | Go on create customer address page, select united state, state field should appear, if you select France, it should disappear
| Possible impacts? | Customer address creation form


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24541)
<!-- Reviewable:end -->
