### PR TITLE
Fix order notes not being saved 

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -230,7 +230,7 @@ class OrderCore extends ObjectModel
             'reference' => ['type' => self::TYPE_STRING],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_upd' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
-            'note' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml'],
+            'note' => ['type' => self::TYPE_HTML],
         ],
     ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | in the object model, the field was of type string, instead of HTML, keeping notes with HTML brackets like `<mynote>` from being stored, because a strip tag was applied. We put it in HTML without any `validate`, so it does not purify it and we can treat it as a simple string. Otherwise using type `STRING` will result of an `escape` call inside the `pSQL` function.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24534
| How to test?      | See steps in #24534
| Possible impacts? | ---


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24867)
<!-- Reviewable:end -->
