### PR TITLE
Hook for PDF invoice file name

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -501,6 +501,18 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
     {
         $id_lang = Context::getContext()->language->id;
         $id_shop = (int) $this->order->id_shop;
+        
+        $invoice_file_name = Hook::exec('actionInvoiceFileNameGet', array(
+            get_class($this->order_invoice) => $this->order_invoice,				
+            'id_lang' => (int) $id_lang,
+            'id_shop' => (int) $id_shop,
+            'number' => (int) $this->order_invoice->number,
+        ));
+
+        if (!empty($invoice_file_name)) {
+            return $invoice_file_name;
+        }
+        
         $format = '%1$s%2$06d';
 
         if (Configuration::get('PS_INVOICE_USE_YEAR')) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Create new hook for PDF invoice file name
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24844
| How to test?      | Create new implementation for the hook in a new customer module. Go to BO > Sell > Orders > Orders > Select order with an invoice > Display invoice > check if PDF file name is changed according to implementation for the hook
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24873)
<!-- Reviewable:end -->
