### PR TITLE
Remove irrelevant "todo" reminder

### DIFF
--- a/src/Core/Domain/Product/ValueObject/ProductType.php
+++ b/src/Core/Domain/Product/ValueObject/ProductType.php
@@ -100,8 +100,6 @@ class ProductType
     }
 
     /**
-     * @todo: DTO containing validation looks strange
-     *      Consider adding static factories for each type instead of constructor?
      *
      * @param string $value
      *

--- a/src/Core/Domain/Product/ValueObject/ProductType.php
+++ b/src/Core/Domain/Product/ValueObject/ProductType.php
@@ -100,7 +100,6 @@ class ProductType
     }
 
     /**
-     *
      * @param string $value
      *
      * @throws ProductConstraintException


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove "todo" from ProductType, because the class purpose was changed. Now classs  is Value object and not a simple DTO anymore, so reminder is not relevant anymore.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | There is nothig to test its just a removal of comment in code
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24649)
<!-- Reviewable:end -->
