### PR TITLE
Fix checkout page details removed and wrong price when adding/removing voucher

### DIFF
--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -95,7 +95,7 @@ prestashop.selectors = {
     detailedTotals: '.cart-detailed-totals, .js-cart-detailed-totals',
     summaryItemsSubtotal: '.cart-summary-items-subtotal, .js-cart-summary-items-subtotal',
     summarySubTotalsContainer: '.cart-summary-subtotals-container, .js-cart-summary-subtotals-container',
-    summaryTotals: '.cart-summary-products, .js-cart-summary-products',
+    summaryTotals: '.cart-summary-totals, .js-cart-summary-totals',
     summaryProducts: '.cart-summary-products, .js-cart-summary-products',
     detailedActions: '.cart-detailed-actions, .js-cart-detailed-actions',
     voucher: '.cart-voucher, .js-cart-voucher',

--- a/themes/classic/templates/checkout/_partials/cart-summary-totals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-totals.tpl
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
-<div class="card-block cart-summary-totals">
+<div class="card-block cart-summary-totals js-cart-summary-totals">
 
   {block name='cart_summary_total'}
     {if !$configuration.display_prices_tax_incl && $configuration.taxes_enabled}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of a wrong selector, the cart details was replaced with the total price. This PR fixes it.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21961
| How to test?      | Please see #21961
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24795)
<!-- Reviewable:end -->
