### PR TITLE
In dev mode, hooks must not swallow exceptions

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -432,7 +432,7 @@ class HookCore extends ObjectModel
                     return static::coreCallHook($module, $methodName, $hookArgs);
                 }
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
             if ($environment->isDebug()) {
                 throw new CoreException($e->getMessage(), $e->getCode(), $e);
@@ -1016,7 +1016,7 @@ class HookCore extends ObjectModel
 
         try {
             return $module->renderWidget($hook_name, $params);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
             if ($environment->isDebug()) {
                 throw new CoreException($e->getMessage(), $e->getCode(), $e);

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -23,7 +23,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class HookCore extends ObjectModel
@@ -411,21 +414,28 @@ class HookCore extends ObjectModel
      */
     private static function callHookOn(Module $module, string $hookName, array $hookArgs)
     {
-        // Note: we need to make sure to call the exact hook name first.
-        // This especially important when the module uses __call() to process the right hook.
-        // Since is_callable() will always return true when __call() is available,
-        // if the module was expecting an aliased hook name to be invoked, but we send
-        // the canonical hook name instead, the hook will never be acknowledged by the module.
-        $methodName = static::getMethodName($hookName);
-        if (is_callable([$module, $methodName])) {
-            return static::coreCallHook($module, $methodName, $hookArgs);
-        }
-
-        // fall back to all other names
-        foreach (static::getAllKnownNames($hookName) as $hook) {
-            $methodName = static::getMethodName($hook);
+        try {
+            // Note: we need to make sure to call the exact hook name first.
+            // This especially important when the module uses __call() to process the right hook.
+            // Since is_callable() will always return true when __call() is available,
+            // if the module was expecting an aliased hook name to be invoked, but we send
+            // the canonical hook name instead, the hook will never be acknowledged by the module.
+            $methodName = static::getMethodName($hookName);
             if (is_callable([$module, $methodName])) {
                 return static::coreCallHook($module, $methodName, $hookArgs);
+            }
+
+            // fall back to all other names
+            foreach (static::getAllKnownNames($hookName) as $hook) {
+                $methodName = static::getMethodName($hook);
+                if (is_callable([$module, $methodName])) {
+                    return static::coreCallHook($module, $methodName, $hookArgs);
+                }
+            }
+        } catch (\Exception $e) {
+            $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
+            if ($environment->isDebug()) {
+                throw new CoreException($e->getMessage(), $e->getCode(), $e);
             }
         }
 
@@ -1004,7 +1014,16 @@ class HookCore extends ObjectModel
             return null;
         }
 
-        return $module->renderWidget($hook_name, $params);
+        try {
+            return $module->renderWidget($hook_name, $params);
+        } catch (\Exception $e) {
+            $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
+            if ($environment->isDebug()) {
+                throw new CoreException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/src/Adapter/Environment.php
+++ b/src/Adapter/Environment.php
@@ -61,7 +61,7 @@ class Environment implements EnvironmentInterface
         if (null !== $name) {
             $this->name = $name;
         } else {
-            if (defined(_PS_ENV_)) {
+            if (defined('_PS_ENV_')) {
                 $this->name = _PS_ENV_;
             } else {
                 $this->name = $this->isDebug ? 'dev' : 'prod';

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter;
 
 use Hook;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -45,7 +46,7 @@ class HookManager
      * @param bool $use_push Force change to be refreshed on Dashboard widgets
      * @param int $id_shop If specified, hook will be execute the shop with this ID
      *
-     * @throws \PrestaShopException
+     * @throws CoreException
      *
      * @return string|array|void modules output
      */
@@ -79,7 +80,11 @@ class HookManager
                 return Hook::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
             } catch (\Exception $e) {
                 $logger = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\LegacyLogger');
+                $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
                 $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type' => 'Module', 'object_id' => $id_module, 'allow_duplicate' => true]);
+                if ($environment->isDebug()) {
+                    throw new CoreException($e->getMessage(), $e->getCode(), $e);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In dev mode, exceptions that are thrown in hooks should be displayed. In production mode, they should be silently swalowed. Displaying exceptions instead of swallowing enhances development experience. 
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no. In production mode, we continue to swallow exceptions. We expect that existing modules rely on the fact that exceptions are swallowed. Changing this would break BC.
| Deprecations?     | no
| Fixed ticket?     | Fixes #24984., partially fixes #25002
| How to test?      | In a module implementing the hook `displayProductExtraContent` throw an exception. Navigate to a product page. In dev environment, the exception must display. In production environment, the page must display normally.
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/24985)
<!-- Reviewable:end -->

### How to test

Using the `ps_qualityassurance` module, register on the `displayProductExtraContent` hook and in the code throw an exception with this code: `throw new \Exception('blocking error');`

Then go to the product page to test it:
- without the PR the exception is never seen whether you are in dev mode or not
- with this PR in prod mode nothing happens, in dev mode, you should have an error page
