### PR TITLE
Cache getProducts with parameters

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -237,6 +237,7 @@ class CartCore extends ObjectModel
         static::$cachePackageList = [];
         static::$cacheDeliveryOptionList = [];
         static::$cacheMultiAddressDelivery = [];
+        static::$cacheProducts = [];
     }
 
     /**
@@ -659,7 +660,7 @@ class CartCore extends ObjectModel
             return [];
         }
 
-        $productsCacheKey = 'Cart::getProducts-'
+        $productsCacheKey = 'Cart::getProducts-' . (int) $this->id
             . $id_product . '-'
             . $id_country . '-'
             . $fullInfos . '-'

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -660,10 +660,10 @@ class CartCore extends ObjectModel
         }
 
         $productsCacheKey = 'Cart::getProducts-'
-            .$id_product.'-'
-            .$id_country.'-'
-            .$fullInfos.'-'
-            .$keepOrderPrices;
+            . $id_product . '-'
+            . $id_country . '-'
+            . $fullInfos . '-'
+            . $keepOrderPrices;
 
         // Product cache must be strictly compared to NULL, or else an empty cart will add dozens of queries
         if (isset(static::$cacheProducts[$productsCacheKey]) && static::$cacheProducts[$productsCacheKey] !== null && !$refresh) {
@@ -796,6 +796,7 @@ class CartCore extends ObjectModel
         if (empty($result)) {
             $this->_products = [];
             static::$cacheProducts[$productsCacheKey] = [];
+
             return [];
         }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -112,6 +112,8 @@ class CartCore extends ObjectModel
     protected static $cachePackageList = [];
     protected static $cacheDeliveryOptionList = [];
     protected static $cacheMultiAddressDelivery = [];
+
+    /** @var array */
     protected static $cacheProducts = [];
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Cache for `Cart::getProducts` wasn't precise, at all, I decided to cache it similar to `Product::getProductProperties`
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22425.
| How to test?      | I believe we should see E2E/integration tests failing if something would be wrong, also there are some instructions in #22425 - you can use `ps_qualityassurance` module with content from below
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Content for `displayTop` and `ps_qualityassurance` module:

```
dump('$fullInfos = false');
//We force cache refresh in first call
dump($this->context->cart->getProducts(true, false, null, false));
dump('$fullInfos = true');
dump($this->context->cart->getProducts(false, false, null, true));
dump('Expected result with $fullInfos = true');
dump($this->context->cart->getProducts(true, false, null, true));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24825)
<!-- Reviewable:end -->
