### PR TITLE
Add missing supplier for product pack in fixtures

### DIFF
--- a/install-dev/fixtures/fashion/data/product_supplier.xml
+++ b/install-dev/fixtures/fashion/data/product_supplier.xml
@@ -64,5 +64,6 @@
     <product_supplier id_product="Hummingbird_notebook" id_product_attribute="product_attribute_94" id_supplier="Accessories_Supplier" product_supplier_price_te="5.490000" id_currency="USD" product_supplier_reference="demo_10_94" />
     <product_supplier id_product="Hummingbird_notebook" id_product_attribute="product_attribute_95" id_supplier="Accessories_Supplier" product_supplier_price_te="5.490000" id_currency="USD" product_supplier_reference="demo_10_95" />
     <product_supplier id_product="Hummingbird_notebook" id_product_attribute="product_attribute_96" id_supplier="Accessories_Supplier" product_supplier_price_te="5.490000" id_currency="USD" product_supplier_reference="demo_10_96" />
+    <product_supplier id_product="Pack_Mug_Framed_poster" id_product_attribute="0" id_supplier="Accessories_Supplier" product_supplier_price_te="0" id_currency="USD" product_supplier_reference="" />
   </entities>
 </entity_product_supplier>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Missing line in product_supplier.xml file for fixtures. It results an uncheck checkbox in Product supplier options for the Pack, Mug and Framed poster..
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24617
| How to test?      | Follow ticket instruction.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24924)
<!-- Reviewable:end -->
