### PR TITLE
Load PrestaShop `Attribute` class before from `symfony/polyfill-php80` polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,7 @@
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/polyfill-php73": "^1.10",
+        "symfony/polyfill-php80": "^1.22",
         "symfony/swiftmailer-bundle": "^3.1",
         "symfony/symfony": "^3.4.37",
         "tecnickcom/tcpdf": "^6.2.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57c69a04756def9111f315174f5eb57f",
+    "content-hash": "aadf13770b2ad2c409c2a46310e70e28",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -8348,6 +8348,89 @@
                 }
             ],
             "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-util",

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -30,3 +30,8 @@ define('_PS_VERSION_', AppKernel::VERSION);
 require_once _PS_CONFIG_DIR_.'alias.php';
 require_once _PS_CLASS_DIR_.'PrestaShopAutoload.php';
 spl_autoload_register(array(PrestaShopAutoload::getInstance(), 'load'));
+
+// make sure Attribute class is never loaded from symfony/polyfill-php80,
+// related with: https://github.com/PrestaShop/PrestaShop/pull/20710
+// remove once PHP 8.0 support is added
+PrestaShopAutoload::getInstance()->load(Attribute::class);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Load PrestaShop `Attribute` class before from `symfony/polyfill-php80` polyfill
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | related with https://github.com/PrestaShop/PrestaShop/pull/20710#issuecomment-721036258 /cc @jderusse
| How to test?      | CI must pass
| Possible impacts? | no

`symfony/polyfill-php80` dep is also added so developers can reply on `str_starts_with` and similar functions present.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24589)
<!-- Reviewable:end -->
