### PR TITLE
Show order confirmation even when order is free

### DIFF
--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -70,7 +70,17 @@ class PaymentOptionsFinderCore extends HookFinder
         $freeOption = new PaymentOption();
         $freeOption->setModuleName('free_order')
             ->setCallToActionText(Context::getContext()->getTranslator()->trans('Free order', [], 'Admin.Orderscustomers.Feature'))
-            ->setAction(Context::getContext()->link->getPageLink('order-confirmation', null, null, 'free_order=1'));
+            ->setAction(Context::getContext()->link->getPageLink(
+                    'order-confirmation',
+                    null,
+                    null,
+                    [
+                        'free_order' => 1,
+                        'key' => Context::getContext()->cart->secure_key,
+                        'id_cart' => (int) Context::getContext()->cart->id,
+                    ]
+                )
+            );
 
         return ['free_order' => [$freeOption]];
     }

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -71,7 +71,7 @@ class OrderConfirmationControllerCore extends FrontController
 
         if (!$this->isFreeOrder) {
             $module = Module::getInstanceById((int) $this->id_module);
-            if ($order->module != $module->name) {
+            if ($order->module !== $module->name) {
                 Tools::redirect($redirectLink);
             }
         }

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -70,7 +70,7 @@ class OrderConfirmationControllerCore extends FrontController
         }
 
         if (!$this->isFreeOrder) {
-            $module = Module::getInstanceById((int) ($this->id_module));
+            $module = Module::getInstanceById((int) $this->id_module);
             if ($order->module != $module->name) {
                 Tools::redirect($redirectLink);
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Before this change, we could not see order confirmation for a free order
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |no
| Fixed ticket?     | Fixes - #23230.
| How to test?      | Create free order before and after this change
| Possible impacts? | n/a


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24828)
<!-- Reviewable:end -->
