### PR TITLE
Remove useless static cache and make sure CI exit in status 1 when installation failed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ jobs:
                         ${{ runner.os }}-composer-
 
             -   name: Composer Install
-                run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+                run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
             -   name: Build assets
                 run: make assets

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
                   ${{ runner.os }}-composer-
 
       -   name: Composer Install
-          run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+          run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       -   name: Run Lint Yaml on `src`
           run: php bin/console lint:yaml src
@@ -111,7 +111,7 @@ jobs:
                   ${{ runner.os }}-composer-
 
       -   name: Composer Install
-          run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+          run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       -   name: Run Lint Twig
           run: php bin/console lint:twig src/PrestaShopBundle/Resources/views/

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -354,7 +354,7 @@ class TabCore extends ObjectModel
     public static function getIdFromClassName($className)
     {
         $className = self::getClassName($className);
-        if (self::$_getIdFromClassName === null) {
+        if (empty(self::$_getIdFromClassName)) {
             self::$_getIdFromClassName = [];
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('SELECT id_tab, class_name FROM `' . _DB_PREFIX_ . 'tab`', true, false);
 

--- a/install-dev/classes/controllerConsole.php
+++ b/install-dev/classes/controllerConsole.php
@@ -162,7 +162,7 @@ abstract class InstallControllerConsole
                     echo(is_string($error) ? $error : print_r($error, true)).PHP_EOL;
                 }
             }
-            die;
+            exit(1);
         }
     }
 

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -103,7 +103,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         $this->clearConfigXML() && $this->clearConfigThemes();
         $steps = explode(',', $this->datas->step);
         if (in_array('all', $steps)) {
-            $steps = array('database', 'fixtures', 'theme', 'modules', 'postInstall');
+            $steps = array('database', 'modules', 'theme', 'fixtures', 'postInstall');
         }
 
         if (in_array('database', $steps)) {
@@ -149,7 +149,6 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
                 $this->printErrors();
             }
         }
-
 
         if (in_array('theme', $steps)) {
             if (!$this->processInstallTheme()) {

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -919,7 +919,6 @@ class Install extends AbstractInstall
         $result = $this->executeAction(
             $modules,
             'install',
-
             $this->translator->trans(
                 'Cannot install module "%module%"',
                 ['%module%' => '%module%'],


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make sure `getIdFromClassName` is properly generated when using the CLI context. The problem is: because all requests are done one after the other, the method fill the value as empty array. If the array is empty, you can redo the SQL request. Than, remove `--quiet` mode when running composer. Also, in the future, instead of `die`, use `exit(1)`, it will make the CI failed, instead of telling you that everything is ok.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is green.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24970)
<!-- Reviewable:end -->
