### PR TITLE
Fix wrong tab selected after changing a product combination on the FO

### DIFF
--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -164,13 +164,13 @@ $(document).ready(() => {
     const nav = $(prestashop.themeSelectors.product.tabs);
     nav.on('show.bs.tab', (e) => {
       const target = $(e.target);
-      target.addClass('js-product-nav-active');
-      $(target.attr('href')).addClass('js-product-tab-active');
+      target.addClass(prestashop.themeSelectors.product.activeNavClass);
+      $(target.attr('href')).addClass(prestashop.themeSelectors.product.activeTabClass);
     });
     nav.on('hide.bs.tab', (e) => {
       const target = $(e.target);
-      target.removeClass('js-product-nav-active');
-      $(target.attr('href')).removeClass('js-product-tab-active');
+      target.removeClass(prestashop.themeSelectors.product.activeNavClass);
+      $(target.attr('href')).removeClass(prestashop.themeSelectors.product.activeTabClass);
     });
   }
 });

--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -31,6 +31,7 @@ $(document).ready(() => {
   createInputFile();
   coverImage();
   imageScrollBox();
+  addJsProductTabActiveSelector();
 
   prestashop.on('updatedProduct', (event) => {
     createInputFile();
@@ -156,6 +157,20 @@ $(document).ready(() => {
           event: e,
         });
       }
+    });
+  }
+
+  function addJsProductTabActiveSelector() {
+    const nav = $(prestashop.themeSelectors.product.tabs);
+    nav.on('show.bs.tab', (e) => {
+      const target = $(e.target);
+      target.addClass('js-product-nav-active');
+      $(target.attr('href')).addClass('js-product-tab-active');
+    });
+    nav.on('hide.bs.tab', (e) => {
+      const target = $(e.target);
+      target.removeClass('js-product-nav-active');
+      $(target.attr('href')).removeClass('js-product-tab-active');
     });
   }
 });

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -27,6 +27,7 @@ import $ from 'jquery';
 
 prestashop.themeSelectors = {
   product: {
+    tabs: '.tabs .nav-link',
     activeTabs: '.tabs .nav-link.active, .js-product-nav-active',
     imagesModal: '.js-product-images-modal',
     thumb: '.js-thumb',

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -28,6 +28,8 @@ import $ from 'jquery';
 prestashop.themeSelectors = {
   product: {
     tabs: '.tabs .nav-link',
+    activeNavClass: 'js-product-nav-active',
+    activeTabClass: 'js-product-tab-active',
     activeTabs: '.tabs .nav-link.active, .js-product-nav-active',
     imagesModal: '.js-product-images-modal',
     thumb: '.js-thumb',
@@ -54,7 +56,7 @@ prestashop.themeSelectors = {
     returnForm: '#order-return-form, .js-order-return-form',
   },
   arrowDown: '.arrow-down, .js-arrow-down',
-  arrowUp: '.arrow-up, .js-arrow-down',
+  arrowUp: '.arrow-up, .js-arrow-up',
   clear: '.clear',
   fileInput: '.js-file-input',
   contentWrapper: '#content-wrapper, .js-content-wrapper',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In #23056, `js-*` selectors have been added but some of them were not updated when the active state of a tab change. This PR fixes it.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24800
| How to test?      | Please see #24800
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24849)
<!-- Reviewable:end -->
