### PR TITLE
Be able to use subquery when using DbQuery class

### DIFF
--- a/classes/db/DbQuery.php
+++ b/classes/db/DbQuery.php
@@ -93,7 +93,13 @@ class DbQueryCore
     public function from($table, $alias = null)
     {
         if (!empty($table)) {
-            $this->query['from'][] = '`' . _DB_PREFIX_ . $table . '`' . ($alias ? ' ' . $alias : '');
+            if ($table instanceof DbQuery) {
+                $query = '(' . $table->build() . ')';
+            } else {
+                $query = '`' . _DB_PREFIX_ . $table . '`';
+            }
+
+            $this->query['from'][] = $query . ($alias ? ' ' . $alias : '');
         }
 
         return $this;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add capability to use subquery when using DbQuery class.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25010
| How to test?      | See below.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


# How to test
```php

    $subQuery = new DbQuery();
    $subQuery->select('*');
    $subQuery->from('product', 'p');
    $subQuery->where('p.active = 1');

    $selectWithSubQuery = new DbQuery();
    $selectWithSubQuery->select('*');
    $selectWithSubQuery->from($subQuery, 'p');
    $selectWithSubQuery->where('p.visibility in ("both", "search")');

    var_dump(Db::getInstance()->executeS($selectWithSubQuery));
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25037)
<!-- Reviewable:end -->
