### PR TITLE
Shop and shop group have now a color property.

### DIFF
--- a/install-dev/upgrade/sql/1.7.8.0.sql
+++ b/install-dev/upgrade/sql/1.7.8.0.sql
@@ -177,6 +177,9 @@ UPDATE `PREFIX_product` SET `product_type` = "combinations" WHERE `cache_default
 UPDATE `PREFIX_product` SET `product_type` = "pack" WHERE `cache_is_pack` = 1;
 UPDATE `PREFIX_product` SET `product_type` = "virtual" WHERE `is_virtual` = 1;
 
+ALTER TABLE `PREFIX_shop_group` ADD `color` VARCHAR(32) NULL AFTER `name`;
+ALTER TABLE `PREFIX_shop` ADD `color` VARCHAR(32) NULL AFTER `name`;
+
 /* PHP:ps_1780_add_feature_flag_tab(); */;
 
 /* this table should be created by Doctrine but we need to perform INSERT and the 1.7.8.0.sql script is called


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes an issue in the sql upgrade script for 1.7.8.0 beta.1. Adds missing columns `color` on table shop and shop_group.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24891.
| How to test?      | Run the upgrade script `1.7.8.0.sql` manually.
| Possible impacts? | A step closer to a working upgrade.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24948)
<!-- Reviewable:end -->
