### PR TITLE
Make sure array keys exist before using it for PHP7.4 compatibility

### DIFF
--- a/classes/DateRange.php
+++ b/classes/DateRange.php
@@ -58,7 +58,7 @@ class DateRangeCore extends ObjectModel
 		SELECT `id_date_range`, `time_end`
 		FROM `' . _DB_PREFIX_ . 'date_range`
 		WHERE `time_end` = (SELECT MAX(`time_end`) FROM `' . _DB_PREFIX_ . 'date_range`)');
-        if (!$result['id_date_range'] || strtotime($result['time_end']) < strtotime(date('Y-m-d H:i:s'))) {
+        if (!isset($result['id_date_range']) || strtotime($result['time_end']) < strtotime(date('Y-m-d H:i:s'))) {
             // The default range is set to 1 day less 1 second (in seconds)
             $rangeSize = 86399;
             $dateRange = new DateRange();

--- a/classes/ProductSupplier.php
+++ b/classes/ProductSupplier.php
@@ -238,6 +238,10 @@ class ProductSupplierCore extends ObjectModel
         $query->where('id_supplier = ' . (int) $idSupplier);
 
         $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($query);
+        if (empty($row)) {
+            return;
+        }
+
         if ($convertedPrice) {
             return Tools::convertPrice($row['price_te'], $row['id_currency']);
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Never trust an SQL query, it can returns false or nothing.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24557 Fixes #24563
| How to test?      | Both require PHP7.4 and see below
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


## First issue #24557 
Steps to reproduce the behavior:

* Go to BO > Orders > Add new Order page
* Choose a customer
* Search a pack product
* Change a product price to 0 + choose a free carrier
* Or create a cart rule with discount amount > Total + free shipping
* Create the Order
* See error

## Second issue #24563 

* Go to BO > Module Manager page & Search for the statsdata module
* Click on Configure
* Enable "Save global page views " and save
* Click View my shop
* See error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24611)
<!-- Reviewable:end -->
