### PR TITLE
Fix for product combination quantity change in RTL panel 

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -339,6 +339,9 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['combinations'][$k]['attribute_unity'] = abs(
                 $this->floatParser->fromString($combination['attribute_unity'])
             );
+            $form_data['combinations'][$k]['attribute_quantity'] = abs(
+                $this->floatParser->fromString($combination['attribute_quantity'])
+            );
         }
 
         //map suppliers


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In arabic version of BO (change your BO to arabic language) try to save a product which has combinations. After doing this all combination's quantities will set to "0". The problem is that in arabic numbers are different from english-based numbers.
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #24505.
| How to test?      | 
| Possible impacts? | Nothing


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24555)
<!-- Reviewable:end -->
