### PR TITLE
The addProductNewInvoiceInfo is not displayed when creating new invoice

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
@@ -255,7 +255,7 @@ export default class OrderProductRenderer {
   toggleProductAddNewInvoiceInfo() {
     $(OrderViewPageMap.productAddNewInvoiceInfo).toggleClass(
       'd-none',
-      parseInt($(OrderViewPageMap.productAddInvoiceSelect).val(), 10) === 0,
+      parseInt($(OrderViewPageMap.productAddInvoiceSelect).val(), 10) !== 0,
     );
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The new invoice has 0 as value, not 1.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24533 #24532 
| How to test?      | Follow ticket instruction.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24718)
<!-- Reviewable:end -->
