### PR TITLE
Fix mobile boostrap column spacing and forgotten class

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -33,12 +33,12 @@
     // remove gutters (except on product page)
     // @todo remove the :not() once the product page has been made responsive
     body:not(.adminproducts) & .row {
-      margin-right: 0;
-      margin-left: 0;
+      margin-right: -7.5px;
+      margin-left: -7.5px;
 
-      [class*="col-"] {
-        padding-right: 0;
-        padding-left: 0;
+      >[class*="col-"], >.col {
+        padding-right: 7.5px;
+        padding-left: 7.5px;
       }
     }
   }

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -25,19 +25,7 @@
     .container {
       padding: 0;
     }
-
-    // remove gutters (except on product page)
-    // @todo remove the :not() once the product page has been made responsive
-    body:not(.adminproducts) & .row {
-      margin-right: -7.5px;
-      margin-left: -7.5px;
-
-      > [class*="col-"],
-      > .col {
-        padding-right: 7.5px;
-        padding-left: 7.5px;
-      }
-    }
+    
   }
 
   &.-notoolbar {

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -25,7 +25,6 @@
     .container {
       padding: 0;
     }
-    
   }
 
   &.-notoolbar {

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -26,10 +26,6 @@
       padding: 0;
     }
 
-    .col {
-      padding: 0;
-    }
-
     // remove gutters (except on product page)
     // @todo remove the :not() once the product page has been made responsive
     body:not(.adminproducts) & .row {

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -36,8 +36,8 @@
       margin-right: -7.5px;
       margin-left: -7.5px;
 
-      >[class*="col-"],
-      >.col {
+      > [class*="col-"],
+      > .col {
         padding-right: 7.5px;
         padding-left: 7.5px;
       }

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -36,7 +36,8 @@
       margin-right: -7.5px;
       margin-left: -7.5px;
 
-      >[class*="col-"], >.col {
+      >[class*="col-"],
+      >.col {
         padding-right: 7.5px;
         padding-left: 7.5px;
       }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There was forgotten boostrap class in CSS and hacked up spacing, which produced stuck items together. If somebody wants no spacing, he should use provided boostrap class `no-gutters`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #00000 - related to #25040, but do not close it.
| How to test?      | See images and check if BO is not broken.
| Possible impacts? | None

Ping @NeOMakinG
before
![before](https://user-images.githubusercontent.com/6097524/122731544-b4bc9400-d27b-11eb-8e2e-fd13d9e3ebdc.jpg)

after
![7 5px](https://user-images.githubusercontent.com/6097524/122731569-b8e8b180-d27b-11eb-9588-9d34a6b20279.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25048)
<!-- Reviewable:end -->
