### PR TITLE
Use language code instead of ISO code in HTML lang

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -525,6 +525,7 @@ class FrontControllerCore extends Controller
             'currency' => $this->getTemplateVarCurrency(),
             'customer' => $this->getTemplateVarCustomer(),
             'language' => $this->objectPresenter->present($this->context->language),
+            'language_code' => $this->getTemplateVarLanguageCode(),
             'page' => $this->getTemplateVarPage(),
             'shop' => $this->getTemplateVarShop(),
             'urls' => $this->getTemplateVarUrls(),
@@ -1701,6 +1702,11 @@ class FrontControllerCore extends Controller
         ];
 
         return $page;
+    }
+
+    public function getTemplateVarLanguageCode()
+    {
+        return preg_replace('/-.*/', '', $this->context->language->language_code);
     }
 
     public function getBreadcrumb()

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <!doctype html>
-<html lang="{$language.language_code|regex_replace:'/-.*/':''}">
+<html lang="{$language_code}">
 
   <head>
     {block name='head'}

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <!doctype html>
-<html lang="{$language.iso_code}">
+<html lang="{$language.language_code|regex_replace:'/-.*/':''}">
 
   <head>
     {block name='head'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use language code instead of ISO code in `<html lang="...">`
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24833
| How to test?      | Create a new language with the `at` ISO code and` de-AT` language code, then look at the front office `html` tag
| Possible impacts? | 

If I create a language with the ISO code `AT` for Austria, it will show `<html lang="at">`, but this is not a real ISO code that should be included here (`<html lang="de">` would be the right value  according to https://www.w3schools.com/tags/ref_language_codes.asp).

Instead, use the first half of the language code, which is sure to contain the correct ISO code.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24832)
<!-- Reviewable:end -->
