### PR TITLE
Reset Germany tax rates

### DIFF
--- a/localization/de.xml
+++ b/localization/de.xml
@@ -7,8 +7,8 @@
     <language iso_code="de"/>
   </languages>
   <taxes>
-    <tax id="1" name="MwSt. DE 16%" rate="16" eu-tax-group="virtual"/>
-    <tax id="2" name="MwSt. DE 5%" rate="5"/>
+    <tax id="1" name="MwSt. DE 19%" rate="19" eu-tax-group="virtual"/>
+    <tax id="2" name="MwSt. DE 7%" rate="7"/>
     <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -36,7 +36,7 @@
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="DE Standard Rate (16%)">
+    <taxRulesGroup name="DE Standard Rate (19%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -66,7 +66,7 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DE Reduced Rate (5%)">
+    <taxRulesGroup name="DE Reduced Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -96,7 +96,7 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DE Foodstuff Rate (5%)">
+    <taxRulesGroup name="DE Foodstuff Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -126,7 +126,7 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DE Books Rate (5%)">
+    <taxRulesGroup name="DE Books Rate (7%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Revert #19897 from @Progi1984. Since 01/01/2021, tax rates in Germany have been reset as before.
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19628.
| How to test?      | -
| Possible impacts? | -
| Sponsor company | @Creabilis

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24921)
<!-- Reviewable:end -->
