### PR TITLE
Remove extracted comments from webpack config of core js

### DIFF
--- a/themes/webpack.config.js
+++ b/themes/webpack.config.js
@@ -22,6 +22,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+const TerserPlugin = require("terser-webpack-plugin");
+
 module.exports = (env, argv) => {
   const path = require('path');
   const mode = argv.mode || 'production';
@@ -52,5 +54,11 @@ module.exports = (env, argv) => {
       prestashop: 'prestashop',
     },
     devtool: 'source-map',
+    optimization: {
+      minimize: true,
+      minimizer: [new TerserPlugin({
+        extractComments: false
+      })],
+    },
   };
 };


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The update to webpack 5 automatically used Terser plugin, with extractComment to true, which is not what we want and leads to a new unwanted js.LICENSE.txt file
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24734.
| How to test?      | No need to test tbh, except that the build is working properly (npm run build inside themes folder)
| Possible impacts? | Core js FO file build


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24846)
<!-- Reviewable:end -->
