### PR TITLE
Remove white-space : nowrap to the category tree.

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -733,7 +733,6 @@ $product-page-padding-bottom: 80px !default;
 
   .category-tree-overflow {
     overflow: auto;
-    white-space: nowrap;
 
     > .main-category {
       display: block;


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Long category titles on product edit page will now wrap, so the main category radio button is not hidden behind an anti-ux scroll.
| Type?             | improvement
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24671
| How to test?      | Look at the category tree on product page, when you have long category names. 
| Possible impacts? | Product page > Category tree visual change

Screenshot : 
![image](https://user-images.githubusercontent.com/16670583/120788076-58920a00-c530-11eb-9905-a2b482d66cee.png)


This is a very small change, but will improve BO product page UX. A lot of my clients have long category names, and a lot of categories. They are lost when they want to change the main category, because they don't see the radio button, nor the scrollbar at the bottom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24808)
<!-- Reviewable:end -->
