### PR TITLE
Improved ux for creating an order from abandoned cart

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
@@ -39,7 +39,6 @@ export default class CartProvider {
   router: Router;
 
   showLoader: boolean;
-  
   loaderSpeed: number;
 
   constructor() {
@@ -62,7 +61,7 @@ export default class CartProvider {
       (cartInfo) => {
         EventEmitter.emit(eventMap.cartLoaded, cartInfo);
       },
-    ).always(() => (this.showLoader ? this.$container.fadeTo(this.loaderSpeed, 1) : true));;
+    ).always(() => (this.showLoader ? this.$container.fadeTo(this.loaderSpeed, 1) : true));
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
@@ -38,14 +38,14 @@ export default class CartProvider {
 
   router: Router;
 
-  showLoader: boolean;
+  isLoaderVisible: boolean;
 
   loaderSpeed: number;
 
   constructor() {
     this.$container = $(createOrderPageMap.orderCreationContainer);
     this.router = new Router();
-    this.showLoader = false;
+    this.isLoaderVisible = false;
     this.loaderSpeed = 200;
   }
 
@@ -55,14 +55,14 @@ export default class CartProvider {
    * @param cartId
    */
   getCart(cartId: number): void {
-    if (this.showLoader) {
+    if (this.isLoaderVisible) {
       this.$container.fadeTo(this.loaderSpeed, 0.2);
     }
     $.get(this.router.generate('admin_carts_info', {cartId})).then(
       (cartInfo) => {
         EventEmitter.emit(eventMap.cartLoaded, cartInfo);
       },
-    ).always(() => (this.showLoader ? this.$container.fadeTo(this.loaderSpeed, 1) : true));
+    ).always(() => (this.isLoaderVisible ? this.$container.fadeTo(this.loaderSpeed, 1) : true));
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
@@ -38,9 +38,15 @@ export default class CartProvider {
 
   router: Router;
 
+  showLoader: boolean;
+  
+  loaderSpeed: number;
+
   constructor() {
     this.$container = $(createOrderPageMap.orderCreationContainer);
     this.router = new Router();
+    this.showLoader = false;
+    this.loaderSpeed = 200;
   }
 
   /**
@@ -49,11 +55,14 @@ export default class CartProvider {
    * @param cartId
    */
   getCart(cartId: number): void {
+    if (this.showLoader) {
+      this.$container.fadeTo(this.loaderSpeed, 0.2);
+    }
     $.get(this.router.generate('admin_carts_info', {cartId})).then(
       (cartInfo) => {
         EventEmitter.emit(eventMap.cartLoaded, cartInfo);
       },
-    );
+    ).always(() => (this.showLoader ? this.$container.fadeTo(this.loaderSpeed, 1) : true));;
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/cart-provider.ts
@@ -39,6 +39,7 @@ export default class CartProvider {
   router: Router;
 
   showLoader: boolean;
+
   loaderSpeed: number;
 
   constructor() {

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -322,9 +322,8 @@ export default class CreateOrderPage {
       ) {
         this.changeCartAddresses();
       }
-      
       if (cartInfo.customerId) {
-        if (cartInfo.addresses.length == 0) {
+        if (cartInfo.addresses.length === 0) {
           this.customerManager.search(<string>cartInfo.customerId);
         } else {
           $(createOrderMap.customerSearchBlock).hide();

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -86,6 +86,8 @@ export default class CreateOrderPage {
     this.$container = $(createOrderMap.orderCreationContainer);
 
     this.cartProvider = new CartProvider();
+    this.cartProvider.showLoader = true;
+
     this.customerManager = new CustomerManager();
     this.shippingRenderer = new ShippingRenderer();
     this.addressesRenderer = new AddressesRenderer();
@@ -319,6 +321,14 @@ export default class CreateOrderPage {
         && !ValidateAddresses(cartInfo.addresses)
       ) {
         this.changeCartAddresses();
+      }
+      
+      if (cartInfo.customerId) {
+        if (cartInfo.addresses.length == 0) {
+          this.customerManager.search(<string>cartInfo.customerId);
+        } else {
+          $(createOrderMap.customerSearchBlock).hide();
+        }
       }
       this.customerManager.loadCustomerCarts(<string><unknown> this.cartId);
       this.customerManager.loadCustomerOrders();

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -86,7 +86,7 @@ export default class CreateOrderPage {
     this.$container = $(createOrderMap.orderCreationContainer);
 
     this.cartProvider = new CartProvider();
-    this.cartProvider.showLoader = true;
+    this.cartProvider.isLoaderVisible = true;
 
     this.customerManager = new CustomerManager();
     this.shippingRenderer = new ShippingRenderer();

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -150,7 +150,8 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
                 $this->extractCartRulesFromLegacySummary($cart, $legacySummary, $currency, $query->hideDiscounts()),
                 $addresses,
                 $this->extractSummaryFromLegacySummary($legacySummary, $currency, $cart),
-                $addresses ? $this->extractShippingFromLegacySummary($cart, $legacySummary, $query->hideDiscounts()) : null
+                $addresses ? $this->extractShippingFromLegacySummary($cart, $legacySummary, $query->hideDiscounts()) : null,
+                (int) $cart->id_customer
             );
         } finally {
             $this->contextStateManager->restorePreviousContext();

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
@@ -58,9 +58,9 @@ class CartForOrderCreation
     private $langId;
 
     /**
-     * @var int|null
+     * @var int
      */
-    private $customerId = null;
+    private $customerId;
 
     /**
      * @var CartRule[]
@@ -91,7 +91,7 @@ class CartForOrderCreation
      * @param CartAddress[] $addresses
      * @param CartSummary $summary
      * @param CartShipping $shipping
-     * @param int|null $customerId
+     * @param int $customerId
      */
     public function __construct(
         int $cartId,
@@ -102,7 +102,7 @@ class CartForOrderCreation
         array $addresses,
         CartSummary $summary,
         CartShipping $shipping = null,
-        ?int $customerId = null
+        int $customerId
     ) {
         $this->cartId = $cartId;
         $this->products = $products;
@@ -140,9 +140,9 @@ class CartForOrderCreation
     }
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getCustomerId(): ?int
+    public function getCustomerId(): int
     {
         return $this->customerId;
     }

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
@@ -90,7 +90,7 @@ class CartForOrderCreation
      * @param CartRule[] $cartRules
      * @param CartAddress[] $addresses
      * @param CartSummary $summary
-     * @param CartShipping $shipping
+     * @param CartShipping|null $shipping
      * @param int $customerId
      */
     public function __construct(
@@ -101,7 +101,7 @@ class CartForOrderCreation
         array $cartRules,
         array $addresses,
         CartSummary $summary,
-        CartShipping $shipping = null,
+        ?CartShipping $shipping,
         int $customerId
     ) {
         $this->cartId = $cartId;

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation.php
@@ -58,6 +58,11 @@ class CartForOrderCreation
     private $langId;
 
     /**
+     * @var int|null
+     */
+    private $customerId = null;
+
+    /**
      * @var CartRule[]
      */
     private $cartRules;
@@ -86,6 +91,7 @@ class CartForOrderCreation
      * @param CartAddress[] $addresses
      * @param CartSummary $summary
      * @param CartShipping $shipping
+     * @param int|null $customerId
      */
     public function __construct(
         int $cartId,
@@ -95,7 +101,8 @@ class CartForOrderCreation
         array $cartRules,
         array $addresses,
         CartSummary $summary,
-        CartShipping $shipping = null
+        CartShipping $shipping = null,
+        ?int $customerId = null
     ) {
         $this->cartId = $cartId;
         $this->products = $products;
@@ -105,6 +112,7 @@ class CartForOrderCreation
         $this->addresses = $addresses;
         $this->shipping = $shipping;
         $this->summary = $summary;
+        $this->customerId = $customerId;
     }
 
     /**
@@ -129,6 +137,14 @@ class CartForOrderCreation
     public function getCurrencyId(): int
     {
         return $this->currencyId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getCustomerId(): ?int
+    {
+        return $this->customerId;
     }
 
     /**

--- a/tests/Unit/Core/Domain/Cart/QueryResult/CartForOrderCreationTest.php
+++ b/tests/Unit/Core/Domain/Cart/QueryResult/CartForOrderCreationTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Domain\Cart\QueryResult;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartAddress;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartProduct;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartRule;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartShipping;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartSummary;
+
+class CartForOrderCreationTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $mockSummary = $this->createMock(CartSummary::class);
+        $mockShipping = $this->createMock(CartShipping::class);
+        $cartProduct = $this->createMock(CartProduct::class);
+        $cartAddress = $this->createMock(CartAddress::class);
+        $cartRule = $this->createMock(CartRule::class);
+
+        $products = [
+            $cartProduct,
+        ];
+
+        $cartAddresses = [
+            $cartAddress,
+        ];
+
+        $cartRules = [
+            $cartRule,
+        ];
+
+        $instance = new CartForOrderCreation(
+            1000,
+            $products,
+            2000,
+            3000,
+            $cartRules,
+            $cartAddresses,
+            $mockSummary,
+            $mockShipping,
+            4000
+        );
+
+        self::assertSame(1000, $instance->getCartId());
+        self::assertContainsOnlyInstancesOf(CartProduct::class, $instance->getProducts());
+        self::assertSame(2000, $instance->getCurrencyId());
+        self::assertSame(3000, $instance->getLangId());
+        self::assertContainsOnlyInstancesOf(CartRule::class, $instance->getCartRules());
+        self::assertContainsOnlyInstancesOf(CartAddress::class, $instance->getAddresses());
+        self::assertSame($mockSummary, $instance->getSummary());
+        self::assertSame($mockShipping, $instance->getShipping());
+        self::assertSame(4000, $instance->getCustomerId());
+    }
+
+    public function testConstructWithoutCustomerId(): void
+    {
+        $mockSummary = $this->createMock(CartSummary::class);
+        $mockShipping = $this->createMock(CartShipping::class);
+        $cartProduct = $this->createMock(CartProduct::class);
+        $cartAddress = $this->createMock(CartAddress::class);
+        $cartRule = $this->createMock(CartRule::class);
+
+        $products = [
+            $cartProduct,
+        ];
+
+        $cartAddresses = [
+            $cartAddress,
+        ];
+
+        $cartRules = [
+            $cartRule,
+        ];
+
+        $instance = new CartForOrderCreation(
+            1000,
+            $products,
+            2000,
+            3000,
+            $cartRules,
+            $cartAddresses,
+            $mockSummary,
+            $mockShipping
+        );
+
+        self::assertSame(1000, $instance->getCartId());
+        self::assertContainsOnlyInstancesOf(CartProduct::class, $instance->getProducts());
+        self::assertSame(2000, $instance->getCurrencyId());
+        self::assertSame(3000, $instance->getLangId());
+        self::assertContainsOnlyInstancesOf(CartRule::class, $instance->getCartRules());
+        self::assertContainsOnlyInstancesOf(CartAddress::class, $instance->getAddresses());
+        self::assertSame($mockSummary, $instance->getSummary());
+        self::assertSame($mockShipping, $instance->getShipping());
+        self::assertNull($instance->getCustomerId());
+    }
+}

--- a/tests/Unit/Core/Domain/Cart/QueryResult/CartForOrderCreationTest.php
+++ b/tests/Unit/Core/Domain/Cart/QueryResult/CartForOrderCreationTest.php
@@ -80,46 +80,4 @@ class CartForOrderCreationTest extends TestCase
         self::assertSame($mockShipping, $instance->getShipping());
         self::assertSame(4000, $instance->getCustomerId());
     }
-
-    public function testConstructWithoutCustomerId(): void
-    {
-        $mockSummary = $this->createMock(CartSummary::class);
-        $mockShipping = $this->createMock(CartShipping::class);
-        $cartProduct = $this->createMock(CartProduct::class);
-        $cartAddress = $this->createMock(CartAddress::class);
-        $cartRule = $this->createMock(CartRule::class);
-
-        $products = [
-            $cartProduct,
-        ];
-
-        $cartAddresses = [
-            $cartAddress,
-        ];
-
-        $cartRules = [
-            $cartRule,
-        ];
-
-        $instance = new CartForOrderCreation(
-            1000,
-            $products,
-            2000,
-            3000,
-            $cartRules,
-            $cartAddresses,
-            $mockSummary,
-            $mockShipping
-        );
-
-        self::assertSame(1000, $instance->getCartId());
-        self::assertContainsOnlyInstancesOf(CartProduct::class, $instance->getProducts());
-        self::assertSame(2000, $instance->getCurrencyId());
-        self::assertSame(3000, $instance->getLangId());
-        self::assertContainsOnlyInstancesOf(CartRule::class, $instance->getCartRules());
-        self::assertContainsOnlyInstancesOf(CartAddress::class, $instance->getAddresses());
-        self::assertSame($mockSummary, $instance->getSummary());
-        self::assertSame($mockShipping, $instance->getShipping());
-        self::assertNull($instance->getCustomerId());
-    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we're trying to convert an abandoned cart to order, UX is a little of, this PR aims to improve that
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23620.
| How to test?      | Follow instructions from an issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

BEFORE:
https://www.dropbox.com/s/djsvinyxok634ub/Nagranie%20z%20ekranu%202021-06-9%20o%2021.26.24.mov?dl=0

AFTER:
https://www.dropbox.com/s/5vatbz1hyecw0hd/Nagranie%20z%20ekranu%202021-06-9%20o%2021.26.59.mov?dl=0


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24896)
<!-- Reviewable:end -->


📓 BC Breaks:

- in `CartForOrderCreation` default value has been removed from 8th parameter of constructor, `$shipping` property is nullable but without default value
- in `CartForOrderCreation` there's one new parameter `int $customerId`