### PR TITLE
PrestashopLogger should save object type, even if object id is not set.

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -656,7 +656,7 @@ class MailCore extends ObjectModel
                 'Swift Error: ' . $e->getMessage(),
                 3,
                 null,
-                'Swift_Message'
+                'SwiftMessage'
             );
 
             return false;

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -656,7 +656,7 @@ class MailCore extends ObjectModel
                 'Swift Error: ' . $e->getMessage(),
                 3,
                 null,
-                'SwiftMessage'
+                'Swift_Message'
             );
 
             return false;

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -144,7 +144,7 @@ class PrestaShopLoggerCore extends ObjectModel
         $log = new PrestaShopLogger();
         $log->severity = (int) $severity;
         $log->error_code = (int) $errorCode;
-        $log->message = pSQL($message);
+        $log->message = $message;
         $log->date_add = date('Y-m-d H:i:s');
         $log->date_upd = date('Y-m-d H:i:s');
 
@@ -158,12 +158,11 @@ class PrestaShopLoggerCore extends ObjectModel
             $log->id_employee = (int) $idEmployee;
         }
 
-        if (!empty($object_type)) {
-            $log->object_type = pSQL($object_type);
-        }
-
-        if (!empty($object_id)) {
-            $log->object_id = (int) $object_id;
+        if (!empty($objectType)) {
+            $log->object_type = $objectType;
+            if (!empty($objectId)) {
+                $log->object_id = (int) $objectId;
+            }
         }
 
         $log->id_lang = (int) $context->language->id ?? null;

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -170,7 +170,7 @@ class PrestaShopLoggerCore extends ObjectModel
         $log->id_shop = (Shop::getContext() == Shop::CONTEXT_SHOP) ? (int) $context->shop->getContextualShopId() : null;
         $log->id_shop_group = (Shop::getContext() == Shop::CONTEXT_GROUP) ? (int) $context->shop->getContextShopGroupID() : null;
 
-        if ($objectType != 'Swift_Message') {
+        if ($objectType != 'SwiftMessage') {
             PrestaShopLogger::sendByMail($log);
         }
 

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -158,9 +158,12 @@ class PrestaShopLoggerCore extends ObjectModel
             $log->id_employee = (int) $idEmployee;
         }
 
-        if (!empty($objectType) && !empty($objectId)) {
-            $log->object_type = pSQL($objectType);
-            $log->object_id = (int) $objectId;
+        if (!empty($object_type)) {
+            $log->object_type = pSQL($object_type);
+        }
+
+        if (!empty($object_id)) {
+            $log->object_id = (int) $object_id;
         }
 
         $log->id_lang = (int) $context->language->id ?? null;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | PrestashopLogger should save object type, even if object id is not set.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24706.
| How to test?      | Follow the steps indicated in #24706 and notice that the object_type is logged now.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24707)
<!-- Reviewable:end -->
