### PR TITLE
Twig extension for multistore shop context URLs

### DIFF
--- a/admin-dev/themes/new-theme/js/components/components-map.js
+++ b/admin-dev/themes/new-theme/js/components/components-map.js
@@ -33,6 +33,17 @@ export default {
     headerButton: '.js-header-multishop-open-modal',
     searchInput: '.js-multishop-modal-search',
     jsScrollbar: '.js-multishop-scrollbar',
-    setContextUrl: (location, urlLetter, itemId) => `${location}&setShopContext=${urlLetter}-${itemId}`,
+    setContextUrl: (location, urlLetter, itemId) => {
+      const setContextParameter = `setShopContext=${urlLetter}-${itemId}`;
+      const url = new URL(location);
+
+      if (url.search === '') {
+        url.search = `?${setContextParameter}`;
+      } else {
+        url.search += `&${setContextParameter}`;
+      }
+
+      return url.toString();
+    },
   },
 };

--- a/admin-dev/themes/new-theme/js/components/multistore-dropdown.js
+++ b/admin-dev/themes/new-theme/js/components/multistore-dropdown.js
@@ -60,8 +60,11 @@ const initMultistoreDropdown = () => {
     /* eslint-disable-next-line no-unused-vars */
     onSelect(selectedItem, event) {
       const contextUrlLetter = typeof selectedItem.groupName !== 'undefined' ? 's' : 'g';
-      const setContextUrl = `${window.location.href}&setShopContext=${contextUrlLetter}-${selectedItem.id}`;
-      window.location.href = setContextUrl;
+      window.location.href = ComponentsMap.multistoreHeader.setContextUrl(
+        window.location.href,
+        contextUrlLetter,
+        selectedItem.id,
+      );
 
       return true;
     },

--- a/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/twig.yml
@@ -125,3 +125,10 @@ services:
         - '@prestashop.core.admin.multistore'
       tags:
         - { name: twig.extension }
+
+    prestashop.bundle.twig.extension.multistore_url:
+        class: 'PrestaShopBundle\Twig\Extension\MultistoreUrlExtension'
+        arguments:
+          - '@=service("request_stack")'
+        tags:
+            - { name: twig.extension }

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/dropdown.html.twig
@@ -37,12 +37,12 @@
         <ul class="multistore-dropdown-group">
           {% for group in groupList %}
           <li class="multistore-dropdown-group-item">
-            <a class="multistore-dropdown-group-name" href="{{ app.request.requestURI ~ '&setShopContext=g-' ~ group.id }}">{{ "Group"|trans({}, 'Admin.Global') ~ ' ' ~ group.name }}</a>
+            <a class="multistore-dropdown-group-name" href="{{ multistore_group_url(group) }}">{{ "Group"|trans({}, 'Admin.Global') ~ ' ' ~ group.name }}</a>
 
             <ul class="multistore-dropdown-shops">
               {% for shop in group.shops %}
                 <li class="multistore-dropdown-shop">
-                  <a class="multistore-dropdown-shop-name{% if shop.hasMainUrl() == false %} multistore-dropdown-no-url">{{ shop.name }}</a>{% else %}" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>{% endif %}
+                  <a class="multistore-dropdown-shop-name{% if shop.hasMainUrl() == false %} multistore-dropdown-no-url">{{ shop.name }}</a>{% else %}" href="{{ multistore_shop_url(shop) }}">{{ shop.name }}</a>{% endif %}
                   {% if shopCustomizationChecker.isConfigurationCustomizedForThisShop(configurationKey, shop, isGroupShopContext) == true %}
                     <p class="multistore-dropdown-shop-status multistore-dropdown-shop-status-locked">
                       <i class="material-icons">https</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Multistore/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Multistore/header.html.twig
@@ -99,7 +99,7 @@
                   {% else %}
                     <span class="multishop-modal-color" style="background-color:#25b9d7;"></span>
                   {% endif %}
-                  <a class="multishop-modal-all-name" href="{{ app.request.requestURI ~ '&setShopContext=' }}">
+                  <a class="multishop-modal-all-name" href="{{ multistore_url() }}">
                     <span>{{ "All shops"|trans({}, 'Admin.Global') }}</span>
                   </a>
                 </li>
@@ -110,7 +110,7 @@
                     <i class="material-icons">check</i>
                     <a class="multishop-modal-color"{% if group.color is not empty %} style="background-color: {{group.color}};"{% endif %} href="{{ getAdminLink('AdminShopGroup', true, {'id_shop_group' : group.id, 'updateshop_group' : true}) }}" data-toggle="popover" data-trigger="hover" data-placement="top" data-content="{{ "Edit color"|trans({}, 'Admin.Global') }}" data-original-title="" title=""></a>
                   </span>
-                    <a class="multishop-modal-group-name" href="{{ app.request.requestURI ~ '&setShopContext=g-' ~ group.id }}">{{ "Group"|trans({}, 'Admin.Global') ~ ' ' ~ group.name }}</a>
+                  <a class="multishop-modal-group-name" href="{{ multistore_group_url(group) }}">{{ "Group"|trans({}, 'Admin.Global') ~ ' ' ~ group.name }}</a>
                 </li>
 
                 {% for shop in group.shops %}
@@ -120,7 +120,7 @@
                       <i class="material-icons">check</i>
                       <a class="multishop-modal-color"{% if shop.color is not empty %} style="background-color: {{shop.color}};"{% endif %} href="{{ getAdminLink('AdminShop', true, {'shop_id' : shop.id, 'updateshop' : true}) }}" data-toggle="popover" data-trigger="hover" data-placement="top" data-content="{{ "Edit color"|trans({}, 'Admin.Global') }}" data-original-title="" title=""></a>
                     </span>
-                      <a class="multishop-modal-shop-name{% if shop.hasMainUrl() == false %} multishop-modal-no-url">{{ shop.name }}</a>{% else %}" href="{{ app.request.requestURI ~ '&setShopContext=s-' ~ shop.id }}">{{ shop.name }}</a>{% endif %}
+                    <a class="multishop-modal-shop-name{% if shop.hasMainUrl() == false %} multishop-modal-no-url">{{ shop.name }}</a>{% else %}" href="{{ multistore_shop_url(shop) }}">{{ shop.name }}</a>{% endif %}
                     </div>
                     {% if shop.hasMainUrl() %}
                       <a class="multishop-modal-shop-view" href="{{ link.getBaseLink(shop.id) }}" target="_blank" rel="noreferrer">{{ "View my shop"|trans({}, 'Admin.Navigation.Header') }} <i class="material-icons">visibility</i></a>

--- a/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Twig\Extension;
 
 use PrestaShopBundle\Entity\Shop;
@@ -55,7 +57,7 @@ class MultistoreUrlExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new SimpleFunction('multistore_url', [$this, 'generateUrl']),

--- a/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
@@ -69,7 +69,7 @@ class MultistoreUrlExtension extends AbstractExtension
     /**
      * Generate URL from current request for a specific shop group.
      *
-     * @param ShopGroup|null $group
+     * @param int|null $id
      * @param string|null $prefix
      *
      * @return string

--- a/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
@@ -69,8 +69,8 @@ class MultistoreUrlExtension extends AbstractExtension
     /**
      * Generate URL from current request for a specific shop group.
      *
-     * @param ?ShopGroup $group
-     * @param ?string $prefix
+     * @param ShopGroup|null $group
+     * @param string|null $prefix
      *
      * @return string
      */
@@ -91,11 +91,11 @@ class MultistoreUrlExtension extends AbstractExtension
     /**
      * Generate URL from current request for a specific shop group.
      *
-     * @param ?ShopGroup $group
+     * @param ShopGroup $group
      *
      * @return string
      */
-    public function generateGroupUrl(?ShopGroup $group = null): string
+    public function generateGroupUrl(ShopGroup $group): string
     {
         return $this->generateUrl($group->getId(), 'g-');
     }
@@ -103,11 +103,11 @@ class MultistoreUrlExtension extends AbstractExtension
     /**
      * Generate URL from current request for a specific shop.
      *
-     * @param ?Shop $shop
+     * @param Shop $shop
      *
      * @return string
      */
-    public function generateShopUrl(?Shop $shop = null): string
+    public function generateShopUrl(Shop $shop = null): string
     {
         return $this->generateUrl($shop->getId(), 's-');
     }

--- a/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/MultistoreUrlExtension.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Twig\Extension;
+
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig_SimpleFunction as SimpleFunction;
+
+/**
+ * Class MultiStoreUrlExtension is responsible for providing a way to generate url with setShopContext parameter.
+ */
+class MultistoreUrlExtension extends AbstractExtension
+{
+    public const SHOP_CONTEXT_PARAMETER = 'setShopContext';
+
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new SimpleFunction('multistore_url', [$this, 'generateUrl']),
+            new SimpleFunction('multistore_group_url', [$this, 'generateGroupUrl']),
+            new SimpleFunction('multistore_shop_url', [$this, 'generateShopUrl']),
+        ];
+    }
+
+    /**
+     * Generate URL from current request for a specific shop group.
+     *
+     * @param ?ShopGroup $group
+     * @param ?string $prefix
+     *
+     * @return string
+     */
+    public function generateUrl(?int $id = null, ?string $prefix = null): string
+    {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        $currentRequest->query->set(
+            static::SHOP_CONTEXT_PARAMETER,
+            $prefix . $id
+        );
+
+        return $currentRequest->getBaseUrl()
+            . $currentRequest->getPathInfo()
+            . '?'
+            . http_build_query($currentRequest->query->all());
+    }
+
+    /**
+     * Generate URL from current request for a specific shop group.
+     *
+     * @param ?ShopGroup $group
+     *
+     * @return string
+     */
+    public function generateGroupUrl(?ShopGroup $group = null): string
+    {
+        return $this->generateUrl($group->getId(), 'g-');
+    }
+
+    /**
+     * Generate URL from current request for a specific shop.
+     *
+     * @param ?Shop $shop
+     *
+     * @return string
+     */
+    public function generateShopUrl(?Shop $shop = null): string
+    {
+        return $this->generateUrl($shop->getId(), 's-');
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Twig/Extension/MultistoreUrlExtensionTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Extension/MultistoreUrlExtensionTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Twig\Extension;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\Shop;
+use PrestaShopBundle\Entity\ShopGroup;
+use PrestaShopBundle\Twig\Extension\MultistoreUrlExtension;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class MultistoreUrlExtensionTest extends TestCase
+{
+    /**
+     * @var MockObject|RequestStack
+     */
+    private $requestStackMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestStackMock = $this
+            ->getMockBuilder(RequestStack::class)
+            ->getMock()
+        ;
+    }
+
+    public function testItShouldReturnsThreeFunctions(): void
+    {
+        $extension = new MultistoreUrlExtension(
+            $this->requestStackMock,
+        );
+
+        $functions = $extension->getFunctions();
+        $this->assertCount(3, $functions);
+        $this->assertEquals('multistore_url', $functions[0]->getName());
+        $this->assertEquals('multistore_group_url', $functions[1]->getName());
+        $this->assertEquals('multistore_shop_url', $functions[2]->getName());
+    }
+
+    public function testItSetShopContext(): void
+    {
+        $extension = new MultistoreUrlExtension(
+            $this->requestStackMock
+        );
+
+        $this->mockRequest(new ParameterBag());
+
+        $result = $extension->generateUrl(25);
+
+        $this->assertEquals('/admin/index.php/categories/test?setShopContext=25', $result);
+    }
+
+    public function testItSetShopContextWithPrefix(): void
+    {
+        $extension = new MultistoreUrlExtension(
+            $this->requestStackMock
+        );
+
+        $this->mockRequest(new ParameterBag());
+
+        $result = $extension->generateUrl(25, 'ps-');
+
+        $this->assertEquals('/admin/index.php/categories/test?setShopContext=ps-25', $result);
+    }
+
+    public function testItSetShopContextWithMultipleParameter(): void
+    {
+        $extension = new MultistoreUrlExtension(
+            $this->requestStackMock
+        );
+
+        $query = new ParameterBag();
+        $query->set('category_id', 12);
+        $this->mockRequest($query);
+
+        $result = $extension->generateUrl(25);
+
+        $this->assertEquals('/admin/index.php/categories/test?category_id=12&setShopContext=25', $result);
+    }
+
+    public function testItSetShopContextFromShop(): void
+    {
+        $extension = new MultistoreUrlExtension(
+            $this->requestStackMock
+        );
+
+        $this->mockRequest(new ParameterBag());
+
+        $shop = $this
+            ->getMockBuilder(Shop::class)
+            ->getMock();
+
+        $shop->method('getId')
+            ->willReturn(42);
+
+        $result = $extension->generateShopUrl($shop);
+
+        $this->assertEquals('/admin/index.php/categories/test?setShopContext=s-42', $result);
+    }
+
+    public function testItSetShopContextFromShopGroup(): void
+    {
+        $extension = new MultistoreUrlExtension(
+            $this->requestStackMock
+        );
+
+        $this->mockRequest(new ParameterBag());
+
+        $shop = $this
+            ->getMockBuilder(ShopGroup::class)
+            ->getMock();
+
+        $shop->method('getId')
+            ->willReturn(43);
+
+        $result = $extension->generateGroupUrl($shop);
+
+        $this->assertEquals('/admin/index.php/categories/test?setShopContext=g-43', $result);
+    }
+
+    protected function mockRequest(ParameterBag $query): void
+    {
+        $requestMock = $this
+            ->getMockBuilder(Request::class)
+            ->getMock()
+        ;
+
+        $requestMock->query = $query;
+
+        $this->requestStackMock
+            ->method('getCurrentRequest')
+            ->willReturn($requestMock)
+        ;
+
+        $requestMock
+            ->method('getBaseUrl')
+            ->willReturn('/admin/index.php')
+        ;
+
+        $requestMock
+            ->method('getPathInfo')
+            ->willReturn('/categories/test')
+        ;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Twig/Extension/MultistoreUrlExtensionTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Extension/MultistoreUrlExtensionTest.php
@@ -57,7 +57,7 @@ class MultistoreUrlExtensionTest extends TestCase
     public function testItShouldReturnsThreeFunctions(): void
     {
         $extension = new MultistoreUrlExtension(
-            $this->requestStackMock,
+            $this->requestStackMock
         );
 
         $functions = $extension->getFunctions();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Create twig extension to be sure URLs are properly created when using the `setShopContext` parameter in URLS. The problem exists when there is nothing in the URL, we are not able to do `&setShopContext` without `?`. Same with javascript behaviour, centralized it into one function instead of custom concatenations.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24818
| How to test?      | Follow ticket instruction.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24851)
<!-- Reviewable:end -->
