### PR TITLE
Fix invalid html attribute on multistore fields

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -74,9 +74,7 @@ class MaintenanceType extends TranslatorAwareType
                 SwitchType::class,
                 [
                     'required' => true,
-                    'attr' => [
-                        'multistore_configuration_key' => 'PS_SHOP_ENABLE',
-                    ],
+                    'multistore_configuration_key' => 'PS_SHOP_ENABLE',
                     'label' => $this->trans('Enable store', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
                         'We recommend that you deactivate your store while performing maintenance. Note that it will not disable the webservice.',
@@ -89,10 +87,10 @@ class MaintenanceType extends TranslatorAwareType
                 IpAddressType::class,
                 [
                     'required' => false,
+                    'multistore_configuration_key' => 'PS_MAINTENANCE_IP',
                     'empty_data' => '',
                     'attr' => [
                         'class' => 'col-md-5',
-                        'multistore_configuration_key' => 'PS_MAINTENANCE_IP',
                     ],
                     'label' => $this->trans('Maintenance IP', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
@@ -113,9 +111,7 @@ class MaintenanceType extends TranslatorAwareType
                     'locales' => $this->locales,
                     'hideTabs' => false,
                     'required' => true,
-                    'attr' => [
-                        'multistore_configuration_key' => 'PS_MAINTENANCE_TEXT',
-                    ],
+                    'multistore_configuration_key' => 'PS_MAINTENANCE_TEXT',
                     'label' => $this->trans('Custom maintenance text', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
                         'Display a customized message when the store is disabled.',

--- a/src/PrestaShopBundle/Form/Admin/Extension/MultistoreDropdownExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/MultistoreDropdownExtension.php
@@ -52,6 +52,7 @@ class MultistoreDropdownExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         parent::buildView($view, $form, $options);
+
         $view->vars = array_replace($view->vars, ['multistore_dropdown' => $options['multistore_dropdown']]);
     }
 
@@ -61,6 +62,12 @@ class MultistoreDropdownExtension extends AbstractTypeExtension
     public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
-        $resolver->setDefaults(['multistore_dropdown' => false]);
+
+        $resolver->setDefaults(
+            [
+                'multistore_dropdown' => false,
+                'multistore_configuration_key' => null
+            ]
+        );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Extension/MultistoreExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/MultistoreExtension.php
@@ -34,7 +34,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MultistoreDropdownExtension extends AbstractTypeExtension
+class MultistoreExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/PrestaShopBundle/Form/Admin/Extension/MultistoreExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/MultistoreExtension.php
@@ -66,7 +66,7 @@ class MultistoreExtension extends AbstractTypeExtension
         $resolver->setDefaults(
             [
                 'multistore_dropdown' => false,
-                'multistore_configuration_key' => null
+                'multistore_configuration_key' => null,
             ]
         );
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -65,7 +65,7 @@ services:
             - { name: form.type_extension, extended_type: PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType }
 
     form.extension.multistore_dropdown:
-        class: 'PrestaShopBundle\Form\Admin\Extension\MultistoreDropdownExtension'
+        class: 'PrestaShopBundle\Form\Admin\Extension\MultistoreExtension'
         tags:
             - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }
 

--- a/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
+++ b/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
@@ -194,11 +194,11 @@ class MultistoreCheckboxEnabler
         $form->add($fieldName, CheckboxType::class, [
             'required' => false,
             'data' => $isOverriddenInCurrentContext,
+            'multistore_configuration_key' => $configurationKey,
             'label' => false,
             'attr' => [
                 'material_design' => true,
                 'class' => 'multistore-checkbox',
-                'multistore_configuration_key' => $configurationKey,
             ],
         ]);
     }

--- a/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
+++ b/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
@@ -113,22 +113,22 @@ class MultistoreCheckboxEnabler
      *
      * @param FormInterface $form (passed by reference)
      */
-    public function addMultistoreElements(FormInterface &$form): void
+    public function addMultistoreElements(FormInterface $form): void
     {
         foreach ($form->all() as $child) {
             $options = $child->getConfig()->getOptions();
-            if (!isset($options['attr']['multistore_configuration_key'])) {
+            if (!isset($options['multistore_configuration_key'])) {
                 continue;
             }
 
-            $isOverriddenInCurrentContext = $this->isOverriddenInCurrentContext($options['attr']['multistore_configuration_key']);
+            $isOverriddenInCurrentContext = $this->isOverriddenInCurrentContext($options['multistore_configuration_key']);
 
             // update current field with disabled attribute
             $this->updateCurrentField($form, $child, $options, $isOverriddenInCurrentContext);
 
             // for each field in the configuration form, we add a multistore checkbox (except in all shop context)
             if (!$this->multiStoreContext->isAllShopContext()) {
-                $this->addCheckbox($form, $child->getName(), $isOverriddenInCurrentContext, $options['attr']['multistore_configuration_key']);
+                $this->addCheckbox($form, $child->getName(), $isOverriddenInCurrentContext, $options['multistore_configuration_key']);
             }
         }
     }
@@ -160,7 +160,7 @@ class MultistoreCheckboxEnabler
      * @param array $options
      * @param bool $isOverriddenInCurrentContext
      */
-    private function updateCurrentField(FormInterface &$form, FormInterface $childElement, array &$options, bool $isOverriddenInCurrentContext): void
+    private function updateCurrentField(FormInterface $form, FormInterface $childElement, array &$options, bool $isOverriddenInCurrentContext): void
     {
         $options['attr']['disabled'] = !$this->multiStoreContext->isAllShopContext() && !$isOverriddenInCurrentContext;
 
@@ -168,7 +168,7 @@ class MultistoreCheckboxEnabler
         if ($this->multiStoreContext->isAllShopContext() || $this->multiStoreContext->isGroupShopContext()) {
             $options['multistore_dropdown'] = $this->multistoreController->configurationDropdown(
                 $this->configuration,
-                $options['attr']['multistore_configuration_key']
+                $options['multistore_configuration_key']
             )->getContent();
         }
 
@@ -188,7 +188,7 @@ class MultistoreCheckboxEnabler
      * @param bool $isOverriddenInCurrentContext
      * @param string $configurationKey
      */
-    private function addCheckbox(FormInterface &$form, string $relatedFieldName, bool $isOverriddenInCurrentContext, string $configurationKey): void
+    private function addCheckbox(FormInterface $form, string $relatedFieldName, bool $isOverriddenInCurrentContext, string $configurationKey): void
     {
         $fieldName = self::MULTISTORE_FIELD_PREFIX . $relatedFieldName;
         $form->add($fieldName, CheckboxType::class, [

--- a/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
@@ -101,7 +101,7 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
 
         // the added multistore checkbox must have the correct `multistore_configuration_key` attribute
         $multistoreFirstFieldCheckboxOptions = $form->get(MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'first_field')->getConfig()->getOptions();
-        $this->assertEquals('TEST_CONFIGURATION_KEY', $multistoreFirstFieldCheckboxOptions['attr']['multistore_configuration_key']);
+        $this->assertEquals('TEST_CONFIGURATION_KEY', $multistoreFirstFieldCheckboxOptions['multistore_configuration_key']);
         $this->assertArrayHasKey('multistore_dropdown', $multistoreFirstFieldCheckboxOptions);
     }
 

--- a/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration as ShopConfiguration;
 use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Controller\Admin\MultistoreController;
-use PrestaShopBundle\Form\Admin\Extension\MultistoreDropdownExtension;
+use PrestaShopBundle\Form\Admin\Extension\MultistoreExtension;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
 use Symfony\Component\Form\FormInterface;
@@ -111,7 +111,7 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
     private function getFormToTest(): FormInterface
     {
         $formFactory = Forms::createFormFactoryBuilder()
-            ->addTypeExtension(new MultistoreDropdownExtension())
+            ->addTypeExtension(new MultistoreExtension())
             ->getFormFactory();
 
         $formBuilder = $formFactory->createBuilder();

--- a/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
@@ -123,9 +123,7 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
                 SwitchType::class,
                 [
                     'required' => true,
-                    'attr' => [
-                        'multistore_configuration_key' => 'TEST_CONFIGURATION_KEY',
-                    ],
+                    'multistore_configuration_key' => 'TEST_CONFIGURATION_KEY',
                 ]
             )
             // second field will not have a multistore checkbox (it doesn't have the `multistore_configuration_key` attribute)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Pass configuration key from options instead of attribute, it fixes potential issue with invalid HTML
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #24812
| Possible impacts? | Multistore checkboxes and dropdown should work just like before on maintenance page form.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24811)
<!-- Reviewable:end -->
