### PR TITLE
Deprecate Tools::safePostVars method

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1080,8 +1080,16 @@ class ToolsCore
         return html_entity_decode((string) $string, ENT_QUOTES, 'utf-8');
     }
 
+    /**
+     * @deprecated Since 1.7.9.0.
+     */
     public static function safePostVars()
     {
+        @trigger_error(
+            'Tools::safePostVars() is deprecated since version 1.7.9.0. ',
+            E_USER_DEPRECATED
+        );
+
         if (!isset($_POST) || !is_array($_POST)) {
             $_POST = [];
         } else {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1086,7 +1086,7 @@ class ToolsCore
     public static function safePostVars()
     {
         @trigger_error(
-            'Tools::safePostVars() is deprecated since version 1.7.9.0. ',
+            'Tools::safePostVars() is deprecated since version 1.7.9.0.',
             E_USER_DEPRECATED
         );
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See title, method is bad as it can mutate global state which should be immutable.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | CI must pass
| Possible impacts? | Method must not be used anywhere, PrestaShop does not use it already.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24701)
<!-- Reviewable:end -->
