### PR TITLE
FO - Validate field values when creating customer account

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -146,7 +146,7 @@ class CustomerAddressFormCore extends AbstractForm
                 $this->getValue('token')
             );
         } catch (PrestaShopException $e) {
-            $this->errors[] = $this->translator->trans('Could not update your information, please check your data.', [], 'Shop.Notifications.Error');
+            $this->errors[''][] = $this->translator->trans('Could not update your information, please check your data.', [], 'Shop.Notifications.Error');
         }
 
         return false;
@@ -280,7 +280,7 @@ class CustomerAddressFormCore extends AbstractForm
             return false;
         }
         if (!empty($value) && false === (bool) Validate::$validationFunction($value)) {
-            $field->AddError($validationFailMessage);
+            $field->addError($validationFailMessage);
 
             return false;
         }

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -149,7 +149,9 @@ class CustomerFormCore extends AbstractForm
                 'Shop.Notifications.Error'
             ));
         }
+
         $this->validateFieldsLengths();
+        $this->validateFieldsValues();
         $this->validateByModules();
 
         return parent::validate();
@@ -273,6 +275,48 @@ class CustomerFormCore extends AbstractForm
                     array_merge($this->formFields, $validatedCustomerFormFields);
                 }
             }
+        }
+    }
+
+    /**
+     * Performs validation on field values.
+     * Adds error to the field object if value is not as expected.
+     */
+    private function validateFieldsValues(): void
+    {
+        $this->validateFirstname();
+        $this->validateLastname();
+    }
+
+    private function validateFirstname(): void
+    {
+        $field = $this->getField('firstname');
+        if (null === $field) {
+            return;
+        }
+        $value = $field->getValue();
+        if (!empty($value) && false === (bool) Validate::isCustomerName($value)) {
+            $field->AddError($this->translator->trans(
+                'Invalid format.',
+                [],
+                'Shop.Forms.Errors'
+            ));
+        }
+    }
+
+    private function validateLastname(): void
+    {
+        $field = $this->getField('lastname');
+        if (null === $field) {
+            return;
+        }
+        $value = $field->getValue();
+        if (!empty($value) && false === (bool) Validate::isCustomerName($value)) {
+            $field->AddError($this->translator->trans(
+                'Invalid format.',
+                [],
+                'Shop.Forms.Errors'
+            ));
         }
     }
 }

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -143,7 +143,7 @@ class CustomerFormCore extends AbstractForm
         $passwordField = $this->getField('password');
         if ((!empty($passwordField->getValue()) || $this->passwordRequired)
             && Validate::isPasswd($passwordField->getValue()) === false) {
-            $passwordField->AddError($this->translator->trans(
+            $passwordField->addError($this->translator->trans(
                 'Password must be between 5 and 72 characters long',
                 [],
                 'Shop.Notifications.Error'
@@ -221,7 +221,7 @@ class CustomerFormCore extends AbstractForm
                     $this->passwordRequired
                 );
             } catch (PrestaShopException $e) {
-                $this->errors[] = $this->translator->trans('Could not update your information, please check your data.', [], 'Shop.Notifications.Error');
+                $this->errors[''][] = $this->translator->trans('Could not update your information, please check your data.', [], 'Shop.Notifications.Error');
                 $ok = false;
             }
 
@@ -306,7 +306,7 @@ class CustomerFormCore extends AbstractForm
         }
         $value = $field->getValue();
         if (!empty($value) && false === (bool) Validate::isCustomerName($value)) {
-            $field->AddError($this->translator->trans(
+            $field->addError($this->translator->trans(
                 'Invalid format.',
                 [],
                 'Shop.Forms.Errors'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Restore validation on customer account creation form. Pre-validate values before trying to save customer or address to avoid exception raise
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24464 
| How to test?      | See the well described issue


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24599)
<!-- Reviewable:end -->
