### PR TITLE
Remove addons modules on install and add postinstall execution

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -459,6 +459,11 @@ abstract class ModuleCore implements ModuleInterface
         return true;
     }
 
+    public function postInstall(): bool
+    {
+        return true;
+    }
+
     public function checkCompliancy()
     {
         if (version_compare(_PS_VERSION_, $this->ps_versions_compliancy['min'], '<') || version_compare(_PS_VERSION_, $this->ps_versions_compliancy['max'], '>')) {

--- a/composer.lock
+++ b/composer.lock
@@ -6399,16 +6399,16 @@
         },
         {
             "name": "prestashop/welcome",
-            "version": "v6.0.4",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/welcome.git",
-                "reference": "2634da35dec6c52a8c3a18dfcf051dbbb6b48edc"
+                "reference": "0113fcb5650a632e5acca6f359b40a5627575351"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/welcome/zipball/2634da35dec6c52a8c3a18dfcf051dbbb6b48edc",
-                "reference": "2634da35dec6c52a8c3a18dfcf051dbbb6b48edc",
+                "url": "https://api.github.com/repos/PrestaShop/welcome/zipball/0113fcb5650a632e5acca6f359b40a5627575351",
+                "reference": "0113fcb5650a632e5acca6f359b40a5627575351",
                 "shasum": ""
             },
             "require": {
@@ -6437,9 +6437,9 @@
             "description": "Welcome module for PrestaShop helping the users to create products.",
             "homepage": "https://github.com/PrestaShop/welcome",
             "support": {
-                "source": "https://github.com/PrestaShop/welcome/tree/v6.0.4"
+                "source": "https://github.com/PrestaShop/welcome/tree/v6.0.5"
             },
-            "time": "2020-12-03T15:11:16+00:00"
+            "time": "2021-06-09T13:39:20+00:00"
         },
         {
             "name": "psr/cache",

--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -32,7 +32,7 @@ class Datas
             'name' => 'step',
             'default' => 'all',
             'validate' => 'isGenericName',
-            'help' => 'all / database,fixtures,theme,modules,addons_modules',
+            'help' => 'all / database,fixtures,theme,modules,postInstall',
         ),
         'language' => array(
             'default' => 'en',

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -150,11 +150,6 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             }
         }
 
-        if (in_array('addons_modules', $steps)) {
-            if (!$this->processInstallAddonsModules()) {
-                $this->printErrors();
-            }
-        }
 
         if (in_array('theme', $steps)) {
             if (!$this->processInstallTheme()) {
@@ -164,6 +159,12 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
 
         if (in_array('fixtures', $steps) && $this->datas->fixtures) {
             if (!$this->processInstallFixtures()) {
+                $this->printErrors();
+            }
+        }
+
+        if (in_array('postInstall', $steps)) {
+            if (!$this->processPostInstall()) {
                 $this->printErrors();
             }
         }
@@ -289,12 +290,11 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
     }
 
     /**
-     * PROCESS : installModulesAddons
-     * Install modules from addons
+     * Process post install execution
      */
-    public function processInstallAddonsModules()
+    public function processPostInstall(): bool
     {
-        return $this->model_install->installModulesAddons();
+        return $this->model_install->postInstall();
     }
 
     /**

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -103,7 +103,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         $this->clearConfigXML() && $this->clearConfigThemes();
         $steps = explode(',', $this->datas->step);
         if (in_array('all', $steps)) {
-            $steps = array('database','fixtures','theme','modules','addons_modules');
+            $steps = array('database', 'fixtures', 'theme', 'modules', 'postInstall');
         }
 
         if (in_array('database', $steps)) {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -260,6 +260,18 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
+    public function onPostInstall(): bool
+    {
+        if (!$this->hasValidInstance()) {
+            return false;
+        }
+
+        return $this->instance->postInstall();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function onUninstall()
     {
         if (!$this->hasValidInstance()) {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -233,7 +233,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onInstall()
+    public function onInstall(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;
@@ -272,7 +272,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onUninstall()
+    public function onUninstall(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;
@@ -287,7 +287,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onUpgrade($version)
+    public function onUpgrade($version): bool
     {
         $this->database->set('version', $this->attributes->get('version_available'));
 
@@ -297,7 +297,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onEnable()
+    public function onEnable(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;
@@ -312,7 +312,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onDisable()
+    public function onDisable(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;
@@ -327,7 +327,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onMobileEnable()
+    public function onMobileEnable(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;
@@ -342,7 +342,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onMobileDisable()
+    public function onMobileDisable(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;
@@ -357,7 +357,7 @@ class Module implements ModuleInterface
     /**
      * {@inheritdoc}
      */
-    public function onReset()
+    public function onReset(): bool
     {
         if (!$this->hasValidInstance()) {
             return false;

--- a/src/Core/Addon/Module/ModuleInterface.php
+++ b/src/Core/Addon/Module/ModuleInterface.php
@@ -32,6 +32,8 @@ interface ModuleInterface extends AddonInterface
 {
     public function onInstall();
 
+    public function onPostInstall(): bool;
+
     public function onUninstall();
 
     /**

--- a/src/Core/Addon/Module/ModuleInterface.php
+++ b/src/Core/Addon/Module/ModuleInterface.php
@@ -30,11 +30,11 @@ use PrestaShop\PrestaShop\Core\Addon\AddonInterface;
 
 interface ModuleInterface extends AddonInterface
 {
-    public function onInstall();
+    public function onInstall(): bool;
 
     public function onPostInstall(): bool;
 
-    public function onUninstall();
+    public function onUninstall(): bool;
 
     /**
      * Called when switching the current theme of the selected shop.
@@ -42,7 +42,7 @@ interface ModuleInterface extends AddonInterface
      *
      * @return bool true for success
      */
-    public function onEnable();
+    public function onEnable(): bool;
 
     /**
      * Not necessarily the opposite of enable. Use this method if
@@ -51,22 +51,22 @@ interface ModuleInterface extends AddonInterface
      *
      * @return bool true for success
      */
-    public function onDisable();
+    public function onDisable(): bool;
 
     /**
      * @return bool
      */
-    public function onMobileEnable();
+    public function onMobileEnable(): bool;
 
     /**
      * @return bool
      */
-    public function onMobileDisable();
+    public function onMobileDisable(): bool;
 
     /**
      * @return bool
      */
-    public function onReset();
+    public function onReset(): bool;
 
     /**
      * Execute up files. You can update configuration, update sql schema.
@@ -74,5 +74,5 @@ interface ModuleInterface extends AddonInterface
      *
      * @return bool true for success
      */
-    public function onUpgrade($version);
+    public function onUpgrade($version): bool;
 }

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShopBundle\Event\ModuleManagementEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -293,7 +294,16 @@ class ModuleManager implements AddonManagerInterface
         if (!empty($source)) {
             $this->moduleZipManager->storeInModulesFolder($source);
         } elseif (!$this->moduleProvider->isOnDisk($name)) {
-            return false;
+            if (!$this->moduleUpdater->setModuleOnDiskFromAddons($name)) {
+                throw new FailedToEnableThemeModuleException(
+                    $name,
+                    $this->translator->trans(
+                        'The module %name% could not be found on Addons.',
+                        ['%name%' => $name],
+                        'Admin.Modules.Notification'
+                    )
+                );
+            }
         }
 
         $module = $this->moduleRepository->getModule($name);

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -34,9 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Core\Addon\AddonManagerInterface;
 use PrestaShop\PrestaShop\Core\Addon\AddonsCollection;
-use PrestaShop\PrestaShop\Core\Addon\Module\Exception\UnconfirmedModuleActionException;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\FailedToEnableThemeModuleException;
 use PrestaShopBundle\Event\ModuleManagementEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -306,7 +304,6 @@ class ModuleManager implements AddonManagerInterface
 
         return $result;
     }
-
 
     /**
      * Execute post install

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -326,7 +326,7 @@ class ModuleManager implements AddonManagerInterface
         }
 
         $module = $this->moduleRepository->getModule($moduleName);
-        /** @var Module */
+        /** @var Module $module */
         $result = $module->onPostInstall();
 
         $this->checkAndClearCache($result);

--- a/src/PrestaShopBundle/Event/ModuleManagementEvent.php
+++ b/src/PrestaShopBundle/Event/ModuleManagementEvent.php
@@ -32,6 +32,7 @@ use Symfony\Component\EventDispatcher\Event;
 class ModuleManagementEvent extends Event
 {
     public const INSTALL = 'module.install';
+    public const POST_INSTALL = 'module.post.install';
     public const UNINSTALL = 'module.uninstall';
     public const DISABLE = 'module.disable';
     public const ENABLE = 'module.enable';

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -28,7 +28,6 @@ namespace PrestaShopBundle\Install;
 
 use AppKernel;
 use Language as LanguageLegacy;
-use PrestaShopException;
 use PhpEncryption;
 use PrestaShop\PrestaShop\Adapter\Entity\Cache;
 use PrestaShop\PrestaShop\Adapter\Entity\Cart;
@@ -58,6 +57,7 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShopBundle\Cache\LocalizationWarmer;
 use PrestaShopBundle\Service\Database\Upgrade as UpgradeDatabase;
+use PrestaShopException;
 use PrestashopInstallerException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -962,7 +962,7 @@ class Install extends AbstractInstall
                         $errorMessage,
                         ['%module%' => $module_name],
                         'Install'
-                    )
+                    ),
                 ];
 
                 if (null !== $moduleException) {

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -896,7 +896,7 @@ class Install extends AbstractInstall
     /**
      * Get all modules present on the disk
      */
-    public function getModulesList(): array
+    public function getModulesOnDisk(): array
     {
         $modules = [];
         foreach (scandir(_PS_MODULE_DIR_, SCANDIR_SORT_NONE) as $module) {
@@ -916,11 +916,11 @@ class Install extends AbstractInstall
      */
     public function installModules(): bool
     {
-        $modules = $this->getModulesList();
+        $modules = $this->getModulesOnDisk();
 
         Module::updateTranslationsAfterInstall(false);
 
-        $result = $this->executeEvent($modules, 'install', 'Cannot install module "%module%"');
+        $result = $this->executeAction($modules, 'install', 'Cannot install module "%module%"');
         if ($result === false) {
             return false;
         }
@@ -933,14 +933,14 @@ class Install extends AbstractInstall
 
     public function postInstall(): bool
     {
-        return $this->executeEvent(
-            $this->getModulesList(),
+        return $this->executeAction(
+            $this->getModulesOnDisk(),
             'postInstall',
             'Cannot execute post install on module "%module%"'
         );
     }
 
-    protected function executeEvent(array $modules, string $event, string $errorMessage): bool
+    protected function executeAction(array $modules, string $action, string $errorMessage): bool
     {
         $moduleManagerBuilder = ModuleManagerBuilder::getInstance();
         $moduleManager = $moduleManagerBuilder->build();
@@ -950,13 +950,13 @@ class Install extends AbstractInstall
             $moduleException = null;
 
             try {
-                $moduleEventIsExecuted = $moduleManager->{$event}($module_name);
+                $moduleActionIsExecuted = $moduleManager->{$action}($module_name);
             } catch (PrestaShopException $e) {
-                $moduleEventIsExecuted = false;
+                $moduleActionIsExecuted = false;
                 $moduleException = $e->getMessage();
             }
 
-            if (!$moduleEventIsExecuted) {
+            if (!$moduleActionIsExecuted) {
                 $moduleErrors = [
                     $this->translator->trans(
                         $errorMessage,

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -920,7 +920,16 @@ class Install extends AbstractInstall
 
         Module::updateTranslationsAfterInstall(false);
 
-        $result = $this->executeAction($modules, 'install', 'Cannot install module "%module%"');
+        $result = $this->executeAction(
+            $modules,
+            'install',
+
+            $this->translator->trans(
+                'Cannot install module "%module%"',
+                ['%module%' => '%module%'],
+                'Install'
+            )
+        );
         if ($result === false) {
             return false;
         }
@@ -936,7 +945,11 @@ class Install extends AbstractInstall
         return $this->executeAction(
             $this->getModulesOnDisk(),
             'postInstall',
-            'Cannot execute post install on module "%module%"'
+            $this->translator->trans(
+                'Cannot execute post install on module "%module%"',
+                ['%module%' => '%module%'],
+                'Install'
+            )
         );
     }
 
@@ -958,10 +971,10 @@ class Install extends AbstractInstall
 
             if (!$moduleActionIsExecuted) {
                 $moduleErrors = [
-                    $this->translator->trans(
-                        $errorMessage,
-                        ['%module%' => $module_name],
-                        'Install'
+                    str_replace(
+                        '%module%',
+                        $module_name,
+                        $errorMessage
                     ),
                 ];
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Install;
 
 use AppKernel;
 use Language as LanguageLegacy;
+use PrestaShopException;
 use PhpEncryption;
 use PrestaShop\PrestaShop\Adapter\Entity\Cache;
 use PrestaShop\PrestaShop\Adapter\Entity\Cart;
@@ -892,169 +893,30 @@ class Install extends AbstractInstall
         return true;
     }
 
-    public function getModulesList()
-    {
-        return [
-            'blockwishlist',
-            'contactform',
-            'dashactivity',
-            'dashtrends',
-            'dashgoals',
-            'dashproducts',
-            'graphnvd3',
-            'gridhtml',
-            'gsitemap',
-            'pagesnotfound',
-            'productcomments',
-            'ps_banner',
-            'ps_categorytree',
-            'ps_checkpayment',
-            'ps_contactinfo',
-            'ps_crossselling',
-            'ps_currencyselector',
-            'ps_customeraccountlinks',
-            'ps_customersignin',
-            'ps_customtext',
-            'ps_dataprivacy',
-            'ps_emailsubscription',
-            'ps_facetedsearch',
-            'ps_faviconnotificationbo',
-            'ps_featuredproducts',
-            'ps_imageslider',
-            'ps_languageselector',
-            'ps_linklist',
-            'ps_mainmenu',
-            'ps_searchbar',
-            'ps_sharebuttons',
-            'ps_shoppingcart',
-            'ps_socialfollow',
-            'ps_themecusto',
-            'ps_wirepayment',
-            'statsbestcategories',
-            'statsbestcustomers',
-            'statsbestproducts',
-            'statsbestsuppliers',
-            'statsbestvouchers',
-            'statscarrier',
-            'statscatalog',
-            'statscheckup',
-            'statsdata',
-            'statsforecast',
-            'statslive',
-            'statsnewsletter',
-            'statspersonalinfos',
-            'statsproduct',
-            'statsregistrations',
-            'statssales',
-            'statssearch',
-            'statsstock',
-            'welcome',
-        ];
-    }
-
-    public function getAddonsModulesList($params = [])
-    {
-        /**
-         * TODO: Remove blacklist once 1.7 is out.
-         */
-        $blacklist = [
-            'bankwire',
-            'blockadvertising',
-            'blockbanner',
-            'blockbestsellers',
-            'blockcart',
-            'blockcategories',
-            'blockcms',
-            'blockcmsinfo',
-            'blockcontact',
-            'blockcontactinfos',
-            'blockcurrencies',
-            'blockcustomerprivacy',
-            'blockfacebook',
-            'blocklanguages',
-            'blocklayered',
-            'blocklink',
-            'blockmanufacturer',
-            'blockmyaccount',
-            'blockmyaccountfooter',
-            'blocknewproducts',
-            'blocknewsletter',
-            'blockpaymentlogo',
-            'blockpermanentlinks',
-            'blockrss',
-            'blocksearch',
-            'blocksharefb',
-            'blocksocial',
-            'blockstore',
-            'blockspecials',
-            'blocksupplier',
-            'blocktags',
-            'blocktopmenu',
-            'blockuserinfo',
-            'blockviewed',
-            'cheque',
-            'crossselling',
-            'homefeatured',
-            'homeslider',
-            'onboarding',
-            'productscategory',
-            'producttooltip',
-            'sendtoafriend',
-            'socialsharing',
-        ];
-
-        $addons_modules = [];
-        $content = Tools::addonsRequest('install-modules', $params);
-        $xml = @simplexml_load_string($content, 'SimpleXMLElement', LIBXML_NOCDATA);
-
-        if ($xml !== false && isset($xml->module)) {
-            foreach ($xml->module as $modaddons) {
-                if (in_array($modaddons->name, $blacklist)) {
-                    continue;
-                }
-                $addons_modules[] = ['id_module' => $modaddons->id, 'name' => $modaddons->name];
-            }
-        }
-
-        return $addons_modules;
-    }
-
     /**
-     * PROCESS : installModules
-     * Download module from addons and Install all modules in ~/modules/ directory.
+     * Get all modules present on the disk
      */
-    public function installModulesAddons($module = null)
+    public function getModulesList(): array
     {
-        $addons_modules = $module ? [$module] : $this->getAddonsModulesList();
         $modules = [];
-
-        foreach ($addons_modules as $addons_module) {
-            if (file_put_contents(_PS_MODULE_DIR_ . $addons_module['name'] . '.zip', Tools::addonsRequest('module', ['id_module' => $addons_module['id_module']]))) {
-                if (Tools::ZipExtract(_PS_MODULE_DIR_ . $addons_module['name'] . '.zip', _PS_MODULE_DIR_)) {
-                    $modules[] = (string) $addons_module['name']; //if the module has been unziped we add the name in the modules list to install
-                    unlink(_PS_MODULE_DIR_ . $addons_module['name'] . '.zip');
-                }
+        foreach (scandir(_PS_MODULE_DIR_, SCANDIR_SORT_NONE) as $module) {
+            if ($module[0] != '.' && is_dir(_PS_MODULE_DIR_ . $module) && file_exists(_PS_MODULE_DIR_ . $module . '/' . $module . '.php')) {
+                $modules[] = $module;
             }
         }
 
-        return count($modules) ? $this->installModules($modules) : true;
+        return $modules;
     }
 
     /**
      * PROCESS : installModules
      * Download module from addons and Install all modules in ~/modules/ directory.
-     *
-     * @param array|string|null $module Module to install. If not provided, installs all modules.
      *
      * @return bool
      */
-    public function installModules($module = null)
+    public function installModules(): bool
     {
-        if ($module && !is_array($module)) {
-            $module = [$module];
-        }
-
-        $modules = $module ? $module : $this->getModulesList();
+        $modules = $this->getModulesList();
 
         Module::updateTranslationsAfterInstall(false);
 
@@ -1063,15 +925,11 @@ class Install extends AbstractInstall
 
         $errors = [];
         foreach ($modules as $module_name) {
-            if (!file_exists(_PS_MODULE_DIR_ . $module_name . '/' . $module_name . '.php')) {
-                continue;
-            }
-
             $moduleException = null;
 
             try {
                 $moduleInstalled = $moduleManager->install($module_name);
-            } catch (\PrestaShopException $e) {
+            } catch (PrestaShopException $e) {
                 $moduleInstalled = false;
                 $moduleException = $e->getMessage();
             }
@@ -1228,5 +1086,41 @@ class Install extends AbstractInstall
                 $db->execute('SET SESSION auto_increment_increment = ' . (int) $backupAiIncrement, false);
             }
         }
+    }
+
+    public function postInstall(): bool
+    {
+        $modules = $this->getModulesList();
+
+        $moduleManagerBuilder = ModuleManagerBuilder::getInstance();
+        $moduleManager = $moduleManagerBuilder->build();
+
+        $errors = [];
+        foreach ($modules as $module_name) {
+            $moduleException = null;
+
+            try {
+                $modulePostInstall = $moduleManager->postInstall($module_name);
+            } catch (PrestaShopException $e) {
+                $modulePostInstall = false;
+                $moduleException = $e->getMessage();
+            }
+
+            if (!$modulePostInstall) {
+                $module_errors = [$this->translator->trans('Cannot execute post install on module "%module%"', ['%module%' => $module_name], 'Install')];
+                if (null !== $moduleException) {
+                    $module_errors[] = $moduleException;
+                }
+                $errors[$module_name] = $module_errors;
+            }
+        }
+
+        if ($errors) {
+            $this->setError($errors);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/UI/campaigns/sanity/01_installShop/01_installShop.js
+++ b/tests/UI/campaigns/sanity/01_installShop/01_installShop.js
@@ -166,15 +166,6 @@ describe('Install Prestashop', async () => {
       args:
         {
           step: {
-            name: 'Install addons modules',
-            timeout: 60000,
-          },
-        },
-    },
-    {
-      args:
-        {
-          step: {
             name: 'Install theme',
             timeout: 60000,
           },
@@ -189,7 +180,15 @@ describe('Install Prestashop', async () => {
           },
         },
     },
-
+    {
+      args:
+        {
+          step: {
+            name: 'Post installation scripts',
+            timeout: 60000,
+          },
+        },
+    },
   ];
 
   tests.forEach((test, index) => {

--- a/tests/UI/pages/install/index.js
+++ b/tests/UI/pages/install/index.js
@@ -67,9 +67,9 @@ class Install extends CommonPage {
     this.populateDatabaseStep = '#process_step_populateDatabase';
     this.configureShopStep = '#process_step_configureShop';
     this.installModulesStep = '#process_step_installModules';
-    this.installModulesAddons = '#process_step_installModulesAddons';
     this.installThemeStep = '#process_step_installTheme';
     this.installFixturesStep = '#process_step_installFixtures';
+    this.installPostInstall = '#process_step_postInstall';
     this.installationFinishedStepPageTitle = '#install_process_success h2';
     this.discoverFoButton = '#foBlock';
   }
@@ -231,16 +231,16 @@ class Install extends CommonPage {
         selector = this.installModulesStep;
         break;
 
-      case 'Install addons modules':
-        selector = this.installModulesAddons;
-        break;
-
       case 'Install theme':
         selector = this.installThemeStep;
         break;
 
       case 'Install fixtures':
         selector = this.installFixturesStep;
+        break;
+
+      case 'Post installation scripts':
+        selector = this.installPostInstall;
         break;
 
       default:

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -78,6 +78,12 @@ class ModuleManagerTest extends TestCase
         $this->assertTrue($this->moduleManager->install(self::INSTALLED_MODULE));
     }
 
+    public function testPostInstallSuccessful()
+    {
+        $this->assertFalse($this->moduleManager->postInstall(self::UNINSTALLED_MODULE));
+        $this->assertTrue($this->moduleManager->postInstall(self::INSTALLED_MODULE));
+    }
+
     public function testUninstallSuccessful()
     {
         $this->assertTrue($this->moduleManager->uninstall(self::INSTALLED_MODULE));
@@ -251,6 +257,9 @@ class ModuleManagerTest extends TestCase
             ->getMock();
         $moduleS
             ->method('onInstall')
+            ->willReturn(true);
+        $moduleS
+            ->method('onPostInstall')
             ->willReturn(true);
         $moduleS
             ->method('onUpgrade')

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -49,7 +49,7 @@ class ModuleManagerTest extends TestCase
     private $employeeS;
     private $cacheClearerS;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // Mocks
         $this->initMocks();
@@ -65,26 +65,26 @@ class ModuleManagerTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // destroy Mocks
         $this->destroyMocks();
         $this->moduleManager = null;
     }
 
-    public function testInstallSuccessful()
+    public function testInstallSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->install(self::UNINSTALLED_MODULE));
         $this->assertTrue($this->moduleManager->install(self::INSTALLED_MODULE));
     }
 
-    public function testPostInstallSuccessful()
+    public function testPostInstallSuccessful(): void
     {
         $this->assertFalse($this->moduleManager->postInstall(self::UNINSTALLED_MODULE));
         $this->assertTrue($this->moduleManager->postInstall(self::INSTALLED_MODULE));
     }
 
-    public function testUninstallSuccessful()
+    public function testUninstallSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->uninstall(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -92,7 +92,7 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($this->moduleManager->uninstall(self::UNINSTALLED_MODULE));
     }
 
-    public function testUpgradeSuccessful()
+    public function testUpgradeSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->upgrade(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -100,7 +100,7 @@ class ModuleManagerTest extends TestCase
         $this->moduleManager->upgrade(self::UNINSTALLED_MODULE);
     }
 
-    public function testDisableSuccessful()
+    public function testDisableSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->disable(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -108,7 +108,7 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($this->moduleManager->disable(self::UNINSTALLED_MODULE));
     }
 
-    public function testEnableSuccessful()
+    public function testEnableSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->enable(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -116,7 +116,7 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($this->moduleManager->enable(self::UNINSTALLED_MODULE));
     }
 
-    public function testDisableOnMobileSuccessful()
+    public function testDisableOnMobileSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->disable_mobile(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -124,7 +124,7 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($this->moduleManager->disable_mobile(self::UNINSTALLED_MODULE));
     }
 
-    public function testEnableOnMobileSuccessful()
+    public function testEnableOnMobileSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->enable_mobile(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -132,7 +132,7 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($this->moduleManager->enable_mobile(self::UNINSTALLED_MODULE));
     }
 
-    public function testResetSuccessful()
+    public function testResetSuccessful(): void
     {
         $this->assertTrue($this->moduleManager->reset(self::INSTALLED_MODULE));
         $this->expectException('Exception');
@@ -140,19 +140,19 @@ class ModuleManagerTest extends TestCase
         $this->assertFalse($this->moduleManager->reset(self::UNINSTALLED_MODULE));
     }
 
-    public function testIsEnabled()
+    public function testIsEnabled(): void
     {
         $this->assertTrue($this->moduleManager->isEnabled(self::INSTALLED_MODULE));
         $this->assertFalse($this->moduleManager->isEnabled(self::UNINSTALLED_MODULE));
     }
 
-    public function testIsInstalled()
+    public function testIsInstalled(): void
     {
         $this->assertTrue($this->moduleManager->isInstalled(self::INSTALLED_MODULE));
         $this->assertFalse($this->moduleManager->isInstalled(self::UNINSTALLED_MODULE));
     }
 
-    public function testRemoveModuleFromDisk()
+    public function testRemoveModuleFromDisk(): void
     {
         $modules = [self::INSTALLED_MODULE, self::UNINSTALLED_MODULE];
         foreach ($modules as $module) {
@@ -160,7 +160,7 @@ class ModuleManagerTest extends TestCase
         }
     }
 
-    private function initMocks()
+    private function initMocks(): void
     {
         $this->mockModuleProvider();
         $this->mockAdminModuleProvider();
@@ -173,7 +173,7 @@ class ModuleManagerTest extends TestCase
         $this->mockCacheClearer();
     }
 
-    private function mockAdminModuleProvider()
+    private function mockAdminModuleProvider(): void
     {
         $this->adminModuleProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider')
             ->disableOriginalConstructor()
@@ -184,7 +184,7 @@ class ModuleManagerTest extends TestCase
             ->willReturn(true);
     }
 
-    private function mockModuleProvider()
+    private function mockModuleProvider(): void
     {
         $providerAuthorizations = [
             [
@@ -234,7 +234,7 @@ class ModuleManagerTest extends TestCase
             ->willReturn(true);
     }
 
-    private function mockModuleUpdater()
+    private function mockModuleUpdater(): void
     {
         $this->moduleUpdaterS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater')
             ->disableOriginalConstructor()
@@ -250,7 +250,7 @@ class ModuleManagerTest extends TestCase
             ->willReturn(true);
     }
 
-    private function mockModuleRepository()
+    private function mockModuleRepository(): void
     {
         $moduleS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\Module')
             ->setConstructorArgs([[], [], []])
@@ -292,7 +292,7 @@ class ModuleManagerTest extends TestCase
             ->willReturn($moduleS);
     }
 
-    private function mockModuleZipManager()
+    private function mockModuleZipManager(): void
     {
         $this->moduleZipManagerS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager')
             ->disableOriginalConstructor()
@@ -306,7 +306,7 @@ class ModuleManagerTest extends TestCase
             ->method('storeInModulesFolder');
     }
 
-    private function mockTranslator()
+    private function mockTranslator(): void
     {
         $this->translatorS = $this->getMockBuilder('Symfony\Component\Translation\Translator')
             ->disableOriginalConstructor()
@@ -317,18 +317,18 @@ class ModuleManagerTest extends TestCase
             ->will($this->returnArgument(0));
     }
 
-    private function mockDispatcher()
+    private function mockDispatcher(): void
     {
         $this->dispatcherS = new NullDispatcher();
     }
 
-    private function mockCacheClearer()
+    private function mockCacheClearer(): void
     {
         $this->cacheClearerS = $this->getMockBuilder(CacheClearerInterface::class)
             ->getMock();
     }
 
-    private function mockEmployee()
+    private function mockEmployee(): void
     {
         /* this is a super admin */
         $this->employeeS = $this->getMockBuilder('Employee')
@@ -340,7 +340,7 @@ class ModuleManagerTest extends TestCase
             ->willReturn(true);
     }
 
-    private function destroyMocks()
+    private function destroyMocks(): void
     {
         $this->adminModuleProviderS = null;
         $this->moduleProviderS = null;

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -222,6 +222,10 @@ class ModuleManagerTest extends TestCase
         $this->moduleProviderS
             ->method('isEnabled')
             ->will($this->returnValueMap($isEnabledValues));
+
+        $this->moduleProviderS
+            ->method('isOnDisk')
+            ->willReturn(true);
     }
 
     private function mockModuleUpdater()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove addons modules download on install, add the capability to install all modules present on the disk inside the module directory. Also, add a postInstall behavior to be able to execute code after the PrestaShop installation is done. The welcome module has been updated because the module has a bug that break the installation process because of undeclared PS_ADMIN_DIR during the instantiation of the module.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #24638
| How to test?      | Install PrestaShop, no addons modules are installed.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


## New behavior & Bc breaks

- Remove addons requests which was downloaded PrestaShop enterprise modules
- Install all modules present inside the `modules` directory
- Add `postInstall` method inside modules
- Remove `getModulesList` and `getAddonsModulesList` inside the `src/PrestaShopBundle/Install/Install.php`
- Rename `getModulesList` into `getModulesOnDisk`
- Remove `processInstallAddonsModules` inside the `install-dev/controllers/console/process.php`
- Remove `processInstallAddonsModules` inside the `install-dev/controllers/http/process.php`
- Interface `PrestaShop\PrestaShop\Core\Addon\Module\ModuleInterface` is now strict typed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24676)
<!-- Reviewable:end -->
