### PR TITLE
Order feature by position then id_feature_value in productForm V2

### DIFF
--- a/src/Adapter/Feature/Repository/FeatureValueRepository.php
+++ b/src/Adapter/Feature/Repository/FeatureValueRepository.php
@@ -237,6 +237,8 @@ class FeatureValueRepository extends AbstractObjectModelRepository
         $qb = $this->connection->createQueryBuilder();
         $qb->from($this->dbPrefix . 'feature_value', 'fv')
             ->leftJoin('fv', $this->dbPrefix . 'feature_product', 'fp', 'fp.id_feature_value = fv.id_feature_value')
+            ->leftJoin('fv', $this->dbPrefix . 'feature', 'f', 'f.id_feature = fv.id_feature')
+            ->orderBy('f.position,fv.id_feature_value', 'ASC')
         ;
 
         $availableFilters = [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Prestashop we can order feature for displaying. But when we set those features on the product form V2, we don't get this order. We should be able to display and edit feature in the order define for the feature. When a feature is set several times, use the same order they were created (ie. in the id_feature_value order).
| Type?             |  improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25053.
| How to test?      | See #25053.
| Possible impacts? | None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25054)
<!-- Reviewable:end -->
