### PR TITLE
Fix create-test-db

### DIFF
--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -311,22 +311,18 @@ class Install extends AbstractInstall
             return false;
         }
 
-        return $this->generateSf2ProductionEnv();
+        return $this->updateSchema();
     }
 
     /**
-     * Pass SF2 to production
      * cache:clear
      * assetic:dump
      * doctrine:schema:update.
      *
      * @return bool
      */
-    public function generateSf2ProductionEnv()
+    public function updateSchema()
     {
-        if (defined('_PS_IN_TEST_')) {
-            return true;
-        }
         $schemaUpgrade = new UpgradeDatabase();
         $schemaUpgrade->addDoctrineSchemaUpdate();
         $output = $schemaUpgrade->execute();

--- a/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
+++ b/tests-legacy/PrestaShopBundle/Utils/DatabaseCreator.php
@@ -30,7 +30,6 @@ use Context;
 use Doctrine\DBAL\DBALException;
 use PrestaShopBundle\Install\DatabaseDump;
 use PrestaShopBundle\Install\Install;
-use Symfony\Component\Process\Process;
 use Tests\Resources\ResourceResetter;
 use Tab;
 
@@ -56,8 +55,6 @@ class DatabaseCreator
             exit(1);
         }
 
-        $process = new Process(PHP_BINARY . ' bin/console prestashop:schema:update-without-foreign --env=test');
-        $process->run();
         $install->initializeTestContext();
         $install->installDefaultData('test_shop', false, false, false);
         $install->populateDatabase();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Some database tables were missing, because doctrine schema wasn't loaded.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes - rename method `src/PrestaShopBundle/Install/Install.php::generateSf2ProductionEnv()` -> `updateSchema()`.
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/24547
| How to test?      | run composer create-test-db and no errors + test_{your_prestashop_db_name} database created locally.
| Possible impacts? | Need to double check if all prestashop installation methods are still working (install through web `/install-dev` and console command (`/install-dev/index_cli`)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24711)
<!-- Reviewable:end -->
