### PR TITLE
Fix experimental product page creation link

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -665,6 +665,7 @@ class ProductController extends FrameworkBundleAdminController
             'drawerModules' => $drawerModules,
             'layoutTitle' => $this->trans('Product', 'Admin.Global'),
             'isProductPageV2Enabled' => ($this->isProductPageV2Enabled()),
+            'isCreationMode' => (int) $product->state === Product::STATE_TEMP,
         ];
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
@@ -106,7 +106,15 @@
       >
         {{ 'Add new product'|trans({}, 'Admin.Catalog.Feature')|raw }}
       </button>
-      {% if isProductPageV2Enabled == true %}
+      {% if isProductPageV2Enabled == true and isCreationMode is same as(true) %}
+        <a
+          class="btn btn-outline-primary ml-3"
+          href="{{ path('admin_products_v2_create') }}"
+        >
+          {{ 'New product on experimental page'|trans({}, 'Admin.Catalog.Feature')|raw }}
+        </a>
+      {% endif %}
+      {% if isProductPageV2Enabled == true and isCreationMode is same as(false) %}
         <a
           class="btn btn-outline-primary ml-3"
           href="{{ path('admin_products_v2_edit', {'productId': productId}) }}"

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -43,7 +43,8 @@
         'is_multishop_context': is_multishop_context,
         'languages': languages,
         'help_link': help_link,
-        'stats_link': stats_link
+        'stats_link': stats_link,
+        'isCreationMode': isCreationMode,
         })
       }}
     {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | On product creation page V1, the link toward v2 product page was a link toward edition mode instead of creation.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24068
| How to test?      | See steps described in the issue, but also test that the link is good (it should be "create" in the URL, and not "edit"...
| Possible impacts? | it's ok

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24892)
<!-- Reviewable:end -->
