### PR TITLE
Fix steps height on carrier page on mobile

### DIFF
--- a/admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl
+++ b/admin-dev/themes/default/template/controllers/carrier_wizard/summary.tpl
@@ -23,18 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 
-<script type="text/javascript">
-	var summary_translation_undefined = '{l s='[undefined]' js=1}';
-	var summary_translation_meta_informations = '{l s='This carrier is %1$s and the transit time is %2$s.' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_free = '{l s='free' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_paid = '{l s='not free' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_range = '{l s='This carrier can deliver orders from %1$s to %2$s.' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_range_limit =  '{l s='If the order is out of range, the behavior is to %3$s.' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_shipping_cost = '{l s='The shipping cost is calculated %1$s and the tax rule %2$s will be applied.' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_price = '{l s='according to the price' js=1 d='Admin.Shipping.Feature'}';
-	var summary_translation_weight = '{l s='according to the weight' js=1 d='Admin.Shipping.Feature'}';
-</script>
-
 <div class="defaultForm">
 	<div class="panel">
 		<div class="panel-heading">{l s='Carrier name:' d='Admin.Shipping.Feature'} <strong id="summary_name"></strong></div>
@@ -60,3 +48,15 @@
 	</div>
 	{$active_form}
 </div>
+
+<script type="text/javascript">
+	var summary_translation_undefined = '{l s='[undefined]' js=1}';
+	var summary_translation_meta_informations = '{l s='This carrier is %1$s and the transit time is %2$s.' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_free = '{l s='free' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_paid = '{l s='not free' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_range = '{l s='This carrier can deliver orders from %1$s to %2$s.' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_range_limit =  '{l s='If the order is out of range, the behavior is to %3$s.' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_shipping_cost = '{l s='The shipping cost is calculated %1$s and the tax rule %2$s will be applied.' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_price = '{l s='according to the price' js=1 d='Admin.Shipping.Feature'}';
+	var summary_translation_weight = '{l s='according to the weight' js=1 d='Admin.Shipping.Feature'}';
+</script>

--- a/js/jquery/plugins/smartWizard/jquery.smartWizard.js
+++ b/js/jquery/plugins/smartWizard/jquery.smartWizard.js
@@ -382,7 +382,7 @@ function SmartWizard(target, options) {
 
         var selStep = this.steps.eq(this.curStepIdx);
         var stepContainer = _step(this, selStep);
-        height += stepContainer.children().outerHeight() > 1000 ? 720 : stepContainer.children().outerHeight();
+        height += stepContainer.children().outerHeight() > 1000 && !this.curStepIdx ? 720 : stepContainer.children().outerHeight();
 
         // These values (5 and 20) are experimentally chosen.
         stepContainer.height(height + 5);

--- a/js/jquery/plugins/smartWizard/jquery.smartWizard.js
+++ b/js/jquery/plugins/smartWizard/jquery.smartWizard.js
@@ -382,9 +382,7 @@ function SmartWizard(target, options) {
 
         var selStep = this.steps.eq(this.curStepIdx);
         var stepContainer = _step(this, selStep);
-        stepContainer.children().each(function() {
-            height += $(this).outerHeight();
-        });
+        height += stepContainer.children().outerHeight() > 1000 ? 720 : stepContainer.children().outerHeight();
 
         // These values (5 and 20) are experimentally chosen.
         stepContainer.height(height + 5);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Steps height was pretty big on mobile and hard to use 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24859.
| How to test?      | Go on carrier page, set to small mobile (320) and refresh the page, the pan height should be fine!
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24909)
<!-- Reviewable:end -->
