### PR TITLE
Fix missing scrollbar on multistore dropdowns

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_multishop-modal.scss
+++ b/admin-dev/themes/new-theme/scss/components/_multishop-modal.scss
@@ -10,7 +10,7 @@ $component-name: multishop-modal;
   align-items: flex-start;
   justify-content: center;
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 78px);
   pointer-events: all;
   background-color: rgba(0, 0, 0, 0.6);
   opacity: 1;
@@ -29,8 +29,9 @@ $component-name: multishop-modal;
   &-dialog {
     width: 100%;
     max-width: 39.375rem;
-    padding: 1.875rem 3.125rem;
-    padding-right: 2.125rem;
+    max-height: 100%;
+    padding: 1.875rem 2.125rem;
+    overflow: auto;
     background: $white;
     border: 1px solid #b7ced3;
     // stylelint-disable

--- a/admin-dev/themes/new-theme/scss/components/_multistore-dropdown.scss
+++ b/admin-dev/themes/new-theme/scss/components/_multistore-dropdown.scss
@@ -59,7 +59,7 @@ $component-name: multistore-dropdown;
   .dropdown-menu {
     width: 100vw;
     max-width: 27.5rem;
-    max-height: 30rem;
+    max-height: 50vh;
     padding: 1.25rem;
     overflow: auto;
 

--- a/admin-dev/themes/new-theme/scss/components/_multistore-dropdown.scss
+++ b/admin-dev/themes/new-theme/scss/components/_multistore-dropdown.scss
@@ -59,7 +59,9 @@ $component-name: multistore-dropdown;
   .dropdown-menu {
     width: 100vw;
     max-width: 27.5rem;
+    max-height: 30rem;
     padding: 1.25rem;
+    overflow: auto;
 
     ul,
     li {

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -24,7 +24,7 @@
  *#}
 {% block multistore_dropdown %}
   <div class="btn-group multistore-dropdown js-multistore-dropdown">
-    <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton4" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton4" data-toggle="dropdown" data-flip="false" aria-haspopup="true" aria-expanded="false">
       <i class="material-icons">storefront</i>
     </button>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton4">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes missing scrollbar on multistore dropdowns (in top bar and next to fields). The dropdown now adapts to the height of the screen (in top bar) and to a fixed height (next to fields), useful when there are many shops.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24333
| How to test?      | Enable multistore, add many shops and see scrollbar
| Possible impacts? | -
| Sponsor company | @Creabilis


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24713)
<!-- Reviewable:end -->
