### PR TITLE
Fix dropzone component design on product page v2

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -598,6 +598,7 @@
 
       &.openfilemanager {
         border-style: dashed;
+        min-width: 130px;
 
         &:hover {
           border-style: solid;
@@ -683,6 +684,7 @@
     align-items: flex-start;
     justify-content: space-between;
     border-radius: 4px;
+    flex-wrap: wrap;
 
     @include media-breakpoint-down(xs) {
       flex-wrap: wrap;
@@ -694,6 +696,10 @@
         height: 100px;
         min-height: 100px;
         margin: 0.5rem;
+
+        &.openfilemanager {
+          min-width: 100px;
+        }
 
         img {
           max-width: 100%;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Dropzone design on product page v2 was broken
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24664.
| How to test?      | Go on product page v2 an try to add 3+ images, the design should be fine, also click on one image to open the window and check design, also check on mobile
| Possible impacts? | Product page v2 dropzone component


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24665)
<!-- Reviewable:end -->
