### PR TITLE
Add regression test 'Access to Menu tab on Bo should be denied'

### DIFF
--- a/tests/UI/campaigns/regression/menu/deniedAccessToMenuTab.js
+++ b/tests/UI/campaigns/regression/menu/deniedAccessToMenuTab.js
@@ -1,0 +1,64 @@
+require('module-alias/register');
+
+const {expect} = require('chai');
+
+// Import utils
+const helper = require('@utils/helpers');
+const loginCommon = require('@commonTests/loginBO');
+
+// Importing pages
+const dashboardPage = require('@pages/BO/dashboard');
+const menuTabPage = require('@pages/BO/advancedParameters/menuTab');
+
+// Setup data
+const pageUrl = `${global.BO.URL}index.php?controller=AdminTabs`;
+
+
+// Import test context
+const testContext = require('@utils/testContext');
+
+const baseContext = 'regression_menu_deniedAccessToMenuTab';
+
+let browserContext;
+let page;
+
+describe('Regression : Access to Menu tab is denied with neither left menu and Url', async () => {
+  // before and after functions
+  before(async function () {
+    browserContext = await helper.createBrowserContext(this.browser);
+    page = await helper.newTab(browserContext);
+  });
+
+  after(async () => {
+    await helper.closeBrowserContext(browserContext);
+  });
+
+  it('should login in BO', async function () {
+    await loginCommon.loginBO(this, page);
+  });
+
+  it('should go check that menu tab on left menu is not visible', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'menuTabNotVisible', baseContext);
+
+    const isMenuTabVisible = await dashboardPage.isSubmenuVisible(
+      page,
+      dashboardPage.ordersParentLink,
+      dashboardPage.menuTabLink,
+    );
+
+    await expect(isMenuTabVisible, 'The Menu tab is still visible').to.be.false;
+  });
+
+  it('should accessing the page by Url be denied', async function () {
+    await testContext.addContextItem(this, 'testIdentifier', 'checkUrlAccessibility', baseContext);
+
+    await dashboardPage.navigateToPageWithInvalidToken(page, pageUrl);
+
+    // Check Title
+    const pageTitle = await menuTabPage.getPageTitle(page);
+    await expect(pageTitle).to.contains(menuTabPage.pageTitle);
+
+    const alertText = await menuTabPage.getAlertDangerBlockParagraphContent(page);
+    await expect(alertText).to.contain(menuTabPage.accessDeniedMessage);
+  });
+});

--- a/tests/UI/campaigns/regression/menu/deniedAccessToMenuTab.js
+++ b/tests/UI/campaigns/regression/menu/deniedAccessToMenuTab.js
@@ -13,7 +13,6 @@ const menuTabPage = require('@pages/BO/advancedParameters/menuTab');
 // Setup data
 const pageUrl = `${global.BO.URL}index.php?controller=AdminTabs`;
 
-
 // Import test context
 const testContext = require('@utils/testContext');
 

--- a/tests/UI/pages/BO/BObasePage.js
+++ b/tests/UI/pages/BO/BObasePage.js
@@ -20,6 +20,9 @@ class BOBasePage extends CommonPage {
     this.successfulDeleteMessage = 'Successful deletion.';
     this.successfulMultiDeleteMessage = 'The selection has been successfully deleted.';
 
+    // Access denied message
+    this.accessDeniedMessage = 'Access denied';
+
     // top navbar
     this.userProfileIconNonMigratedPages = '#employee_infos';
     this.userProfileIcon = '#header_infos #header-employee-container';
@@ -152,6 +155,8 @@ class BOBasePage extends CommonPage {
     this.logsLink = '#subtab-AdminLogs';
     // Multistore
     this.multistoreLink = '#subtab-AdminShopGroup';
+    // Deprecated tab used for regression test
+    this.menuTabLink = '#subtab-AdminTabs';
 
     // welcome module
     this.onboardingCloseButton = 'button.onboarding-button-shut-down';
@@ -183,6 +188,10 @@ class BOBasePage extends CommonPage {
     // Sidebar
     this.rightSidebar = '#right-sidebar';
     this.helpDocumentURL = `${this.rightSidebar} div.quicknav-scroller._fullspace object`;
+
+    // Invalid token block
+    this.invalidTokenContinuelink = 'a.btn-continue';
+    this.invalidTokenCancellink = 'a.btn-cancel';
   }
 
   /*
@@ -399,6 +408,23 @@ class BOBasePage extends CommonPage {
    */
   getAlertInfoBlockParagraphContent(page) {
     return this.getTextContent(page, this.alertInfoBlockParagraph);
+  }
+
+  /**
+   * Navigate to Bo page without token
+   * @param page {Page} Browser tab
+   * @param url {string} Url to BO page
+   * @param continueToPage {boolean} True to continue false to cancel and return to dashboard page
+   * @returns {Promise<void>}
+   */
+  async navigateToPageWithInvalidToken(page, url, continueToPage = true) {
+    await this.goTo(page, url);
+    await this.waitForVisibleSelector(page, this.invalidTokenContinuelink);
+
+    await this.clickAndWaitForNavigation(
+      page,
+      continueToPage ? this.invalidTokenContinuelink : this.invalidTokenCancellink,
+    );
   }
 }
 

--- a/tests/UI/pages/BO/advancedParameters/menuTab/index.js
+++ b/tests/UI/pages/BO/advancedParameters/menuTab/index.js
@@ -1,0 +1,37 @@
+require('module-alias/register');
+const BOBasePage = require('@pages/BO/BObasePage');
+
+/**
+ * MenuTab page, should not be displayed on BO
+ * @class
+ * @extends BOBasePage
+ */
+class MenuTab extends BOBasePage {
+  /**
+   * @constructs
+   * Setting up titles and selectors to use on MenuTab page
+   */
+  constructor() {
+    super();
+
+    this.pageTitle = 'Menus';
+
+    // Selectors
+    this.alertDangerBlockParagraph = '.alert-danger';
+    this.pageH1Title = 'h1.page-title';
+  }
+
+  // Functions
+
+  /**
+   * @override
+   * Get title from selector instead of header
+   * @param page {Page} Browser tab
+   * @returns {Promise<string>}
+   */
+  getPageTitle(page) {
+    return this.getTextContent(page, this.pageH1Title);
+  }
+}
+
+module.exports = new MenuTab();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Access to Menu tab on Bo should be denied (linked to #24330)
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | `TEST_PATH="regression/menu/deniedAccessToMenuTab.js" URL_FO=shopUrl/ npm run specific-test`
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24787)
<!-- Reviewable:end -->
