### PR TITLE
Option to override CMS category template

### DIFF
--- a/classes/Smarty/TemplateFinder.php
+++ b/classes/Smarty/TemplateFinder.php
@@ -103,6 +103,12 @@ class TemplateFinderCore
                 $template,
                 'cms/page',
             ];
+        } elseif ('cms_category' === $entity) {
+            $templates = [
+                'cms/category-' . $id,
+                $template,
+                'cms/category',
+            ];
         } else {
             $templates = [$template];
         }

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -137,7 +137,10 @@ class CmsControllerCore extends FrontController
             }
 
             $this->context->smarty->assign($cmsCategoryVar);
-            $this->setTemplate('cms/category');
+            $this->setTemplate(
+                'cms/category',
+                ['entity' => 'cms_category', 'id' => $this->cms_category->id]
+            );
         }
         parent::initContent();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add cms_category to TemplateFinder, details in Issue
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24683.
| How to test?      | Details at the bottom of the issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions

# How to test?

Create CMS Category, if CMS Category has ID 2 or 3, create file, for example `themes/classic/templates/cms/category-2.tpl` with this content:

```
{extends file='./category.tpl'}

{block name='page_title'}
  {$cms_category.name} - override
{/block}
```

When you visit newly created CMS category (you can find URL in Sitemap), you should see title like this:

> Name of your category - override


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24684)
<!-- Reviewable:end -->
