### PR TITLE
Fixed default value for Currency after upgrade

### DIFF
--- a/install-dev/upgrade/sql/1.7.7.6.sql
+++ b/install-dev/upgrade/sql/1.7.7.6.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8';
+
+ALTER TABLE `PREFIX_currency` MODIFY COLUMN `numeric_iso_code` varchar(3) DEFAULT NULL NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Fixed default value for Currency after upgrade<br>From 1744, the upgrade in `1.7.6.0.sql` add a field `numeric_iso_code` not nullable (`ADD "numeric_iso_code" varchar(3) NOT NULL DEFAULT '0'`). But in `1.7.7.0`, the field became nullable (#14972 - Thanks @jolelievre :tada:) but without upgrade script.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24871
| How to test?      | Cf. #24871



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24908)
<!-- Reviewable:end -->
