### PR TITLE
Add router to defined javascript components

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -37,6 +37,7 @@ import TextWithLengthCounter from '@components/form/text-with-length-counter';
 import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field.js';
 import {EventEmitter} from '@components/event-emitter';
+import Router from '@components/router';
 
 const initPrestashopComponents = () => {
   window.prestashop = {...window.prestashop};
@@ -93,6 +94,7 @@ const initPrestashopComponents = () => {
     TextWithLengthCounter,
     MultistoreConfigField,
     PreviewOpener,
+    Router,
   };
 };
 export default initPrestashopComponents;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add Router component to javascript initComponents function, so its available to initiate the router from modules
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Developer can test it by calling `window.prestashop.component.initComponents(['Router']) in any new page javascript. There is related module that uses this and will not work without this PR. (https://github.com/PrestaShop/example-modules/pull/58)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24628)
<!-- Reviewable:end -->
