### PR TITLE
Fix - It is not possible to create a BYN currency

### DIFF
--- a/localization/CLDR/core/common/supplemental/supplementalData.xml
+++ b/localization/CLDR/core/common/supplemental/supplementalData.xml
@@ -5146,6 +5146,7 @@ XXX Code for transations where no currency is involved
 		<currencyCodes type="BWP" numeric="72"/>
 		<currencyCodes type="BYR" numeric="974"/>
 		<currencyCodes type="BZD" numeric="84"/>
+		<currencyCodes type="BYN" numeric="933"/>
 		<currencyCodes type="CAD" numeric="124"/>
 		<currencyCodes type="CDF" numeric="976"/>
 		<currencyCodes type="CHE" numeric="947"/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x 
| Description?      | Need CurrencyCode for BYN
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no 
| Fixed ticket?     | Fixes #24692
| How to test?      | Go to Localization -> currency and choose BYN
| Possible impacts? | Empty cache after update the file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24763)
<!-- Reviewable:end -->
