### PR TITLE
Wrong get and set data for employee options configuration

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsFormDataProvider.php
@@ -52,9 +52,7 @@ final class EmployeeOptionsFormDataProvider implements FormDataProviderInterface
      */
     public function getData()
     {
-        return [
-            'options' => $this->employeeOptionsConfiguration->getConfiguration(),
-        ];
+        return $this->employeeOptionsConfiguration->getConfiguration();
     }
 
     /**
@@ -62,6 +60,6 @@ final class EmployeeOptionsFormDataProvider implements FormDataProviderInterface
      */
     public function setData(array $data)
     {
-        return $this->employeeOptionsConfiguration->updateConfiguration($data['options']);
+        return $this->employeeOptionsConfiguration->updateConfiguration($data);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Do not retrieve data from a custom array, it was the old behavior.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24615
| How to test?      | 1. Go to BO > Advanced Parameters > Team > Employees page<br>2. Try to change `Password regeneration` to 5 min, enable `Memorize the language used in Admin panel forms`<br>3. Save<br>4. See error: no data saved<br>5. try to Sign out from the BO <br>6. Click `I forget my password` and reset it<br>7. Try to reset it again => See error.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24632)
<!-- Reviewable:end -->
