### PR TITLE
Add ids for link to download sample file on import page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -89,7 +89,7 @@
 
 {# Show link to import file sample #}
 {% macro import_file_sample(label, filename) %}
-    <a class="list-group-item list-group-item-action" href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
+    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
         {{ label|trans({}, 'Admin.Advparameters.Feature') }}
     </a>
 {% endmacro %}

--- a/tests/UI/pages/BO/advancedParameters/import/index.js
+++ b/tests/UI/pages/BO/advancedParameters/import/index.js
@@ -12,7 +12,7 @@ class Import extends BOBasePage {
 
     // Selectors
     this.alertSuccessBlockParagraph = `${this.alertSuccessBlock} p.alert-text.js-import-file`;
-    this.downloadSampleFileLink = type => `a[href*='import/sample/download/${type}']`;
+    this.downloadSampleFileLink = type => `#download-sample-${type}-file-link`;
     this.fileInputField = '#file';
     this.nextStepButton = 'button[name=submitImportFile]';
     this.importButton = '#import';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x 
| Description?      | Add ids for link to download sample file on import page
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | `TEST_PATH="functional/BO/14_advancedParameters/05_import/01_downloadSampleFiles.js" URL_FO=shopUrl/ npm run specific-test`
| Possible impacts? | no impacts


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24737)
<!-- Reviewable:end -->
