### PR TITLE
In PDF, Use "freeserif" for Armenian language (hy)

### DIFF
--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -90,6 +90,7 @@ class PDFGeneratorCore extends TCPDF
         'zh' => 'cid0cs',
         'tw' => 'cid0cs',
         'th' => 'freeserif',
+        'hy' => 'freeserif',
     ];
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use "freeserif" for Armenian language (hy), otherwise symbols are replaced with '?' in generated pdf files
| Type?             | improvement
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24937
| How to test?      | Add Armenian language to website, change BO language to Armenia an generate an invoice.
| Possible impacts? | BO order invoice generation


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24936)
<!-- Reviewable:end -->
