### PR TITLE
Check if regeneration is wanted before checking filesystem

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -63,7 +63,7 @@ class ImageManagerCore
             return '';
         }
 
-        if (file_exists(_PS_TMP_IMG_DIR_ . $cacheImage) && $regenerate) {
+        if ($regenerate && file_exists(_PS_TMP_IMG_DIR_ . $cacheImage)) {
             @unlink(_PS_TMP_IMG_DIR_ . $cacheImage);
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Performance and readability update: it costs less to verify a boolean than check if a file exist on the filesystem. Plus, it's more readable regarding to the second `if` statement which include similarly-typed conditions in the inverse order
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | None
| How to test?      | No tests needed
| Possible impacts? | None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24834)
<!-- Reviewable:end -->
