### PR TITLE
BO - New Order - Warn when product's stock of a pack are empty

### DIFF
--- a/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
@@ -30,6 +30,7 @@ use Attribute;
 use Cart;
 use Context;
 use Customer;
+use Pack;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
@@ -37,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateProductQuantityI
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
@@ -177,18 +179,31 @@ final class UpdateProductQuantityInCartHandler extends AbstractCartHandler imple
      * @param UpdateProductQuantityInCartCommand $command
      *
      * @throws ProductOutOfStockException
+     * @throws PackOutOfStockException
      */
-    private function assertProductIsInStock(Product $product, UpdateProductQuantityInCartCommand $command)
+    private function assertProductIsInStock(Product $product, UpdateProductQuantityInCartCommand $command): void
     {
+        $isAvailableWhenOutOfStock = Product::isAvailableWhenOutOfStock($product->out_of_stock);
         if (null !== $command->getCombinationId()) {
-            $isAvailableWhenOutOfStock = Product::isAvailableWhenOutOfStock($product->out_of_stock);
             $isEnoughQuantity = Attribute::checkAttributeQty(
                 $command->getCombinationId()->getValue(),
                 $command->getNewQuantity()
             );
 
             if (!$isAvailableWhenOutOfStock && !$isEnoughQuantity) {
-                throw new ProductOutOfStockException(sprintf('Product with id "%s" is out of stock, thus cannot be added to cart', $product->id));
+                throw new ProductOutOfStockException(
+                    sprintf('Product with id "%s" is out of stock, thus cannot be added to cart', $product->id)
+                );
+            }
+
+            return;
+        } elseif (Pack::isPack($product->id)) {
+            $hasPackEnoughQuantity = Pack::isInStock($product->id, $command->getNewQuantity());
+
+            if (!$isAvailableWhenOutOfStock && !$hasPackEnoughQuantity) {
+                throw new PackOutOfStockException(
+                    sprintf('Product with id "%s" is out of stock, thus cannot be added to cart', $product->id)
+                );
             }
 
             return;

--- a/src/Core/Domain/Product/Exception/PackOutOfStockException.php
+++ b/src/Core/Domain/Product/Exception/PackOutOfStockException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Exception;
+
+/**
+ * Is thrown when using pack (e.g. adding to cart) which is out of stock
+ */
+class PackOutOfStockException extends ProductOutOfStockException
+{
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -51,6 +51,7 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\FileUploadException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\SpecificPrice\Command\AddSpecificPriceCommand;
@@ -592,6 +593,10 @@ class CartController extends FrameworkBundleAdminController
             ],
             ProductCustomizationNotFoundException::class => $this->trans(
                 'Product customization could not be found. Go to Catalog > Products to customize the product.',
+                'Admin.Catalog.Notification'
+            ),
+            PackOutOfStockException::class => $this->trans(
+                'There are not enough products in stock.',
                 'Admin.Catalog.Notification'
             ),
             ProductOutOfStockException::class => $this->trans(

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -56,6 +56,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForOrderCreation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
@@ -281,6 +282,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
             Cart::resetStaticCache();
         } catch (MinimalQuantityException $e) {
             $this->lastException = $e;
+        } catch (PackOutOfStockException $e) {
+            $this->lastException = $e;
         }
     }
 
@@ -384,7 +387,7 @@ class CartFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @When I select :countryIsoCode address as delivery and invoice address for customer :customerReference in cart :cartReference
-     * @Given cart :cartReference delivery and invoice address country for customer :customeReferenceis is :countryIsoCode
+     * @Given cart :cartReference delivery and invoice address country for customer :customerReference is :countryIsoCode
      *
      * @param string $countryIsoCode
      * @param string $customerReference
@@ -975,12 +978,20 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then I should get error that carrier is invalid
      */
-    public function assertLastErrorIsInvalidCarrier()
+    public function assertLastErrorIsInvalidCarrier(): void
     {
         $this->assertLastErrorIs(
             CartConstraintException::class,
             CartConstraintException::INVALID_CARRIER
         );
+    }
+
+    /**
+     * @Then I should get an error that you have the maximum quantity available for this pack
+     */
+    public function assertLastErrorMaxQuantityAvailableForThisProduct(): void
+    {
+        $this->assertLastErrorIs(PackOutOfStockException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Updating/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Updating/Product/update_pack.feature
@@ -1,0 +1,133 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-updating-product-pack
+@reset-database-before-feature
+@cart-updating-product-pack
+Feature: Add product pack in cart
+  As a customer
+  I must be able to correctly update product packs in my cart
+
+  Background:
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And country "US" is enabled
+    Given I create an empty cart "cart_pack" for customer "testCustomer"
+    And there is a product in the catalog named "product_in_pack_1" with a price of 12.34 and 10 items in stock
+    And there is a product in the catalog named "product_in_pack_2" with a price of 56.78 and 10 items in stock
+    And there is a product in the catalog named "product_pack" with a price of 90.12 and 10 items in stock
+    And product "product_pack" is a pack containing 1 items of product "product_in_pack_1"
+    And product "product_pack" is a pack containing 2 items of product "product_in_pack_2"
+    Then the available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to deny order and only pack is decremented
+    # As I check pack stock 10 is the limit
+    Given the product "product_pack" denies order if out of stock
+    And the pack "product_pack" decrements pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 11
+    Then I should get an error that you have the maximum quantity available for this pack
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 10
+    Then I should get no error
+    And the remaining available stock for product "product_pack" should be 0
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    And cart "cart_pack" should contain product "product_pack"
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to deny order and only products in pack is decremented
+    # As I check products stock, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" denies order if out of stock
+    And the pack "product_pack" decrements products in pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 6
+    Then I should get an error that you have the maximum quantity available for this pack
+    And cart "cart_pack" should not contain product "product_pack"
+    ## The stock of pack is calculated from the stock of its unit
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 5
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 0
+    And the remaining available stock for product "product_in_pack_1" should be 5
+    And the remaining available stock for product "product_in_pack_2" should be 0
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to deny order and both packs and products are decremented
+    # As I check both, the products stock is limiting, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" denies order if out of stock
+    And the pack "product_pack" decrements both packs and products
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 6
+    Then I should get an error that you have the maximum quantity available for this pack
+    And cart "cart_pack" should not contain product "product_pack"
+    ## The stock of pack is calculated from the stock of its unit
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 5
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to allow order and only pack is decremented
+    # As I check pack stock 10 is the limit
+    Given the product "product_pack" allows order if out of stock
+    And the pack "product_pack" decrements pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 11
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be -1
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to allow order and only products in pack is decremented
+    # As I check products stock, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" allows order if out of stock
+    And the pack "product_pack" decrements products in pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 6
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be -1
+    And the remaining available stock for product "product_in_pack_1" should be 4
+    And the remaining available stock for product "product_in_pack_2" should be -2
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to allow order and both packs and products are decremented
+    # As I check both, the products stock is limiting, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" allows order if out of stock
+    And the pack "product_pack" decrements both packs and products
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 11
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be -6
+    And the remaining available stock for product "product_in_pack_1" should be -1
+    And the remaining available stock for product "product_in_pack_2" should be -12
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -54,10 +54,11 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\OrderFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\EmployeeFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
         order:
             paths:
                 - %paths.base%/Features/Scenario/Order


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | BO - New Order - Warn when product's stock of a pack are empty but the stock of a pack is not empty
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24553
| How to test?      | Cf. #24553


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24657)
<!-- Reviewable:end -->
