### PR TITLE
BO - New Order - Empty gift message is not a null value

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -278,7 +278,7 @@ class CartController extends FrameworkBundleAdminController
                 $request->request->getBoolean('freeShipping'),
                 ($giftSettingsEnabled ? $request->request->getBoolean('isAGift', null) : null),
                 ($recycledPackagingEnabled ? $request->request->getBoolean('useRecycledPackaging', null) : null),
-                ((!empty($request->request->get('giftMessage', null))) ? $request->request->get('giftMessage', null) : null)
+                $request->request->get('giftMessage', null)
             ));
 
             return $this->json($this->getCartInfo($cartId));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | An empty gift message (``) was considered as `null` and wasn't saved
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24562
| How to test?      | Cf. #24562


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24576)
<!-- Reviewable:end -->
