### PR TITLE
Fix domain wordings

### DIFF
--- a/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
@@ -1,11 +1,1199 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="a536fd360caf34452a84d97775aeb74a">
-        <source>An order message with the same name already exists in %s.</source>
-        <target>An order message with the same name already exists in %s.</target>
-        <note>Line: 259</note>
+      <trans-unit id="764368526633c5baf14291ba7fbb9e05">
+        <source>For this particular customer group, prices are displayed as:</source>
+        <target>For this particular customer group, prices are displayed as:</target>
+        <note>Line: 221</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/_product_line.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="65247263c6ea1d91027b28a41db8cb4b">
+        <source>Editing this product line will remove the reduction and base price.</source>
+        <target>Editing this product line will remove the reduction and base price.</target>
+        <note>Line: 47</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c6ba3f7beac8724d025d570d002b1579">
+        <source>No voucher was found</source>
+        <target>No voucher was found</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1b638a956fae226de3740f63a4e7d48">
+        <source>Are you sure you want to add this quantity?</source>
+        <target>Are you sure you want to add this quantity?</target>
+        <note>Line: 43</note>
+      </trans-unit>
+      <trans-unit id="bcab2ed7cab19f8e119317a7e59d316a">
+        <source>Error: No product has been selected</source>
+        <target>Error: No product has been selected</target>
+        <note>Line: 45</note>
+      </trans-unit>
+      <trans-unit id="cd5cb1c932fc6f41a4fb3f6ec2f0c2da">
+        <source>Error: Quantity of products must be set</source>
+        <target>Error: Quantity of products must be set</target>
+        <note>Line: 46</note>
+      </trans-unit>
+      <trans-unit id="894fdeeda7d3575fd6775732d026992c">
+        <source>Error: Product price must be set</source>
+        <target>Error: Product price must be set</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="7137dec9b59978006f8b0ec036099346">
+        <source>This warning also concerns order </source>
+        <target>This warning also concerns order </target>
+        <note>Line: 412</note>
+      </trans-unit>
+      <trans-unit id="f38c718d5cc5ea7331d8acf533f9bf0d">
+        <source>This warning also concerns the next orders:</source>
+        <target>This warning also concerns the next orders:</target>
+        <note>Line: 414</note>
+      </trans-unit>
+      <trans-unit id="de78da3154b793d64d302db27e65baec">
+        <source>No payment methods are available</source>
+        <target>No payment methods are available</target>
+        <note>Line: 497</note>
+      </trans-unit>
+      <trans-unit id="ecd2046a1d4a6e46c11914c04b9559e4">
+        <source>A registered customer account has already claimed this email address</source>
+        <target>A registered customer account has already claimed this email address</target>
+        <note>Line: 604</note>
+      </trans-unit>
+      <trans-unit id="341ee6bf57abde84135c32f55a607de2">
+        <source>Do you want to send this message to the customer?</source>
+        <target>Do you want to send this message to the customer?</target>
+        <note>Line: 828</note>
+      </trans-unit>
+      <trans-unit id="44f36e0e113ab5d842c47691364f6eb4">
+        <source>This product cannot be returned.</source>
+        <target>This product cannot be returned.</target>
+        <note>Line: 893</note>
+      </trans-unit>
+      <trans-unit id="b8d649752e2493d7d761b05cc255c3fd">
+        <source>Quantity to cancel is greater than quantity available.</source>
+        <target>Quantity to cancel is greater than quantity available.</target>
+        <note>Line: 893</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="classes/order/OrderHistory.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e1e95b3cea70730a922b35808ca3dce3">
+        <source>Invalid new order status</source>
+        <target>Invalid new order status</target>
+        <note>Line: 362</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminAddressesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a58058b92c1584b1bdc413ac3d2e6699">
+        <source>This customer ID is not recognized.</source>
+        <target>This customer ID is not recognized.</target>
+        <note>Line: 384</note>
+      </trans-unit>
+      <trans-unit id="02c1c5ece60602356e41d407a81cb1fe">
+        <source>This email address is not valid. Please use an address like bob@example.com.</source>
+        <target>This email address is not valid. Please use an address like bob@example.com.</target>
+        <note>Line: 387</note>
+      </trans-unit>
+      <trans-unit id="7c77177e0084c27161d63e7de535a1c6">
+        <source>The identification number is incorrect or has already been used.</source>
+        <target>The identification number is incorrect or has already been used.</target>
+        <note>Line: 390</note>
+      </trans-unit>
+      <trans-unit id="27ac5352d430b82c99157e2dc13a96e3">
+        <source>You have selected a state for a country that does not contain states.</source>
+        <target>You have selected a state for a country that does not contain states.</target>
+        <note>Line: 398</note>
+      </trans-unit>
+      <trans-unit id="86de674d7405670db52e79ec1665b0b1">
+        <source>An address located in a country containing states must have a state selected.</source>
+        <target>An address located in a country containing states must have a state selected.</target>
+        <note>Line: 403</note>
+      </trans-unit>
+      <trans-unit id="03c123f62aad70a9533f5049cf3af959">
+        <source>An error occurred while linking this address to its order.</source>
+        <target>An error occurred while linking this address to its order.</target>
+        <note>Line: 443</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCartsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="996a45aa702d041706f6388d54c53b12">
+        <source>Invalid order</source>
+        <target>Invalid order</target>
+        <note>Line: 571</note>
+      </trans-unit>
+      <trans-unit id="5125d7cea2749d85f13a55a023a56c71">
+        <source>The order cannot be renewed.</source>
+        <target>The order cannot be renewed.</target>
+        <note>Line: 578</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomerThreadsController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b3d571edf77b87b3be5cb3db48d88aa6">
+        <source>An error occurred. Your message was not sent. Please contact your system administrator.</source>
+        <target>An error occurred. Your message was not sent. Please contact your system administrator.</target>
+        <note>Line: 505</note>
+      </trans-unit>
+      <trans-unit id="d9c93c77e4f2eb90e8457f586e0c5cb3">
+        <source>Cannot create message in a new thread.</source>
+        <target>Cannot create message in a new thread.</target>
+        <note>Line: 1084</note>
+      </trans-unit>
+      <trans-unit id="142c7111dc9e81f5cf273851ccce9fcc">
+        <source>The message body is empty, cannot import it.</source>
+        <target>The message body is empty, cannot import it.</target>
+        <note>Line: 1152</note>
+      </trans-unit>
+      <trans-unit id="5d1cbbd2b78574a8cfac676d8bdb9ea4">
+        <source>Invalid message content for subject: %s</source>
+        <target>Invalid message content for subject: %s</target>
+        <note>Line: 1160</note>
+      </trans-unit>
+      <trans-unit id="f70f856f6d471d374aaf5080afeb1e53">
+        <source>The message content is not valid, cannot import it.</source>
+        <target>The message content is not valid, cannot import it.</target>
+        <note>Line: 1166</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminCustomersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="03552140a267acc27f494dc3ab368067">
+        <source>Unknown delete mode:</source>
+        <target>Unknown delete mode:</target>
+        <note>Line: 870</note>
+      </trans-unit>
+      <trans-unit id="7298a088a582ffc05f2c777afb3115cb">
+        <source>Password cannot be empty.</source>
+        <target>Password cannot be empty.</target>
+        <note>Line: 900</note>
+      </trans-unit>
+      <trans-unit id="0a53e9e61f2a9bf59e9028b42fbd8166">
+        <source>An error occurred while loading the object.</source>
+        <target>An error occurred while loading the object.</target>
+        <note>Line: 929</note>
+      </trans-unit>
+      <trans-unit id="77ae44aa6c998166fcf1a87496278ad5">
+        <source>(cannot load object)</source>
+        <target>(cannot load object)</target>
+        <note>Line: 930</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminOrdersController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="accfc34fe6c65228a926b524870161ab">
+        <source>This cart does not exists</source>
+        <target>This cart does not exists</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="3d4d2d9627d3f1b1c0d22b9e85c687d1">
+        <source>The cart must have a customer</source>
+        <target>The cart must have a customer</target>
+        <note>Line: 235</note>
+      </trans-unit>
+      <trans-unit id="a42a075994b3ee0f6fe5956110d85889">
+        <source>Order status #%id% cannot be loaded</source>
+        <target>Order status #%id% cannot be loaded</target>
+        <note>Line: 389</note>
+      </trans-unit>
+      <trans-unit id="45d4b3afac71a54470a6cbf828e8cb0d">
+        <source>The order carrier ID is invalid.</source>
+        <target>The order carrier ID is invalid.</target>
+        <note>Line: 477</note>
+      </trans-unit>
+      <trans-unit id="e52d022f0fb2160ec1cf7b4122ab9589">
+        <source>The tracking number is incorrect.</source>
+        <target>The tracking number is incorrect.</target>
+        <note>Line: 479</note>
+      </trans-unit>
+      <trans-unit id="f465ea6c7866853ecc49286449720ac9">
+        <source>The order carrier cannot be updated.</source>
+        <target>The order carrier cannot be updated.</target>
+        <note>Line: 519</note>
+      </trans-unit>
+      <trans-unit id="c2572d1fee836c06c88e0bdc9fa7ffa1">
+        <source>The new order status is invalid.</source>
+        <target>The new order status is invalid.</target>
+        <note>Line: 531</note>
+      </trans-unit>
+      <trans-unit id="4f51deabdeba4ee61b998d3b0cf188b4">
+        <source>An error occurred while changing order status, or we were unable to send an email to the customer.</source>
+        <target>An error occurred while changing order status, or we were unable to send an email to the customer.</target>
+        <note>Line: 565</note>
+      </trans-unit>
+      <trans-unit id="c5e4a57d9572678ffbb124db39542928">
+        <source>The order has already been assigned this status.</source>
+        <target>The order has already been assigned this status.</target>
+        <note>Line: 567</note>
+      </trans-unit>
+      <trans-unit id="f61c60ff8d82ebd1012606e5bc3a2002">
+        <source>The customer is invalid.</source>
+        <target>The customer is invalid.</target>
+        <note>Line: 578</note>
+      </trans-unit>
+      <trans-unit id="3dc245110e1f3601860c20299d97c01d">
+        <source>The message cannot be blank.</source>
+        <target>The message cannot be blank.</target>
+        <note>Line: 580</note>
+      </trans-unit>
+      <trans-unit id="204c3558e41366f3d558ce8e01426a22">
+        <source>field %s is required.</source>
+        <target>field %s is required.</target>
+        <note>Line: 587</note>
+      </trans-unit>
+      <trans-unit id="c4d82e8095bb903683e0b0e73887aef0">
+        <source>Please enter a quantity to proceed with your refund.</source>
+        <target>Please enter a quantity to proceed with your refund.</target>
+        <note>Line: 881</note>
+      </trans-unit>
+      <trans-unit id="8a5f368eac3aab699cf8e6e1ec28b695">
+        <source>Please enter an amount to proceed with your refund.</source>
+        <target>Please enter an amount to proceed with your refund.</target>
+        <note>Line: 883</note>
+      </trans-unit>
+      <trans-unit id="598db0342f11f89d4268942b9491c455">
+        <source>You cannot generate a partial credit slip.</source>
+        <target>You cannot generate a partial credit slip.</target>
+        <note>Line: 769</note>
+      </trans-unit>
+      <trans-unit id="b1db8cec4ec0de83c3934a22bc758a3b">
+        <source>You cannot generate a voucher.</source>
+        <target>You cannot generate a voucher.</target>
+        <note>Line: 1127</note>
+      </trans-unit>
+      <trans-unit id="bd4457c0f19f796f3d66726f9fadc041">
+        <source>The partial refund data is incorrect.</source>
+        <target>The partial refund data is incorrect.</target>
+        <note>Line: 892</note>
+      </trans-unit>
+      <trans-unit id="991bbcc5660531bc1a1c8f1c235794c0">
+        <source>You must select a product.</source>
+        <target>You must select a product.</target>
+        <note>Line: 901</note>
+      </trans-unit>
+      <trans-unit id="6d3fd0eb289900145d482634d6e86b90">
+        <source>You must enter a quantity.</source>
+        <target>You must enter a quantity.</target>
+        <note>Line: 903</note>
+      </trans-unit>
+      <trans-unit id="8001500c3284edd9c4dd07ae508e5a95">
+        <source>No quantity has been selected for this product.</source>
+        <target>No quantity has been selected for this product.</target>
+        <note>Line: 967</note>
+      </trans-unit>
+      <trans-unit id="38eaecfc1ef14b98b5d6e4eb77494369">
+        <source>An invalid quantity was selected for this product.</source>
+        <target>An invalid quantity was selected for this product.</target>
+        <note>Line: 971</note>
+      </trans-unit>
+      <trans-unit id="edeff0d68d3d20ce1f6189f6070cb2ba">
+        <source>A credit slip cannot be generated.</source>
+        <target>A credit slip cannot be generated.</target>
+        <note>Line: 1048</note>
+      </trans-unit>
+      <trans-unit id="b81f0a0540938a2e7daa684f02866696">
+        <source>No product or quantity has been selected.</source>
+        <target>No product or quantity has been selected.</target>
+        <note>Line: 1157</note>
+      </trans-unit>
+      <trans-unit id="fdb259bd3d5479c25f5d23af490b5ec3">
+        <source>The order cannot be found</source>
+        <target>The order cannot be found</target>
+        <note>Line: 1182</note>
+      </trans-unit>
+      <trans-unit id="9391de9e24bd71839f6f72a1517de2d6">
+        <source>The amount is invalid.</source>
+        <target>The amount is invalid.</target>
+        <note>Line: 1184</note>
+      </trans-unit>
+      <trans-unit id="6ab061ec12504fab2c41f0689579d623">
+        <source>The selected payment method is invalid.</source>
+        <target>The selected payment method is invalid.</target>
+        <note>Line: 1186</note>
+      </trans-unit>
+      <trans-unit id="7d0d71a3e577be4c20799b52286191d6">
+        <source>The transaction ID is invalid.</source>
+        <target>The transaction ID is invalid.</target>
+        <note>Line: 1188</note>
+      </trans-unit>
+      <trans-unit id="3b512b6c31ef4f46605159612691eb56">
+        <source>The selected currency is invalid.</source>
+        <target>The selected currency is invalid.</target>
+        <note>Line: 1190</note>
+      </trans-unit>
+      <trans-unit id="06fc8d486e9f83c5810a21857da7b656">
+        <source>The invoice is invalid.</source>
+        <target>The invoice is invalid.</target>
+        <note>Line: 1192</note>
+      </trans-unit>
+      <trans-unit id="f50c7cba4df874039d73ee480d678f5e">
+        <source>The date is invalid</source>
+        <target>The date is invalid</target>
+        <note>Line: 1194</note>
+      </trans-unit>
+      <trans-unit id="04e3713831c71d70817d4a69eadbc53c">
+        <source>An error occurred during payment.</source>
+        <target>An error occurred during payment.</target>
+        <note>Line: 1197</note>
+      </trans-unit>
+      <trans-unit id="0d906d12a6321e5f13e69dab92e39a4e">
+        <source>The invoice note was not saved.</source>
+        <target>The invoice note was not saved.</target>
+        <note>Line: 1214</note>
+      </trans-unit>
+      <trans-unit id="7f5a75ac350db917dc60cfbd8299da5b">
+        <source>Failed to upload the invoice and edit its note.</source>
+        <target>Failed to upload the invoice and edit its note.</target>
+        <note>Line: 1220</note>
+      </trans-unit>
+      <trans-unit id="68b7afe49451dbdab7cbeff4f66be369">
+        <source>This delivery address country is not active.</source>
+        <target>This delivery address country is not active.</target>
+        <note>Line: 1240</note>
+      </trans-unit>
+      <trans-unit id="a9320eb7be798958cba0a93262521ede">
+        <source>This invoice address country is not active.</source>
+        <target>This invoice address country is not active.</target>
+        <note>Line: 1242</note>
+      </trans-unit>
+      <trans-unit id="95aa605fa7f396d370b4c87afad9201c">
+        <source>This address can't be loaded</source>
+        <target>This address can't be loaded</target>
+        <note>Line: 1284</note>
+      </trans-unit>
+      <trans-unit id="b0535e1868ad530e5faadf295516a724">
+        <source>You cannot change the currency.</source>
+        <target>You cannot change the currency.</target>
+        <note>Line: 1398</note>
+      </trans-unit>
+      <trans-unit id="8dcb8970b8eeeac73c8d312d1db3d1f9">
+        <source>Invoice management has been disabled.</source>
+        <target>Invoice management has been disabled.</target>
+        <note>Line: 1405</note>
+      </trans-unit>
+      <trans-unit id="f98321e34948f600959c5c4200c953c8">
+        <source>This order already has an invoice.</source>
+        <target>This order already has an invoice.</target>
+        <note>Line: 1407</note>
+      </trans-unit>
+      <trans-unit id="0da1c0afe7d3d89a53a5d00998bb4295">
+        <source>You cannot edit this cart rule.</source>
+        <target>You cannot edit this cart rule.</target>
+        <note>Line: 1447</note>
+      </trans-unit>
+      <trans-unit id="db7cb022c7b6058d0f1668faa22a54fa">
+        <source>You must specify a name in order to create a new discount.</source>
+        <target>You must specify a name in order to create a new discount.</target>
+        <note>Line: 1455</note>
+      </trans-unit>
+      <trans-unit id="7b56734426bcdd50629f41c58cb1f241">
+        <source>The discount value is invalid.</source>
+        <target>The discount value is invalid.</target>
+        <note>Line: 1494</note>
+      </trans-unit>
+      <trans-unit id="8dc19f50ae30ac7d61e67c795b32fd47">
+        <source>The discount value is greater than the order invoice total.</source>
+        <target>The discount value is greater than the order invoice total.</target>
+        <note>Line: 1515</note>
+      </trans-unit>
+      <trans-unit id="574875d4553bada6682a07ae86298bc6">
+        <source>The discount value is greater than the order total.</source>
+        <target>The discount value is greater than the order total.</target>
+        <note>Line: 1526</note>
+      </trans-unit>
+      <trans-unit id="9a9d54664b6ba23a9588f6b795dc03ab">
+        <source>The discount type is invalid.</source>
+        <target>The discount type is invalid.</target>
+        <note>Line: 1564</note>
+      </trans-unit>
+      <trans-unit id="b046e96ee00ad2ef4ed135eab1c13df4">
+        <source>An error occurred during the OrderCartRule creation</source>
+        <target>An error occurred during the OrderCartRule creation</target>
+        <note>Line: 1617</note>
+      </trans-unit>
+      <trans-unit id="0fa578512847280157dd62ae18e92979">
+        <source>An error occurred while loading order status.</source>
+        <target>An error occurred while loading order status.</target>
+        <note>Line: 1628</note>
+      </trans-unit>
+      <trans-unit id="773b660773e6106c248814fa87b480f7">
+        <source>Error in sending the email to your customer.</source>
+        <target>Error in sending the email to your customer.</target>
+        <note>Line: 2097</note>
+      </trans-unit>
+      <trans-unit id="4dc1c8fa2f766c5e201155ee3737ed3f">
+        <source>The order object cannot be loaded.</source>
+        <target>The order object cannot be loaded.</target>
+        <note>Line: 2869</note>
+      </trans-unit>
+      <trans-unit id="7152cf69405fd47a8bd2f7b625ce324e">
+        <source>You cannot add products to delivered orders.</source>
+        <target>You cannot add products to delivered orders.</target>
+        <note>Line: 2117</note>
+      </trans-unit>
+      <trans-unit id="9b7508b5ee1050d5c5efb9b1cf76fd36">
+        <source>The product object cannot be loaded.</source>
+        <target>The product object cannot be loaded.</target>
+        <note>Line: 2479</note>
+      </trans-unit>
+      <trans-unit id="74bd055cec720c9f41563ff6a6a40b7b">
+        <source>The combination object cannot be loaded.</source>
+        <target>The combination object cannot be loaded.</target>
+        <note>Line: 2140</note>
+      </trans-unit>
+      <trans-unit id="0d38c90d843c787c0be14f790998210c">
+        <source>You must add %d minimum quantity</source>
+        <target>You must add %d minimum quantity</target>
+        <note>Line: 2224</note>
+      </trans-unit>
+      <trans-unit id="de10fc28511b894f704c1a67fcff7b4f">
+        <source>You already have the maximum quantity available for this product.</source>
+        <target>You already have the maximum quantity available for this product.</target>
+        <note>Line: 2226</note>
+      </trans-unit>
+      <trans-unit id="4e670964e358534a827dc7e0359281b0">
+        <source>The OrderDetail object cannot be loaded.</source>
+        <target>The OrderDetail object cannot be loaded.</target>
+        <note>Line: 2471</note>
+      </trans-unit>
+      <trans-unit id="0c8a625097a9b711bfca4724517eeb01">
+        <source>The address object cannot be loaded.</source>
+        <target>The address object cannot be loaded.</target>
+        <note>Line: 2487</note>
+      </trans-unit>
+      <trans-unit id="7da127d075ca24fec224c1d497aac11f">
+        <source>An error occurred while editing the product line.</source>
+        <target>An error occurred while editing the product line.</target>
+        <note>Line: 2678</note>
+      </trans-unit>
+      <trans-unit id="fde52aaef1e1e23770e40a458a1cac46">
+        <source>An error occurred while attempting to delete the product line.</source>
+        <target>An error occurred while attempting to delete the product line.</target>
+        <note>Line: 2747</note>
+      </trans-unit>
+      <trans-unit id="e3a212006776535d5da7d11f7c62d727">
+        <source>The Order Detail object could not be loaded.</source>
+        <target>The Order Detail object could not be loaded.</target>
+        <note>Line: 2862</note>
+      </trans-unit>
+      <trans-unit id="823eba6da615c2a384cf8e13cd70980b">
+        <source>The invoice object cannot be loaded.</source>
+        <target>The invoice object cannot be loaded.</target>
+        <note>Line: 2796</note>
+      </trans-unit>
+      <trans-unit id="0af3cc300f35caff086e21bf2f865960">
+        <source>You cannot edit the order detail for this order.</source>
+        <target>You cannot edit the order detail for this order.</target>
+        <note>Line: 2810</note>
+      </trans-unit>
+      <trans-unit id="7ea9212dcdaccc580b9e6b548609e7fd">
+        <source>You cannot edit a delivered order.</source>
+        <target>You cannot edit a delivered order.</target>
+        <note>Line: 2884</note>
+      </trans-unit>
+      <trans-unit id="675b81dace2c99f5ef5eb6ac3f69dbe4">
+        <source>You cannot use this invoice for the order</source>
+        <target>You cannot use this invoice for the order</target>
+        <note>Line: 2825</note>
+      </trans-unit>
+      <trans-unit id="2591b6d46f45d8f60e24c6c9c96a2a11">
+        <source>Invalid price</source>
+        <target>Invalid price</target>
+        <note>Line: 2836</note>
+      </trans-unit>
+      <trans-unit id="01816dd287bcb3b88ad3f63970ce045f">
+        <source>Invalid quantity</source>
+        <target>Invalid quantity</target>
+        <note>Line: 2850</note>
+      </trans-unit>
+      <trans-unit id="c181d4415ea3fd71c407da3697be421f">
+        <source>You cannot delete the order detail.</source>
+        <target>You cannot delete the order detail.</target>
+        <note>Line: 2876</note>
+      </trans-unit>
+      <trans-unit id="671cd4e79283dd9931f0452000bf2744">
+        <source>This product cannot be re-stocked.</source>
+        <target>This product cannot be re-stocked.</target>
+        <note>Line: 3032</note>
+      </trans-unit>
+      <trans-unit id="bf772d53e730d2e0169ed2f746044606">
+        <source>An error occurred while attempting to delete the product.</source>
+        <target>An error occurred while attempting to delete the product.</target>
+        <note>Line: 988</note>
+      </trans-unit>
+      <trans-unit id="77d97f5686dfef72ee577e779d5bb74f">
+        <source>An error occurred while attempting to delete product customization.</source>
+        <target>An error occurred while attempting to delete product customization.</target>
+        <note>Line: 1010</note>
+      </trans-unit>
+      <trans-unit id="4fe1644600a7dad640143da346a9211b">
+        <source>Order #%d cannot be loaded</source>
+        <target>Order #%d cannot be loaded</target>
+        <note>Line: 394</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminPdfController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f193c3dd6da8a06a610c632db03d55c8">
+        <source>The order ID -- or the invoice order ID -- is missing.</source>
+        <target>The order ID -- or the invoice order ID -- is missing.</target>
+        <note>Line: 89</note>
+      </trans-unit>
+      <trans-unit id="48607ff5af8c52b5efbc057b852a37ee">
+        <source>No invoice was found.</source>
+        <target>No invoice was found.</target>
+        <note>Line: 140</note>
+      </trans-unit>
+      <trans-unit id="57bf4b0dd7dd3e5af10533785a343f88">
+        <source>No order slips were found.</source>
+        <target>No order slips were found.</target>
+        <note>Line: 124</note>
+      </trans-unit>
+      <trans-unit id="f2e9d5988718c8a3dde49c6bcb55125b">
+        <source>The supply order ID is missing.</source>
+        <target>The supply order ID is missing.</target>
+        <note>Line: 149</note>
+      </trans-unit>
+      <trans-unit id="4fc152e203df7a77fa3c1bc7f1249f36">
+        <source>The supply order cannot be found within your database.</source>
+        <target>The supply order cannot be found within your database.</target>
+        <note>Line: 156</note>
+      </trans-unit>
+      <trans-unit id="d7e5dfc920c9871caaf7562d8ba9ab36">
+        <source>The order invoice cannot be found within your database.</source>
+        <target>The order invoice cannot be found within your database.</target>
+        <note>Line: 199</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminReturnController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7582ef2f5b5de8a479994d0412986bc2">
+        <source>An error occurred while deleting the details of your order return.</source>
+        <target>An error occurred while deleting the details of your order return.</target>
+        <note>Line: 230</note>
+      </trans-unit>
+      <trans-unit id="d4430672c8b3c123ae5f4c2f4b5b458d">
+        <source>You need at least one product.</source>
+        <target>You need at least one product.</target>
+        <note>Line: 233</note>
+      </trans-unit>
+      <trans-unit id="e7a58e52e848f513c3e9185d34d61a50">
+        <source>The order return is invalid.</source>
+        <target>The order return is invalid.</target>
+        <note>Line: 236</note>
+      </trans-unit>
+      <trans-unit id="5431bd88788ce2df4278c84f402e3cb6">
+        <source>The order return content is invalid.</source>
+        <target>The order return content is invalid.</target>
+        <note>Line: 239</note>
+      </trans-unit>
+      <trans-unit id="16f2adf6c4fd1317acba5871267a60f2">
+        <source>No order return ID has been specified.</source>
+        <target>No order return ID has been specified.</target>
+        <note>Line: 288</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminSearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5844cf5e9f752e6eb7cc1166a3022183">
+        <source>No order was found with this ID:</source>
+        <target>No order was found with this ID:</target>
+        <note>Line: 152</note>
+      </trans-unit>
+      <trans-unit id="3b27bc623d860beacbe5d5cde18fdec0">
+        <source>No invoice was found with this ID:</source>
+        <target>No invoice was found with this ID:</target>
+        <note>Line: 162</note>
+      </trans-unit>
+      <trans-unit id="ec79affe41245b47969a2451211b263a">
+        <source>No cart was found with this ID:</source>
+        <target>No cart was found with this ID:</target>
+        <note>Line: 170</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/admin/AdminStatusesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="35af021c4bdb02cad86c917022e053da">
+        <source>An error has occurred: Can't save the current order's return status.</source>
+        <target>An error has occurred: Can't save the current order's return status.</target>
+        <note>Line: 566</note>
+      </trans-unit>
+      <trans-unit id="ca215ff3d829e3a6a9c0c672987d5959">
+        <source>An error has occurred: Can't delete the current order's return status.</source>
+        <target>An error has occurred: Can't delete the current order's return status.</target>
+        <note>Line: 595</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bde13610a2ae2521b30aa7821d553862">
+        <source>There is no status defined for this order.</source>
+        <target>There is no status defined for this order.</target>
+        <note>Line: 268</note>
+      </trans-unit>
+      <trans-unit id="14542f5997c4a02d4276da364657f501">
+        <source>Direct link</source>
+        <target>Direct link</target>
+        <note>Line: 497</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f22b1baf8dcfb014646921be9841cb41">
+        <source>expires on %s.</source>
+        <target>expires on %s.</target>
+        <note>Line: 423</note>
+      </trans-unit>
+      <trans-unit id="0db24e725e6876d0fc7467554e8b6c03">
+        <source>downloadable %d time(s)</source>
+        <target>downloadable %d time(s)</target>
+        <note>Line: 424</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6a94d8492279c2bfd3e81f3158658980">
+        <source>[Generated] CartRule for Free Shipping</source>
+        <target>[Generated] CartRule for Free Shipping</target>
+        <note>Line: 423</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/CommandHandler/CancelOrderProductHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1166740db50174894a068c0c51b94c66">
+        <source><![CDATA[Order history email could not be sent, test your email configuration in the Advanced Parameters > E-mail section of your back office.]]></source>
+        <target><![CDATA[Order history email could not be sent, test your email configuration in the Advanced Parameters > E-mail section of your back office.]]></target>
+        <note>Line: 166</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Order/Delivery/SlipPdfConfiguration.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3ffd1b6c5e4ab9c98104475480477307">
+        <source>No delivery slip was found for this period.</source>
+        <target>No delivery slip was found for this period.</target>
+        <note>Line: 82</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/PDF/DeliverySlipPdfGenerator.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1244f34e7f971d0b80cd2fd7cbbfb22c">
+        <source>The order cannot be found within your database.</source>
+        <target>The order cannot be found within your database.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Form/ChoiceProvider/CustomerDeleteMethodChoiceProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ecace08642e28fc9c2704b5f73605b6d">
+        <source>I want my customers to be able to register again with the same email address. All data will be removed from the database.</source>
+        <target>I want my customers to be able to register again with the same email address. All data will be removed from the database.</target>
+        <note>Line: 57</note>
+      </trans-unit>
+      <trans-unit id="fd5b3faeaab816c19b1337785c0b531b">
+        <source>I do not want my customer(s) to register again with the same email address. All selected customer(s) will be removed from this list but their corresponding data will be kept in the database.</source>
+        <target>I do not want my customer(s) to register again with the same email address. All selected customer(s) will be removed from this list but their corresponding data will be kept in the database.</target>
+        <note>Line: 63</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9e2dcf2660b82a0204f668565417010a">
+        <source>An account already exists for this email address:</source>
+        <target>An account already exists for this email address:</target>
+        <note>Line: 513</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1c623b291d95f4f1b1d0c03d0dc0ffa1">
+        <source>This email address is not registered.</source>
+        <target>This email address is not registered.</target>
+        <note>Line: 885</note>
+      </trans-unit>
+      <trans-unit id="c0498039cc042a1109b53933dc33b2e7">
+        <source>A default customer group must be selected in group box.</source>
+        <target>A default customer group must be selected in group box.</target>
+        <note>Line: 881</note>
+      </trans-unit>
+      <trans-unit id="8562db06e3931e51ac8c456b56088b02">
+        <source>This customer does not exist.</source>
+        <target>This customer does not exist.</target>
+        <note>Line: 872</note>
+      </trans-unit>
+      <trans-unit id="4383b950a18d0fd893e237148f5f58ca">
+        <source>This customer already exists as a non-guest.</source>
+        <target>This customer already exists as a non-guest.</target>
+        <note>Line: 922</note>
+      </trans-unit>
+      <trans-unit id="beaa75cbedc3443661b894ed66c76b13">
+        <source>An error occurred while updating customer information.</source>
+        <target>An error occurred while updating customer information.</target>
+        <note>Line: 926</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9cdca3c7972c48111e79648c942ac672">
+        <source>The message was successfully sent to the customer.</source>
+        <target>The message was successfully sent to the customer.</target>
+        <note>Line: 138</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="53a60d3bbec32a4bf2777704834dc35e">
+        <source>You must add a minimum quantity of %d</source>
+        <target>You must add a minimum quantity of %d</target>
+        <note>Line: 609</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cdbb58c797028e137b1ebf1dcc9efe92">
+        <source>No order slips were found for this period.</source>
+        <target>No order slips were found for this period.</target>
+        <note>Line: 193</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1923e1e610686f1182bf54f573b86921">
+        <source>A partial refund was successfully created.</source>
+        <target>A partial refund was successfully created.</target>
+        <note>Line: 558</note>
+      </trans-unit>
+      <trans-unit id="aea807cc550550acd7b8d9a7bc469f6a">
+        <source>You have to select a shop before creating new orders.</source>
+        <target>You have to select a shop before creating new orders.</target>
+        <note>Line: 227</note>
+      </trans-unit>
+      <trans-unit id="409f3dfd9f910287f86fd6c25c94c4d8">
+        <source>Order #%d has already been assigned this status.</source>
+        <target>Order #%d has already been assigned this status.</target>
+        <note>Line: 1850</note>
+      </trans-unit>
+      <trans-unit id="18893a82469e2cd9492fc8d46fa8ac01">
+        <source>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</source>
+        <target>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</target>
+        <note>Line: 1839</note>
+      </trans-unit>
+      <trans-unit id="561918c3c49ff748f543e28f5c405d3c">
+        <source>An error occurred while sending an email to the customer.</source>
+        <target>An error occurred while sending an email to the customer.</target>
+        <note>Line: 1228</note>
+      </trans-unit>
+      <trans-unit id="fded441ef916f653d49abf142b535b52">
+        <source>An error occurred while sending the e-mail to the customer.</source>
+        <target>An error occurred while sending the e-mail to the customer.</target>
+        <note>Line: 1697</note>
+      </trans-unit>
+      <trans-unit id="aeddc664f1e95691c69ea44a5c1c18f5">
+        <source>This product is out of stock: </source>
+        <target>This product is out of stock:</target>
+        <note>Line: 1814</note>
+      </trans-unit>
+      <trans-unit id="4174f012bc63b679f092acd1a933bf5c">
+        <source>The email was sent to your customer.</source>
+        <target>The email was sent to your customer.</target>
+        <note>Line: 1498</note>
+      </trans-unit>
+      <trans-unit id="50c5ffd8dadba5bcc7b83cfe3d874f54">
+        <source>A standard refund was successfully created.</source>
+        <target>A standard refund was successfully created.</target>
+        <note>Line: 591</note>
+      </trans-unit>
+      <trans-unit id="676add5006e766a2f0bf5ba22e231e09">
+        <source>A return product was successfully created.</source>
+        <target>A return product was successfully created.</target>
+        <note>Line: 552</note>
+      </trans-unit>
+      <trans-unit id="4c8098d3dded08ff50537ed2814277ca">
+        <source>You cannot edit the cart once the order delivered</source>
+        <target>You cannot edit the cart once the order delivered</target>
+        <note>Line: 1405</note>
+      </trans-unit>
+      <trans-unit id="918093e8ad4567f6b99e9851eab8bc69">
+        <source>Order #%d cannot be loaded.</source>
+        <target>Order #%d cannot be loaded.</target>
+        <note>Line: 1863</note>
+      </trans-unit>
+      <trans-unit id="2a11327ffe3e46a9ffadddf38b4b9fff">
+        <source>Please enter a maximum quantity of [1].</source>
+        <target>Please enter a maximum quantity of [1].</target>
+        <note>Line: 1736</note>
+      </trans-unit>
+      <trans-unit id="97f014aa339f5b37951f100fb1a086d8">
+        <source>Please select at least one product.</source>
+        <target>Please select at least one product.</target>
+        <note>Line: 1741</note>
+      </trans-unit>
+      <trans-unit id="d31c479bcda04bd5b859f7cff371c3d0">
+        <source>Please enter a positive amount.</source>
+        <target>Please enter a positive amount.</target>
+        <note>Line: 1745</note>
+      </trans-unit>
+      <trans-unit id="4b0c5f16b969b647ff0b63481af6c3e5">
+        <source>Please generate at least one credit slip or voucher.</source>
+        <target>Please generate at least one credit slip or voucher.</target>
+        <note>Line: 1749</note>
+      </trans-unit>
+      <trans-unit id="282426403b9a14678d5dd35e024ec84c">
+        <source>This product is out of stock:</source>
+        <target>This product is out of stock:</target>
+        <note>Line: 652</note>
+      </trans-unit>
+      <trans-unit id="265b2b7a9f792e941faac362bc37f30b">
+        <source>The product was successfully returned.</source>
+        <target>The product was successfully returned.</target>
+        <note>Line: 624</note>
+      </trans-unit>
+      <trans-unit id="f77fd3f9865f0c725901d48dbc00619f">
+        <source>You cannot edit the cart once the order delivered.</source>
+        <target>You cannot edit the cart once the order delivered.</target>
+        <note>Line: 1689</note>
+      </trans-unit>
+      <trans-unit id="f131fb3c210a32ca24a4910b42b6e2ef">
+        <source>Only numbers and decimal points (".") are allowed in the amount fields, e.g. 10.50 or 1050.</source>
+        <target>Only numbers and decimal points (".") are allowed in the amount fields, e.g. 10.50 or 1050.</target>
+        <note>Line: 1705</note>
+      </trans-unit>
+      <trans-unit id="dfa3f525e479dd1038c7947c62b9341a">
+        <source>It looks like the value is invalid:</source>
+        <target>It looks like the value is invalid:</target>
+        <note>Line: 1476</note>
+      </trans-unit>
+      <trans-unit id="8ac6b197a0fd1d1395ba76121814e9fe">
+        <source>Percent or amount value must be greater than 0.</source>
+        <target>Percent or amount value must be greater than 0.</target>
+        <note>Line: 1477</note>
+      </trans-unit>
+      <trans-unit id="7f35d95de964c02a558f322bf683ff93">
+        <source>Percent value cannot exceed 100.</source>
+        <target>Percent value cannot exceed 100.</target>
+        <note>Line: 1714</note>
+      </trans-unit>
+      <trans-unit id="bd69d7116253ba1407fa8f2611ea6866">
+        <source>Discount value cannot exceed the total price of this order.</source>
+        <target>Discount value cannot exceed the total price of this order.</target>
+        <note>Line: 1722</note>
+      </trans-unit>
+      <trans-unit id="c3cb19afc3cf5cd7d07346dcd3504fe2">
+        <source>Only numbers and decimal points (".") are allowed in the amount fields of the payment block, e.g. 10.50 or 1050.</source>
+        <target>Only numbers and decimal points (".") are allowed in the amount fields of the payment block, e.g. 10.50 or 1050.</target>
+        <note>Line: 1818</note>
+      </trans-unit>
+      <trans-unit id="7b310c5ac94a5e50139d50574395683b">
+        <source>Percent value must be greater than 0.</source>
+        <target>Percent value must be greater than 0.</target>
+        <note>Line: 1710</note>
+      </trans-unit>
+      <trans-unit id="2b0c8d4ac85a4f8ddf1427f7ad537f55">
+        <source>Amount value must be greater than 0.</source>
+        <target>Amount value must be greater than 0.</target>
+        <note>Line: 1718</note>
+      </trans-unit>
+      <trans-unit id="0e6becfb4c6566c35a8fda2d94891c70">
+        <source>Shipping discount value cannot exceed the total price of this order.</source>
+        <target>Shipping discount value cannot exceed the total price of this order.</target>
+        <note>Line: 1726</note>
+      </trans-unit>
+      <trans-unit id="500f3380713af59cab7bdd14d8fefea2">
+        <source>You must choose a payment module to create the order.</source>
+        <target>You must choose a payment module to create the order.</target>
+        <note>Line: 1754</note>
+      </trans-unit>
+      <trans-unit id="b2f61848a1b9245fb4d79db939e04c02">
+        <source>You must choose an order status to create the order.</source>
+        <target>You must choose an order status to create the order.</target>
+        <note>Line: 1783</note>
+      </trans-unit>
+      <trans-unit id="53efa65204c54a806b9df6707fc8a326">
+        <source>The order message given is invalid.</source>
+        <target>The order message given is invalid.</target>
+        <note>Line: 1790</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Improve/International/Currencies/CurrencyType.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f569be19b537a76af7e287ace573cd3e">
+        <source>Please enter a positive value</source>
+        <target>Please enter a positive value</target>
+        <note>Line: 218</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceByStatusFormHandler.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="7af95cd9cbe318a15ef10e5e30000501">
+        <source>No invoice has been found for this status.</source>
+        <target>No invoice has been found for this status.</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="599b433088f71a8712de225a693ce20e">
+        <source>Invalid invoice number.</source>
+        <target>Invalid invoice number.</target>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByDateDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9178a1a9fc82617864593a784163d86a">
+        <source>Invalid "From" date</source>
+        <target>Invalid "From" date</target>
+        <note>Line: 88</note>
+      </trans-unit>
+      <trans-unit id="915bd2c5cf6e420095a64d309e443849">
+        <source>Invalid "To" date</source>
+        <target>Invalid "To" date</target>
+        <note>Line: 96</note>
+      </trans-unit>
+      <trans-unit id="f775c161c8662af8f70a128ad5779036">
+        <source>No invoice has been found for this period.</source>
+        <target>No invoice has been found for this period.</target>
+        <note>Line: 104</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoicesByStatusDataProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eb9173ba78d315a23d8978a2b772bd9a">
+        <source>You must select at least one order status.</source>
+        <target>You must select at least one order status.</target>
+        <note>Line: 67</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1c28cbdd010068123432a5885ebfdb65">
+        <source>No cart is available</source>
+        <target>No cart is available</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/personal_information.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c7b085efe30557dbc76c2ba487506049">
+        <source>A registered customer account using the defined email address already exists. </source>
+        <target>A registered customer account using the defined email address already exists.</target>
+        <note>Line: 170</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/delete_modal.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a37bf274ad160c76e7d17b9178bc1f57">
+        <source>How do you want to delete the selected customers?</source>
+        <target>How do you want to delete the selected customers?</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="6513e5e8645f98d950d6174b30c151b8">
+        <source>There are two ways of deleting a customer. Please choose your preferred method.</source>
+        <target>There are two ways of deleting a customer. Please choose your preferred method.</target>
+        <note>Line: 38</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="df46bf546fc69b1cda65afe1001b73fc">
+        <source>You have to select a shop if you want to create a customer.</source>
+        <target>You have to select a shop if you want to create a customer.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="43c2b5547b84d3fe632a8297c27ed20e">
+        <source>You must add at least one address to process the order.</source>
+        <target>You must add at least one address to process the order.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="b9af8635591dc44009ccd8e5389722ec">
+        <source>No products found</source>
+        <target>No products found</target>
+        <note>Line: 47</note>
+      </trans-unit>
+      <trans-unit id="453c92894f48764318534163c2bb2830">
+        <source>The prices are without taxes.</source>
+        <target>The prices are without taxes.</target>
+        <note>Line: 144</note>
+      </trans-unit>
+      <trans-unit id="088f451a8ce01d3cea0fa2a6e886d310">
+        <source>Searching for products</source>
+        <target>Searching for products</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="afdbd71037839ec5a581febacab7bad7">
+        <source>No customers found</source>
+        <target>No customers found</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="a9b14221307d90ff672c5cbb61b4c500">
+        <source>Searching for customers</source>
+        <target>Searching for customers</target>
+        <note>Line: 66</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="29c14e1df15d10b73ec9605fd146b9fe">
+        <source>No carrier can be applied to this order</source>
+        <target>No carrier can be applied to this order</target>
+        <note>Line: 118</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4d734cc32a5cac86597621969696baa8">
+        <source>This value must include taxes.</source>
+        <target>This value must include taxes.</target>
+        <note>Line: 74</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="2e66149518ba8dc45a9e51c4f153cebf">
+        <source><![CDATA[Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings]]></source>
+        <target><![CDATA[Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings]]></target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e2103a9e878a2280b3163e5ee098cbdf">
+        <source>Are you sure you want to create a new invoice?</source>
+        <target>Are you sure you want to create a new invoice?</target>
+        <note>Line: 67</note>
+      </trans-unit>
+      <trans-unit id="ca4c54eff098a5785c2016718a00ef1f">
+        <source>Are you sure you want to edit this product price? It will be applied to all invoices of this order.</source>
+        <target>Are you sure you want to edit this product price? It will be applied to all invoices of this order.</target>
+        <note>Line: 71</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5db361171166373b9694fc4aeb0932b5">
+        <source>There is no available document</source>
+        <target>There is no available document</target>
+        <note>Line: 135</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="14c7a12fdbf437a0545aed3365ce3f84">
+        <source>No merchandise returned yet</source>
+        <target>No merchandise returned yet</target>
+        <note>Line: 55</note>
+      </trans-unit>
+      <trans-unit id="8132fa66932aa7c4ed3e16f35e228194">
+        <source>Merchandise returns are not applicable for virtual orders</source>
+        <target>Merchandise returns are not applicable for virtual orders</target>
+        <note>Line: 62</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/messages.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dc8d1b4e8c9bdf1eed97eb9ed5877a43">
+        <source>Do you want to overwrite your existing message?</source>
+        <target>Do you want to overwrite your existing message?</target>
+        <note>Line: 73</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="153c7809e6b00b6cbfa01b8aa9db43e3">
+        <source>paid instead of</source>
+        <target>paid instead of</target>
+        <note>Line: 39</note>
+      </trans-unit>
+      <trans-unit id="0f9e99e69b4986359118744a2a670fed">
+        <source>This warning also concerns order:</source>
+        <target>This warning also concerns order:</target>
+        <note>Line: 44</note>
+      </trans-unit>
+      <trans-unit id="804e12a31196cf44ec13212952a59158">
+        <source>This warning also concerns the following orders:</source>
+        <target>This warning also concerns the following orders:</target>
+        <note>Line: 46</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="c4832c266d52c6cef340a9c656ddda26">
+        <source>Error. You cannot refund a negative amount.</source>
+        <target>Error. You cannot refund a negative amount.</target>
+        <note>Line: 257</note>
+      </trans-unit>
+      <trans-unit id="49641a1085f245fe45d45881544d1cec">
+        <source>For this customer group, prices are displayed as: [1]%tax_method%[/1]</source>
+        <target>For this customer group, prices are displayed as: [1]%tax_method%[/1]</target>
+        <note>Line: 226</note>
+      </trans-unit>
+      <trans-unit id="ef5f330df17f8c955005c26466c2463c">
+        <source>Merchandise returns are disabled</source>
+        <target>Merchandise returns are disabled</target>
+        <note>Line: 233</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
+++ b/app/Resources/translations/default/AdminOrderscustomersNotification.xlf
@@ -134,12 +134,12 @@
       <trans-unit id="996a45aa702d041706f6388d54c53b12">
         <source>Invalid order</source>
         <target>Invalid order</target>
-        <note>Line: 571</note>
+        <note>Line: 582</note>
       </trans-unit>
       <trans-unit id="5125d7cea2749d85f13a55a023a56c71">
         <source>The order cannot be renewed.</source>
         <target>The order cannot be renewed.</target>
-        <note>Line: 578</note>
+        <note>Line: 589</note>
       </trans-unit>
     </body>
   </file>
@@ -322,11 +322,6 @@
         <source>The amount is invalid.</source>
         <target>The amount is invalid.</target>
         <note>Line: 1184</note>
-      </trans-unit>
-      <trans-unit id="6ab061ec12504fab2c41f0689579d623">
-        <source>The selected payment method is invalid.</source>
-        <target>The selected payment method is invalid.</target>
-        <note>Line: 1186</note>
       </trans-unit>
       <trans-unit id="7d0d71a3e577be4c20799b52286191d6">
         <source>The transaction ID is invalid.</source>
@@ -555,32 +550,32 @@
       <trans-unit id="f193c3dd6da8a06a610c632db03d55c8">
         <source>The order ID -- or the invoice order ID -- is missing.</source>
         <target>The order ID -- or the invoice order ID -- is missing.</target>
-        <note>Line: 89</note>
+        <note>Line: 88</note>
       </trans-unit>
       <trans-unit id="48607ff5af8c52b5efbc057b852a37ee">
         <source>No invoice was found.</source>
         <target>No invoice was found.</target>
-        <note>Line: 140</note>
+        <note>Line: 139</note>
       </trans-unit>
       <trans-unit id="57bf4b0dd7dd3e5af10533785a343f88">
         <source>No order slips were found.</source>
         <target>No order slips were found.</target>
-        <note>Line: 124</note>
+        <note>Line: 123</note>
       </trans-unit>
       <trans-unit id="f2e9d5988718c8a3dde49c6bcb55125b">
         <source>The supply order ID is missing.</source>
         <target>The supply order ID is missing.</target>
-        <note>Line: 149</note>
+        <note>Line: 148</note>
       </trans-unit>
       <trans-unit id="4fc152e203df7a77fa3c1bc7f1249f36">
         <source>The supply order cannot be found within your database.</source>
         <target>The supply order cannot be found within your database.</target>
-        <note>Line: 156</note>
+        <note>Line: 155</note>
       </trans-unit>
       <trans-unit id="d7e5dfc920c9871caaf7562d8ba9ab36">
         <source>The order invoice cannot be found within your database.</source>
         <target>The order invoice cannot be found within your database.</target>
-        <note>Line: 199</note>
+        <note>Line: 198</note>
       </trans-unit>
     </body>
   </file>
@@ -618,17 +613,17 @@
       <trans-unit id="5844cf5e9f752e6eb7cc1166a3022183">
         <source>No order was found with this ID:</source>
         <target>No order was found with this ID:</target>
-        <note>Line: 152</note>
+        <note>Line: 164</note>
       </trans-unit>
       <trans-unit id="3b27bc623d860beacbe5d5cde18fdec0">
         <source>No invoice was found with this ID:</source>
         <target>No invoice was found with this ID:</target>
-        <note>Line: 162</note>
+        <note>Line: 174</note>
       </trans-unit>
       <trans-unit id="ec79affe41245b47969a2451211b263a">
         <source>No cart was found with this ID:</source>
         <target>No cart was found with this ID:</target>
-        <note>Line: 170</note>
+        <note>Line: 182</note>
       </trans-unit>
     </body>
   </file>
@@ -637,12 +632,12 @@
       <trans-unit id="35af021c4bdb02cad86c917022e053da">
         <source>An error has occurred: Can't save the current order's return status.</source>
         <target>An error has occurred: Can't save the current order's return status.</target>
-        <note>Line: 566</note>
+        <note>Line: 576</note>
       </trans-unit>
       <trans-unit id="ca215ff3d829e3a6a9c0c672987d5959">
         <source>An error has occurred: Can't delete the current order's return status.</source>
         <target>An error has occurred: Can't delete the current order's return status.</target>
-        <note>Line: 595</note>
+        <note>Line: 605</note>
       </trans-unit>
     </body>
   </file>
@@ -665,12 +660,12 @@
       <trans-unit id="f22b1baf8dcfb014646921be9841cb41">
         <source>expires on %s.</source>
         <target>expires on %s.</target>
-        <note>Line: 423</note>
+        <note>Line: 424</note>
       </trans-unit>
       <trans-unit id="0db24e725e6876d0fc7467554e8b6c03">
         <source>downloadable %d time(s)</source>
         <target>downloadable %d time(s)</target>
-        <note>Line: 424</note>
+        <note>Line: 425</note>
       </trans-unit>
     </body>
   </file>
@@ -679,7 +674,7 @@
       <trans-unit id="6a94d8492279c2bfd3e81f3158658980">
         <source>[Generated] CartRule for Free Shipping</source>
         <target>[Generated] CartRule for Free Shipping</target>
-        <note>Line: 423</note>
+        <note>Line: 444</note>
       </trans-unit>
     </body>
   </file>
@@ -729,7 +724,7 @@
       <trans-unit id="9e2dcf2660b82a0204f668565417010a">
         <source>An account already exists for this email address:</source>
         <target>An account already exists for this email address:</target>
-        <note>Line: 513</note>
+        <note>Line: 519</note>
       </trans-unit>
     </body>
   </file>
@@ -738,27 +733,27 @@
       <trans-unit id="1c623b291d95f4f1b1d0c03d0dc0ffa1">
         <source>This email address is not registered.</source>
         <target>This email address is not registered.</target>
-        <note>Line: 885</note>
+        <note>Line: 910</note>
       </trans-unit>
       <trans-unit id="c0498039cc042a1109b53933dc33b2e7">
         <source>A default customer group must be selected in group box.</source>
         <target>A default customer group must be selected in group box.</target>
-        <note>Line: 881</note>
+        <note>Line: 906</note>
       </trans-unit>
       <trans-unit id="8562db06e3931e51ac8c456b56088b02">
         <source>This customer does not exist.</source>
         <target>This customer does not exist.</target>
-        <note>Line: 872</note>
+        <note>Line: 897</note>
       </trans-unit>
       <trans-unit id="4383b950a18d0fd893e237148f5f58ca">
         <source>This customer already exists as a non-guest.</source>
         <target>This customer already exists as a non-guest.</target>
-        <note>Line: 922</note>
+        <note>Line: 947</note>
       </trans-unit>
       <trans-unit id="beaa75cbedc3443661b894ed66c76b13">
         <source>An error occurred while updating customer information.</source>
         <target>An error occurred while updating customer information.</target>
-        <note>Line: 926</note>
+        <note>Line: 951</note>
       </trans-unit>
     </body>
   </file>
@@ -771,12 +766,21 @@
       </trans-unit>
     </body>
   </file>
+  <file original="src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="a536fd360caf34452a84d97775aeb74a">
+        <source>An order message with the same name already exists in %s.</source>
+        <target>An order message with the same name already exists in %s.</target>
+        <note>Line: 259</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="53a60d3bbec32a4bf2777704834dc35e">
         <source>You must add a minimum quantity of %d</source>
         <target>You must add a minimum quantity of %d</target>
-        <note>Line: 609</note>
+        <note>Line: 617</note>
       </trans-unit>
     </body>
   </file>
@@ -791,35 +795,40 @@
   </file>
   <file original="src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
+      <trans-unit id="6ab061ec12504fab2c41f0689579d623">
+        <source>The selected payment method is invalid.</source>
+        <target>The selected payment method is invalid.</target>
+        <note>Line: 2001</note>
+      </trans-unit>
       <trans-unit id="1923e1e610686f1182bf54f573b86921">
         <source>A partial refund was successfully created.</source>
         <target>A partial refund was successfully created.</target>
-        <note>Line: 558</note>
+        <note>Line: 584</note>
       </trans-unit>
       <trans-unit id="aea807cc550550acd7b8d9a7bc469f6a">
         <source>You have to select a shop before creating new orders.</source>
         <target>You have to select a shop before creating new orders.</target>
-        <note>Line: 227</note>
+        <note>Line: 240</note>
       </trans-unit>
       <trans-unit id="409f3dfd9f910287f86fd6c25c94c4d8">
         <source>Order #%d has already been assigned this status.</source>
         <target>Order #%d has already been assigned this status.</target>
-        <note>Line: 1850</note>
+        <note>Line: 2040</note>
       </trans-unit>
       <trans-unit id="18893a82469e2cd9492fc8d46fa8ac01">
         <source>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</source>
         <target>An error occurred while changing the status for order #%d, or we were unable to send an email to the customer.</target>
-        <note>Line: 1839</note>
+        <note>Line: 2029</note>
       </trans-unit>
       <trans-unit id="561918c3c49ff748f543e28f5c405d3c">
         <source>An error occurred while sending an email to the customer.</source>
         <target>An error occurred while sending an email to the customer.</target>
-        <note>Line: 1228</note>
+        <note>Line: 1282</note>
       </trans-unit>
       <trans-unit id="fded441ef916f653d49abf142b535b52">
         <source>An error occurred while sending the e-mail to the customer.</source>
         <target>An error occurred while sending the e-mail to the customer.</target>
-        <note>Line: 1697</note>
+        <note>Line: 1873</note>
       </trans-unit>
       <trans-unit id="aeddc664f1e95691c69ea44a5c1c18f5">
         <source>This product is out of stock: </source>
@@ -829,12 +838,12 @@
       <trans-unit id="4174f012bc63b679f092acd1a933bf5c">
         <source>The email was sent to your customer.</source>
         <target>The email was sent to your customer.</target>
-        <note>Line: 1498</note>
+        <note>Line: 1626</note>
       </trans-unit>
       <trans-unit id="50c5ffd8dadba5bcc7b83cfe3d874f54">
         <source>A standard refund was successfully created.</source>
         <target>A standard refund was successfully created.</target>
-        <note>Line: 591</note>
+        <note>Line: 617</note>
       </trans-unit>
       <trans-unit id="676add5006e766a2f0bf5ba22e231e09">
         <source>A return product was successfully created.</source>
@@ -849,47 +858,47 @@
       <trans-unit id="918093e8ad4567f6b99e9851eab8bc69">
         <source>Order #%d cannot be loaded.</source>
         <target>Order #%d cannot be loaded.</target>
-        <note>Line: 1863</note>
+        <note>Line: 2053</note>
       </trans-unit>
       <trans-unit id="2a11327ffe3e46a9ffadddf38b4b9fff">
         <source>Please enter a maximum quantity of [1].</source>
         <target>Please enter a maximum quantity of [1].</target>
-        <note>Line: 1736</note>
+        <note>Line: 1912</note>
       </trans-unit>
       <trans-unit id="97f014aa339f5b37951f100fb1a086d8">
         <source>Please select at least one product.</source>
         <target>Please select at least one product.</target>
-        <note>Line: 1741</note>
+        <note>Line: 1917</note>
       </trans-unit>
       <trans-unit id="d31c479bcda04bd5b859f7cff371c3d0">
         <source>Please enter a positive amount.</source>
         <target>Please enter a positive amount.</target>
-        <note>Line: 1745</note>
+        <note>Line: 1921</note>
       </trans-unit>
       <trans-unit id="4b0c5f16b969b647ff0b63481af6c3e5">
         <source>Please generate at least one credit slip or voucher.</source>
         <target>Please generate at least one credit slip or voucher.</target>
-        <note>Line: 1749</note>
+        <note>Line: 1925</note>
       </trans-unit>
       <trans-unit id="282426403b9a14678d5dd35e024ec84c">
         <source>This product is out of stock:</source>
         <target>This product is out of stock:</target>
-        <note>Line: 652</note>
+        <note>Line: 678</note>
       </trans-unit>
       <trans-unit id="265b2b7a9f792e941faac362bc37f30b">
         <source>The product was successfully returned.</source>
         <target>The product was successfully returned.</target>
-        <note>Line: 624</note>
+        <note>Line: 650</note>
       </trans-unit>
       <trans-unit id="f77fd3f9865f0c725901d48dbc00619f">
         <source>You cannot edit the cart once the order delivered.</source>
         <target>You cannot edit the cart once the order delivered.</target>
-        <note>Line: 1689</note>
+        <note>Line: 1865</note>
       </trans-unit>
       <trans-unit id="f131fb3c210a32ca24a4910b42b6e2ef">
         <source>Only numbers and decimal points (".") are allowed in the amount fields, e.g. 10.50 or 1050.</source>
         <target>Only numbers and decimal points (".") are allowed in the amount fields, e.g. 10.50 or 1050.</target>
-        <note>Line: 1705</note>
+        <note>Line: 1881</note>
       </trans-unit>
       <trans-unit id="dfa3f525e479dd1038c7947c62b9341a">
         <source>It looks like the value is invalid:</source>
@@ -904,47 +913,47 @@
       <trans-unit id="7f35d95de964c02a558f322bf683ff93">
         <source>Percent value cannot exceed 100.</source>
         <target>Percent value cannot exceed 100.</target>
-        <note>Line: 1714</note>
+        <note>Line: 1890</note>
       </trans-unit>
       <trans-unit id="bd69d7116253ba1407fa8f2611ea6866">
         <source>Discount value cannot exceed the total price of this order.</source>
         <target>Discount value cannot exceed the total price of this order.</target>
-        <note>Line: 1722</note>
+        <note>Line: 1898</note>
       </trans-unit>
       <trans-unit id="c3cb19afc3cf5cd7d07346dcd3504fe2">
         <source>Only numbers and decimal points (".") are allowed in the amount fields of the payment block, e.g. 10.50 or 1050.</source>
         <target>Only numbers and decimal points (".") are allowed in the amount fields of the payment block, e.g. 10.50 or 1050.</target>
-        <note>Line: 1818</note>
+        <note>Line: 1994</note>
       </trans-unit>
       <trans-unit id="7b310c5ac94a5e50139d50574395683b">
         <source>Percent value must be greater than 0.</source>
         <target>Percent value must be greater than 0.</target>
-        <note>Line: 1710</note>
+        <note>Line: 1886</note>
       </trans-unit>
       <trans-unit id="2b0c8d4ac85a4f8ddf1427f7ad537f55">
         <source>Amount value must be greater than 0.</source>
         <target>Amount value must be greater than 0.</target>
-        <note>Line: 1718</note>
+        <note>Line: 1894</note>
       </trans-unit>
       <trans-unit id="0e6becfb4c6566c35a8fda2d94891c70">
         <source>Shipping discount value cannot exceed the total price of this order.</source>
         <target>Shipping discount value cannot exceed the total price of this order.</target>
-        <note>Line: 1726</note>
+        <note>Line: 1902</note>
       </trans-unit>
       <trans-unit id="500f3380713af59cab7bdd14d8fefea2">
         <source>You must choose a payment module to create the order.</source>
         <target>You must choose a payment module to create the order.</target>
-        <note>Line: 1754</note>
+        <note>Line: 1930</note>
       </trans-unit>
       <trans-unit id="b2f61848a1b9245fb4d79db939e04c02">
         <source>You must choose an order status to create the order.</source>
         <target>You must choose an order status to create the order.</target>
-        <note>Line: 1783</note>
+        <note>Line: 1959</note>
       </trans-unit>
       <trans-unit id="53efa65204c54a806b9df6707fc8a326">
         <source>The order message given is invalid.</source>
         <target>The order message given is invalid.</target>
-        <note>Line: 1790</note>
+        <note>Line: 1966</note>
       </trans-unit>
     </body>
   </file>
@@ -953,7 +962,7 @@
       <trans-unit id="f569be19b537a76af7e287ace573cd3e">
         <source>Please enter a positive value</source>
         <target>Please enter a positive value</target>
-        <note>Line: 218</note>
+        <note>Line: 264</note>
       </trans-unit>
     </body>
   </file>
@@ -971,7 +980,7 @@
       <trans-unit id="599b433088f71a8712de225a693ce20e">
         <source>Invalid invoice number.</source>
         <target>Invalid invoice number.</target>
-        <note>Line: 95</note>
+        <note>Line: 93</note>
       </trans-unit>
     </body>
   </file>
@@ -980,17 +989,17 @@
       <trans-unit id="9178a1a9fc82617864593a784163d86a">
         <source>Invalid "From" date</source>
         <target>Invalid "From" date</target>
-        <note>Line: 88</note>
+        <note>Line: 86</note>
       </trans-unit>
       <trans-unit id="915bd2c5cf6e420095a64d309e443849">
         <source>Invalid "To" date</source>
         <target>Invalid "To" date</target>
-        <note>Line: 96</note>
+        <note>Line: 94</note>
       </trans-unit>
       <trans-unit id="f775c161c8662af8f70a128ad5779036">
         <source>No invoice has been found for this period.</source>
         <target>No invoice has been found for this period.</target>
-        <note>Line: 104</note>
+        <note>Line: 102</note>
       </trans-unit>
     </body>
   </file>
@@ -1017,7 +1026,7 @@
       <trans-unit id="c7b085efe30557dbc76c2ba487506049">
         <source>A registered customer account using the defined email address already exists. </source>
         <target>A registered customer account using the defined email address already exists.</target>
-        <note>Line: 170</note>
+        <note>Line: 173</note>
       </trans-unit>
     </body>
   </file>
@@ -1040,7 +1049,7 @@
       <trans-unit id="df46bf546fc69b1cda65afe1001b73fc">
         <source>You have to select a shop if you want to create a customer.</source>
         <target>You have to select a shop if you want to create a customer.</target>
-        <note>Line: 71</note>
+        <note>Line: 61</note>
       </trans-unit>
     </body>
   </file>
@@ -1063,7 +1072,7 @@
       <trans-unit id="453c92894f48764318534163c2bb2830">
         <source>The prices are without taxes.</source>
         <target>The prices are without taxes.</target>
-        <note>Line: 144</note>
+        <note>Line: 146</note>
       </trans-unit>
       <trans-unit id="088f451a8ce01d3cea0fa2a6e886d310">
         <source>Searching for products</source>
@@ -1136,6 +1145,15 @@
       </trans-unit>
     </body>
   </file>
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="99def74fcec1306526eaf054ccd2a5f7">
+        <source>Are you sure you want to edit this product price? It will be applied to all identical products in this order.</source>
+        <target>Are you sure you want to edit this product price? It will be applied to all identical products in this order.</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/merchandise_returns.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="14c7a12fdbf437a0545aed3365ce3f84">
@@ -1159,22 +1177,22 @@
       </trans-unit>
     </body>
   </file>
-  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
+  <file original="src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/payments_alert.html.twig" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="153c7809e6b00b6cbfa01b8aa9db43e3">
         <source>paid instead of</source>
         <target>paid instead of</target>
-        <note>Line: 39</note>
+        <note>Line: 30</note>
       </trans-unit>
       <trans-unit id="0f9e99e69b4986359118744a2a670fed">
         <source>This warning also concerns order:</source>
         <target>This warning also concerns order:</target>
-        <note>Line: 44</note>
+        <note>Line: 35</note>
       </trans-unit>
       <trans-unit id="804e12a31196cf44ec13212952a59158">
         <source>This warning also concerns the following orders:</source>
         <target>This warning also concerns the following orders:</target>
-        <note>Line: 46</note>
+        <note>Line: 37</note>
       </trans-unit>
     </body>
   </file>
@@ -1183,17 +1201,17 @@
       <trans-unit id="c4832c266d52c6cef340a9c656ddda26">
         <source>Error. You cannot refund a negative amount.</source>
         <target>Error. You cannot refund a negative amount.</target>
-        <note>Line: 257</note>
+        <note>Line: 246</note>
       </trans-unit>
       <trans-unit id="49641a1085f245fe45d45881544d1cec">
         <source>For this customer group, prices are displayed as: [1]%tax_method%[/1]</source>
         <target>For this customer group, prices are displayed as: [1]%tax_method%[/1]</target>
-        <note>Line: 226</note>
+        <note>Line: 215</note>
       </trans-unit>
       <trans-unit id="ef5f330df17f8c955005c26466c2463c">
         <source>Merchandise returns are disabled</source>
         <target>Merchandise returns are disabled</target>
-        <note>Line: 233</note>
+        <note>Line: 222</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeCatalog.xlf
+++ b/app/Resources/translations/default/ShopThemeCatalog.xlf
@@ -19,12 +19,12 @@
       <trans-unit id="9dea4016dbcc290b773ab2fae678aaa8">
         <source>Items</source>
         <target>Items</target>
-        <note>Line: 1048</note>
+        <note>Line: 1125</note>
       </trans-unit>
       <trans-unit id="7d74f3b92b19da5e606d737d339a9679">
         <source>Item</source>
         <target>Item</target>
-        <note>Line: 1048</note>
+        <note>Line: 1125</note>
       </trans-unit>
     </body>
   </file>
@@ -61,7 +61,7 @@
       <trans-unit id="aa89fd8bf65df5c1a1c11474bf2c16b5">
         <source>Category: %category_name%</source>
         <target>Category: %category_name%</target>
-        <note>Line: 270</note>
+        <note>Line: 284</note>
       </trans-unit>
     </body>
   </file>
@@ -74,12 +74,21 @@
       </trans-unit>
     </body>
   </file>
+  <file original="controllers/front/listing/PricesDropController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="6de5d0b17afc50642850ff9486934f87">
+        <source>Prices drop</source>
+        <target>Prices drop</target>
+        <note>Line: 75</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="controllers/front/listing/SearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2">
         <source>Search results</source>
         <target>Search results</target>
-        <note>Line: 112</note>
+        <note>Line: 113</note>
       </trans-unit>
     </body>
   </file>
@@ -113,6 +122,20 @@
         <source>%1$s: </source>
         <target>%1$s: </target>
         <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_searchbar/ps_searchbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5bdba1fc0fba1010d61ce253c2e57da8">
+        <source>Search our catalog</source>
+        <target>Search our catalog</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
+        <source>Search</source>
+        <target>Search</target>
+        <note>Line: 30</note>
       </trans-unit>
     </body>
   </file>
@@ -164,72 +187,72 @@
       <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
         <source>New product</source>
         <target>New product</target>
-        <note>Line: 226</note>
+        <note>Line: 484</note>
       </trans-unit>
       <trans-unit id="03de921a8ea82897e13d33d66c28b4db">
         <source>Online only</source>
         <target>Online only</target>
-        <note>Line: 437</note>
+        <note>Line: 451</note>
       </trans-unit>
       <trans-unit id="800e90e940e7f1fb938b0fda5137f38c">
         <source>On sale!</source>
         <target>On sale!</target>
-        <note>Line: 444</note>
+        <note>Line: 458</note>
       </trans-unit>
       <trans-unit id="63b539babcf7978229d66ba4052ca71f">
         <source>Reduced price</source>
         <target>Reduced price</target>
-        <note>Line: 462</note>
+        <note>Line: 476</note>
       </trans-unit>
       <trans-unit id="4492081ca02b059f9e8af4ddaf0f7292">
         <source>Pack</source>
         <target>Pack</target>
-        <note>Line: 477</note>
+        <note>Line: 491</note>
       </trans-unit>
       <trans-unit id="cb3c718c905f00adbb6735f55bfb38ef">
         <source>Product available with different options</source>
         <target>Product available with different options</target>
-        <note>Line: 847</note>
+        <note>Line: 920</note>
       </trans-unit>
       <trans-unit id="348325afced7f3da215310efbe21f1c1">
         <source>Last items in stock</source>
         <target>Last items in stock</target>
-        <note>Line: 872</note>
+        <note>Line: 945</note>
       </trans-unit>
       <trans-unit id="a3b6a4d0897451813950029a3066f219">
         <source>ean13</source>
         <target>ean13</target>
-        <note>Line: 888</note>
+        <note>Line: 961</note>
       </trans-unit>
       <trans-unit id="6496117322fd76fa12ac1b87d8a4db6c">
         <source>isbn</source>
         <target>isbn</target>
-        <note>Line: 890</note>
+        <note>Line: 963</note>
       </trans-unit>
       <trans-unit id="2f9e567efb6a38663162f65eaac2d73b">
         <source>upc</source>
         <target>upc</target>
-        <note>Line: 892</note>
+        <note>Line: 965</note>
       </trans-unit>
       <trans-unit id="019d1ca7d50cc54b995f60d456435e87">
         <source>Used</source>
         <target>Used</target>
-        <note>Line: 232</note>
+        <note>Line: 246</note>
       </trans-unit>
       <trans-unit id="6da03a74721a0554b7143254225cc08a">
         <source>Refurbished</source>
         <target>Refurbished</target>
-        <note>Line: 240</note>
+        <note>Line: 252</note>
       </trans-unit>
       <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
         <source>New</source>
         <target>New</target>
-        <note>Line: 470</note>
+        <note>Line: 240</note>
       </trans-unit>
       <trans-unit id="294598238a4d88a9920c7e6fba9bb843">
         <source>MPN</source>
         <target>MPN</target>
-        <note>Line: 894</note>
+        <note>Line: 967</note>
       </trans-unit>
     </body>
   </file>
@@ -306,12 +329,17 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       <trans-unit id="84be54bb4bd1b755a27d86388700d097">
         <source>Brands</source>
         <target>Brands</target>
-        <note>Line: 30</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="8e41eae149ff3fa38cc9c4fde945f2c3">
         <source>No brand</source>
         <target>No brand</target>
-        <note>Line: 37</note>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="633fb5d52c05cf5e69790ed8a01e0260">
+        <source>brands</source>
+        <target>brands</target>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>
@@ -408,20 +436,6 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       </trans-unit>
     </body>
   </file>
-  <file original="themes/classic/modules/ps_searchbar/ps_searchbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5bdba1fc0fba1010d61ce253c2e57da8">
-        <source>Search our catalog</source>
-        <target>Search our catalog</target>
-        <note>Line: 29</note>
-      </trans-unit>
-      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
-        <source>Search</source>
-        <target>Search</target>
-        <note>Line: 32</note>
-      </trans-unit>
-    </body>
-  </file>
   <file original="themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="588907ab2d492aca0b07b5bf9c931eea">
@@ -450,12 +464,12 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
         <source>Suppliers</source>
         <target>Suppliers</target>
-        <note>Line: 30</note>
+        <note>Line: 34</note>
       </trans-unit>
       <trans-unit id="496689fbd342f80d30f1f266d060415a">
         <source>No supplier</source>
         <target>No supplier</target>
-        <note>Line: 37</note>
+        <note>Line: 42</note>
       </trans-unit>
     </body>
   </file>
@@ -491,12 +505,12 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
         <source>Price</source>
         <target>Price</target>
-        <note>Line: 71</note>
+        <note>Line: 78</note>
       </trans-unit>
       <trans-unit id="4d8adffdc001189e0202c01ac529a3a9">
         <source>Regular price</source>
         <target>Regular price</target>
-        <note>Line: 61</note>
+        <note>Line: 68</note>
       </trans-unit>
     </body>
   </file>
@@ -567,42 +581,51 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       <trans-unit id="d502fa4950894baeaeaf3c5195bb8206">
         <source>Save %percentage%</source>
         <target>Save %percentage%</target>
-        <note>Line: 51</note>
+        <note>Line: 52</note>
       </trans-unit>
       <trans-unit id="5e9ce3b8961433dfa8cd441709c78176">
         <source>Save %amount%</source>
         <target>Save %amount%</target>
-        <note>Line: 54</note>
+        <note>Line: 55</note>
       </trans-unit>
       <trans-unit id="e532954941a2469e3b3ae35ce44885d6">
         <source>%price% tax excl.</source>
         <target>%price% tax excl.</target>
-        <note>Line: 70</note>
+        <note>Line: 71</note>
       </trans-unit>
       <trans-unit id="a72a454b308052ed277f7b69ab307caa">
         <source>Instead of %price%</source>
         <target>Instead of %price%</target>
-        <note>Line: 76</note>
+        <note>Line: 77</note>
       </trans-unit>
       <trans-unit id="98508b5a9b590896cc627beb46d86b96">
         <source>Including %amount% for ecotax</source>
         <target>Including %amount% for ecotax</target>
-        <note>Line: 82</note>
+        <note>Line: 83</note>
       </trans-unit>
       <trans-unit id="a134618182b99ff9151d7e0b6b92410a">
         <source>(not impacted by the discount)</source>
         <target>(not impacted by the discount)</target>
-        <note>Line: 84</note>
+        <note>Line: 85</note>
       </trans-unit>
       <trans-unit id="48fa315ec57b5fea80176d1c5f9f6bbf">
         <source>(%unit_price%)</source>
         <target>(%unit_price%)</target>
-        <note>Line: 62</note>
+        <note>Line: 63</note>
       </trans-unit>
       <trans-unit id="6f3455d187a23443796efdcbe044096b">
         <source>No tax</source>
         <target>No tax</target>
-        <note>Line: 94</note>
+        <note>Line: 95</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-variants.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e265492707dd0595fd1f399bb8a2690e">
+        <source>: </source>
+        <target>: </target>
+        <note>Line: 29</note>
       </trans-unit>
     </body>
   </file>
@@ -629,6 +652,20 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       </trans-unit>
     </body>
   </file>
+  <file original="themes/classic/templates/catalog/listing/search.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f3b6c3bd1bbeb3a3077a5bd6c56c52aa">
+        <source>No matches were found for your search</source>
+        <target>No matches were found for your search</target>
+        <note>Line: 8</note>
+      </trans-unit>
+      <trans-unit id="efa34a2b5f4bc39bf375243c2a33cad0">
+        <source>Please try other keywords to describe what you are looking for.</source>
+        <target>Please try other keywords to describe what you are looking for.</target>
+        <note>Line: 9</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="themes/classic/templates/catalog/listing/supplier.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="4c5c40c99a89125e22218cb62335c60a">
@@ -643,27 +680,27 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
       <trans-unit id="56e11b516943cb38a57c9a53219a8370">
         <source>This pack contains</source>
         <target>This pack contains</target>
-        <note>Line: 109</note>
+        <note>Line: 108</note>
       </trans-unit>
       <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
         <source>Description</source>
         <target>Description</target>
-        <note>Line: 153</note>
+        <note>Line: 152</note>
       </trans-unit>
       <trans-unit id="b8900d8adf598b6653bb8c071bc49a1d">
         <source>Product Details</source>
         <target>Product Details</target>
-        <note>Line: 163</note>
+        <note>Line: 162</note>
       </trans-unit>
       <trans-unit id="7e2708aeb65763c54052f57ed1a1ec1d">
         <source>Attachments</source>
         <target>Attachments</target>
-        <note>Line: 172</note>
+        <note>Line: 171</note>
       </trans-unit>
       <trans-unit id="3767d4f3efe17bd95a1bc7cf4194bb93">
         <source>You might also like</source>
         <target>You might also like</target>
-        <note>Line: 232</note>
+        <note>Line: 231</note>
       </trans-unit>
     </body>
   </file>
@@ -698,6 +735,20 @@ File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:3
         <source>Product customization</source>
         <target>Product customization</target>
         <note>Line: 131</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/errors/404.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="85c435036ee6b5b6ae8dc26b5c336e3a">
+        <source>No products available yet</source>
+        <target>No products available yet</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="539fcfb998ae696968c089223fb0500d">
+        <source>Stay tuned! More products will be shown here as they are added.</source>
+        <target>Stay tuned! More products will be shown here as they are added.</target>
+        <note>Line: 35</note>
       </trans-unit>
     </body>
   </file>

--- a/app/Resources/translations/default/ShopThemeCatalog.xlf
+++ b/app/Resources/translations/default/ShopThemeCatalog.xlf
@@ -1,11 +1,703 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/controller/FrontController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="104d9898c04874d0fbac36e125fa1369">
+        <source>Discount</source>
+        <target>Discount</target>
+        <note>Line: 1542</note>
+      </trans-unit>
+      <trans-unit id="af342023e90ca45b0d69be497168ac56">
+        <source>Unit discount</source>
+        <target>Unit discount</target>
+        <note>Line: 1563</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/ProductController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9dea4016dbcc290b773ab2fae678aaa8">
+        <source>Items</source>
+        <target>Items</target>
+        <note>Line: 1048</note>
+      </trans-unit>
+      <trans-unit id="7d74f3b92b19da5e606d737d339a9679">
+        <source>Item</source>
+        <target>Item</target>
+        <note>Line: 1048</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/SitemapController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="af1b98adf7f686b84cd0b443e022b7a0">
+        <source>Categories</source>
+        <target>Categories</target>
+        <note>Line: 40</note>
+      </trans-unit>
+      <trans-unit id="453aceb005ceaf54a47da15fee8b2a26">
+        <source>Pages</source>
+        <target>Pages</target>
+        <note>Line: 42</note>
+      </trans-unit>
+      <trans-unit id="c8f312df214e2295809027c6ca79d232">
+        <source>Price drop</source>
+        <target>Price drop</target>
+        <note>Line: 162</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/BestSalesController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="01f7ac959c1e6ebbb2e0ee706a7a5255">
+        <source>Best sellers</source>
+        <target>Best sellers</target>
+        <note>Line: 87</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/CategoryController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="aa89fd8bf65df5c1a1c11474bf2c16b5">
+        <source>Category: %category_name%</source>
+        <target>Category: %category_name%</target>
+        <note>Line: 270</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/ManufacturerController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="bd51980476ab3cd93603c9548fb78775">
+        <source>List of all brands</source>
+        <target>List of all brands</target>
+        <note>Line: 93</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/SearchController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="eb6b06cab0dd72e04c4da68d511facf2">
+        <source>Search results</source>
+        <target>Search results</target>
+        <note>Line: 112</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="controllers/front/listing/SupplierController.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="108b413416adf90e7c6f21a68bb02dd2">
+        <source>%number% products</source>
+        <target>%number% products</target>
+        <note>Line: 191</note>
+      </trans-unit>
+      <trans-unit id="8e7fb1213c4692b195ed6b7cf580d7f3">
+        <source>%number% product</source>
+        <target>%number% product</target>
+        <note>Line: 192</note>
+      </trans-unit>
+      <trans-unit id="d9e0619813f9247f8a506b9b1e61599f">
+        <source>List of all suppliers</source>
+        <target>List of all suppliers</target>
+        <note>Line: 94</note>
+      </trans-unit>
+      <trans-unit id="bcdf044a723993079e77ec66e4d6cbf2">
+        <source>List of products by supplier %supplier_name%</source>
+        <target>List of products by supplier %supplier_name%</target>
+        <note>Line: 81</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="modules/ps_facetedsearch/views/templates/front/catalog/active-filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="cfff8593a3adedd98a18631f85152d23">
+        <source>%1$s: </source>
+        <target>%1$s: </target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/BestSales/BestSalesProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="05d61847840bcddb5d37374de3be0ccc">
+        <source>Name, A to Z</source>
+        <target>Name, A to Z</target>
+        <note>Line: 99</note>
+      </trans-unit>
+      <trans-unit id="e21f2ef58ff858167655c18a874f9706">
+        <source>Name, Z to A</source>
+        <target>Name, Z to A</target>
+        <note>Line: 102</note>
+      </trans-unit>
+      <trans-unit id="e2174d7435696694b8f4d984d99eef03">
+        <source>Price, low to high</source>
+        <target>Price, low to high</target>
+        <note>Line: 105</note>
+      </trans-unit>
+      <trans-unit id="0ee81913615b71aba7dc8bbf1f144672">
+        <source>Price, high to low</source>
+        <target>Price, high to low</target>
+        <note>Line: 108</note>
+      </trans-unit>
+      <trans-unit id="b56ffaa1656269759857ba14573dc144">
+        <source>Sales, highest to lowest</source>
+        <target>Sales, highest to lowest</target>
+        <note>Line: 69</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/NewProducts/NewProductsProductSearchProvider.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="900a70008b0ed52ee5f6907f7b61f0e8">
+        <source>Date added, newest to oldest</source>
+        <target>Date added, newest to oldest</target>
+        <note>Line: 104</note>
+      </trans-unit>
+      <trans-unit id="c2718c816e7ebf8495e3c9ce20061317">
+        <source>Date added, oldest to newest</source>
+        <target>Date added, oldest to newest</target>
+        <note>Line: 107</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Adapter/Presenter/Product/ProductLazyArray.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="656c3be690ee43df4b845bd2a2ebe587">
+        <source>New product</source>
+        <target>New product</target>
+        <note>Line: 226</note>
+      </trans-unit>
+      <trans-unit id="03de921a8ea82897e13d33d66c28b4db">
+        <source>Online only</source>
+        <target>Online only</target>
+        <note>Line: 437</note>
+      </trans-unit>
+      <trans-unit id="800e90e940e7f1fb938b0fda5137f38c">
+        <source>On sale!</source>
+        <target>On sale!</target>
+        <note>Line: 444</note>
+      </trans-unit>
+      <trans-unit id="63b539babcf7978229d66ba4052ca71f">
+        <source>Reduced price</source>
+        <target>Reduced price</target>
+        <note>Line: 462</note>
+      </trans-unit>
+      <trans-unit id="4492081ca02b059f9e8af4ddaf0f7292">
+        <source>Pack</source>
+        <target>Pack</target>
+        <note>Line: 477</note>
+      </trans-unit>
+      <trans-unit id="cb3c718c905f00adbb6735f55bfb38ef">
+        <source>Product available with different options</source>
+        <target>Product available with different options</target>
+        <note>Line: 847</note>
+      </trans-unit>
+      <trans-unit id="348325afced7f3da215310efbe21f1c1">
+        <source>Last items in stock</source>
+        <target>Last items in stock</target>
+        <note>Line: 872</note>
+      </trans-unit>
+      <trans-unit id="a3b6a4d0897451813950029a3066f219">
+        <source>ean13</source>
+        <target>ean13</target>
+        <note>Line: 888</note>
+      </trans-unit>
+      <trans-unit id="6496117322fd76fa12ac1b87d8a4db6c">
+        <source>isbn</source>
+        <target>isbn</target>
+        <note>Line: 890</note>
+      </trans-unit>
+      <trans-unit id="2f9e567efb6a38663162f65eaac2d73b">
+        <source>upc</source>
+        <target>upc</target>
+        <note>Line: 892</note>
+      </trans-unit>
+      <trans-unit id="019d1ca7d50cc54b995f60d456435e87">
+        <source>Used</source>
+        <target>Used</target>
+        <note>Line: 232</note>
+      </trans-unit>
+      <trans-unit id="6da03a74721a0554b7143254225cc08a">
+        <source>Refurbished</source>
+        <target>Refurbished</target>
+        <note>Line: 240</note>
+      </trans-unit>
+      <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e">
+        <source>New</source>
+        <target>New</target>
+        <note>Line: 470</note>
+      </trans-unit>
+      <trans-unit id="294598238a4d88a9920c7e6fba9bb843">
+        <source>MPN</source>
+        <target>MPN</target>
+        <note>Line: 894</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="src/Core/Product/Search/SortOrdersCollection.php" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ad24ffca4f9e9c0c7e80fe1512df6db9">
+        <source>Relevance</source>
+        <target>Relevance</target>
+        <note>Line: 55</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/catalog/_partials/active_filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="53cea05976132fada38935bdc05ad156">
+        <source>%facet_label%: %facet_value%</source>
+        <target>%facet_label%: %facet_value%</target>
+        <note>Context:
+File: themes/StarterTheme/templates/catalog/_partials/active_filters.tpl:30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e54a973d0c3342dac6ee7d9e145c6f83">
+        <source>Pack content</source>
+        <target>Pack content</target>
+        <note>Context:
+File: themes/StarterTheme/templates/catalog/product.tpl:197</note>
+      </trans-unit>
+      <trans-unit id="98edb85b00d9527ad5acebe451b3fae6">
+        <source>Accessories</source>
+        <target>Accessories</target>
+        <note>Context:
+File: themes/StarterTheme/templates/catalog/product.tpl:210</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fdfac28b5ad628f25649d9c2eb4fc62e">
+        <source>Returned</source>
+        <target>Returned</target>
+        <note>Context:
+File: themes/StarterTheme/templates/customer/_partials/order-detail-return.tpl:35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d7b2933ba512ada478c97fa43dd7ebe6">
+        <source>Best Sellers</source>
+        <target>Best Sellers</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="eae99cd6a931f3553123420b16383812">
+        <source>All best sellers</source>
+        <target>All best sellers</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_brandlist/views/templates/_partials/brand_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="e18a22d145b38e4fff582663b5b4ec1e">
+        <source>All brands</source>
+        <target>All brands</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="633fb5d52c05cf5e69790ed8a01e0260">
-        <source>brands</source>
-        <target>brands</target>
+      <trans-unit id="84be54bb4bd1b755a27d86388700d097">
+        <source>Brands</source>
+        <target>Brands</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="8e41eae149ff3fa38cc9c4fde945f2c3">
+        <source>No brand</source>
+        <target>No brand</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f55e0a28b86c2ab66ac632ab9ddf1833">
+        <source>%s other product in the same category:</source>
+        <target>%s other product in the same category:</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="bebb44f38b03407098d48198c1d0aaa5">
+        <source>%s other products in the same category:</source>
+        <target>%s other products in the same category:</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_crossselling/views/templates/hook/ps_crossselling.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ef2b66b0b65479e08ff0cce29e19d006">
+        <source>Customers who bought this product also bought:</source>
+        <target>Customers who bought this product also bought:</target>
+        <note>Line: 27</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_emailalerts/views/templates/hook/my-account-footer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4edfd10d0bb5f51e0fd2327df608b5a8">
+        <source>My alerts</source>
+        <target>My alerts</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="f473acb18ebcd825235ca5624203f31a">
+        <source>Popular Products</source>
+        <target>Popular Products</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="40dec546414c1ebdfde8d9858f0938c3">
+        <source>All products</source>
+        <target>All products</target>
+        <note>Line: 31</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="9ff0635f5737513b1a6f559ac2bff745">
+        <source>New products</source>
+        <target>New products</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="60efcc704ef1456678f77eb9ee20847b">
+        <source>All new products</source>
+        <target>All new products</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_productinfo/views/templates/hook/ps_productinfo.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="035749e4c50392a661c0f1b220ae0516">
+        <source>1 person is currently watching this product.</source>
+        <target>1 person is currently watching this product.</target>
         <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="c24cf2abae9286b8f69a8ccdf7ed8d5e">
+        <source>%nb_people% people are currently watching this product.</source>
+        <target>%nb_people% people are currently watching this product.</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="247f15e3dc0e7906ab9573685423899f">
+        <source>Last time this product was bought: %date_last_order%</source>
+        <target>Last time this product was bought: %date_last_order%</target>
+        <note>Line: 37</note>
+      </trans-unit>
+      <trans-unit id="160b4798999cb85c815beeb40ac268cc">
+        <source>Last time this product was added to a cart: %date_last_cart%</source>
+        <target>Last time this product was added to a cart: %date_last_cart%</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_rssfeed/views/templates/hook/ps_rssfeed.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="10fd25dcd3353c0ba3731d4a23657f2e">
+        <source>No RSS feed added</source>
+        <target>No RSS feed added</target>
+        <note>Line: 36</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_searchbar/ps_searchbar.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5bdba1fc0fba1010d61ce253c2e57da8">
+        <source>Search our catalog</source>
+        <target>Search our catalog</target>
+        <note>Line: 29</note>
+      </trans-unit>
+      <trans-unit id="13348442cc6a27032d2b4aa28b75a5d3">
+        <source>Search</source>
+        <target>Search</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_specials/views/templates/hook/ps_specials.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="588907ab2d492aca0b07b5bf9c931eea">
+        <source>On sale</source>
+        <target>On sale</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="f95ceb82c51c99dc9b9e5678b291c44b">
+        <source>All sale products</source>
+        <target>All sale products</target>
+        <note>Line: 32</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_supplierlist/views/templates/_partials/supplier_form.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ecf253735ac0cba84a9d2eeff1f1b87c">
+        <source>All suppliers</source>
+        <target>All suppliers</target>
+        <note>Line: 33</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_supplierlist/views/templates/hook/ps_supplierlist.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1814d65a76028fdfbadab64a5a8076df">
+        <source>Suppliers</source>
+        <target>Suppliers</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="496689fbd342f80d30f1f266d060415a">
+        <source>No supplier</source>
+        <target>No supplier</target>
+        <note>Line: 37</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/modules/ps_viewedproduct/views/templates/hook/ps_viewedproduct.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="43560641f91e63dc83682bc598892fa1">
+        <source>Viewed products</source>
+        <target>Viewed products</target>
+        <note>Line: 26</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/_partials/pagination.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fb526aaa0add86e4e124263db50438c8">
+        <source>Showing %from%-%to% of %total% item(s)</source>
+        <target>Showing %from%-%to% of %total% item(s)</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/active_filters.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="734346d44245de59214137842ab17744">
+        <source>%1$s:</source>
+        <target>%1$s:</target>
+        <note>Line: 35</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/miniatures/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="3601146c4e948c32b6424d2c0a7f0118">
+        <source>Price</source>
+        <target>Price</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="4d8adffdc001189e0202c01ac529a3a9">
+        <source>Regular price</source>
+        <target>Regular price</target>
+        <note>Line: 61</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-customization.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5d1190edfb16f1dcaaecc56570c864be">
+        <source>Your customization:</source>
+        <target>Your customization:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-details.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="1be6f9eb563f3bf85c78b4219bf09de9">
+        <source>Brand</source>
+        <target>Brand</target>
+        <note>Line: 14</note>
+      </trans-unit>
+      <trans-unit id="fcebe56087b9373f15514831184fa572">
+        <source>In stock</source>
+        <target>In stock</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="ea254ced8be4adb6c4a2750e84087da6">
+        <source>Availability date:</source>
+        <target>Availability date:</target>
+        <note>Line: 41</note>
+      </trans-unit>
+      <trans-unit id="7dcd185f890fd28f69d1ed210292d77f">
+        <source>Data sheet</source>
+        <target>Data sheet</target>
+        <note>Line: 56</note>
+      </trans-unit>
+      <trans-unit id="4594f39c6dac58760daeb19d79389576">
+        <source>Specific References</source>
+        <target>Specific References</target>
+        <note>Line: 71</note>
+      </trans-unit>
+      <trans-unit id="9e2941b3c81256fac10392aaca4ccfde">
+        <source>Condition</source>
+        <target>Condition</target>
+        <note>Line: 85</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-discounts.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="fc21aa6a8b0bceb8570c8c81b6b38307">
+        <source>Volume discounts</source>
+        <target>Volume discounts</target>
+        <note>Line: 27</note>
+      </trans-unit>
+      <trans-unit id="861c0c6ef832cd96c5fe152f9d610973">
+        <source>You Save</source>
+        <target>You Save</target>
+        <note>Line: 34</note>
+      </trans-unit>
+      <trans-unit id="64c22a1426c5b8fce46c6314d73dc99e">
+        <source>Up to %discount%</source>
+        <target>Up to %discount%</target>
+        <note>Line: 42</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/product-prices.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d502fa4950894baeaeaf3c5195bb8206">
+        <source>Save %percentage%</source>
+        <target>Save %percentage%</target>
+        <note>Line: 51</note>
+      </trans-unit>
+      <trans-unit id="5e9ce3b8961433dfa8cd441709c78176">
+        <source>Save %amount%</source>
+        <target>Save %amount%</target>
+        <note>Line: 54</note>
+      </trans-unit>
+      <trans-unit id="e532954941a2469e3b3ae35ce44885d6">
+        <source>%price% tax excl.</source>
+        <target>%price% tax excl.</target>
+        <note>Line: 70</note>
+      </trans-unit>
+      <trans-unit id="a72a454b308052ed277f7b69ab307caa">
+        <source>Instead of %price%</source>
+        <target>Instead of %price%</target>
+        <note>Line: 76</note>
+      </trans-unit>
+      <trans-unit id="98508b5a9b590896cc627beb46d86b96">
+        <source>Including %amount% for ecotax</source>
+        <target>Including %amount% for ecotax</target>
+        <note>Line: 82</note>
+      </trans-unit>
+      <trans-unit id="a134618182b99ff9151d7e0b6b92410a">
+        <source>(not impacted by the discount)</source>
+        <target>(not impacted by the discount)</target>
+        <note>Line: 84</note>
+      </trans-unit>
+      <trans-unit id="48fa315ec57b5fea80176d1c5f9f6bbf">
+        <source>(%unit_price%)</source>
+        <target>(%unit_price%)</target>
+        <note>Line: 62</note>
+      </trans-unit>
+      <trans-unit id="6f3455d187a23443796efdcbe044096b">
+        <source>No tax</source>
+        <target>No tax</target>
+        <note>Line: 94</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/_partials/products-top.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="498007f495e00b14f415d5f6ae6a1362">
+        <source>There are %product_count% products.</source>
+        <target>There are %product_count% products.</target>
+        <note>Line: 28</note>
+      </trans-unit>
+      <trans-unit id="79ac892bd1769d83ef1c16dae9f4eddd">
+        <source>There is 1 product.</source>
+        <target>There is 1 product.</target>
+        <note>Line: 30</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/manufacturer.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="d0679d37c204278465192d34b1917c01">
+        <source>List of products by brand %brand_name%</source>
+        <target>List of products by brand %brand_name%</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/listing/supplier.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="4c5c40c99a89125e22218cb62335c60a">
+        <source>List of products by supplier %s</source>
+        <target>List of products by supplier %s</target>
+        <note>Line: 28</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/catalog/product.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="56e11b516943cb38a57c9a53219a8370">
+        <source>This pack contains</source>
+        <target>This pack contains</target>
+        <note>Line: 109</note>
+      </trans-unit>
+      <trans-unit id="b5a7adde1af5c87d7fd797b6245c2a39">
+        <source>Description</source>
+        <target>Description</target>
+        <note>Line: 153</note>
+      </trans-unit>
+      <trans-unit id="b8900d8adf598b6653bb8c071bc49a1d">
+        <source>Product Details</source>
+        <target>Product Details</target>
+        <note>Line: 163</note>
+      </trans-unit>
+      <trans-unit id="7e2708aeb65763c54052f57ed1a1ec1d">
+        <source>Attachments</source>
+        <target>Attachments</target>
+        <note>Line: 172</note>
+      </trans-unit>
+      <trans-unit id="3767d4f3efe17bd95a1bc7cf4194bb93">
+        <source>You might also like</source>
+        <target>You might also like</target>
+        <note>Line: 232</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="themes/classic/templates/customer/_partials/order-detail-no-return.tpl" source-language="en-US" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="63d5049791d9d79d86e9a108b0a999ca">
+        <source>Reference</source>
+        <target>Reference</target>
+        <note>Line: 126</note>
+      </trans-unit>
+      <trans-unit id="deb10517653c255364175796ace3553f">
+        <source>Product</source>
+        <target>Product</target>
+        <note>Line: 30</note>
+      </trans-unit>
+      <trans-unit id="694e8d1f2ee056f98ee488bdc4982d73">
+        <source>Quantity</source>
+        <target>Quantity</target>
+        <note>Line: 31</note>
+      </trans-unit>
+      <trans-unit id="6c957f72dc8cdacc75762f2cbdcdfaf2">
+        <source>Unit price</source>
+        <target>Unit price</target>
+        <note>Line: 32</note>
+      </trans-unit>
+      <trans-unit id="0eede552438475bdfe820c13f24c9399">
+        <source>Total price</source>
+        <target>Total price</target>
+        <note>Line: 33</note>
+      </trans-unit>
+      <trans-unit id="54c02ba7929b1fda4847991a45b58a48">
+        <source>Product customization</source>
+        <target>Product customization</target>
+        <note>Line: 131</note>
       </trans-unit>
     </body>
   </file>

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
@@ -257,7 +257,7 @@ class OrderMessageController extends FrameworkBundleAdminController
             ),
             OrderMessageNameAlreadyUsedException::class => $this->trans(
                 'An order message with the same name already exists in %s.',
-                'Admin.OrdersCustomers.Notification',
+                'Admin.Orderscustomers.Notification',
                 [
                     $language,
                 ]

--- a/themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
+++ b/themes/classic/modules/ps_brandlist/views/templates/hook/ps_brandlist.tpl
@@ -26,7 +26,7 @@
 <div id="search_filters_brands">
   <section class="facet">
     {if $display_link_brand}
-      <a href="{$page_link}" class="h6 text-uppercase facet-label" title="{l s='brands' d='shop.theme.catalog'}">
+      <a href="{$page_link}" class="h6 text-uppercase facet-label" title="{l s='brands' d='Shop.Theme.Catalog'}">
         {l s='Brands' d='Shop.Theme.Catalog'}
       </a>
     {else}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fix two domains that were not correctly extracted
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Go to Translation interface and check for these two domains `Admin.Orderscustomers.Notification` and `Shop.Theme.Catalog` they should contain more than one wording
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24723)
<!-- Reviewable:end -->
