### PR TITLE
Fix order create page on product qty update

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/product-manager.js
@@ -145,12 +145,12 @@ export default class ProductManager {
     };
 
     // on success
-    EventEmitter.on(eventMap.productQtyChanged, (cartInfo) => {
+    EventEmitter.on(eventMap.productQtyChanged, (data) => {
       this.productRenderer.cleanCartBlockAlerts();
-      this.updateStockOnQtyChange(cartInfo.product);
+      this.updateStockOnQtyChange(data.product);
 
       $(createOrderMap.createOrderButton).prop('disabled', false);
-      EventEmitter.emit(eventMap.cartLoaded, cartInfo);
+      EventEmitter.emit(eventMap.cartLoaded, data.cartInfo);
 
       enableQtyInputs();
     });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | When you were updating a product qty, the whole JS was broken on create order page
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24554.
| How to test?      | Go on create order page, add a product and try to update the product qty, everything should work as usual
| Possible impacts? | Create order page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24594)
<!-- Reviewable:end -->
