### PR TITLE
Fixed default value for name or color. In Prestashop updated from PS versions 1.7.6.x to 1.7.7.5 (1.7.7.x).

### DIFF
--- a/src/Core/Domain/Order/QueryResult/OrderStatusForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderStatusForViewing.php
@@ -73,8 +73,8 @@ class OrderStatusForViewing
     /**
      * @param int $orderHistoryId
      * @param int $orderStatusId
-     * @param string $name
-     * @param string $color
+     * @param string|null $name
+     * @param string|null $color
      * @param DateTimeImmutable $createdAt
      * @param bool $withEmail
      * @param string|null $employeeFirstName
@@ -83,8 +83,8 @@ class OrderStatusForViewing
     public function __construct(
         int $orderHistoryId,
         int $orderStatusId,
-        string $name,
-        string $color,
+        ?string $name,
+        ?string $color,
         DateTimeImmutable $createdAt,
         bool $withEmail,
         ?string $employeeFirstName,
@@ -119,7 +119,7 @@ class OrderStatusForViewing
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -127,7 +127,7 @@ class OrderStatusForViewing
     /**
      * @return string
      */
-    public function getColor(): string
+    public function getColor(): ?string
     {
         return $this->color;
     }


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x / 1.7.7.x
| Description?      | PS updated from versions 1.7.6.x to 1.7.7.4 and 1.7.7.5  <br> After the update, it shows an error when opening an order previous to the update.<br><br>Fixed default variable type in `$name` or `$color`. In PS updated from versions 1.7.6.x to 1.7.7.4 and 1.7.7.5 (1.7.7.x). <br>After the update, it shows an error when opening an order previous to the update.<br>Error img: ![image](https://user-images.githubusercontent.com/1533248/128685974-4c395986-fa55-4afc-ad0b-4f3dab5e20a0.png)<br>Issues: #22386<br><br>In the change, I specify var `$name` or `$color` can be a `string|null`. <br>Allows you to open previous orders without any problem.
| Type?             | bug fix 
| Deprecations?     |  no
| Fixed ticket?     | Fixes #22386


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24971)
<!-- Reviewable:end -->
