### PR TITLE
Order detail product price

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3392,7 +3392,7 @@ class ProductCore extends ObjectModel
             $sql->innerJoin('product_shop', 'product_shop', '(product_shop.id_product=p.id_product AND product_shop.id_shop = ' . (int) $id_shop . ')');
             $sql->where('p.`id_product` = ' . (int) $id_product);
             if (Combination::isFeatureActive()) {
-                $sql->select('IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, product_attribute_shop.`price` AS attribute_price, product_attribute_shop.default_on');
+                $sql->select('IFNULL(product_attribute_shop.id_product_attribute,0) id_product_attribute, product_attribute_shop.`price` AS attribute_price, product_attribute_shop.default_on, product_attribute_shop.`ecotax` AS attribute_ecotax');
                 $sql->leftJoin('product_attribute_shop', 'product_attribute_shop', '(product_attribute_shop.id_product = p.id_product AND product_attribute_shop.id_shop = ' . (int) $id_shop . ')');
             } else {
                 $sql->select('0 as id_product_attribute');
@@ -3406,6 +3406,7 @@ class ProductCore extends ObjectModel
                         'price' => $row['price'],
                         'ecotax' => $row['ecotax'],
                         'attribute_price' => (isset($row['attribute_price']) ? $row['attribute_price'] : null),
+                        'attribute_ecotax' => (isset($row['attribute_ecotax']) ? $row['attribute_ecotax'] : null),
                     ];
                     self::$_pricesLevel2[$cache_id_2][(int) $row['id_product_attribute']] = $array_tmp;
 

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -64,7 +64,11 @@ class OrderDetailCore extends ObjectModel
     /** @var int */
     public $product_quantity_reinjected;
 
-    /** @var float Without taxes, includes ecotax */
+    /**
+     * @deprecated Use unit_price_tax_excl instead
+     *
+     * @var float Without taxes, includes ecotax
+     */
     public $product_price;
 
     /** @var float */
@@ -628,7 +632,7 @@ class OrderDetailCore extends ObjectModel
         $this->setContext((int) $product['id_shop']);
         Product::getPriceStatic((int) $product['id_product'], true, (int) $product['id_product_attribute'], 6, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{Configuration::get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, $this->context);
         $this->specificPrice = $specific_price;
-        $this->product_price = $this->original_product_price = Product::getPriceStatic(
+        $this->original_product_price = Product::getPriceStatic(
             $product['id_product'],
             false,
             (int) $product['id_product_attribute'],
@@ -647,7 +651,7 @@ class OrderDetailCore extends ObjectModel
             $this->context
         );
         $this->unit_price_tax_incl = (float) $product['price_wt'];
-        $this->unit_price_tax_excl = (float) $product['price'];
+        $this->product_price = $this->unit_price_tax_excl = (float) $product['price'];
         $this->total_price_tax_incl = (float) $product['total_wt'];
         $this->total_price_tax_excl = (float) $product['total'];
 

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -65,7 +65,7 @@ class OrderDetailCore extends ObjectModel
     public $product_quantity_reinjected;
 
     /**
-     * @deprecated Use unit_price_tax_excl instead
+     * @deprecated since 1.5 Use unit_price_tax_excl instead
      *
      * @var float Without taxes, includes ecotax
      */

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -132,8 +132,8 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And cart rule "CartRuleAmountOnSelectedProduct" is restricted to product "Test Product With Discount and SpecificPrice"
     When I add products to order "bo_order1" with new invoice and the following products details:
       | name          | Test Product With Discount and SpecificPrice |
-      | amount        | 2                                     |
-      | price         | 120                                   |
+      | amount        | 2                                            |
+      | price         | 120                                          |
     Then product "Test Product With Discount and SpecificPrice" in order "bo_order1" should have no specific price
 #    For product "Test Product With Discount and SpecificPrice"
 #    Due to the specific price 25% of €160, the customer have to pay 75% of the product price : €120
@@ -155,6 +155,7 @@ Feature: Multiple currencies for Order in Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2        |
       | product_price               | 119.00   |
+      | original_product_price      | 119.00   |
       | unit_price_tax_incl         | 126.14   |
       | unit_price_tax_excl         | 119.00   |
       | total_price_tax_incl        | 252.28   |
@@ -226,12 +227,13 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | price         | 11.90                   |
     Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 3     |
-      | product_price               | 11.90 |
+      | product_quantity            | 3      |
+      | original_product_price      | 119.00 |
+      | product_price               | 11.90  |
       | unit_price_tax_incl         | 12.614 |
-      | unit_price_tax_excl         | 11.90 |
-      | total_price_tax_incl        | 37.84 |
-      | total_price_tax_excl        | 35.70 |
+      | unit_price_tax_excl         | 11.90  |
+      | total_price_tax_incl        | 37.84  |
+      | total_price_tax_excl        | 35.70  |
     And order "bo_order1" should have following details:
       | total_products           | 35.70 |
       | total_products_wt        | 37.84 |
@@ -248,12 +250,13 @@ Feature: Multiple currencies for Order in Back Office (BO)
       | price         | 20.00                   |
     Then order "bo_order1" should contain 3 products "Mug The best is yet to come"
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
-      | product_quantity            | 3     |
-      | product_price               | 20.00 |
-      | unit_price_tax_incl         | 21.20 |
-      | unit_price_tax_excl         | 20.00 |
-      | total_price_tax_incl        | 63.60 |
-      | total_price_tax_excl        | 60.00 |
+      | product_quantity            | 3      |
+      | original_product_price      | 119.00 |
+      | product_price               | 20.00  |
+      | unit_price_tax_incl         | 21.20  |
+      | unit_price_tax_excl         | 20.00  |
+      | total_price_tax_incl        | 63.60  |
+      | total_price_tax_excl        | 60.00  |
     And order "bo_order1" should have following details:
       | total_products           | 60.00 |
       | total_products_wt        | 63.60 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_combination.feature
@@ -25,11 +25,11 @@ Feature: Ecotax for Order in Back Office (BO)
     ## Create Product
     And there is a product in the catalog named "Test Ecotax Product Combination" with a price of 15.0 and 100 items in stock
     And I set tax rule group "fr-tax-6-group" to product "Test Ecotax Product Combination"
-    ## Create combination
+    ## Create combination (remember that price column is actually the impact on price)
     And product "Test Ecotax Product Combination" has combinations with following details:
       | reference    | quantity | price | attributes |
-      | combination1 | 100      | 16.0  | Size:L     |
-      | combination2 | 100      | 17.0  | Size:M     |
+      | combination1 | 100      | 1.0   | Size:L     |
+      | combination2 | 100      | 2.0   | Size:M     |
     Then the available stock for combination "combination1" of product "Test Ecotax Product Combination" should be 100
     And the available stock for combination "combination2" of product "Test Ecotax Product Combination" should be 100
     ## Enable payment
@@ -73,6 +73,7 @@ Feature: Ecotax for Order in Back Office (BO)
     And product "Test Ecotax Product Combination" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | ecotax                      | 0.00  |
+      | original_product_price      | 16.00 |
       | product_price               | 16.00 |
       | unit_price_tax_excl         | 16.00 |
       | unit_price_tax_incl         | 16.96 |
@@ -114,6 +115,8 @@ Feature: Ecotax for Order in Back Office (BO)
       | product_quantity            | 2     |
       | ecotax                      | 5.12  |
       | product_price               | 21.12 |
+      # 21.12 = 16 + 5.12
+      | original_product_price      | 21.12 |
       # 21.12 = 16 + 5.12
       | unit_price_tax_excl         | 21.12 |
       # 21.12 = 16 + 5.12
@@ -163,6 +166,8 @@ Feature: Ecotax for Order in Back Office (BO)
       | ecotax                      | 5.12      |
       | product_price               | 20.83     |
       # 20.83 = 15.71 + 5.12
+      | original_product_price      | 21.12     |
+      # 21.12 = 16 + 5.12
       | unit_price_tax_excl         | 20.83     |
       # 20.83 = 15.71 + 5.12
       | unit_price_tax_incl         | 21.7726   |
@@ -226,6 +231,8 @@ Feature: Ecotax for Order in Back Office (BO)
       | ecotax                      | 5.12      |
       | product_price               | 24.99     |
       # 24.99 = 19.87 + 5.12
+      | original_product_price      | 21.12     |
+      # 21.12 = 16 + 5.12
       | unit_price_tax_excl         | 24.99     |
       # 24.99 = 19.87 + 5.12
       | unit_price_tax_incl         | 26.1822   |
@@ -288,6 +295,8 @@ Feature: Ecotax for Order in Back Office (BO)
       | ecotax                      | 5.12       |
       | product_price               | 20.12      |
       # 20.12 = 15 + 5.12
+      | original_product_price      | 21.12      |
+      # 21.12 = 16 + 5.12
       | unit_price_tax_excl         | 20.12      |
       # 20.12 = 15 + 5.12
       | unit_price_tax_incl         | 21.02      |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_french_tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_french_tax.feature
@@ -42,6 +42,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 11.90 |
+      | original_product_price      | 11.90 |
       | unit_price_tax_incl         | 14.28 |
       | unit_price_tax_excl         | 11.90 |
       | total_price_tax_incl        | 28.56 |
@@ -88,7 +89,7 @@ Feature: Order from Back Office (BO)
       | amount         | 2                       |
       | price          | 83.33                   |
       | price_tax_incl | 100.00                  |
-    # product_price is computed for backward compatibility which is why it is rounded
+    # product_price is computed for backward compatibility which is why it is rounded (database value is correct though)
     And the product "Mug The best is yet to come" in the first invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 2         |
       | product_price               | 83.33     |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -345,6 +345,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 3      |
       | product_price               | 11.90  |
+      | original_product_price      | 11.90  |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.90  |
       | total_price_tax_incl        | 37.84  |
@@ -389,6 +390,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.9   |
+      | original_product_price      | 11.90  |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.9   |
       | total_price_tax_incl        | 25.230000 |
@@ -414,6 +416,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.9   |
+      | original_product_price      | 11.90  |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.9   |
       | total_price_tax_incl        | 25.23  |
@@ -518,6 +521,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.90  |
+      | original_product_price      | 11.90  |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.90  |
       | total_price_tax_incl        | 25.23  |
@@ -528,6 +532,7 @@ Feature: Order from Back Office (BO)
       | price          | 94.34                   |
       | price_tax_incl | 100                     |
     When I generate invoice for "bo_order1" order
+    # product_price is computed for backward compatibility which is why it is rounded (database value is correct though)
     Then the product "Mug The best is yet to come" in the first invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1         |
       | product_price               | 94.34     |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
@@ -46,6 +46,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -95,6 +96,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -120,6 +122,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -152,6 +155,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -199,6 +203,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -236,6 +241,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the first invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -243,6 +249,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the second invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -268,6 +275,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the first invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -275,6 +283,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the second invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -311,6 +320,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the first invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -318,6 +328,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the second invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -344,6 +355,7 @@ Feature: Order from Back Office (BO)
     And the product "Test Product Gifted" in the second invoice from the order "bo_order1" should have the following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -380,6 +392,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -387,6 +400,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -459,6 +473,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -466,6 +481,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -523,6 +539,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -530,6 +547,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -556,6 +574,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -592,6 +611,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -618,6 +638,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -625,6 +646,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -650,6 +672,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -687,6 +710,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -694,6 +718,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -719,6 +744,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -757,6 +783,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -764,6 +791,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -789,6 +817,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -829,6 +858,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -836,6 +866,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -863,6 +894,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 15.90 |
@@ -870,6 +902,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -895,6 +928,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -902,6 +936,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -927,6 +962,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product With Auto Gift" in order "bo_order1" has following details:
       | product_quantity            | 1     |
       | product_price               | 12.00 |
+      | original_product_price      | 12.00 |
       | unit_price_tax_incl         | 12.72 |
       | unit_price_tax_excl         | 12.00 |
       | total_price_tax_incl        | 12.72 |
@@ -964,6 +1000,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -1010,6 +1047,7 @@ Feature: Order from Back Office (BO)
     And product "Test Product Gifted" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -1054,6 +1092,7 @@ Feature: Order from Back Office (BO)
     And product "gifted product" in order "bo_order1" has following details:
       | product_quantity            | 2     |
       | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
       | unit_price_tax_incl         | 15.90 |
       | unit_price_tax_excl         | 15.00 |
       | total_price_tax_incl        | 31.80 |
@@ -1208,6 +1247,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.72 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 12.72 |
@@ -1215,6 +1255,7 @@ Feature: Order from Back Office (BO)
     And product "Gift product" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 13.00 |
+      | original_product_price   | 13.00 |
       | unit_price_tax_incl      | 13.78 |
       | unit_price_tax_excl      | 13.00 |
       | total_price_tax_incl     | 13.78 |
@@ -1246,6 +1287,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.00 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 12.00 |
@@ -1277,6 +1319,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.72 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 12.72 |
@@ -1284,6 +1327,7 @@ Feature: Order from Back Office (BO)
     And product "Gift product" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 13.00 |
+      | original_product_price   | 13.00 |
       | unit_price_tax_incl      | 13.78 |
       | unit_price_tax_excl      | 13.00 |
       | total_price_tax_incl     | 13.78 |
@@ -1326,6 +1370,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 3     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.72 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 38.16 |
@@ -1333,6 +1378,7 @@ Feature: Order from Back Office (BO)
     And product "Gift product" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 13.00 |
+      | original_product_price   | 13.00 |
       | unit_price_tax_incl      | 13.78 |
       | unit_price_tax_excl      | 13.00 |
       | total_price_tax_incl     | 13.78 |
@@ -1357,6 +1403,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.72 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 12.72 |
@@ -1381,6 +1428,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 3     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.72 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 38.16 |
@@ -1388,6 +1436,7 @@ Feature: Order from Back Office (BO)
     And product "Gift product" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 13.00 |
+      | original_product_price   | 13.00 |
       | unit_price_tax_incl      | 13.78 |
       | unit_price_tax_excl      | 13.00 |
       | total_price_tax_incl     | 13.78 |
@@ -1429,6 +1478,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 12.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 12.72 |
       | unit_price_tax_excl      | 12.00 |
       | total_price_tax_incl     | 12.72 |
@@ -1453,6 +1503,7 @@ Feature: Order from Back Office (BO)
     And product "Product 12345" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 30.00 |
+      | original_product_price   | 12.00 |
       | unit_price_tax_incl      | 31.80 |
       | unit_price_tax_excl      | 30.00 |
       | total_price_tax_incl     | 31.80 |
@@ -1460,6 +1511,7 @@ Feature: Order from Back Office (BO)
     And product "Gift product" in order "bo_order1" has following details:
       | product_quantity         | 1     |
       | product_price            | 13.00 |
+      | original_product_price   | 13.00 |
       | unit_price_tax_incl      | 13.78 |
       | unit_price_tax_excl      | 13.00 |
       | total_price_tax_incl     | 13.78 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -43,6 +43,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 3      |
       | product_price               | 11.90  |
+      | original_product_price      | 11.90 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.90  |
       | total_price_tax_incl        | 37.84  |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_odd_tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_odd_tax.feature
@@ -93,7 +93,7 @@ Feature: Order from Back Office (BO)
       | price          | 7.80 |
       | price_tax_incl | 9.44 |
     Then product "Test Product With Odd Tax" in order "bo_order1" should have no specific price
-    # product_price is computed for backward compatibility which is why it is rounded
+    # product_price is computed for backward compatibility which is why it is rounded (database value is correct though)
     And product "Test Product With Odd Tax" in order "bo_order1" has following details:
       | product_quantity            | 80     |
       | product_price               | 7.80   |
@@ -167,7 +167,7 @@ Feature: Order from Back Office (BO)
       | amount         | 80    |
       | price          | 78.02 |
       | price_tax_incl | 94.40 |
-    # product_price is computed for backward compatibility which is why it is rounded
+    # product_price is computed for backward compatibility which is why it is rounded (database value is correct though)
     And product "Test Product With Odd Tax" in order "bo_order1" has following details:
       | product_quantity            | 80        |
       | product_price               | 78.02     |
@@ -242,7 +242,7 @@ Feature: Order from Back Office (BO)
       | amount         | 80   |
       | price          | 7.85 |
       | price_tax_incl | 9.50 |
-    # product_price is computed for backward compatibility which is why it is rounded
+    # product_price is computed for backward compatibility which is why it is rounded (database value is correct though)
     And product "Test Product With Odd Tax" in order "bo_order1" has following details:
       | product_quantity            | 80       |
       | product_price               | 7.85     |
@@ -269,7 +269,7 @@ Feature: Order from Back Office (BO)
       | amount         | 80   |
       | price          | 7.44 |
       | price_tax_incl | 9.00 |
-    # product_price is computed for backward compatibility which is why it is rounded
+    # product_price is computed for backward compatibility which is why it is rounded (database value is correct though)
     And product "Test Product With Odd Tax" in order "bo_order1" has following details:
       | product_quantity            | 80       |
       | product_price               | 7.44     |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -448,6 +448,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -483,6 +484,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -512,6 +514,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
@@ -554,6 +557,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -588,6 +592,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -616,6 +621,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
@@ -652,6 +658,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -678,6 +685,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -708,6 +716,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -755,6 +764,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
@@ -803,6 +813,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.614 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.230 |
@@ -844,6 +855,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
@@ -896,6 +908,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800 |
@@ -944,6 +957,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 12.610000 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 25.220000 |
@@ -985,6 +999,7 @@ Feature: Order from Back Office (BO)
     And product "Mug The best is yet to come" in order "bo_order1" has following details:
       | product_quantity            | 2      |
       | product_price               | 11.900 |
+      | original_product_price      | 11.900 |
       | unit_price_tax_incl         | 11.900 |
       | unit_price_tax_excl         | 11.900 |
       | total_price_tax_incl        | 23.800000 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | `OrderDetail::product_price` is actually a deprecated field and is synonym to `OrderDetail::unit_price_tax_excl` This PR fixes some issues in the creation of OrderDetail so that the two values are always in sync It was already handled in `Order::getProducts` (see link below) but now the database is also correctly synced<br>Also this PR includes a fix in the ecotax computation of combination price which caused `OrderDetail::original_product_price` to be incorrect (ecotax was absent)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #24529
| How to test?      | Unlike what was stated in the original issue `OrderDetail::product_price` shouldn't be equal to `OrderDetail::original_product_price` but rather to `OrderDetail::unit_price_tax_excl`
| Possible impacts? | This PR might fix some bugs related to ecotax and combinations, although most of the time the computation seemed to be correct (based on existing behat tests) so it's probably computed differently for regular prices but a mistake was still present in the computation of original_product_price


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Here is the code that ensures `OrderDetail::original_product_price` and `OrderDetail::unit_price_tax_excl` are equal when getting order products, so the database should be equal as well
https://github.com/PrestaShop/PrestaShop/blob/948ecce8461176c507512c977633731bc3550a24/classes/order/Order.php#L607

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24675)
<!-- Reviewable:end -->