### PR TITLE
Handle CustomerAddressGridDefinitionFactory in CLI context

### DIFF
--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CustomerAddressGridDefinitionFactory defines customer's addresses grid structure.
@@ -50,10 +51,10 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
      */
     private $backUrl;
 
-    public function __construct(HookDispatcherInterface $hookDispatcher, string $backUrl)
+    public function __construct(HookDispatcherInterface $hookDispatcher, ?Request $currentRequest)
     {
         parent::__construct($hookDispatcher);
-        $this->backUrl = $backUrl;
+        $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -90,7 +90,7 @@ services:
         class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerAddressGridDefinitionFactory'
         parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
         arguments:
-            - '@=service("request_stack").getCurrentRequest().getUri()'
+            - '@=service("request_stack").getCurrentRequest()'
         public: true
 
     prestashop.core.grid.definition.factory.language:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In CLI context, `'@=service("request_stack").getCurrentRequest()'` is `null` so calling `getUri()` from `null` throw an exception. To solve the issue, only the result of `getCurrentRequest()` is passed to the constructor and we check if it's `null` before calling `getUri()`.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24023
| How to test?      | Please see #24023
| Possible impacts? | #19912 should still be fixed

#### Not a BC Break
Even though the constructor signature changed, it's not a BC break as this class has been introduced in 1.7.8

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24821)
<!-- Reviewable:end -->
