### PR TITLE
Fix primary buttons not being inline on Theme & Logo > Pages configurations

### DIFF
--- a/admin-dev/themes/default/scss/controllers/_themes.scss
+++ b/admin-dev/themes/default/scss/controllers/_themes.scss
@@ -53,3 +53,17 @@
 .addons-style-search-bar {
   padding-top: 0;
 }
+
+&#content #psthemecusto {
+  @media (max-width: $screen-xs) {
+    .panel .panel-heading {
+      display: flex;
+      flex-wrap: wrap;
+      padding-top: 5rem;
+
+      .btn.btn-primary {
+        margin: 0.5rem;
+      }
+    }
+  }
+}

--- a/admin-dev/themes/default/scss/partials/_buttons.scss
+++ b/admin-dev/themes/default/scss/partials/_buttons.scss
@@ -55,7 +55,7 @@
   }
 
   &-primary {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     color: $btn-primary-color;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Buttons were not inline anymore when we switched to an uikit like theming
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24501.
| How to test?      | Go on Theme & Logo > Pages configurations and see if buttons are centered and aligned
| Possible impacts? | Design of Theme & Logo > Pages configurations


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24596)
<!-- Reviewable:end -->
