### PR TITLE
Add missing Grid and Router JS components

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -37,6 +37,17 @@ import TextWithLengthCounter from '@components/form/text-with-length-counter';
 import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field.js';
 import {EventEmitter} from '@components/event-emitter';
+import GridComponent from '@components/grid/grid';
+
+// Grid extensions
+import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
+
+const Grid = {
+  instance: GridComponent,
+  extension: {
+    FiltersResetExtension
+  }
+}
 
 const initPrestashopComponents = () => {
   window.prestashop = {...window.prestashop};
@@ -93,6 +104,7 @@ const initPrestashopComponents = () => {
     TextWithLengthCounter,
     MultistoreConfigField,
     PreviewOpener,
+    Grid
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -45,9 +45,9 @@ import FiltersResetExtension from '@components/grid/extension/filters-reset-exte
 const Grid = {
   instance: GridComponent,
   extension: {
-    FiltersResetExtension
-  }
-}
+    FiltersResetExtension,
+  },
+};
 
 const initPrestashopComponents = () => {
   window.prestashop = {...window.prestashop};
@@ -104,7 +104,7 @@ const initPrestashopComponents = () => {
     TextWithLengthCounter,
     MultistoreConfigField,
     PreviewOpener,
-    Grid
+    Grid,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -38,14 +38,47 @@ import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field.js';
 import {EventEmitter} from '@components/event-emitter';
 import GridComponent from '@components/grid/grid';
+import Router from '@components/router';
 
 // Grid extensions
-import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
+import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
+import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
+import BulkOpenTabsExtension from '@components/grid/extension/bulk-open-tabs-extension';
+import ChoiceExtension from '@components/grid/extension/choice-extension';
+import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
+import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
+import FiltersResetExtension from '@components/grid/extension/filters-reset-extension.js';
+import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
+import ModalFormSubmitExtension from '@components/grid/extension/modal-form-submit-extension';
+import PositionExtension from '@components/grid/extension/position-extension';
+import PreviewExtension from '@components/grid/extension/preview-extension';
+import ReloadListExtension from '@components/grid/extension/reload-list-extension';
+import SortingExtension from '@components/grid/extension/sorting-extension';
+import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
+import SubmitGridActionExtension from '@components/grid/extension/submit-grid-action-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 
 const Grid = {
-  instance: GridComponent,
+  core: GridComponent,
   extension: {
+    AsyncToggleColumnExtension,
+    BulkActionCheckboxExtension,
+    BulkOpenTabsExtension,
+    ChoiceExtension,
+    ColumnTogglingExtension,
+    ExportToSqlManagerExtension,
     FiltersResetExtension,
+    FiltersSubmitButtonEnablerExtension,
+    LinkRowActionExtension,
+    ModalFormSubmitExtension,
+    PositionExtension,
+    PreviewExtension,
+    ReloadListExtension,
+    SortingExtension,
+    SubmitBulkActionExtension,
+    SubmitGridActionExtension,
+    SubmitRowActionExtension,
   },
 };
 
@@ -105,6 +138,7 @@ const initPrestashopComponents = () => {
     MultistoreConfigField,
     PreviewOpener,
     Grid,
+    Router,
   };
 };
 export default initPrestashopComponents;

--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -37,7 +37,7 @@ import TextWithLengthCounter from '@components/form/text-with-length-counter';
 import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field.js';
 import {EventEmitter} from '@components/event-emitter';
-import GridComponent from '@components/grid/grid';
+import Grid from '@components/grid/grid';
 import Router from '@components/router';
 
 // Grid extensions
@@ -59,27 +59,24 @@ import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-ac
 import SubmitGridActionExtension from '@components/grid/extension/submit-grid-action-extension';
 import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 
-const Grid = {
-  core: GridComponent,
-  extension: {
-    AsyncToggleColumnExtension,
-    BulkActionCheckboxExtension,
-    BulkOpenTabsExtension,
-    ChoiceExtension,
-    ColumnTogglingExtension,
-    ExportToSqlManagerExtension,
-    FiltersResetExtension,
-    FiltersSubmitButtonEnablerExtension,
-    LinkRowActionExtension,
-    ModalFormSubmitExtension,
-    PositionExtension,
-    PreviewExtension,
-    ReloadListExtension,
-    SortingExtension,
-    SubmitBulkActionExtension,
-    SubmitGridActionExtension,
-    SubmitRowActionExtension,
-  },
+const GridExtensions = {
+  AsyncToggleColumnExtension,
+  BulkActionCheckboxExtension,
+  BulkOpenTabsExtension,
+  ChoiceExtension,
+  ColumnTogglingExtension,
+  ExportToSqlManagerExtension,
+  FiltersResetExtension,
+  FiltersSubmitButtonEnablerExtension,
+  LinkRowActionExtension,
+  ModalFormSubmitExtension,
+  PositionExtension,
+  PreviewExtension,
+  ReloadListExtension,
+  SortingExtension,
+  SubmitBulkActionExtension,
+  SubmitGridActionExtension,
+  SubmitRowActionExtension,
 };
 
 const initPrestashopComponents = () => {
@@ -138,6 +135,7 @@ const initPrestashopComponents = () => {
     MultistoreConfigField,
     PreviewOpener,
     Grid,
+    GridExtensions,
     Router,
   };
 };


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | It is a must have for module developers to use Grid extensions on their own modern pages with lists based on Grid
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | dev qa
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions

I really hope we can have it in 1.7.8, we should have it, `Router` too...


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24682)
<!-- Reviewable:end -->
