### PR TITLE
Don't require password for Customer on import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3138,7 +3138,7 @@ class AdminImportControllerCore extends AdminController
 
         if (!$customer->id) {
             if (empty($info['passwd'])) {
-                $customer->passwd = $this->get('hashing')->hash(Tools::passwdGen(8, 'RANDOM'), _COOKIE_KEY_);
+                $customer->passwd = $this->get('hashing')->hash(Tools::passwdGen(8, Tools::PASSWORDGEN_FLAG_RANDOM)), _COOKIE_KEY_);
             } else {
                 $customer->passwd = $this->get('hashing')->hash($customer->passwd, _COOKIE_KEY_);
             }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3138,7 +3138,7 @@ class AdminImportControllerCore extends AdminController
 
         if (!$customer->id) {
             if (empty($info['passwd'])) {
-                $customer->passwd = $this->get('hashing')->hash(Tools::passwdGen(8, Tools::PASSWORDGEN_FLAG_RANDOM)), _COOKIE_KEY_);
+                $customer->passwd = $this->get('hashing')->hash(Tools::passwdGen(8, Tools::PASSWORDGEN_FLAG_RANDOM), _COOKIE_KEY_);
             } else {
                 $customer->passwd = $this->get('hashing')->hash($customer->passwd, _COOKIE_KEY_);
             }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -375,7 +375,7 @@ class AdminImportControllerCore extends AdminController
 
             case $this->entities[$this->trans('Customers', [], 'Admin.Global')]:
                 //Overwrite required_fields AS only email is required whereas other entities
-                $this->required_fields = ['email', 'passwd', 'lastname', 'firstname'];
+                $this->required_fields = ['email', 'lastname', 'firstname'];
 
                 $this->available_fields = [
                     'no' => ['label' => $this->trans('Ignore this column', [], 'Admin.Advparameters.Feature')],
@@ -383,7 +383,7 @@ class AdminImportControllerCore extends AdminController
                     'active' => ['label' => $this->trans('Active  (0/1)', [], 'Admin.Advparameters.Feature')],
                     'id_gender' => ['label' => $this->trans('Titles ID (Mr = 1, Ms = 2, else 0)', [], 'Admin.Advparameters.Feature')],
                     'email' => ['label' => $this->trans('Email', [], 'Admin.Global') . '*'],
-                    'passwd' => ['label' => $this->trans('Password', [], 'Admin.Global') . '*'],
+                    'passwd' => ['label' => $this->trans('Password', [], 'Admin.Global')],
                     'birthday' => ['label' => $this->trans('Birth date (yyyy-mm-dd)', [], 'Admin.Advparameters.Feature')],
                     'lastname' => ['label' => $this->trans('Last name', [], 'Admin.Global') . '*'],
                     'firstname' => ['label' => $this->trans('First name', [], 'Admin.Global') . '*'],
@@ -3136,8 +3136,16 @@ class AdminImportControllerCore extends AdminController
 
         AdminImportController::arrayWalk($info, ['AdminImportController', 'fillInfo'], $customer);
 
-        if ($customer->passwd) {
-            $customer->passwd = $this->get('hashing')->hash($customer->passwd, _COOKIE_KEY_);
+        if (!$customer->id) {
+            if (empty($info['passwd'])) {
+                $customer->passwd = $this->get('hashing')->hash(Tools::passwdGen(8, 'RANDOM'), _COOKIE_KEY_);
+            } else {
+                $customer->passwd = $this->get('hashing')->hash($customer->passwd, _COOKIE_KEY_);
+            }
+        } else {
+            if (!empty($info['passwd'])) {
+                $customer->passwd = $this->get('hashing')->hash($customer->passwd, _COOKIE_KEY_);
+            }
         }
 
         $id_shop_list = explode($this->multiple_value_separator, $customer->id_shop);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It makes sense to allow people to import customers without providing passwords, first of all we may not have password in plain text (obviously), secondly when we update customer we don't want to override his password
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23106.
| How to test?      | Follow issue, you'll find two templates for import, try to import new customer, with and without password, after that update with or without password :)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24801)
<!-- Reviewable:end -->
