### PR TITLE
Correctly displayed precise product weight

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -159,6 +159,7 @@ class ProductCombination extends CommonAbstractType
                 ],
             ])
             ->add('attribute_weight', NumberType::class, [
+                'scale' => self::PRESTASHOP_WEIGHT_DECIMALS,
                 'required' => false,
                 'label' => $this->translator->trans('Impact on weight', [], 'Admin.Catalog.Feature'),
                 'attr' => ['class' => 'attribute_weight'],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -159,7 +159,7 @@ class ProductCombination extends CommonAbstractType
                 ],
             ])
             ->add('attribute_weight', NumberType::class, [
-                'scale' => self::PRESTASHOP_WEIGHT_DECIMALS,
+                'scale' => static::PRESTASHOP_WEIGHT_DECIMALS,
                 'required' => false,
                 'label' => $this->translator->trans('Impact on weight', [], 'Admin.Catalog.Feature'),
                 'attr' => ['class' => 'attribute_weight'],

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -150,7 +150,7 @@ class ProductShipping extends CommonAbstractType
                 'weight',
                 FormType\NumberType::class,
                 [
-                    'scale' => 6,
+                    'scale' => self::PRESTASHOP_WEIGHT_DECIMALS,
                     'required' => false,
                     'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -150,6 +150,7 @@ class ProductShipping extends CommonAbstractType
                 'weight',
                 FormType\NumberType::class,
                 [
+                    'scale' => 6,
                     'required' => false,
                     'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -150,7 +150,7 @@ class ProductShipping extends CommonAbstractType
                 'weight',
                 FormType\NumberType::class,
                 [
-                    'scale' => self::PRESTASHOP_WEIGHT_DECIMALS,
+                    'scale' => static::PRESTASHOP_WEIGHT_DECIMALS,
                     'required' => false,
                     'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -35,6 +35,7 @@ use Symfony\Component\Form\AbstractType;
 abstract class CommonAbstractType extends AbstractType
 {
     public const PRESTASHOP_DECIMALS = 6;
+    public const PRESTASHOP_WEIGHT_DECIMALS = 6;
 
     /**
      * Get the configuration adapter.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Weight is not correctly displayed if has more than 3 decimals
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24687
| How to test?      | See #24687 
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24688)
<!-- Reviewable:end -->
