### PR TITLE
Improved performance for watermarking on import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1280,10 +1280,9 @@ class AdminImportControllerCore extends AdminController
                             }
                         }
                     }
-                    if (in_array($image_type['id_image_type'], $watermark_types)) {
-                        Hook::exec('actionWatermark', ['id_image' => $id_image, 'id_product' => $id_entity]);
-                    }
                 }
+                
+                Hook::exec('actionWatermark', ['id_image' => $id_image, 'id_product' => $id_entity]);
             }
         } else {
             @unlink($orig_tmpfile);

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1281,7 +1281,7 @@ class AdminImportControllerCore extends AdminController
                         }
                     }
                 }
-                
+
                 Hook::exec('actionWatermark', ['id_image' => $id_image, 'id_product' => $id_entity]);
             }
         } else {

--- a/src/Adapter/Import/ImageCopier.php
+++ b/src/Adapter/Import/ImageCopier.php
@@ -204,16 +204,15 @@ final class ImageCopier
                             }
                         }
                     }
-                    if (in_array($imageType['id_image_type'], $watermarkTypes)) {
-                        $this->hookDispatcher->dispatchWithParameters(
-                            'actionWatermark',
-                            [
-                                'id_image' => $imageId,
-                                'id_product' => $entityId,
-                            ]
-                        );
-                    }
                 }
+
+                $this->hookDispatcher->dispatchWithParameters(
+                    'actionWatermark',
+                    [
+                        'id_image' => $imageId,
+                        'id_product' => $entityId,
+                    ]
+                );
             }
         } else {
             @unlink($origTmpfile);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Below and in Issue
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23164.
| How to test?      | Instructions below.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions

## How to test?

0. You can use this module:
https://github.com/PrestaShop/watermark

2. Download, unpack, change from `watermark-dev` to `watermark`, `composer install` and you're ready

3. Select only one type of the images in module.

4. Import product from attached csv, make sure that watermark is properly generated - [import.csv](https://github.com/PrestaShop/PrestaShop/files/6593784/import.csv)

Watch out, import doesn't work in `All shops` context if you're using multi-store :trollface: 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24799)
<!-- Reviewable:end -->
