### PR TITLE
Fix addons modules not being installed in CI

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -107,6 +107,9 @@ csa_guzzle:
                     timeout: "5.0"
                 headers:
                     Accept: "application/json"
+                curl:
+                    'forbid_reuse': true
+                    'fresh_connect': true
 
 prestashop:
     addons:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -108,8 +108,8 @@ csa_guzzle:
                 headers:
                     Accept: "application/json"
                 curl:
-                    'forbid_reuse': true
-                    'fresh_connect': true
+                    forbid_reuse: true
+                    fresh_connect: true
 
 prestashop:
     addons:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of a curl settings associated to the CI context, the request to get addons modules was not successful. This PR fixes it
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should pass
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24586)
<!-- Reviewable:end -->
