### PR TITLE
Fix TinyMCE max length computing in BO

### DIFF
--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -260,7 +260,7 @@ class TinyMCEEditor {
     const counter = textarea.attr('counter');
     const counterType = textarea.attr('counter_type');
     const editor = window.tinyMCE.get(id);
-    const max = editor.getContent().length;
+    const max = editor.getBody() ? editor.getBody().textContent.length : 0;
 
     textarea
       .parent()

--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -251,7 +251,9 @@ class TinyMCEEditor {
   }
 
   /**
-   * Updates the characters counter
+   * Updates the characters counter. This counter is used for front but if you don't want to encounter Validation
+   * problems you should be in sync with the TinyMceMaxLengthValidator PHP class. Both codes must behave the same
+   * way.
    *
    * @param id
    */

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2071,7 +2071,18 @@ class AdminProductsControllerCore extends AdminController
         }
         foreach ($languages as $language) {
             if ($this->isProductFieldUpdated('description_short', $language['id_lang']) && ($value = Tools::getValue('description_short_' . $language['id_lang']))) {
-                if (Tools::strlen(strip_tags($value)) > $limit) {
+                // This validation computation actually comes from TinyMceMaxLengthValidator if you modify it here you
+                // should keep the validator in sync (along with other parts of the code, more info in the
+                // TinyMceMaxLengthValidator comments).
+                $replaceArray = [
+                    "\n",
+                    "\r",
+                    "\n\r",
+                    "\r\n",
+                ];
+                $str = str_replace($replaceArray, [''], strip_tags($value));
+                $shortDescriptionLength = iconv_strlen($str);
+                if ($shortDescriptionLength > $limit) {
                     $this->errors[] = $this->trans(
                         'This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).',
                         [

--- a/js/admin/tinymce_loader.js
+++ b/js/admin/tinymce_loader.js
@@ -43,7 +43,8 @@ $(document).ready(function() {
     let textarea = $('#' + id);
     let counter = textarea.attr('counter');
     let counter_type = textarea.attr('counter_type');
-    let max = tinyMCE.activeEditor.getContent().length;
+    const editor = window.tinyMCE.get(id);
+    const max = editor.getBody() ? editor.getBody().textContent.length : 0;
 
     textarea
       .parent()

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -184,6 +184,11 @@ class ProductInformation extends CommonAbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
+        $shortDescriptionLimit = (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT');
+        if ($shortDescriptionLimit <= 0) {
+            $shortDescriptionLimit = 800;
+        }
+
         $builder->add('type_product', FormType\ChoiceType::class, [
             'choices' => [
                 $this->translator->trans('Standard product', [], 'Admin.Catalog.Feature') => 0,
@@ -254,11 +259,11 @@ class ProductInformation extends CommonAbstractType
                     'attr' => [
                         'class' => 'autoload_rte',
                         'placeholder' => $this->translator->trans('The summary is a short sentence describing your product.<br />It will appears at the top of your shop\'s product page, in product lists, and in search engines\' results page (so it\'s important for SEO). To give more details about your product, use the "Description" tab.', [], 'Admin.Catalog.Help'),
-                        'counter' => (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT') <= 0 ? 800 : (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
+                        'counter' => $shortDescriptionLimit,
                     ],
                     'constraints' => [
                         new TinyMceMaxLength([
-                            'max' => (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT') <= 0 ? 800 : (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
+                            'max' => $shortDescriptionLimit,
                         ]),
                     ],
                     'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\Feature\FeatureDataProvider;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Manufacturer\ManufacturerDataProvider;
 use PrestaShop\PrestaShop\Adapter\Product\ProductDataProvider;
+use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShopBundle\Form\Admin\Category\SimpleCategory;
 use PrestaShopBundle\Form\Admin\Feature\ProductFeature;
 use PrestaShopBundle\Form\Admin\Type\ChoiceCategoriesTreeType;
@@ -186,7 +187,7 @@ class ProductInformation extends CommonAbstractType
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
         $shortDescriptionLimit = (int) $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT');
         if ($shortDescriptionLimit <= 0) {
-            $shortDescriptionLimit = 800;
+            $shortDescriptionLimit = ProductSettings::MAX_DESCRIPTION_SHORT_LENGTH;
         }
 
         $builder->add('type_product', FormType\ChoiceType::class, [

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -26,12 +26,23 @@
 
 namespace PrestaShopBundle\Form\Validator\Constraints;
 
-use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 class TinyMceMaxLengthValidator extends ConstraintValidator
 {
+    /** @var TranslatorInterface */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     /**
      * @param mixed $value
      * @param TinyMceMaxLength $constraint
@@ -48,7 +59,7 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
 
         if ($length > $constraint->max) {
             $this->context->addViolation(
-                (new LegacyContext())->getContext()->getTranslator()->trans('This value is too long. It should have %limit% characters or less.', [], 'Admin.Catalog.Notification'),
+                $this->translator->trans('This value is too long. It should have %limit% characters or less.', [], 'Admin.Catalog.Notification'),
                 ['%limit%' => $constraint->max]
             );
         }

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -30,6 +30,15 @@ use PrestaShopBundle\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
+/**
+ * The computation here means to only count the raw text, not the rich text with html strip tags, also all the
+ * line breaks are simply ignored (not event replaced with spaces). This computation is made to match the one
+ * from the TinyMce text count. You can see it in TinyMCEEditor.js component, if the js component is modified
+ * so should this validator.
+ *
+ * Note: if you rely on Product class validation you might also need to update Product::validateField
+ * Note: if you are still using the legacy AdminProductsController you should also update the checkProduct() function
+ */
 class TinyMceMaxLengthValidator extends ConstraintValidator
 {
     /** @var TranslatorInterface */

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -53,6 +53,7 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
             "\n",
             "\r",
             "\n\r",
+            "\r\n",
         ];
         $str = str_replace($replaceArray, [''], strip_tags($value));
         $length = iconv_strlen($str);

--- a/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
+++ b/src/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidator.php
@@ -32,6 +32,10 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class TinyMceMaxLengthValidator extends ConstraintValidator
 {
+    /**
+     * @param mixed $value
+     * @param TinyMceMaxLength $constraint
+     */
     public function validate($value, Constraint $constraint)
     {
         $replaceArray = [
@@ -40,8 +44,9 @@ class TinyMceMaxLengthValidator extends ConstraintValidator
             "\n\r",
         ];
         $str = str_replace($replaceArray, [''], strip_tags($value));
+        $length = iconv_strlen($str);
 
-        if ($constraint instanceof TinyMceMaxLength && iconv_strlen($str) > $constraint->max) {
+        if ($length > $constraint->max) {
             $this->context->addViolation(
                 (new LegacyContext())->getContext()->getTranslator()->trans('This value is too long. It should have %limit% characters or less.', [], 'Admin.Catalog.Notification'),
                 ['%limit%' => $constraint->max]

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_validator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_validator.yml
@@ -2,7 +2,7 @@ services:
     _defaults:
         public: true
 
-    prestashop.bundle.form.data_transformer.string_array_to_integer_array:
+    prestashop.bundle.form.validator.constraints.tiny_mce_max_length_validator:
         class: 'PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLengthValidator'
         arguments:
             - '@translator'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_validator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_validator.yml
@@ -1,0 +1,10 @@
+services:
+    _defaults:
+        public: true
+
+    prestashop.bundle.form.data_transformer.string_array_to_integer_array:
+        class: 'PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLengthValidator'
+        arguments:
+            - '@translator'
+        tags:
+            - { name: validator.constraint_validator }

--- a/tests/Unit/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidatorTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidatorTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Validator\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLength;
+use PrestaShopBundle\Form\Validator\Constraints\TinyMceMaxLengthValidator;
+use PrestaShopBundle\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class TinyMceMaxLengthValidatorTest extends TestCase
+{
+    private const MAX_LENGTH = 42;
+
+    /**
+     * @dataProvider getValidationData
+     *
+     * @param string $content
+     * @param bool $isValid
+     */
+    public function testValidate(string $content, bool $isValid): void
+    {
+        $validator = new TinyMceMaxLengthValidator($this->getTranslator());
+        $context = $this->getContext($isValid);
+        $validator->initialize($context);
+
+        $constraint = new TinyMceMaxLength([
+            'max' => static::MAX_LENGTH,
+        ]);
+        $validator->validate($content, $constraint);
+    }
+
+    public function getValidationData(): iterable
+    {
+        yield [
+            'Valid text',
+            true,
+        ];
+
+        yield [
+            'Valid text too long only because of HTML',
+            true,
+        ];
+
+        yield [
+            '<p>Valid text too long only because of HTML</p>',
+            true,
+        ];
+
+        yield [
+            'Invalid text that is a too long even without HTML',
+            false,
+        ];
+
+        yield [
+            '<p>Invalid text that is a too long even without HTML</p>',
+            false,
+        ];
+    }
+
+    private function getContext(bool $isValid): ExecutionContextInterface
+    {
+        $context = $this->getMockBuilder(ExecutionContextInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        if ($isValid) {
+            $context
+                ->expects($this->never())
+                ->method('addViolation')
+            ;
+        } else {
+            $context
+                ->expects($this->once())
+                ->method('addViolation')
+            ;
+        }
+
+        return $context;
+    }
+
+    private function getTranslator(): TranslatorInterface
+    {
+        $translator = $this->getMockBuilder(TranslatorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $translator
+            ->expects($this->any())
+            ->method('trans')
+            ->willReturn('translated wording')
+        ;
+
+        return $translator;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidatorTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Validator/Constraints/TinyMceMaxLengthValidatorTest.php
@@ -43,15 +43,16 @@ class TinyMceMaxLengthValidatorTest extends TestCase
      *
      * @param string $content
      * @param bool $isValid
+     * @param int|null $maxLength
      */
-    public function testValidate(string $content, bool $isValid): void
+    public function testValidate(string $content, bool $isValid, ?int $maxLength = null): void
     {
         $validator = new TinyMceMaxLengthValidator($this->getTranslator());
         $context = $this->getContext($isValid);
         $validator->initialize($context);
 
         $constraint = new TinyMceMaxLength([
-            'max' => static::MAX_LENGTH,
+            'max' => $maxLength ?? static::MAX_LENGTH,
         ]);
         $validator->validate($content, $constraint);
     }
@@ -81,6 +82,82 @@ class TinyMceMaxLengthValidatorTest extends TestCase
         yield [
             '<p>Invalid text that is a too long even without HTML</p>',
             false,
+        ];
+
+        yield [
+            '<p>White Ceramic Mug. 325ml</p>
+<p>White Ceramic Mug. 325ml</p>',
+            false,
+        ];
+
+        yield [
+            '<p>White Hot Ceramic Mug</p>
+<p>White Hot Ceramic Mug</p>',
+            true,
+        ];
+
+        yield [
+            '<p>White Hot Ceramic Mug</p>
+<p></p>
+<p>White Hot Ceramic Mug</p>
+<p></p>',
+            true,
+        ];
+
+        yield [
+            'White Hot Ceramic Mug
+
+White Hot Ceramic Mug',
+            true,
+        ];
+
+        yield [
+            '<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>
+<p>testtesttesttesttesttesttesttesttest</p>
+<p></p>',
+            true,
+            800,
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The max length for tinymce was not correctly computed and not synced with the server validator The max length is only about the text itself not the whole HTML content This PR fixes the way the length was computed in tinymce and adds minor improvement on the server side
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #24131
| How to test?      | See issue, but mainly edit description or summary The displayed max length must be consistent with the error returned from the server-side (HTML content and multiple break lines shouldn't be computed)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25038)
<!-- Reviewable:end -->

## Breaking Change

`TinyMceMaxLengthValidator` is now a service that needs the translator service as a dependency. Although it should change nothing for end-users or developers since the validator is automatically created by the framework anyway.