### PR TITLE
Fixed cart rule on selected product with product with ecotax

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1274,7 +1274,10 @@ class CartRuleCore extends ObjectModel
                             if ($use_tax) {
                                 $infos = Product::getTaxesInformations($product, $context);
                                 $tax_rate = $infos['rate'] / 100;
+                                // As the price is tax excluded but ecotax included, we need to substract the ecotax before getting the price tax included
+                                $price -= $product['ecotax'];
                                 $price *= (1 + $tax_rate);
+                                $price += $product['ecotax'];
                             }
 
                             $selected_products_reduction += $price * $product['cart_quantity'];

--- a/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CarrierFeatureContext.php
@@ -383,6 +383,7 @@ class CarrierFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $this->checkAddressWithNameExists($addresssName);
         $this->getCurrentCart()->id_address_delivery = $this->addresses[$addresssName]->id;
+        Context::getContext()->country = new Country((int) $this->addresses[$addresssName]->id_country);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -271,6 +271,16 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @Given /^cart rule "(.+)" is restricted on the selection of products$/
+     */
+    public function cartRuleIsRestrictedToSelectionProducts(string $cartRuleName): void
+    {
+        $this->checkCartRuleWithNameExists($cartRuleName);
+        $this->cartRules[$cartRuleName]->reduction_product = -2;
+        $this->cartRules[$cartRuleName]->save();
+    }
+
+    /**
      * @Given /^cart rule "(.+)" is applied on every order$/
      */
     public function cartRuleIsRestrictedToEveryOrder($cartRuleName)

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
@@ -1,0 +1,59 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-calculation-cartrule-ecotax
+
+@reset-database-before-feature
+@clear-cache-before-scenario
+@cart-calculation-cartrule-ecotax
+Feature: Cart rule (percent) calculation with one cart rule
+  As a customer
+  I must be able to have correct cart total when adding cart rules
+
+  Background:
+    Given there is a zone named "zone1"
+    And there is a country named "country1" and iso code "FR" in zone "zone1"
+    And there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
+    And there is an address named "address1" with postcode "1" in state "state1"
+
+  Scenario:
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a tax named "tax4Percent" and rate 4.0%
+    And there is a tax rule named "taxRule4Percent" in country "country1" where tax "tax4Percent" is applied
+    And I have an empty default cart
+    ## Set Product
+    And there is a product in the catalog named "product_without_ecotax" with a price of 10.000 and 1000 items in stock
+    And product "product_without_ecotax" belongs to tax group "taxRule4Percent"
+    ## Set Cart Rule
+    When there is a cart rule named "cartRuleFiftyPercent" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    And cart rule "cartRuleFiftyPercent" is restricted to product "product_without_ecotax"
+    And cart rule "cartRuleFiftyPercent" is restricted on the selection of products
+    And cart rule "cartRuleFiftyPercent" has a discount code "cartRuleFiftyPercent"
+    ## Add product
+    When I add 1 item of product "product_without_ecotax" in my cart
+    And I select address "address1" in my cart
+    Then my cart total should be 10.400 tax included
+    And my cart total should be 10.000 tax excluded
+    And I use the discount "cartRuleFiftyPercent"
+    Then my cart total should be 5.200 tax included
+    And my cart total should be 5.000 tax excluded
+
+  Scenario:
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a tax named "tax4Percent" and rate 4.0%
+    And there is a tax rule named "taxRule4Percent" in country "country1" where tax "tax4Percent" is applied
+    And I have an empty default cart
+    ## Set Product
+    And there is a product in the catalog named "product_with_ecotax" with a price of 10.000 and 1000 items in stock
+    And the product "product_with_ecotax" ecotax is 2.00
+    And product "product_with_ecotax" belongs to tax group "taxRule4Percent"
+    ## Set Cart Rule
+    When there is a cart rule named "cartRuleFiftyPercent" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    And cart rule "cartRuleFiftyPercent" is restricted to product "product_with_ecotax"
+    And cart rule "cartRuleFiftyPercent" is restricted on the selection of products
+    And cart rule "cartRuleFiftyPercent" has a discount code "cartRuleFiftyPercent"
+    ## Add product
+    When I add 1 item of product "product_with_ecotax" in my cart
+    And I select address "address1" in my cart
+    Then my cart total should be 10.400 tax included
+    And my cart total should be 10.000 tax excluded
+    And I use the discount "cartRuleFiftyPercent"
+    Then my cart total should be 5.200 tax included
+    And my cart total should be 5.000 tax excluded

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Taxes/tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Taxes/tax.feature
@@ -28,7 +28,7 @@ Feature: Cart calculation with tax
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     When I add 1 items of product "product1" in my cart
     When I select address "address1" in my cart
@@ -50,7 +50,7 @@ Feature: Cart calculation with tax
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 6.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product5" belongs to tax group "taxrule1"
     When I add 1 items of product "product5" in my cart
     When I select address "address1" in my cart
@@ -72,7 +72,7 @@ Feature: Cart calculation with tax
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 0.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product5" belongs to tax group "taxrule1"
     When I add 1 items of product "product5" in my cart
     When I select address "address1" in my cart
@@ -94,7 +94,7 @@ Feature: Cart calculation with tax
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     When I add 3 items of product "product1" in my cart
     When I select address "address1" in my cart
@@ -118,13 +118,13 @@ Feature: Cart calculation with tax
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given there is a tax named "tax2" and rate 6.0%
-    Given there is a tax rule named "taxrule2"in country "country1" and state "state1" where tax "tax2" is applied
+    Given there is a tax rule named "taxrule2" in country "country1" and state "state1" where tax "tax2" is applied
     Given product "product2" belongs to tax group "taxrule2"
     Given there is a tax named "tax3" and rate 10.0%
-    Given there is a tax rule named "taxrule3"in country "country1" and state "state1" where tax "tax3" is applied
+    Given there is a tax rule named "taxrule3" in country "country1" and state "state1" where tax "tax3" is applied
     Given product "product3" belongs to tax group "taxrule3"
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product2" in my cart
@@ -150,13 +150,13 @@ Feature: Cart calculation with tax
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given there is a tax named "tax2" and rate 0.0%
-    Given there is a tax rule named "taxrule2"in country "country1" and state "state1" where tax "tax2" is applied
+    Given there is a tax rule named "taxrule2" in country "country1" and state "state1" where tax "tax2" is applied
     Given product "product2" belongs to tax group "taxrule2"
     Given there is a tax named "tax3" and rate 10.0%
-    Given there is a tax rule named "taxrule3"in country "country1" and state "state1" where tax "tax3" is applied
+    Given there is a tax rule named "taxrule3" in country "country1" and state "state1" where tax "tax3" is applied
     Given product "product3" belongs to tax group "taxrule3"
     When I add 3 items of product "product1" in my cart
     When I add 1 items of product "product2" in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -15,7 +15,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
@@ -51,7 +51,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
@@ -89,7 +89,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given product "product2" belongs to tax group "taxrule1"
     Given product "product3" belongs to tax group "taxrule1"
@@ -131,7 +131,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given product "product2" belongs to tax group "taxrule1"
     Given product "product3" belongs to tax group "taxrule1"
@@ -171,7 +171,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"
@@ -208,7 +208,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given product "product4" belongs to tax group "taxrule1"
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
@@ -245,7 +245,7 @@ Feature: Check cart to order data copy
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given product "product4" belongs to tax group "taxrule1"
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
@@ -25,7 +25,7 @@ Feature: Compute correct delivery options
     Given there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     Given there is an address named "address1" with postcode "1" in state "state1"
     Given there is a tax named "tax1" and rate 4.0%
-    Given there is a tax rule named "taxrule1"in country "country1" and state "state1" where tax "tax1" is applied
+    Given there is a tax rule named "taxrule1" in country "country1" and state "state1" where tax "tax1" is applied
     Given product "product1" belongs to tax group "taxrule1"
     Given there is a customer named "customer1" whose email is "fake@prestashop.com"
     Given address "address1" is associated to customer "customer1"

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_cartrule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_cartrule.feature
@@ -1,0 +1,144 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-ecotax-cartrule
+@reset-database-before-feature
+@reboot-kernel-before-feature
+@clear-cache-before-feature
+@order-ecotax
+@order-ecotax-cartrule
+Feature: Ecotax for Order in Back Office (BO)
+
+  Background:
+    Given email sending is disabled
+    And shop configuration for "PS_USE_ECOTAX" is set to 1
+    And the current currency is "USD"
+    And country "FR" is enabled
+    ## Create Tax
+    And I add new tax "fr-tax-6" with following properties:
+      | name         | FR Tax (6%)   |
+      | rate         | 6             |
+      | is_enabled   | true          |
+    And I add the tax rule group "fr-tax-6-group" for the tax "fr-tax-6" with the following conditions:
+      | name         | FR Tax (6%)   |
+      | country      | FR            |
+    ## Create Product
+    And there is a product in the catalog named "Free Product" with a price of 0.0 and 100 items in stock
+    Then the available stock for product "Free Product" should be 100
+    ## Create Product
+    And there is a product in the catalog named "Test Ecotax Product" with a price of 15.0 and 100 items in stock
+    Then the available stock for product "Test Ecotax Product" should be 100
+    And I set tax rule group "fr-tax-6-group" to product "Test Ecotax Product"
+    ## Enable payment
+    And the module "dummy_payment" is installed
+    ## Employee
+    And I am logged in as "test@prestashop.com" employee
+    ## Customer
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "FR" country
+    ## Carrier
+    And a carrier "default_carrier" with name "My carrier" exists
+    And I associate the tax rule group "fr-tax-6-group" to carrier "default_carrier"
+    ## Cart for Customer
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I select "FR" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    ## Cart > Produits
+    When I add 1 products "Free Product" to the cart "dummy_cart"
+    ## Cart > Carrier
+    And I select carrier "default_carrier" for cart "dummy_cart"
+    Then cart "dummy_cart" should have "default_carrier" as a carrier
+    ## Create Order
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+
+  Scenario: Add product (without ecotax) to an Order
+    ## Set Cart Rule
+    When there is a cart rule named "cartRuleFiftyPercent" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    And cart rule "cartRuleFiftyPercent" is restricted to product "Test Ecotax Product"
+    When I set tax rule group "fr-tax-6-group" to product "Test Ecotax Product"
+    And I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Ecotax Product |
+      | amount        | 2                   |
+      | price         | 15.00               |
+      | price_tax_incl| 15.90               |
+    ## Check informations
+    Then order "bo_order1" should contain 2 products "Test Ecotax Product"
+    And the available stock for product "Test Ecotax Product" should be 98
+    And order "bo_order1" should have 3 products in total
+    And order "bo_order1" should have 0 invoices
+    And order "bo_order1" should have 1 cart rule
+    And product "Test Ecotax Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | ecotax                      | 0.00  |
+      | product_price               | 15.00 |
+      | original_product_price      | 15.00 |
+      | unit_price_tax_excl         | 15.00 |
+      | unit_price_tax_incl         | 15.90 |
+      | total_price_tax_excl        | 30.00 |
+      | total_price_tax_incl        | 31.80 |
+    When I generate invoice for "bo_order1" order
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products              | 30.00 |
+      | total_products_wt           | 31.80 |
+      | total_discount_tax_excl     | 15.00 |
+      | total_discount_tax_incl     | 15.90 |
+      | total_paid_tax_excl         | 22.00 |
+      | total_paid_tax_incl         | 23.32 |
+      | total_shipping_tax_excl     | 7.0   |
+      | total_shipping_tax_incl     | 7.42  |
+    ## Reset
+    When I remove product "Test Ecotax Product" from order "bo_order1"
+    Then order "bo_order1" should have 1 products in total
+    And order "bo_order1" should have 0 cart rule
+
+  Scenario: Add product (with ecotax) to an Order
+    ## Set Cart Rule
+    When there is a cart rule named "cartRuleFiftyPercent" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    And cart rule "cartRuleFiftyPercent" is restricted to product "Test Ecotax Product"
+    ## Set EcoTax
+    When the product "Test Ecotax Product" ecotax is 5.12
+    And I set tax rule group "fr-tax-6-group" to product "Test Ecotax Product"
+    And I add products to order "bo_order1" with new invoice and the following products details:
+      | name          | Test Ecotax Product |
+      | amount        | 2                   |
+      | price         | 20.12               |
+      | price_tax_incl| 21.02               |
+    ## Check informations
+    Then the ecotax of the product "Test Ecotax Product" should be 5.12
+    And product "Test Ecotax Product" price is 15.00
+    And order "bo_order1" should contain 2 products "Test Ecotax Product"
+    And the available stock for product "Test Ecotax Product" should be 98
+    And order "bo_order1" should have 3 products in total
+    And order "bo_order1" should have 0 invoices
+    And order "bo_order1" should have 1 cart rule
+    And product "Test Ecotax Product" in order "bo_order1" has following details:
+      | product_quantity            | 2     |
+      | ecotax                      | 5.12  |
+      | product_price               | 20.12 |
+      # 20.12 = 15 + 5.12
+      | original_product_price      | 20.12 |
+      # 20.12 = 15 + 5.12
+      | unit_price_tax_excl         | 20.12 |
+      # 20.12 = 15 + 5.12
+      | unit_price_tax_incl         | 21.02 |
+      # 21.02 = (15 + 6%) + 5.12
+      | total_price_tax_excl        | 40.24 |
+      # 40.24 = 20.12 * 2
+      | total_price_tax_incl        | 42.04 |
+      # 42.04 = 21.02 * 2
+    When I generate invoice for "bo_order1" order
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products              | 40.24 |
+      | total_products_wt           | 42.04 |
+      | total_discount_tax_excl     | 20.12 |
+      | total_discount_tax_incl     | 21.02 |
+      | total_paid_tax_excl         | 27.12 |
+      | total_paid_tax_incl         | 28.44 |
+      | total_shipping_tax_excl     | 7.0   |
+      | total_shipping_tax_incl     | 7.42  |
+    # Reset
+    When the product "Test Ecotax Product" ecotax is 0.00
+    Then the ecotax of the product "Test Ecotax Product" should be 0.00
+    When I remove product "Test Ecotax Product" from order "bo_order1"
+    And order "bo_order1" should have 1 products in total
+    And order "bo_order1" should have 0 cart rule

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -59,6 +59,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
         order:
             paths:
                 - %paths.base%/Features/Scenario/Order


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Fixed cart rule on selected product with product with ecotax : the price with taxes is calculated from tax rate but the price contains ecotax. It must be removed before calculation.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24788
| How to test?      | Cf #24788



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24868)
<!-- Reviewable:end -->
