### PR TITLE
Check that $session is set before using it

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -589,7 +589,7 @@ class CookieCore
             $session = new CustomerSession($sessionId);
         }
 
-        if (!empty($session->getId())) {
+        if (isset($session) && Validate::isLoadedObject($session)) {
             return $session;
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Check that $session is set before calling its methods
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24781
| How to test?      | Call getSession without proper session
| Possible impacts? | Session handling gets more robust with small defensive coding..

Special thanks for the slack discussions on this: @PierreRambaud @cdcvince

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24782)
<!-- Reviewable:end -->
