### PR TITLE
Register hook for PDF invoice file name

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -2895,5 +2895,10 @@
       <title>Modify product identifiable object data after updating it</title>
       <description>This hook allows to modify product identifiable object form data after it was updated</description>
     </hook>
+    <hook id="actionInvoiceFileNameGet">
+      <name>actionInvoiceFileNameGet</name>
+      <title>Get file name for invoice</title>
+      <description>This hook allows to modify the name of PDF invoice</description>
+    </hook>    
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Register new hook for PDF invoice file name
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24844
| How to test?      | Create new implementation for the hook in a new customer module. Go to BO > Sell > Orders > Orders > Select order with an invoice > Display invoice > check if PDF file name is changed according to implementation for the hook
| Possible impacts? |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24875)
<!-- Reviewable:end -->
