### PR TITLE
Fix free shipping cart rule should not be recalculate when PS_ORDER_RECALCULATE_SHIPPING is false

### DIFF
--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -322,11 +322,9 @@ class OrderAmountUpdater
             $order->total_shipping_tax_excl = $totalShippingTaxExcluded;
 
             if (!$freeShipping) {
-                $shippingDiffTaxIncluded = $order->total_shipping_tax_incl - $totalShippingTaxIncluded;
-                $shippingDiffTaxExcluded = $order->total_shipping_tax_excl - $totalShippingTaxExcluded;
-                $order->total_paid -= $shippingDiffTaxIncluded;
-                $order->total_paid_tax_incl -= $shippingDiffTaxIncluded;
-                $order->total_paid_tax_excl -= $shippingDiffTaxExcluded;
+                $order->total_paid -= ($order->total_shipping_tax_incl - $totalShippingTaxIncluded);
+                $order->total_paid_tax_incl -= ($order->total_shipping_tax_incl - $totalShippingTaxIncluded);
+                $order->total_paid_tax_excl -= ($order->total_shipping_tax_excl - $totalShippingTaxExcluded);
             }
         }
     }
@@ -575,10 +573,8 @@ class OrderAmountUpdater
                 $invoice->total_shipping_tax_excl = $totalShippingTaxExcluded;
 
                 if (!$freeShipping) {
-                    $shippingDiffTaxIncluded = $invoice->total_shipping_tax_incl - $totalShippingTaxIncluded;
-                    $shippingDiffTaxExcluded = $invoice->total_shipping_tax_excl - $totalShippingTaxExcluded;
-                    $invoice->total_paid_tax_incl -= $shippingDiffTaxIncluded;
-                    $invoice->total_paid_tax_excl -= $shippingDiffTaxExcluded;
+                    $invoice->total_paid_tax_incl -= ($invoice->total_shipping_tax_incl - $totalShippingTaxIncluded);
+                    $invoice->total_paid_tax_excl -= ($invoice->total_shipping_tax_excl - $totalShippingTaxExcluded);
                 }
             }
 
@@ -593,7 +589,7 @@ class OrderAmountUpdater
      *
      * @return bool
      */
-    protected function isFreeShipping(Order $order)
+    protected function isFreeShipping(Order $order): bool
     {
         foreach ($order->getCartRules() as $cartRule) {
             if ($cartRule['free_shipping']) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -309,16 +309,31 @@ class OrderAmountUpdater
         $order->total_shipping_tax_incl = $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $orderProducts, $carrierId, false, $this->keepOrderPrices);
 
         if (!$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
-            $shippingDiffTaxIncluded = $order->total_shipping_tax_incl - $totalShippingTaxIncluded;
-            $shippingDiffTaxExcluded = $order->total_shipping_tax_excl - $totalShippingTaxExcluded;
+            $freeShipping = false;
+            foreach ($order->getCartRules() as $cartRule) {
+                if ($cartRule['free_shipping']) {
+                    $freeShipping = true;
+                    break;
+                }
+            }
+
+            if ($freeShipping) {
+                $order->total_discounts = $order->total_discounts - $order->total_shipping_tax_incl + $totalShippingTaxIncluded;
+                $order->total_discounts_tax_excl = $order->total_discounts_tax_excl - $order->total_shipping_tax_excl + $totalShippingTaxExcluded;
+                $order->total_discounts_tax_incl = $order->total_discounts_tax_incl - $order->total_shipping_tax_incl + $totalShippingTaxIncluded;
+            }
 
             $order->total_shipping = $totalShippingTaxIncluded;
             $order->total_shipping_tax_incl = $totalShippingTaxIncluded;
             $order->total_shipping_tax_excl = $totalShippingTaxExcluded;
 
-            $order->total_paid -= $shippingDiffTaxIncluded;
-            $order->total_paid_tax_incl -= $shippingDiffTaxIncluded;
-            $order->total_paid_tax_excl -= $shippingDiffTaxExcluded;
+            if (!$freeShipping) {
+                $shippingDiffTaxIncluded = $order->total_shipping_tax_incl - $totalShippingTaxIncluded;
+                $shippingDiffTaxExcluded = $order->total_shipping_tax_excl - $totalShippingTaxExcluded;
+                $order->total_paid -= $shippingDiffTaxIncluded;
+                $order->total_paid_tax_incl -= $shippingDiffTaxIncluded;
+                $order->total_paid_tax_excl -= $shippingDiffTaxExcluded;
+            }
         }
     }
 
@@ -448,6 +463,12 @@ class OrderAmountUpdater
                     $orderCartRule->free_shipping = $cartRule->free_shipping;
                     $orderCartRule->value = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxIncluded(), $computingPrecision);
                     $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
+
+                    if ($orderCartRule->free_shipping && !$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
+                        $orderCartRule->value = $orderCartRule->value - $cart->getTotalShippingCost() + $order->total_shipping;
+                        $orderCartRule->value_tax_excl = $orderCartRule->value_tax_excl - $cart->getTotalShippingCost(null, false) + $order->total_shipping_tax_excl;
+                    }
+
                     $orderCartRule->save();
                     continue 2;
                 }
@@ -549,16 +570,28 @@ class OrderAmountUpdater
             $invoice->total_shipping_tax_incl = $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices);
 
             if (!$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
-                $shippingDiffTaxIncluded = $invoice->total_shipping_tax_incl - $totalShippingTaxIncluded;
-                $shippingDiffTaxExcluded = $invoice->total_shipping_tax_excl - $totalShippingTaxExcluded;
+                $freeShipping = false;
+                foreach ($order->getCartRules() as $cartRule) {
+                    if ($cartRule['free_shipping']) {
+                        $freeShipping = true;
+                        break;
+                    }
+                }
 
-                $invoice->total_shipping = $totalShippingTaxIncluded;
+                if ($freeShipping) {
+                    $invoice->total_discount_tax_excl = $invoice->total_discount_tax_excl - $invoice->total_shipping_tax_excl + $totalShippingTaxExcluded;
+                    $invoice->total_discount_tax_incl = $invoice->total_discount_tax_incl - $invoice->total_shipping_tax_incl + $totalShippingTaxIncluded;
+                }
+
                 $invoice->total_shipping_tax_incl = $totalShippingTaxIncluded;
                 $invoice->total_shipping_tax_excl = $totalShippingTaxExcluded;
 
-                $invoice->total_paid -= $shippingDiffTaxIncluded;
-                $invoice->total_paid_tax_incl -= $shippingDiffTaxIncluded;
-                $invoice->total_paid_tax_excl -= $shippingDiffTaxExcluded;
+                if (!$freeShipping) {
+                    $shippingDiffTaxIncluded = $invoice->total_shipping_tax_incl - $totalShippingTaxIncluded;
+                    $shippingDiffTaxExcluded = $invoice->total_shipping_tax_excl - $totalShippingTaxExcluded;
+                    $invoice->total_paid_tax_incl -= $shippingDiffTaxIncluded;
+                    $invoice->total_paid_tax_excl -= $shippingDiffTaxExcluded;
+                }
             }
 
             if (!$invoice->update()) {

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -309,13 +309,7 @@ class OrderAmountUpdater
         $order->total_shipping_tax_incl = $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $orderProducts, $carrierId, false, $this->keepOrderPrices);
 
         if (!$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
-            $freeShipping = false;
-            foreach ($order->getCartRules() as $cartRule) {
-                if ($cartRule['free_shipping']) {
-                    $freeShipping = true;
-                    break;
-                }
-            }
+            $freeShipping = $this->isFreeShipping($order);
 
             if ($freeShipping) {
                 $order->total_discounts = $order->total_discounts - $order->total_shipping_tax_incl + $totalShippingTaxIncluded;
@@ -570,13 +564,7 @@ class OrderAmountUpdater
             $invoice->total_shipping_tax_incl = $cart->getOrderTotal(true, Cart::ONLY_SHIPPING, $currentInvoiceProducts, $carrierId, false, $this->keepOrderPrices);
 
             if (!$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
-                $freeShipping = false;
-                foreach ($order->getCartRules() as $cartRule) {
-                    if ($cartRule['free_shipping']) {
-                        $freeShipping = true;
-                        break;
-                    }
-                }
+                $freeShipping = $this->isFreeShipping($order);
 
                 if ($freeShipping) {
                     $invoice->total_discount_tax_excl = $invoice->total_discount_tax_excl - $invoice->total_shipping_tax_excl + $totalShippingTaxExcluded;
@@ -598,6 +586,22 @@ class OrderAmountUpdater
                 throw new OrderException('Could not update order invoice in database.');
             }
         }
+    }
+
+    /**
+     * @param Order $order
+     *
+     * @return bool
+     */
+    protected function isFreeShipping(Order $order)
+    {
+        foreach ($order->getCartRules() as $cartRule) {
+            if ($cartRule['free_shipping']) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -457,8 +457,8 @@ class OrderAmountUpdater
                     $orderCartRule->value_tax_excl = Tools::ps_round($cartRuleData->getDiscountApplied()->getTaxExcluded(), $computingPrecision);
 
                     if ($orderCartRule->free_shipping && !$this->getOrderConfiguration('PS_ORDER_RECALCULATE_SHIPPING', $order)) {
-                        $orderCartRule->value = $orderCartRule->value - $cart->getTotalShippingCost() + $order->total_shipping;
-                        $orderCartRule->value_tax_excl = $orderCartRule->value_tax_excl - $cart->getTotalShippingCost(null, false) + $order->total_shipping_tax_excl;
+                        $orderCartRule->value = $orderCartRule->value - $calculator->getFees()->getInitialShippingFees()->getTaxIncluded() + $order->total_shipping;
+                        $orderCartRule->value_tax_excl = $orderCartRule->value_tax_excl - $calculator->getFees()->getInitialShippingFees()->getTaxExcluded() + $order->total_shipping_tax_excl;
                     }
 
                     $orderCartRule->save();

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -309,19 +309,22 @@ Feature: Order from Back Office (BO)
       | message             | test                       |
       | payment module name | dummy_payment              |
       | status              | Awaiting bank wire payment |
+    And I add discount to order "bo_order1" with following details:
+      | name        | FreeShippingAndAmount |
+      | type        | free_shipping         |
     And order "bo_order1" should have 2 products in total
     And order "bo_order1" should have 0 invoices
-    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have 1 cart rule
     # Carrier less expensive is chosen by default
     And order "bo_order1" should have "weight_carrier" as a carrier
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0    |
-      | total_discounts_tax_incl | 0.0    |
-      | total_paid_tax_excl      | 25.800 |
-      | total_paid_tax_incl      | 27.350 |
-      | total_paid               | 27.350 |
+      | total_discounts_tax_excl | 2.0    |
+      | total_discounts_tax_incl | 2.12   |
+      | total_paid_tax_excl      | 23.800 |
+      | total_paid_tax_incl      | 25.230 |
+      | total_paid               | 25.230 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
@@ -340,11 +343,11 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products           | 53.800 |
       | total_products_wt        | 57.030 |
-      | total_discounts_tax_excl | 0.0000 |
-      | total_discounts_tax_incl | 0.0000 |
-      | total_paid_tax_excl      | 55.8   |
-      | total_paid_tax_incl      | 59.150 |
-      | total_paid               | 59.150 |
+      | total_discounts_tax_excl | 2.0000 |
+      | total_discounts_tax_incl | 2.1200 |
+      | total_paid_tax_excl      | 53.8   |
+      | total_paid_tax_incl      | 57.030 |
+      | total_paid               | 57.030 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
@@ -360,11 +363,11 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products           | 53.80  |
       | total_products_wt        | 57.03  |
-      | total_discounts_tax_excl | 0.0000 |
-      | total_discounts_tax_incl | 0.0000 |
-      | total_paid_tax_excl      | 55.80  |
-      | total_paid_tax_incl      | 59.15  |
-      | total_paid               | 59.15  |
+      | total_discounts_tax_excl | 2.0000 |
+      | total_discounts_tax_incl | 2.1200 |
+      | total_paid_tax_excl      | 53.80  |
+      | total_paid_tax_incl      | 57.03  |
+      | total_paid               | 57.03  |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
@@ -378,11 +381,11 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products           | 53.80  |
       | total_products_wt        | 57.03  |
-      | total_discounts_tax_excl | 0.0000 |
-      | total_discounts_tax_incl | 0.0000 |
-      | total_paid_tax_excl      | 55.80  |
-      | total_paid_tax_incl      | 59.15  |
-      | total_paid               | 59.15  |
+      | total_discounts_tax_excl | 2.0000 |
+      | total_discounts_tax_incl | 2.1200 |
+      | total_paid_tax_excl      | 53.80  |
+      | total_paid_tax_incl      | 57.03  |
+      | total_paid               | 57.03  |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |
@@ -396,11 +399,11 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products           | 53.80  |
       | total_products_wt        | 57.03  |
-      | total_discounts_tax_excl | 0.0000 |
-      | total_discounts_tax_incl | 0.0000 |
-      | total_paid_tax_excl      | 55.80  |
-      | total_paid_tax_incl      | 59.15  |
-      | total_paid               | 59.15  |
+      | total_discounts_tax_excl | 2.0000 |
+      | total_discounts_tax_incl | 2.1200 |
+      | total_paid_tax_excl      | 53.80  |
+      | total_paid_tax_incl      | 57.03  |
+      | total_paid               | 57.03  |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 2.0    |
       | total_shipping_tax_incl  | 2.12   |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | When a modification is done on the order, cart rules are recalculate but the option PS_ORDER_RECALCULATE_SHIPPING was not take into account when doing so. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24598
| How to test?      | Please see #24598
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24679)
<!-- Reviewable:end -->
