### PR TITLE
Avoid setting height to 0 if height isn't defined on product dropzone

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1335,7 +1335,10 @@ window.imagesProduct = (function () {
       dropZoneElem.css('height', '');
       const closedHeight = dropZoneElem.outerHeight();
       const realHeight = dropZoneElem[0].scrollHeight;
-      dropZoneElem.css('height', oldHeight);
+
+      if (oldHeight !== '0px') {
+        dropZoneElem.css('height', oldHeight);
+      }
 
       return (realHeight > closedHeight);
     },

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1336,7 +1336,6 @@ window.imagesProduct = (function () {
       const closedHeight = dropZoneElem.outerHeight();
       const realHeight = dropZoneElem[0].scrollHeight;
 
-      console.log(realHeight, closedHeight);
       if (oldHeight !== '0px') {
         dropZoneElem.css('height', oldHeight);
       }

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -1336,11 +1336,12 @@ window.imagesProduct = (function () {
       const closedHeight = dropZoneElem.outerHeight();
       const realHeight = dropZoneElem[0].scrollHeight;
 
+      console.log(realHeight, closedHeight);
       if (oldHeight !== '0px') {
         dropZoneElem.css('height', oldHeight);
       }
 
-      return (realHeight > closedHeight);
+      return (realHeight > closedHeight) && dropZoneElem.find('.dz-preview:not(.openfilemanager)').length;
     },
     updateExpander() {
       if (this.shouldDisplayExpander()) {

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -427,6 +427,12 @@ $product-page-padding-bottom: 80px !default;
     @include border-bottom-radius(0);
     @include transition(width 0.5s ease-out, margin 0.5s ease-out);
 
+    .product-images-dropzone-error {
+      p {
+        margin-bottom: 0;
+      }
+    }
+
     &.col-md-8 {
       min-height: 200px;
       border-right: solid 1px $gray-light;
@@ -586,7 +592,7 @@ $product-page-padding-bottom: 80px !default;
     z-index: 0;
     float: left;
     min-height: 200px;
-    margin: 10px 0 5px 5px;
+    margin: 10px 0 5px;
     cursor: default;
 
     .close {
@@ -604,6 +610,7 @@ $product-page-padding-bottom: 80px !default;
   #product-images-container {
     position: relative;
     display: flex;
+    flex-wrap: wrap;
     width: 100%;
     border: solid 1px $gray-light;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The height was wrong if the element doesn't exist on the page or is hidden, it should be avoided if the current height === 0px
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24809.
| How to test?      | Go on product page, go on price tab, refresh the page and go on basic tab, the height should be fine
| Possible impacts? | Product page v1 dropzone


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24848)
<!-- Reviewable:end -->
