### PR TITLE
Fix delete modal translation

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -118,7 +118,7 @@
                     e.preventDefault();
                     var _this = $(this);
 
-                    modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
+                    modalConfirmation.create(translate_javascripts['Are you sure you want to delete this item?'], null, {
                         onContinue: function(){
                             _this.closest('li').remove();
                             if(_this.parent().parent().length == 0){
@@ -238,7 +238,7 @@
                 e.preventDefault();
                 var _this = $(this);
 
-                modalConfirmation.create(translate_javascripts['Are you sure to delete this?'], null, {
+                modalConfirmation.create(translate_javascripts['Are you sure you want to delete this item?'], null, {
                     onContinue: function(){
                         _this.closest('li').remove();
                         _this.parent().parent().hide();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The delete wording in product page has been updated in this PR https://github.com/PrestaShop/PrestaShop/pull/21239 but they wording keys also changed in the translation wordings list but they were not updated in the typeahed template so the text was blank
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24142
| How to test?      | See issue (delete customer in specific price and delete pack)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24696)
<!-- Reviewable:end -->
