### PR TITLE
Fix fixtures when addons modules are not installed

### DIFF
--- a/install-dev/fixtures/fashion/install.php
+++ b/install-dev/fixtures/fashion/install.php
@@ -60,6 +60,13 @@ class InstallFixturesFashion extends XmlLoader
 
         parent::populateFromXmlFiles();
 
+        Db::getInstance()->execute(
+            'UPDATE ' . _DB_PREFIX_ . 'country SET active = 1 ' .
+            'WHERE id_country IN (' .
+            '  SELECT id_country FROM ' . _DB_PREFIX_ . 'address' .
+            ')'
+        );
+
         /**
          * Refresh facetedsearch cache
          */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When addons modules are not installed, countries are not properly configured, you if install your shop in English (United Kingdom) you will see no carrier available in the BO. So the handle it, activate countries that are used in addresses table.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a new Order, see carrier part. To disable addons modules, you have to remove calls during installation process, this can be tested by a dev or you can comment theses lines: https://github.com/PrestaShop/PrestaShop/blob/develop/install-dev/controllers/http/process.php#L245-L252 
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24588)
<!-- Reviewable:end -->
