### PR TITLE
Display tab for extra modules in product page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.js
@@ -32,6 +32,7 @@ import CustomizationsManager from '@pages/product/edit/customizations-manager';
 import FeatureValuesManager from '@pages/product/edit/feature-values-manager';
 import ProductFooterManager from '@pages/product/edit/product-footer-manager';
 import ProductFormModel from '@pages/product/edit/product-form-model';
+import ProductModulesManager from '@pages/product/edit/product-modules-manager';
 import ProductPartialUpdater from '@pages/product/edit/product-partial-updater';
 import ProductSEOManager from '@pages/product/edit/product-seo-manager';
 import ProductSuppliersManager from '@pages/product/edit/product-suppliers-manager';
@@ -77,6 +78,7 @@ $(() => {
   new ProductTypeManager($(ProductMap.productTypeSelector), $productForm);
   new CategoriesManager(eventEmitter);
   new ProductFooterManager();
+  new ProductModulesManager();
 
   const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);
   new ProductPartialUpdater(

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-modules-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-modules-manager.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import ProductMap from '@pages/product/product-map';
+
+export default class ProductModulesManager {
+  constructor() {
+    this.$previewContainer = $(ProductMap.modules.previewContainer);
+    this.$selectorContainer = $(ProductMap.modules.selectorContainer);
+    this.$contentContainer = $(ProductMap.modules.contentContainer);
+    this.$moduleSelector = $(ProductMap.modules.moduleSelector);
+    this.$selectorPreviews = $(ProductMap.modules.selectorPreviews);
+    this.$moduleContents = $(ProductMap.modules.moduleContents);
+
+    this.init();
+
+    return {};
+  }
+
+  /**
+   * @private
+   */
+  init() {
+    this.$previewContainer.removeClass('d-none');
+    this.$selectorContainer.addClass('d-none');
+    this.$contentContainer.addClass('d-none');
+    this.$selectorPreviews.addClass('d-none');
+    this.$moduleContents.addClass('d-none');
+
+    this.$previewContainer.on('click', ProductMap.modules.previewButton, (event) => {
+      const $button = $(event.target);
+      this.selectModule($button.data('target'));
+    });
+
+    this.$moduleSelector.on('change', () => this.showSelectedModule());
+  }
+
+  /**
+   * @param {string} moduleId
+   *
+   * @private
+   */
+  selectModule(moduleId) {
+    this.$previewContainer.addClass('d-none');
+    this.$selectorContainer.removeClass('d-none');
+    this.$contentContainer.removeClass('d-none');
+
+    this.$moduleSelector.val(moduleId);
+    // trigger change because this is a select2 component, and module is switched when change even triggers
+    this.$moduleSelector.trigger('change');
+  }
+
+  /**
+   * @private
+   */
+  showSelectedModule() {
+    this.$selectorPreviews.addClass('d-none');
+    this.$moduleContents.addClass('d-none');
+
+    const moduleId = this.$moduleSelector.val();
+    $(ProductMap.modules.selectorPreview(moduleId)).removeClass('d-none');
+    $(ProductMap.modules.moduleContent(moduleId)).removeClass('d-none');
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.js
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.js
@@ -179,4 +179,15 @@ export default {
     expandAllButton: '#categories-tree-expand',
     reduceAllButton: '#categories-tree-reduce',
   },
+  modules: {
+    previewContainer: '.module-render-container.all-modules',
+    previewButton: '.modules-list-button',
+    selectorContainer: '.module-selection',
+    moduleSelector: '.modules-list-select',
+    selectorPreviews: '.module-selection .module-render-container',
+    selectorPreview: (moduleId) => `.module-selection .module-render-container.${moduleId}`,
+    contentContainer: '.module-contents',
+    moduleContents: '.module-contents .module-render-container',
+    moduleContent: (moduleId) => `.module-contents .module-render-container.${moduleId}`,
+  },
 };

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -986,7 +986,8 @@ $product-page-padding-bottom: 80px !default;
   }
 
   /* Last tab modules selection */
-  #hooks.form-contenttab {
+  #hooks.form-contenttab,
+  #modules-tab {
     .top-logo {
       float: left;
       max-width: 45px;

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1046,6 +1046,12 @@ $product-page-padding-bottom: 80px !default;
   }
 }
 
+.product-page-v2 {
+  .maxLength {
+    float: none;
+  }
+}
+
 #external-combination-tab {
   padding-bottom: $product-page-padding-bottom;
   margin-top: -$product-page-padding-bottom;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
@@ -1,0 +1,62 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div class="row module-selection d-none">
+  <div class="col-md-12 col-lg-7">
+    {% for module in extraModules %}
+      <div class="module-render-container module-{{ module.attributes.name }}">
+        <div>
+          <img class="top-logo" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
+          <h2 class="text-ellipsis module-name-grid">
+            {{ module.attributes.displayName }}
+          </h2>
+          <div class="text-ellipsis small-text module-version">
+            {{ module.attributes.version }} by {{ module.attributes.author }}
+          </div>
+        </div>
+        <div class="small no-padding">
+          {{ module.attributes.description }}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+
+  <div class="col-md-12 col-lg-5">
+    <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+    <select class="modules-list-select" data-toggle="select2">
+      {% for module in extraModules %}
+        <option value="module-{{ module.attributes.name }}">{{ module.attributes.displayName }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</div>
+
+<div class="module-contents d-none">
+  {% for module in extraModules %}
+    <div id="module_{{ module.id }}" class="module-render-container module-{{ module.attributes.name }}">
+      {{ module.content|raw }}
+    </div>
+  {% endfor %}
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig
@@ -1,0 +1,60 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div class="module-render-container all-modules">
+  <p>
+    <h2>{{ 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+    {{ 'These modules are relative to the product page of your shop.'|trans({}, 'Admin.Catalog.Feature') }}<br />
+    {{ 'To manage all your modules go to the [1]Installed module page[/1]'|trans({}, 'Admin.Catalog.Feature')|replace({'[1]': '<a href="' ~ path("admin_module_manage") ~ '">', '[/1]': '</a>'})|raw }}
+  </p>
+
+  <div class="row">
+    {% for module in extraModules %}
+      <div class="col-md-12 col-lg-6 col-xl-4">
+        <div class="module-item-wrapper-grid">
+          <div class="module-item-heading-grid">
+            <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
+            <h3 class="text-ellipsis module-name-grid">
+              {{ module.attributes.displayName }}
+            </h3>
+            <div class="text-ellipsis small-text module-version-author-grid">
+              {{ module.attributes.version }} by {{ module.attributes.author }}
+            </div>
+          </div>
+          <div class="module-quick-description-grid small no-padding">
+            {{ module.attributes.description }}
+          </div>
+          <div class="module-container">
+            <div class="module-quick-action-grid clearfix">
+              <button type="button" class="modules-list-button btn btn-outline-primary pull-xs-right" data-target="module-{{ module.id }}">
+                {{ 'Configure'|trans({}, 'Admin.Actions') }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -89,7 +89,7 @@
       </a>
     </li>
 
-    {% if hooksarraycontent(hooks) is not empty %}
+    {% if hooksarraycontent(extraHooks) is not empty %}
       <li id="hooks-tab-nav" class="nav-item">
         <a href="#hooks-tab" role="tab" data-toggle="tab" class="nav-link">
           {{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -89,9 +89,9 @@
       </a>
     </li>
 
-    {% if hooksarraycontent(extraHooks) is not empty %}
-      <li id="hooks-tab-nav" class="nav-item">
-        <a href="#hooks-tab" role="tab" data-toggle="tab" class="nav-link">
+    {% if hooksarraycontent(extraModulesHooks) is not empty %}
+      <li id="modules-tab-nav" class="nav-item">
+        <a href="#modules-tab" role="tab" data-toggle="tab" class="nav-link">
           {{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}
         </a>
       </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -77,7 +77,7 @@
       </a>
     </li>
 
-    <li id="options-tab-nav" class="nav-item{% if not isSEOTabValid %} has-error{% endif %}">
+    <li id="seo-tab-nav" class="nav-item{% if not isSEOTabValid %} has-error{% endif %}">
       <a href="#seo-tab" role="tab" data-toggle="tab" class="nav-link">
         {{ 'SEO'|trans({}, 'Admin.Catalog.Feature') }}
       </a>
@@ -88,6 +88,14 @@
         {{ 'Options'|trans({}, 'Admin.Global') }}
       </a>
     </li>
+
+    {% if hooksarraycontent(hooks) is not empty %}
+      <li id="hooks-tab-nav" class="nav-item">
+        <a href="#hooks-tab" role="tab" data-toggle="tab" class="nav-link">
+          {{ 'Modules'|trans({}, 'Admin.Catalog.Feature') }}
+        </a>
+      </li>
+    {% endif %}
   </ul>
 
   <div class="arrow d-xl-none js-arrow right-arrow visible float-right">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% if hooksarraycontent(hooks) is not empty %}
+{% if hooksarraycontent(extraHooks) is not empty %}
 <div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="hooks-tab">
   {{ include('@PrestaShop/Admin/Common/unavailable-feature.html.twig', {
     'featureTitle': 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% if hooksarraycontent(hooks) is not empty %}
-<div role="tabpanel" class="form-contenttab tab-pane container-fluid active" id="hooks-tab">
+<div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="hooks-tab">
   {{ include('@PrestaShop/Admin/Common/unavailable-feature.html.twig', {
     'featureTitle': 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature'),
   }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig
@@ -1,0 +1,32 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% if hooksarraycontent(hooks) is not empty %}
+<div role="tabpanel" class="form-contenttab tab-pane container-fluid active" id="hooks-tab">
+  {{ include('@PrestaShop/Admin/Common/unavailable-feature.html.twig', {
+    'featureTitle': 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature'),
+  }) }}
+</div>
+{% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/modules.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Tabs/modules.html.twig
@@ -23,10 +23,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% if hooksarraycontent(extraHooks) is not empty %}
-<div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="hooks-tab">
-  {{ include('@PrestaShop/Admin/Common/unavailable-feature.html.twig', {
-    'featureTitle': 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature'),
+{% if hooksarraycontent(extraModulesHooks) is not empty %}
+<div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="modules-tab">
+  {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig', {
+    'extraModules': extraModulesHooks,
+  }) }}
+
+  {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig', {
+    'extraModules': extraModulesHooks,
   }) }}
 </div>
 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -38,6 +38,7 @@
 {% block content %}
   {% set productType = productForm.vars.product_type %}
   {% set productId = productForm.vars.product_id %}
+  {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
 
   {{ form_start(productForm, {'attr': {
     'class': 'form-horizontal product-page product-page-v2 row justify-content-md-center', 'novalidate': 'novalidate',
@@ -71,7 +72,8 @@
     {% block product_tabs_container %}
       {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig', {
         'productForm': productForm,
-        'productType': productType
+        'productType': productType,
+        'hooks': hooks
       }) }}
     {% endblock %}
 
@@ -120,7 +122,11 @@
         }) }}
       {% endblock %}
 
-      {% block product_extra_tabs %}
+      {% block product_extra_tab %}
+        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig', {
+          'productForm': productForm,
+          'hooks': hooks,
+        }) }}
       {% endblock %}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -38,7 +38,7 @@
 {% block content %}
   {% set productType = productForm.vars.product_type %}
   {% set productId = productForm.vars.product_id %}
-  {% set hooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
+  {% set extraHooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
 
   {{ form_start(productForm, {'attr': {
     'class': 'form-horizontal product-page product-page-v2 row justify-content-md-center', 'novalidate': 'novalidate',
@@ -73,7 +73,7 @@
       {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig', {
         'productForm': productForm,
         'productType': productType,
-        'hooks': hooks
+        'extraHooks': extraHooks
       }) }}
     {% endblock %}
 
@@ -125,7 +125,7 @@
       {% block product_extra_tab %}
         {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig', {
           'productForm': productForm,
-          'hooks': hooks,
+          'extraHooks': extraHooks,
         }) }}
       {% endblock %}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -38,7 +38,7 @@
 {% block content %}
   {% set productType = productForm.vars.product_type %}
   {% set productId = productForm.vars.product_id %}
-  {% set extraHooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
+  {% set extraModulesHooks = renderhooksarray('displayAdminProductsExtra', { 'id_product': productId }) %}
 
   {{ form_start(productForm, {'attr': {
     'class': 'form-horizontal product-page product-page-v2 row justify-content-md-center', 'novalidate': 'novalidate',
@@ -73,7 +73,7 @@
       {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig', {
         'productForm': productForm,
         'productType': productType,
-        'extraHooks': extraHooks
+        'extraModulesHooks': extraModulesHooks
       }) }}
     {% endblock %}
 
@@ -123,9 +123,9 @@
       {% endblock %}
 
       {% block product_extra_tab %}
-        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/hooks.html.twig', {
+        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Tabs/modules.html.twig', {
           'productForm': productForm,
-          'extraHooks': extraHooks,
+          'extraModulesHooks': extraModulesHooks,
         }) }}
       {% endblock %}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -40,7 +40,7 @@
   {% set productId = productForm.vars.product_id %}
 
   {{ form_start(productForm, {'attr': {
-    'class': 'form-horizontal product-page row justify-content-md-center', 'novalidate': 'novalidate',
+    'class': 'form-horizontal product-page product-page-v2 row justify-content-md-center', 'novalidate': 'novalidate',
     'data-product-id': productId,
     'data-product-type': productType
   }}) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Display tab for modules in product page
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24249
| How to test?      | You will need modules that are displayed in the extra modules Tab (for example `blockyoutubevideos` and `colissimo`)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24661)
<!-- Reviewable:end -->
