### PR TITLE
Remove _PS_API_DOMAIN_ constant

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3958,7 +3958,7 @@ exit;
 
         $post_data = http_build_query($post_query_data);
 
-        $end_point = 'api.addons.prestashop.com';
+        $endpoint = 'https://api.addons.prestashop.com/';
 
         switch ($request) {
             case 'native':
@@ -4035,7 +4035,7 @@ exit;
             ],
         ]);
 
-        if ($content = Tools::file_get_contents('https://' . $end_point, false, $context)) {
+        if ($content = Tools::file_get_contents($endpoint, false, $context)) {
             return $content;
         }
 

--- a/config/defines_uri.inc.php
+++ b/config/defines_uri.inc.php
@@ -67,8 +67,7 @@ define('_MAIL_DIR_', __PS_BASE_URI__.'mails/');
 define('_MODULE_DIR_', __PS_BASE_URI__.'modules/');
 
 /* Define API URLs if not defined before */
-Tools::safeDefine('_PS_API_DOMAIN_', 'api.prestashop.com');
-Tools::safeDefine('_PS_API_URL_', 'http://'._PS_API_DOMAIN_);
+Tools::safeDefine('_PS_API_URL_', 'https://api.prestashop.com');
 /** @deprecated Since 1.7.7 */
 Tools::safeDefine('_PS_TAB_MODULE_LIST_URL_', '');
 /** @deprecated Since 1.7.7 */

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -304,7 +304,7 @@ class AdminDashboardControllerCore extends AdminController
             'hookDashboardZoneTwo' => Hook::exec('dashboardZoneTwo', $params),
             'action' => '#',
             'warning' => $this->getWarningDomainName(),
-            'new_version_url' => Tools::getCurrentUrlProtocolPrefix() . _PS_API_DOMAIN_ . '/version/check_version.php?v=' . _PS_VERSION_ . '&lang=' . $this->context->language->iso_code . '&autoupgrade=' . (int) ($moduleManager->isInstalled('autoupgrade') && $moduleManager->isEnabled('autoupgrade')) . '&hosted_mode=' . (int) defined('_PS_HOST_MODE_'),
+            'new_version_url' => _PS_API_URL_ . '/version/check_version.php?v=' . _PS_VERSION_ . '&lang=' . $this->context->language->iso_code . '&autoupgrade=' . (int) ($moduleManager->isInstalled('autoupgrade') && $moduleManager->isEnabled('autoupgrade')) . '&hosted_mode=' . (int) defined('_PS_HOST_MODE_'),
             'dashboard_use_push' => Configuration::get('PS_DASHBOARD_USE_PUSH'),
             'calendar' => $calendar_helper->generate(),
             'PS_DASHBOARD_SIMULATION' => Configuration::get('PS_DASHBOARD_SIMULATION'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | see title
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes - `_PS_API_DOMAIN_` constant is removed
| Deprecations?     | no
| Fixed ticket?     | na
| How to test?      | CI must be 🟢 
| Possible impacts? | see BC break above


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24755)
<!-- Reviewable:end -->
