### PR TITLE
If the product has no combinations then the `specific_references` must be filled in

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3145,7 +3145,7 @@ class AdminControllerCore extends Controller
     }
 
     /**
-     * Get the current objects' list form the database.
+     * Get the current objects' list from the database.
      *
      * @param int $id_lang Language used for display
      * @param string|null $order_by ORDER BY clause

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -538,40 +538,50 @@ class ProductLazyArray extends AbstractLazyArray
     /**
      * @arrayAccess
      *
-     * @return 0|null
+     * @return array|null
      */
     public function getSpecificReferences()
     {
-        if (isset($this->product['attributes']) && !isset($this->product['cart_quantity'])) {
-            $specificReferences = array_slice($this->product['attributes'], 0)[0];
-            //this attributes should not be displayed in FO
-            unset(
-                $specificReferences['id_attribute'],
-                $specificReferences['id_attribute_group'],
-                $specificReferences['name'],
-                $specificReferences['group'],
-                $specificReferences['reference']
-            );
-
-            //if the attribute's references doesn't exist then get the product's references or unset it
-            foreach ($specificReferences as $key => $value) {
-                if (empty($value)) {
-                    $translatedKey = $this->getTranslatedKey($key);
-                    unset($specificReferences[$key]);
-                    if (!empty($this->product[$key])) {
-                        $specificReferences[$translatedKey] = $this->product[$key];
-                    }
-                }
-            }
-
-            if (empty($specificReferences)) {
-                $specificReferences = null;
-            }
-
-            return $specificReferences;
+        if (isset($this->product['cart_quantity'])) {
+            return null;
         }
 
-        return null;
+        // If the product has no combinations then the `specific_references` must be filled in
+        if (isset($this->product['attributes'])) {
+            $specificReferences = array_slice($this->product['attributes'], 0)[0];
+        } else {
+            $specificReferences = [
+                'isbn' => $this->product['isbn'] ?? false,
+                'upc' => $this->product['upc'] ?? false,
+                'ean13' => $this->product['ean13'] ?? false,
+                'mpn' => $this->product['mpn'] ?? false,
+            ];
+        }
+        //this attributes should not be displayed in FO
+        unset(
+            $specificReferences['id_attribute'],
+            $specificReferences['id_attribute_group'],
+            $specificReferences['name'],
+            $specificReferences['group'],
+            $specificReferences['reference']
+        );
+
+        //if the attribute's references doesn't exist then get the product's references or unset it
+        foreach ($specificReferences as $key => $value) {
+            if (empty($value)) {
+                $translatedKey = $this->getTranslatedKey($key);
+                unset($specificReferences[$key]);
+                if (!empty($this->product[$key])) {
+                    $specificReferences[$translatedKey] = $this->product[$key];
+                }
+            }
+        }
+
+        if (empty($specificReferences)) {
+            $specificReferences = null;
+        }
+
+        return $specificReferences;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | #15783
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #15783
| How to test?      | #15783
| Possible impacts? | #15783

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24792)
<!-- Reviewable:end -->
