### PR TITLE
Fix 404 layout for wrong category

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -36,6 +36,9 @@ class CategoryControllerCore extends ProductListingFrontController
     /** @var bool If set to false, customer cannot view the current category. */
     public $customer_access = true;
 
+    /** @var bool */
+    protected $notFound = false;
+
     /**
      * @var Category
      */
@@ -91,8 +94,8 @@ class CategoryControllerCore extends ProductListingFrontController
         if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
-            $this->errors[] = $this->trans('This category does not exist.', [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
+            $this->notFound = true;
 
             return;
         } elseif (!$this->category->checkAccess($this->context->customer->id)) {
@@ -155,7 +158,7 @@ class CategoryControllerCore extends ProductListingFrontController
      */
     public function getLayout()
     {
-        if (!$this->category->checkAccess($this->context->customer->id)) {
+        if (!$this->category->checkAccess($this->context->customer->id) || $this->notFound) {
             return 'layouts/layout-full-width.tpl';
         }
 
@@ -263,10 +266,16 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         $page = parent::getTemplateVarPage();
 
-        $page['body_classes']['category-id-' . $this->category->id] = true;
-        $page['body_classes']['category-' . $this->category->name] = true;
-        $page['body_classes']['category-id-parent-' . $this->category->id_parent] = true;
-        $page['body_classes']['category-depth-level-' . $this->category->level_depth] = true;
+        if ($this->notFound) {
+            $page['page_name'] = 'pagenotfound';
+            $page['body_classes']['pagenotfound'] = true;
+            $page['title'] = $this->trans('The page you are looking for was not found.', [], 'Shop.Theme.Global');
+        } else {
+            $page['body_classes']['category-id-' . $this->category->id] = true;
+            $page['body_classes']['category-' . $this->category->name] = true;
+            $page['body_classes']['category-id-parent-' . $this->category->id_parent] = true;
+            $page['body_classes']['category-depth-level-' . $this->category->level_depth] = true;
+        }
 
         return $page;
     }

--- a/themes/classic/_dev/css/components/errors.scss
+++ b/themes/classic/_dev/css/components/errors.scss
@@ -14,6 +14,7 @@
     max-width: 570px;
     padding: 1rem;
     margin: 0 auto;
+    overflow: auto;
     font-size: $font-size-sm;
     color: $gray;
     background: $white;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since #21258, when trying to access a disabled or unexisting category, there is no redirection anymore. We display the 404 template directly. This needed some adjustments to have a matching 404 page everywhere.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24370
| How to test?      | Please see #24370
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24852)
<!-- Reviewable:end -->
