### PR TITLE
Fix unexpected condition in country-state-selection-toggler

### DIFF
--- a/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
+++ b/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
@@ -106,7 +106,7 @@ export default class CountryStateSelectionToggler {
   toggle(): void {
     this.$stateSelectionBlock.toggleClass(
       'd-none',
-      !this.$countryStateSelector.find('option').length,
+      this.$countryStateSelector.find('option').length === 0,
     );
   }
 }

--- a/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
+++ b/admin-dev/themes/new-theme/js/components/country-state-selection-toggler.ts
@@ -106,7 +106,7 @@ export default class CountryStateSelectionToggler {
   toggle(): void {
     this.$stateSelectionBlock.toggleClass(
       'd-none',
-      !(this.$countryStateSelector.find('option').length > 0),
+      !this.$countryStateSelector.find('option').length,
     );
   }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Simplify the unexpected condition that can confuse the developer
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | -
| Possible impacts? | no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24932)
<!-- Reviewable:end -->


Probably the author wanted to write: `!(this.$countryStateSelector.find('option').length > 0)`
current code works because:
```js
false > 0 == false
true > 0 == true
```
but it sure was not the desired/expected code