### PR TITLE
Allow HOOK_DISPLAY_PDF to fill the whole page area

### DIFF
--- a/pdf/delivery-slip.tpl
+++ b/pdf/delivery-slip.tpl
@@ -81,8 +81,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="2">&nbsp;</td>
-		<td colspan="10">
+		<td colspan="12">
 			{$HOOK_DISPLAY_PDF}
 		</td>
 	</tr>

--- a/pdf/invoice-b2b.tpl
+++ b/pdf/invoice-b2b.tpl
@@ -121,8 +121,7 @@
 		</tr>
 
 		<tr>
-			<td colspan="2">&nbsp;</td>
-			<td colspan="10">
+			<td colspan="12">
 				{$HOOK_DISPLAY_PDF}
 			</td>
 		</tr>

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -132,8 +132,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="2">&nbsp;</td>
-		<td colspan="10">
+		<td colspan="12">
 			{$HOOK_DISPLAY_PDF}
 		</td>
 	</tr>

--- a/pdf/order-return.tpl
+++ b/pdf/order-return.tpl
@@ -81,8 +81,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="2">&nbsp;</td>
-		<td colspan="10">
+		<td colspan="12">
 			{$HOOK_DISPLAY_PDF}
 		</td>
 	</tr>

--- a/pdf/order-slip.tpl
+++ b/pdf/order-slip.tpl
@@ -103,8 +103,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="2">&nbsp;</td>
-		<td colspan="10">
+		<td colspan="12">
 			{$HOOK_DISPLAY_PDF}
 		</td>
 	</tr>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow HOOK_DISPLAY_PDF content to be 100% width 
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24956
| How to test?      | 1) Install https://github.com/PrestaShop/ps_qualityassurance<br>2) in ps_qualityassurance Register new; Hook name: `displayPDFInvoice` content: `return '<div style="border: 1px solid red;">foobar</div>';`<br>3) go to order and click on `View invoice`<br>4) check in invoice document that the new `foobar` area with its red border is 100% width.
| Possible impacts? | If some module developers are counting on the content to always start 2/12 from the left side of the pdf hooks they might have to make small changes to their templates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24958)
<!-- Reviewable:end -->
