### PR TITLE
fix new invoice info being displayed when adding a new product in order detail page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.js
@@ -255,7 +255,7 @@ export default class OrderProductRenderer {
   toggleProductAddNewInvoiceInfo() {
     $(OrderViewPageMap.productAddNewInvoiceInfo).toggleClass(
       'd-none',
-      parseInt($(OrderViewPageMap.productAddInvoiceSelect).val(), 10) === 0,
+      $(OrderViewPageMap.productAddInvoiceSelect).length === 0,
     );
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In order page detail, when clicking on "add new product" and when there is no invoice yet, the "new invoice info" block was displayed, which was a bug: there was a check made on the invoice selector, checking that the value is empty/zero, but now the invoice selector isn't there anymore so we must check its existence instead of its value.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24532
| How to test?      | See detailed steps in issue #24532
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24719)
<!-- Reviewable:end -->
