### PR TITLE
Make getValue more strict to avoid false negative

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -694,7 +694,8 @@ abstract class DbCore
             $sql = $sql->build();
         }
 
-        if (false === $result = $this->getRow($sql, $use_cache)) {
+        $result = $this->getRow($sql, $use_cache);
+        if (false === $result) {
             return false;
         }
 

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -694,7 +694,7 @@ abstract class DbCore
             $sql = $sql->build();
         }
 
-        if (!$result = $this->getRow($sql, $use_cache)) {
+        if (false === $result = $this->getRow($sql, $use_cache)) {
             return false;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When using `getValue` with a "three state boolean" like: -1, 0 or 1, getValue return false on both `0` and `-1`, it shouldn't.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | None found.
| How to test?      | No test needed.
| Possible impacts? | None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24757)
<!-- Reviewable:end -->
