### PR TITLE
Fixed adding a free shipping cart rule on a 0.00 order

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -247,7 +247,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
         }
         if (!empty($orderInvoices)) {
             foreach ($orderInvoices as $invoice) {
-                if ($invoice->total_paid_tax_incl <= $invoice->total_shipping_tax_incl) {
+                if ($invoice->total_paid_tax_incl < $invoice->total_shipping_tax_incl) {
                     throw new InvalidCartRuleDiscountValueException(
                         'Discount amount specified is too high',
                         InvalidCartRuleDiscountValueException::INVALID_FREE_SHIPPING
@@ -255,7 +255,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
                 }
             }
         } else {
-            if ($order->total_paid_tax_incl <= $order->total_shipping_tax_incl) {
+            if ($order->total_paid_tax_incl < $order->total_shipping_tax_incl) {
                 throw new InvalidCartRuleDiscountValueException(
                     'Discount amount specified is too high',
                     InvalidCartRuleDiscountValueException::INVALID_FREE_SHIPPING

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -686,3 +686,89 @@ Feature: Order from Back Office (BO)
     Then cart "dummy_cart_freegift" should contain 2 products
     When I select carrier "carrier2" for cart "dummy_cart_freegift"
     Then cart "dummy_cart_freegift" should contain 1 products
+
+  Scenario: Add a cart rule with free shipping to an order with a total of 0
+    Given there is a product in the catalog named "product1" with a price of 0.00 and 100 items in stock
+    When I create an empty cart "dummy_cart_free_shipping" for customer "testCustomer"
+    And I add 1 products "product1" to the cart "dummy_cart_free_shipping"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart_free_shipping"
+    Then cart "dummy_cart_free_shipping" should contain 1 products
+    When I add order "bo_order1" with the following details:
+      | cart                | dummy_cart_free_shipping   |
+      | message             |                            |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    Then order "bo_order1" should have 1 products in total
+    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have following details:
+      | total_products           | 0.000  |
+      | total_products_wt        | 0.000  |
+      | total_discounts_tax_excl | 0.000  |
+      | total_discounts_tax_incl | 0.000  |
+      | total_paid_tax_excl      | 7.000  |
+      | total_paid_tax_incl      | 7.420  |
+      | total_paid               | 7.420  |
+      | total_paid_real          | 0.000  |
+      | total_shipping_tax_excl  | 7.000  |
+      | total_shipping_tax_incl  | 7.420  |
+    When I add discount to order "bo_order1" with following details:
+      | name      | Free Shipping |
+      | type      | free_shipping |
+    Then I should get no error
+    And order "bo_order1" should have 1 cart rule
+    And order "bo_order1" should have 1 products in total
+    And order "bo_order1" should have following details:
+      | total_products           | 0.000  |
+      | total_products_wt        | 0.000  |
+      | total_discounts_tax_excl | 7.000  |
+      | total_discounts_tax_incl | 7.420  |
+      | total_paid_tax_excl      | 0.000  |
+      | total_paid_tax_incl      | 0.000  |
+      | total_paid               | 0.000  |
+      | total_paid_real          | 0.000  |
+      | total_shipping_tax_excl  | 7.000  |
+      | total_shipping_tax_incl  | 7.420  |
+
+  @order-cart-rules1
+  Scenario: Add a cart rule with free shipping to an order with a total of 0 and existing order
+    Given there is a product in the catalog named "product1" with a price of 0.00 and 100 items in stock
+    When I create an empty cart "dummy_cart_free_shipping" for customer "testCustomer"
+    And I add 1 products "product1" to the cart "dummy_cart_free_shipping"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart_free_shipping"
+    Then cart "dummy_cart_free_shipping" should contain 1 products
+    When I add order "bo_order1" with the following details:
+      | cart                | dummy_cart_free_shipping   |
+      | message             |                            |
+      | payment module name | dummy_payment              |
+      | status              | Payment accepted           |
+    Then order "bo_order1" should have 1 products in total
+    And order "bo_order1" should have 0 cart rule
+    And order "bo_order1" should have following details:
+      | total_products           | 0.000  |
+      | total_products_wt        | 0.000  |
+      | total_discounts_tax_excl | 0.000  |
+      | total_discounts_tax_incl | 0.000  |
+      | total_paid_tax_excl      | 7.000  |
+      | total_paid_tax_incl      | 7.420  |
+      | total_paid               | 7.420  |
+      | total_paid_real          | 7.420  |
+      | total_shipping_tax_excl  | 7.000  |
+      | total_shipping_tax_incl  | 7.420  |
+    And order "bo_order1" should have invoice
+    When I add discount to order "bo_order1" on first invoice and following details:
+      | name      | Free Shipping |
+      | type      | free_shipping |
+    Then I should get no error
+    And order "bo_order1" should have 1 cart rule
+    And order "bo_order1" should have 1 products in total
+    And order "bo_order1" should have following details:
+      | total_products           | 0.000  |
+      | total_products_wt        | 0.000  |
+      | total_discounts_tax_excl | 7.000  |
+      | total_discounts_tax_incl | 7.420  |
+      | total_paid_tax_excl      | 0.000  |
+      | total_paid_tax_incl      | 0.000  |
+      | total_paid               | 0.000  |
+      | total_paid_real          | 7.420  |
+      | total_shipping_tax_excl  | 7.000  |
+      | total_shipping_tax_incl  | 7.420  |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Fixed adding a free shipping cart rule on a 0.00 order
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24753
| How to test?      | Cf. #24753
| Possible impacts? | Adding a cart rule with free shipping in the BO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24762)
<!-- Reviewable:end -->
