### PR TITLE
Disable product V2 page when multistore is used

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -286,8 +286,12 @@ class ProductController extends FrameworkBundleAdminController
         $this->addFlash(
             'error',
             $this->trans(
-                'The new experimental product page is disabled when multistore is used, because multistore is not properly implemented yet.',
-                'Admin.Catalog.Notification'
+                'This page is not yet compatible with the multistore feature. To access the page, please %sdisable the multistore feature%s.',
+                'Admin.Notifications.Info',
+                [
+                    sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
+                    '</a>',
+                ]
             )
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -286,7 +286,7 @@ class ProductController extends FrameworkBundleAdminController
         $this->addFlash(
             'error',
             $this->trans(
-                'This page is not yet compatible with the multistore feature. To access the page, please %sdisable the multistore feature%s.',
+                'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
                 'Admin.Notifications.Info',
                 [
                     sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -81,9 +81,17 @@ class ProductController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_product_new');
         }
         if ($this->get('prestashop.adapter.multistore_feature')->isUsed()) {
-            $this->addFlashMessageNotMultistoreCompatible();
-
-            return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig');
+            return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig', [
+                'errorMessage' => $this->trans(
+                    'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
+                    'Admin.Notifications.Info',
+                    [
+                        '[1]' => sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
+                        '[/1]' => '</a>',
+                    ]
+                ),
+                'standardPageUrl' => $this->generateUrl('admin_product_new'),
+            ]);
         }
 
         $productForm = $this->getProductFormBuilder()->getForm();
@@ -119,6 +127,20 @@ class ProductController extends FrameworkBundleAdminController
             $this->addFlashMessageProductV2IsDisabled();
 
             return $this->redirectToRoute('admin_product_form', ['id' => $productId]);
+        }
+
+        if ($this->get('prestashop.adapter.multistore_feature')->isUsed()) {
+            return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig', [
+                'errorMessage' => $this->trans(
+                    'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
+                    'Admin.Notifications.Info',
+                    [
+                        '[1]' => sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
+                        '[/1]' => '</a>',
+                    ]
+                ),
+                'standardPageUrl' => $this->generateUrl('admin_product_form', ['id' => $productId]),
+            ]);
         }
 
         $productForm = $this->getProductFormBuilder()->getFormFor($productId, [], [
@@ -275,21 +297,6 @@ class ProductController extends FrameworkBundleAdminController
                 'Admin.Catalog.Notification',
                 [
                     sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index')),
-                    '</a>',
-                ]
-            )
-        );
-    }
-
-    private function addFlashMessageNotMultistoreCompatible(): void
-    {
-        $this->addFlash(
-            'error',
-            $this->trans(
-                'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
-                'Admin.Notifications.Info',
-                [
-                    sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
                     '</a>',
                 ]
             )

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -81,17 +81,7 @@ class ProductController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_product_new');
         }
         if ($this->get('prestashop.adapter.multistore_feature')->isUsed()) {
-            return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig', [
-                'errorMessage' => $this->trans(
-                    'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
-                    'Admin.Notifications.Info',
-                    [
-                        '[1]' => sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
-                        '[/1]' => '</a>',
-                    ]
-                ),
-                'standardPageUrl' => $this->generateUrl('admin_product_new'),
-            ]);
+            return $this->renderDisableMultistorePage();
         }
 
         $productForm = $this->getProductFormBuilder()->getForm();
@@ -130,17 +120,7 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         if ($this->get('prestashop.adapter.multistore_feature')->isUsed()) {
-            return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig', [
-                'errorMessage' => $this->trans(
-                    'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
-                    'Admin.Notifications.Info',
-                    [
-                        '[1]' => sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
-                        '[/1]' => '</a>',
-                    ]
-                ),
-                'standardPageUrl' => $this->generateUrl('admin_product_form', ['id' => $productId]),
-            ]);
+            return $this->renderDisableMultistorePage($productId);
         }
 
         $productForm = $this->getProductFormBuilder()->getFormFor($productId, [], [
@@ -301,5 +281,28 @@ class ProductController extends FrameworkBundleAdminController
                 ]
             )
         );
+    }
+
+    /**
+     * @param int|null $productId
+     *
+     * @return Response
+     */
+    private function renderDisableMultistorePage(int $productId = null): Response
+    {
+        return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig', [
+            'errorMessage' => $this->trans(
+                'This page is not yet compatible with the multistore feature. To access the page, please [1]disable the multistore feature[/1].',
+                'Admin.Notifications.Info',
+                [
+                    '[1]' => sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences')),
+                    '[/1]' => '</a>',
+                ]
+            ),
+            'standardPageUrl' => $this->generateUrl(
+                !empty($productId) ? 'admin_product_form' : 'admin_product_new',
+                !empty($productId) ? ['id' => $productId] : []
+            ),
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -80,6 +80,11 @@ class ProductController extends FrameworkBundleAdminController
 
             return $this->redirectToRoute('admin_product_new');
         }
+        if ($this->get('prestashop.adapter.multistore_feature')->isUsed()) {
+            $this->addFlashMessageNotMultistoreCompatible();
+
+            return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/disabled.html.twig');
+        }
 
         $productForm = $this->getProductFormBuilder()->getForm();
 
@@ -272,6 +277,17 @@ class ProductController extends FrameworkBundleAdminController
                     sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index')),
                     '</a>',
                 ]
+            )
+        );
+    }
+
+    private function addFlashMessageNotMultistoreCompatible(): void
+    {
+        $this->addFlash(
+            'error',
+            $this->trans(
+                'The new experimental product page is disabled when multistore is used, because multistore is not properly implemented yet.',
+                'Admin.Catalog.Notification'
             )
         );
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/disabled.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/disabled.html.twig
@@ -23,3 +23,19 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+<div class="alert alert-danger d-print-none" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true"><i class="material-icons">close</i></span>
+  </button>
+  <div class="alert-text">
+    <p>{{ errorMessage|raw }}</p>
+  </div>
+</div>
+
+<a class="btn-outline-secondary btn" href="{{ standardPageUrl }}">
+  <i class="material-icons"></i>
+  {{ 'Back to standard page'|trans({}, 'Admin.Catalog.Feature') }}
+</a>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/disabled.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/disabled.html.twig
@@ -1,0 +1,25 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+{% extends '@PrestaShop/Admin/layout.html.twig' %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The product V2 page is not multistore compatible yet (it could work but it has not been tested), so the page is disabled when multistore is being used
| Type?             | improvement 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24471
| How to test?      | 1/ Enable multistore<br>2/ add at least one shop<br>3/ Enable product v2 experimental feature<br>4/ Go on product v2 creation or edition page => you should see a message instead of the product form
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25039)
<!-- Reviewable:end -->

This is how it looks like:

<img width="1576" alt="Capture d’écran 2021-06-21 à 17 06 51" src="https://user-images.githubusercontent.com/1784781/122784918-2cf27c00-d2b3-11eb-99d7-0b0e38b69e57.png">
