### PR TITLE
Avoid errors display when Emails translations lang.php does not exist

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2806,9 +2806,8 @@ class AdminTranslationsControllerCore extends AdminController
 
         foreach ($modules_has_mails as $module_name => $module_path) {
             $module_path = rtrim($module_path, '/');
-            $module_locale_mails_path = $module_path . '/mails/' . $this->lang_selected->iso_code . '/';
-            $module_mails[$module_name] = $this->getMailFiles($module_locale_mails_path, 'module_mail');
-            $module_mails[$module_name]['subject'] = $this->getSubjectMailContent($module_locale_mails_path);
+            $module_mails[$module_name] = $this->getMailFiles($module_path . '/mails/' . $this->lang_selected->iso_code . '/', 'module_mail');
+            $module_mails[$module_name]['subject'] = $core_mails['subject'];
             $module_mails[$module_name]['display'] = $this->displayMailContent($module_mails[$module_name], $subject_mail, $this->lang_selected, Tools::strtolower($module_name), $module_name, $module_name);
         }
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2806,8 +2806,9 @@ class AdminTranslationsControllerCore extends AdminController
 
         foreach ($modules_has_mails as $module_name => $module_path) {
             $module_path = rtrim($module_path, '/');
-            $module_mails[$module_name] = $this->getMailFiles($module_path . '/mails/' . $this->lang_selected->iso_code . '/', 'module_mail');
-            $module_mails[$module_name]['subject'] = $core_mails['subject'];
+            $module_locale_mails_path = $module_path . '/mails/' . $this->lang_selected->iso_code . '/';
+            $module_mails[$module_name] = $this->getMailFiles($module_locale_mails_path, 'module_mail');
+            $module_mails[$module_name]['subject'] = $this->getSubjectMailContent($module_locale_mails_path);
             $module_mails[$module_name]['display'] = $this->displayMailContent($module_mails[$module_name], $subject_mail, $this->lang_selected, Tools::strtolower($module_name), $module_name, $module_name);
         }
 
@@ -3329,8 +3330,6 @@ class AdminTranslationsControllerCore extends AdminController
                 $subject_mail_content[$key]['trad'] = htmlentities($subject, ENT_QUOTES, 'UTF-8');
                 $subject_mail_content[$key]['use_sprintf'] = $this->checkIfKeyUseSprintf($key);
             }
-        } else {
-            $this->errors[] = $this->trans('Email subject translation file not found in %path%', ['%path%' => $directory], 'Admin.International.Notification');
         }
 
         return $subject_mail_content;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The lang.php is the file where mails template overrides are stored.<br>When you go Go to Admin > International > Translations, In modify translations form, choose Emails, Emails body, choose a language, the modifications made are saved in /mails/LOCALE/lang.php.<br>If no override have been done yet, this file doesn't exist.<br><br>The goal of this PR is to not display errors when lang.php file doesn't exist in the locale mails directory as before 1.7.8.x.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23878 
| How to test?      | Go to Admin > International > Translations, In modify translations form, choose Emails, Emails body, choose a language<br><ul><li>When no lang.php exists in /mails/LOCALE/, no error has to be display </li><li>If you override a module mail subject and refresh the page, the updated subject have to be displayed (see https://github.com/PrestaShop/PrestaShop/issues/19288)</li></ul>
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24899)
<!-- Reviewable:end -->
