### PR TITLE
Add a hook 'actionValidateOrderAfter', This hook is called after the complete creation of an order

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -730,7 +730,13 @@ abstract class PaymentModuleCore extends Module
             if (self::DEBUG_MODE) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - End of validateOrder', 1, null, 'Cart', (int) $id_cart, true);
             }
-
+            Hook::exec('actionValidateOrderAfter', [
+                'cart' => $this->context->cart,
+                'order' => $order,
+                'customer' => $this->context->customer,
+                'currency' => $this->context->currency,
+                'orderStatus' => new OrderState($order->current_state)
+            ]);
             return true;
         } else {
             $error = $this->trans('Cart cannot be loaded or an order has already been placed using this cart', [], 'Admin.Payment.Notification');

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -735,7 +735,7 @@ abstract class PaymentModuleCore extends Module
                 'order' => $order,
                 'customer' => $this->context->customer,
                 'currency' => $this->context->currency,
-                'orderStatus' => new OrderState($order->current_state)
+                'orderStatus' => new OrderState($order->current_state),
             ]);
             return true;
         } else {

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -737,6 +737,7 @@ abstract class PaymentModuleCore extends Module
                 'currency' => $this->context->currency,
                 'orderStatus' => new OrderState($order->current_state),
             ]);
+
             return true;
         } else {
             $error = $this->trans('Cart cannot be loaded or an order has already been placed using this cart', [], 'Admin.Payment.Notification');

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -11,6 +11,11 @@
       <title>New orders</title>
       <description/>
     </hook>
+    <hook id="actionValidateOrderAfter">
+      <name>actionValidateOrderAfter</name>
+      <title>New orders</title>
+      <description>This hook is called after the complete creation of an order</description>
+    </hook>
     <hook id="displayMaintenance">
       <name>displayMaintenance</name>
       <title>Maintenance Page</title>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -13,7 +13,7 @@
     </hook>
     <hook id="actionValidateOrderAfter">
       <name>actionValidateOrderAfter</name>
-      <title>New orders</title>
+      <title>After validating an order</title>
       <description>This hook is called after validating an order by core</description>
     </hook>
     <hook id="displayMaintenance">

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -14,7 +14,7 @@
     <hook id="actionValidateOrderAfter">
       <name>actionValidateOrderAfter</name>
       <title>New orders</title>
-      <description>This hook is called after the complete creation of an order</description>
+      <description>This hook is called after validating an order by core</description>
     </hook>
     <hook id="displayMaintenance">
       <name>displayMaintenance</name>

--- a/install-dev/upgrade/sql/1.7.9.0.sql
+++ b/install-dev/upgrade/sql/1.7.9.0.sql
@@ -8,4 +8,4 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
     ('PS_MAIL_DKIM_KEY', '', NOW(), NOW())
 ;
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
-  (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after the complete creation of an order', '1');
+  (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after validating an order by core', '1');

--- a/install-dev/upgrade/sql/1.7.9.0.sql
+++ b/install-dev/upgrade/sql/1.7.9.0.sql
@@ -7,3 +7,5 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
     ('PS_MAIL_DKIM_SELECTOR', '', NOW(), NOW()),
     ('PS_MAIL_DKIM_KEY', '', NOW(), NOW())
 ;
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after the complete creation of an order', '1');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add a new hook 'actionValidateOrderAfter', This hook is called after the complete creation of an order
| Type?             | new feature 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Possible impacts? | No impact
| Fixes | Fixes #23787

When an order is created, several modules can be called by the validateOrder hook or other hooks.
There are very often problems and an order is not completely created, no status, no confirmation email sent etc... the reasons can be multiple, poorly developed module, unexpected error, call to an api that does not respond.
Linking PrestaShop to an ERP is more and more common and the exchanges must be reliable.
Also sending to an ERP can generate a change of status for the order but since it is not completely created, there can be conflicts.
This hook allows to create the order completely and then the hook is executed, sending the order to an ERP for example, allows to have the whole order with a status etc. and if the link with the ERP does not work, the order is not "corrupted".
I took the example of liaison with an ERP because I added this hook on several sites and it is very useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24738)
<!-- Reviewable:end -->
