### PR TITLE
Fix header toolbar getting over content on mobile and table

### DIFF
--- a/admin-dev/themes/default/scss/partials/_toolbar.scss
+++ b/admin-dev/themes/default/scss/partials/_toolbar.scss
@@ -21,6 +21,10 @@
 
   &.with-tabs {
     height: 140px;
+
+    @include media-breakpoint-down(md) {
+      height: auto;
+    }
   }
 
   > .wrapper {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | On legacy pages, sometime the head toolbar is going over the content due to a fixed height
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24804.
| How to test?      | Go on the attributes pages and try to check on mobile or tablet if the header is not over the content anymore


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24813)
<!-- Reviewable:end -->
