### PR TITLE
Fix no active payment module displayed in Payment Methods

### DIFF
--- a/src/Adapter/Module/Presenter/PaymentModulesPresenter.php
+++ b/src/Adapter/Module/Presenter/PaymentModulesPresenter.php
@@ -31,8 +31,17 @@ use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
 use PrestaShop\PrestaShop\Core\Module\DataProvider\TabModuleListProviderInterface;
 
+@trigger_error(
+    sprintf(
+        '%s is deprecated since version 1.7.8.0 and will be removed in the next major version.',
+        PaymentModulesPresenter::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
- * Class PaymentModulesPresenter is responsible for presenting payment modules.
+ * @deprecated since 1.7.8.0
+ * @see \PrestaShop\PrestaShop\Adapter\Presenter\Module\PaymentModulesPresenter
  */
 class PaymentModulesPresenter
 {

--- a/src/Adapter/Module/TabModuleListProvider.php
+++ b/src/Adapter/Module/TabModuleListProvider.php
@@ -29,8 +29,18 @@ namespace PrestaShop\PrestaShop\Adapter\Module;
 use PrestaShop\PrestaShop\Adapter\Entity\Tab;
 use PrestaShop\PrestaShop\Core\Module\DataProvider\TabModuleListProviderInterface;
 
+@trigger_error(
+    sprintf(
+        '%s is deprecated since version 1.7.8.0 and will be removed in the next major version.',
+        TabModuleListProvider::class
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
  * Class TabModuleListProvider is responsible for providing tab modules.
+ *
+ * @deprecated since 1.7.8.0
  */
 final class TabModuleListProvider implements TabModuleListProviderInterface
 {

--- a/src/Adapter/Presenter/Module/PaymentModulesPresenter.php
+++ b/src/Adapter/Presenter/Module/PaymentModulesPresenter.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Module;
 
 use PrestaShop\PrestaShop\Adapter\Module\PaymentModuleListProvider;

--- a/src/Adapter/Presenter/Module/PaymentModulesPresenter.php
+++ b/src/Adapter/Presenter/Module/PaymentModulesPresenter.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Module;
+
+use PrestaShop\PrestaShop\Adapter\Module\PaymentModuleListProvider;
+use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
+
+/**
+ * Class PaymentModulesPresenter is responsible for presenting payment modules.
+ */
+class PaymentModulesPresenter
+{
+    /**
+     * @var PresenterInterface
+     */
+    private $modulePresenter;
+
+    /**
+     * @var PaymentModuleListProvider
+     */
+    private $paymentModuleListProvider;
+
+    /**
+     * @param PresenterInterface $modulePresenter
+     * @param PaymentModuleListProvider $paymentModuleListProvider
+     */
+    public function __construct(
+        PresenterInterface $modulePresenter,
+        PaymentModuleListProvider $paymentModuleListProvider
+    ) {
+        $this->modulePresenter = $modulePresenter;
+        $this->paymentModuleListProvider = $paymentModuleListProvider;
+    }
+
+    /**
+     * Get presented payment modules.
+     *
+     * @return array
+     */
+    public function present(): array
+    {
+        $installedModules = $this->paymentModuleListProvider->getPaymentModuleList();
+
+        $paymentModulesToDisplay = [];
+        foreach ($installedModules as $module) {
+            $paymentModulesToDisplay[] = $this->modulePresenter->present($module);
+        }
+
+        return $paymentModulesToDisplay;
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentMethodsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentMethodsController.php
@@ -54,7 +54,7 @@ class PaymentMethodsController extends FrameworkBundleAdminController
         $paymentModules = [];
 
         if ($isSingleShopContext) {
-            $paymentMethodsPresenter = $this->get('prestashop.adapter.module.presenter.payment');
+            $paymentMethodsPresenter = $this->get('prestashop.adapter.presenter.module.payment');
             $paymentModules = $paymentMethodsPresenter->present();
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -63,6 +63,7 @@ services:
 
     prestashop.adapter.module.data_provider.tab_module_list:
         class: PrestaShop\PrestaShop\Adapter\Module\TabModuleListProvider
+        deprecated: 'The "%service_id%" service is deprecated since 1.7.8.0 and will be removed in next major.'
 
     prestashop.adapter.presenter.module.payment:
         class: PrestaShop\PrestaShop\Adapter\Presenter\Module\PaymentModulesPresenter

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -64,6 +64,12 @@ services:
     prestashop.adapter.module.data_provider.tab_module_list:
         class: PrestaShop\PrestaShop\Adapter\Module\TabModuleListProvider
 
+    prestashop.adapter.presenter.module.payment:
+        class: PrestaShop\PrestaShop\Adapter\Presenter\Module\PaymentModulesPresenter
+        arguments:
+            - '@prestashop.adapter.presenter.module'
+            - '@prestashop.adapter.module.payment_module_provider'
+
     prestashop.adapter.module.presenter.payment:
         class: PrestaShop\PrestaShop\Adapter\Module\Presenter\PaymentModulesPresenter
         arguments:
@@ -71,6 +77,7 @@ services:
             - '@prestashop.adapter.data_provider.module'
             - '@prestashop.adapter.presenter.module'
             - '@prestashop.core.admin.module.repository'
+        deprecated: 'The "%service_id% service is deprecated. Use "prestashop.adapter.presenter.module.payment" instead'
 
     prestashop.adapter.module.payment_module_provider:
         class: PrestaShop\PrestaShop\Adapter\Module\PaymentModuleListProvider


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since #19944, `_PS_TAB_MODULE_LIST_URL_` is defined as an empty string but in `PaymentModulesPresenter::present()`, `tabModuleListProvider->getTabModules()` calls [`Tab::getTabModulesList()`](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/classes/Tab.php#L704) that relies on `_PS_TAB_MODULE_LIST_URL_` which leads to an empty list of modules in Payments > Payment Methods. This PR fixes it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes partially #24463
| How to test?      | See #24463, second step of step 4/6 should be working
| Possible impacts? | 

## 📓 Deprecation
`\PrestaShop\PrestaShop\Adapter\Module\Presenter\PaymentModulesPresenter`
use `\PrestaShop\PrestaShop\Adapter\Presenter\Module\PaymentModulesPresenter` instead
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24869)
<!-- Reviewable:end -->
