### PR TITLE
Validate image if needed first when adding new brand

### DIFF
--- a/src/Adapter/Image/Uploader/AbstractImageUploader.php
+++ b/src/Adapter/Image/Uploader/AbstractImageUploader.php
@@ -49,7 +49,7 @@ abstract class AbstractImageUploader
      *
      * @throws UploadedImageConstraintException
      */
-    protected function checkImageIsAllowedForUpload(UploadedFile $image)
+    public function checkImageIsAllowedForUpload(UploadedFile $image)
     {
         $maxFileSize = Tools::getMaxUploadSize();
 

--- a/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\AddManufacturerComman
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\EditManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use PrestaShop\PrestaShop\Adapter\Image\Uploader\AbstractImageUploader;
+use PrestaShop\PrestaShop\Adapter\Image\Uploader\ManufacturerImageUploader;
 
 /**
  * Handles submitted manufacturer form data
@@ -43,17 +43,17 @@ final class ManufacturerFormDataHandler implements FormDataHandlerInterface
      */
     private $bus;
     /**
-     * @var AbstractImageUploader
+     * @var ManufacturerImageUploader
      */
     private $imageUploader;
 
     /**
      * @param CommandBusInterface $bus
-     * @param AbstractImageUploader $imageUploader
+     * @param ManufacturerImageUploader $imageUploader
      */
     public function __construct(
         CommandBusInterface $bus,
-        AbstractImageUploader $imageUploader
+        ManufacturerImageUploader $imageUploader
     ) {
         $this->bus = $bus;
         $this->imageUploader = $imageUploader;

--- a/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\AddManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\EditManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
-use PrestaShop\PrestaShop\Core\Image\Uploader\ImageUploaderInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use PrestaShop\PrestaShop\Adapter\Image\Uploader\AbstractImageUploader;
 

--- a/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
@@ -26,12 +26,12 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
+use PrestaShop\PrestaShop\Adapter\Image\Uploader\ManufacturerImageUploader;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\AddManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\EditManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use PrestaShop\PrestaShop\Adapter\Image\Uploader\ManufacturerImageUploader;
 
 /**
  * Handles submitted manufacturer form data
@@ -85,7 +85,7 @@ final class ManufacturerFormDataHandler implements FormDataHandlerInterface
             $data['meta_description'],
             $data['meta_keyword'],
             $data['shop_association']
-        ));   
+        ));
 
         if ($uploadedLogo instanceof UploadedFile) {
             $this->imageUploader->upload($manufacturerId->getValue(), $uploadedLogo);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Image is validated after entity creation, we should validate it first if needed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22737.
| How to test?      | Follow instructions from #22737 
| Possible impacts? | n/a
| Sponsor company | impSolutions

@PrestaShop/prestashop-core-developers need information if that's a correct way or we should do it differently, same problem exists for other entities 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24823)
<!-- Reviewable:end -->

📓 BC Breaks:

`src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php` 2nd parameter is now `ManufacturerImageUploader` instead of `ImageUploaderInterface`
