### PR TITLE
Fix BO order create responsivity

### DIFF
--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig
@@ -28,18 +28,16 @@
     {{ 'Addresses'|trans({}, 'Admin.Global') }}
   </h3>
   <div class="card-body">
-    <div class="row d-none" id="addresses-warning">
-      <div class="col">
+    <div class="d-none" id="addresses-warning">
         <div class="alert alert-warning">
           <div class="alert-text">
             {{ 'You must add at least one address to process the order.'|trans({}, 'Admin.Orderscustomers.Notification') }}
           </div>
         </div>
-      </div>
     </div>
     <div class="row d-none" id="addresses-content">
-      <div class="col">
-        <span>{{ 'Delivery'|trans({}, 'Admin.Global') }}</span>
+      <div class="col-md-6">
+        <label for="delivery-address-select">{{ 'Delivery'|trans({}, 'Admin.Global') }}</label>
         <select class="form-control js-address-select custom-select" id="delivery-address-select"></select>
 
         <div class="card mt-3">
@@ -49,8 +47,8 @@
           </div>
         </div>
       </div>
-      <div class="col">
-        <span>{{ 'Invoice'|trans({}, 'Admin.Global') }}</span>
+      <div class="col-md-6">
+        <label for="invoice-address-select">{{ 'Invoice'|trans({}, 'Admin.Global') }}</label>
         <select class="form-control js-address-select custom-select" id="invoice-address-select"></select>
 
         <div class="card mt-3">
@@ -61,12 +59,10 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col">
-        <a class="btn btn-primary" id="js-add-address-btn" href="{{ path('admin_addresses_create', {'liteDisplaying': 1, 'submitFormAjax': 1}) }}">
-          {{ 'Add new address'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </a>
-      </div>
-    </div>
+
+    <a class="btn btn-primary" id="js-add-address-btn" href="{{ path('admin_addresses_create', {'liteDisplaying': 1, 'submitFormAjax': 1}) }}">
+      {{ 'Add new address'|trans({}, 'Admin.Orderscustomers.Feature') }}
+    </a>
+
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -30,10 +30,8 @@
       <div class="alert-text"></div>
     </div>
     <div class="row">
-      <div class="col-3">
-        <span class="float-right">{{ 'Search for a product'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-      </div>
-      <div class="col-4">
+      <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="product-search">{{ 'Search for a product'|trans({}, 'Admin.Orderscustomers.Feature') }}</label>
+      <div class="col-md-6 col-xl-4">
         <input id="product-search" type="text" class="form-control">
         <small class="form-text">
           {{ 'Search for an existing product by typing the first letters of its name.'|trans({}, 'Admin.Orderscustomers.Help') }}
@@ -41,61 +39,45 @@
       </div>
     </div>
 
-    <div class="row js-no-products-found d-none">
-      <div class="col">
+    <div class="js-no-products-found d-none">
         <div class="alert alert-danger" role="alert">
           <p class="alert-text">{{ 'No products found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
         </div>
-      </div>
     </div>
 
-    <div class="row js-searching-products d-none">
-      <div class="col">
+    <div class="js-searching-products d-none">
         <div class="alert alert-info" role="alert">
           <p class="alert-text">{{ 'Searching for products'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
         </div>
-      </div>
     </div>
 
     <hr class="mt-3 mb-3">
 
-    <div class="row">
-      <div class="col">
         <div id="product-search-results" class="d-none">
           <form id="js-add-product-form">
 
             <div class="row js-product-select-row">
-              <div class="col-3">
-                <span class="float-right">{{ 'Product'|trans({}, 'Admin.Global') }}</span>
-              </div>
-              <div class="col-4">
+              <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="product-select">{{ 'Product'|trans({}, 'Admin.Global') }}</label>
+              <div class="col-md-6 col-xl-4">
                 <select name="product_id" id="product-select" class="form-control custom-select" data-customization-label="{{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}"></select>
               </div>
             </div>
 
             <div class="row mt-3 js-combinations-row d-none">
-              <div class="col-3">
-                <span class="float-right">{{ 'Combination'|trans({}, 'Admin.Global') }}</span>
-              </div>
-              <div class="col-4">
+              <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="combination-select">{{ 'Combination'|trans({}, 'Admin.Global') }}</label>
+              <div class="col-md-6 col-xl-4">
                 <select name="combination_id" id="combination-select" class="form-control custom-select"></select>
               </div>
             </div>
 
             <div class="row mt-3 d-none" id="js-customization-container">
-              <div class="col-3">
-                <span class="float-right">
-                  {{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}
-                </span>
-              </div>
-              <div class="col-4 custom-fields-container" id="js-custom-fields-container"></div>
+              <span class="col-md-6 col-xl-3 text-md-right col-form-label">{{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}</span>
+              <div class="col-md-6 col-xl-4 custom-fields-container" id="js-custom-fields-container"></div>
             </div>
 
             <div class="row mt-3 js-quantity-row">
-              <div class="col-3">
-                <span class="float-right">{{ 'Quantity'|trans({}, 'Admin.Global') }}</span>
-              </div>
-              <div class="col-2">
+              <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="quantity-input">{{ 'Quantity'|trans({}, 'Admin.Global') }}</label>
+              <div class="col-6 col-xl-3">
                 <input name="product_quantity" id="quantity-input" type="number" min="1" value="1" class="form-control">
                 {% if stockManagementEnabled %}
                   <small class="form-text">
@@ -106,7 +88,7 @@
               </div>
             </div>
             <div class="row mt-3">
-              <div class="col-1 offset-sm-3">
+              <div class="col-md-6 offset-md-6 offset-xl-3">
                 <button id="add-product-to-cart-btn" type="button" class="btn btn-primary">
                   {{ 'Add to cart'|trans({}, 'Admin.Orderscustomers.Feature') }}
                 </button>
@@ -114,16 +96,10 @@
             </div>
 
           </form>
-          <div class="row">
-            <div class="col">
-              <hr>
-            </div>
-          </div>
+          <hr>
         </div>
         <div class="js-no-records-found"></div>
-        <div class="row">
-          <div class="col">
-            <table id="products-table" class="table d-none">
+            <table id="products-table" class="table table-responsive-md d-none">
               <thead>
               <tr>
                 <th>{{ 'Product'|trans({}, 'Admin.Global') }}</th>
@@ -137,10 +113,8 @@
               </thead>
               <tbody></tbody>
             </table>
-          </div>
-        </div>
         <div class="row js-tax-warning d-none">
-          <div class="col-4 offset-sm-3">
+          <div class="col-xl-6 offset-xl-3">
             <div class="alert alert-warning">
               <div class="alert-text">
                 {{ 'The prices are without taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
@@ -149,12 +123,8 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-3">
-            <span class="float-right">
-              {{ 'Currency'|trans({}, 'Admin.Global') }}
-            </span>
-          </div>
-          <div class="col-4">
+          <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="js-cart-currency-select">{{ 'Currency'|trans({}, 'Admin.Global') }}</label>
+          <div class="col-md-6 col-xl-4">
             <select class="form-control custom-select" id="js-cart-currency-select">
               {% for name, id in currencies %}
                 <option value="{{ id }}">{{ name }}</option>
@@ -163,12 +133,8 @@
           </div>
         </div>
         <div class="row mt-3">
-          <div class="col-3">
-            <span class="float-right">
-              {{ 'Language'|trans({}, 'Admin.Global') }}
-            </span>
-          </div>
-          <div class="col-4">
+          <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="js-cart-language-select">{{ 'Language'|trans({}, 'Admin.Global') }}</label>
+          <div class="col-md-6 col-xl-4">
             <select class="form-control custom-select" id="js-cart-language-select">
               {% for name, id in languages %}
                 <option value="{{ id }}">{{ name }}</option>
@@ -176,8 +142,6 @@
             </select>
           </div>
         </div>
-      </div>
-    </div>
   </div>
 </div>
 
@@ -186,18 +150,13 @@
 {% endset %}
 
 <script id="js-product-custom-text-template" type="text/template">
-  <div class="row">
-    <div class="col">
       {{ requiredFieldMarkTemplate }}
       <label for="" class="js-product-custom-input-label"></label>
       <input name="" type="text" class="form-control js-product-custom-input">
-    </div>
-  </div>
 </script>
 
 <script id="js-product-custom-file-template" type="text/template">
-  <div class="row mt-3">
-    <div class="col">
+  <div class="mt-3">
       {{ requiredFieldMarkTemplate }}
       <label for="" class="js-product-custom-input-label"></label>
       <div class="custom-file">
@@ -206,7 +165,6 @@
           {{ 'Choose file(s)'|trans({}, 'Admin.Actions') }}
         </label>
       </div>
-    </div>
   </div>
 </script>
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -99,7 +99,8 @@
           <hr>
         </div>
         <div class="js-no-records-found"></div>
-            <table id="products-table" class="table table-responsive-md d-none">
+          <div class="table-responsive">
+            <table id="products-table" class="table d-none">
               <thead>
               <tr>
                 <th>{{ 'Product'|trans({}, 'Admin.Global') }}</th>
@@ -113,6 +114,7 @@
               </thead>
               <tbody></tbody>
             </table>
+          </div>
         <div class="row js-tax-warning d-none">
           <div class="col-xl-6 offset-xl-3">
             <div class="alert alert-warning">

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart_rules.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart_rules.html.twig
@@ -29,10 +29,8 @@
   </h3>
   <div class="card-body">
     <div class="row">
-      <div class="col-3">
-        <span class="float-right">{{ 'Search for a voucher'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-      </div>
-      <div class="col-4" id="cart-rules-search-block">
+      <label class="col-md-3 text-md-right col-form-label" for="search-cart-rules-input">{{ 'Search for a voucher'|trans({}, 'Admin.Orderscustomers.Feature') }}</label>
+      <div class="col-md-4 mb-2" id="cart-rules-search-block">
         <div class="col p-0">
           <input type="text" class="form-control" id="search-cart-rules-input">
           <ul id="search-cart-rules-result-box" class="position-absolute bg-white w-100 form-control d-none list-unstyled"></ul>
@@ -44,11 +42,8 @@
       </div>
       <div class="col">
         <span class="mr-2">{{ 'or'|trans({}, 'Admin.Global') }}</span>
-        <a
-          class="btn btn-primary"
-          id="js-add-cart-rule-btn"
-          href="{{ getAdminLink('AdminCartRules', true, {'liteDisplaying': 1, 'submitFormAjax': 1, 'addcart_rule': 1}) }}"
-        >
+        <a class="btn btn-primary" id="js-add-cart-rule-btn"
+          href="{{ getAdminLink('AdminCartRules', true, {'liteDisplaying': 1, 'submitFormAjax': 1, 'addcart_rule': 1}) }}">
           {{ 'Add new voucher'|trans({}, 'Admin.Orderscustomers.Feature') }}
         </a>
       </div>
@@ -86,4 +81,3 @@
 <script id="found-cart-rule-template" type="text/template">
   <li data-cart-rule-id="" class="js-found-cart-rule found-cart-rule"></li>
 </script>
-

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -103,33 +103,37 @@
         </ul>
         <div class="tab-content collapse show" id="customer-tab-content-container">
           <div class="tab-pane fade active show" id="customer-carts-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
-            <table class="table table-responsive-md mb-0" id="customer-carts-table">
-              <thead class="d-none">
+            <div class="table-responsive">
+              <table class="table mb-0" id="customer-carts-table">
+                <thead class="d-none">
+                  <tr>
+                    <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
+                    <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+                    <th>{{ 'Total'|trans({}, 'Admin.Global') }}</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+          <div class="tab-pane fade" id="customer-orders-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
+            <div class="table-responsive">
+              <table class="table mb-0" id="customer-orders-table">
+                <thead class="d-none">
                 <tr>
                   <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
                   <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Total'|trans({}, 'Admin.Global') }}</th>
+                  <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
+                  <th>{{ 'Total paid'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+                  <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
+                  <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
                   <th></th>
                 </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-          <div class="tab-pane fade" id="customer-orders-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
-            <table class="table table-responsive-md mb-0" id="customer-orders-table">
-              <thead class="d-none">
-              <tr>
-                <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Total paid'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-                <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
-                <th></th>
-              </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
           </div>
         </div>
     </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -26,11 +26,11 @@
 <div class="card" id="customer-search-block">
   <h3 class="card-header">{{ 'Customer'|trans({}, 'Admin.Global') }}</h3>
   <div class="card-body">
-    <div class="row js-search-customer-row mb-3">
-      <div class="col-3">
-        <span class="float-right">{{ 'Search for a customer'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
-      </div>
-      <div class="col-4">
+    <div class="row js-search-customer-row mb-4">
+      <label class="col-md-3 text-md-right col-form-label" for="customer-search-input">
+        {{ 'Search for a customer'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </label>
+      <div class="col-md-4 mb-2">
         <input type="text"
                class="form-control"
                id="customer-search-input"
@@ -41,42 +41,28 @@
       </div>
       <div class="col">
         <span class="mr-2">{{ 'or'|trans({}, 'Admin.Global') }}</span>
-
         <a id="customer-add-btn" class="btn btn-primary" href="{{ path('admin_customers_create', {'liteDisplaying': 1, 'submitFormAjax': 1}) }}">
           {{ 'Add new customer'|trans({}, 'Admin.Orderscustomers.Feature') }}
         </a>
       </div>
     </div>
 
-    <div id="customer-search-empty-result-warn" class="row d-none">
-      <div class="col">
-        <div class="col">
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">{{ 'No customers found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
-          </div>
+    <div id="customer-search-empty-result-warn" class="d-none">
+        <div class="alert alert-warning" role="alert">
+          <p class="alert-text">{{ 'No customers found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
         </div>
-      </div>
     </div>
 
-    <div id="customer-search-loading-notice" class="row d-none">
-      <div class="col">
-        <div class="col">
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'Searching for customers'|trans({}, 'Admin.Orderscustomers.Notification') }}
-            </p>
-          </div>
+    <div id="customer-search-loading-notice" class="d-none">
+        <div class="alert alert-info" role="alert">
+          <p class="alert-text">
+            {{ 'Searching for customers'|trans({}, 'Admin.Orderscustomers.Notification') }}
+          </p>
         </div>
-      </div>
     </div>
 
-    <div class="row">
-      <div class="col">
-        <div class="row js-customer-search-results"></div>
-      </div>
-    </div>
-    <div class="row d-none" id="customer-checkout-history">
-      <div class="col">
+    <div class="row js-customer-search-results"></div>
+    <div class="d-none mt-4" id="customer-checkout-history">
         <ul class="nav nav-pills" role="tablist">
           <li class="nav-item">
             <a class="nav-link active show js-customer-carts-tab"
@@ -117,7 +103,7 @@
         </ul>
         <div class="tab-content collapse show" id="customer-tab-content-container">
           <div class="tab-pane fade active show" id="customer-carts-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
-            <table class="table" id="customer-carts-table">
+            <table class="table table-responsive-md mb-0" id="customer-carts-table">
               <thead class="d-none">
                 <tr>
                   <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
@@ -130,7 +116,7 @@
             </table>
           </div>
           <div class="tab-pane fade" id="customer-orders-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
-            <table class="table" id="customer-orders-table">
+            <table class="table table-responsive-md mb-0" id="customer-orders-table">
               <thead class="d-none">
               <tr>
                 <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
@@ -146,13 +132,12 @@
             </table>
           </div>
         </div>
-      </div>
     </div>
   </div>
 </div>
 
 <div id="customer-search-result-template" class="d-none">
-  <div class="col-4 js-customer-search-result-col">
+  <div class="col-sm-6 col-md-4 col-xl-3 js-customer-search-result-col">
     <div class="card js-customer-search-result">
       <div class="card-header">
         <h3 class="card-header-title d-inline-block js-customer-name"></h3>
@@ -211,7 +196,7 @@
     <td class="text-right">
       <a
         title="{{ 'View this order'|trans({}, 'Admin.Orderscustomers.Feature') }}"
-        class="btn btn-outline-primary js-order-details-btn">
+        class="btn btn-outline-secondary js-order-details-btn">
         {{ 'Details'|trans({}, 'Admin.Global') }}
       </a>
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig
@@ -30,32 +30,26 @@
 
     <form class="js-shipping-form d-none">
       <div class="form-group row">
-        <div class="col-3">
-        <span class="float-right">
+        <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="delivery-option-select">
           {{ 'Delivery option'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </span>
-        </div>
-        <div class="col-4">
+        </label>
+        <div class="col-md-6 col-xl-4">
           <select class="form-control" id="delivery-option-select" name="carrier-id"></select>
         </div>
       </div>
       <div class="form-group row">
-        <div class="col-3">
-        <span class="float-right">
+        <span class="col-md-6 col-xl-3 text-md-right col-form-label">
           {{ 'Shipping price (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}
         </span>
-        </div>
-        <div class="col-4">
-          <p><strong class="js-total-shipping-tax-inc"></strong></p>
+        <div class="col-md-6 col-xl-4">
+          <span class="js-total-shipping-tax-inc font-weight-bold"></span>
         </div>
       </div>
       <div class="form-group row">
-        <div class="col-3">
-        <span class="float-right">
+        <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="free-shipping_0">
           {{ 'Free shipping'|trans({}, 'Admin.Shipping.Feature') }}
-        </span>
-        </div>
-        <div class="col-4">
+        </label>
+        <div class="col-md-6 col-xl-4">
         <span class="ps-switch">
           <input id="free-shipping_0" class="js-free-shipping-switch" name="free_shipping" value="0" type="radio">
           <label for="free-shipping_0">{{ 'No'|trans({}, 'Admin.Global') }}</label>
@@ -66,12 +60,10 @@
         </div>
       </div>
       <div class="form-group row {% if not recycledPackagingEnabled %}d-none{% endif %}">
-        <div class="col-3">
-        <span class="float-right">
+        <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="recycled-packaging_0">
           {{ 'Recycled packaging'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </span>
-        </div>
-        <div class="col-4">
+        </label>
+        <div class="col-md-6 col-xl-4">
           <span class="ps-switch">
             <input id="recycled-packaging_0" class="js-recycled-packaging-switch" name="recycled_packaging" value="0" checked="" type="radio">
             <label for="recycled-packaging_0">{{ 'No'|trans({}, 'Admin.Global') }}</label>
@@ -82,12 +74,10 @@
         </div>
       </div>
       <div class="form-group row {% if not giftSettingsEnabled %}d-none{% endif %}">
-        <div class="col-3">
-        <span class="float-right">
+        <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="is-gift_0">
           {{ 'Gift'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </span>
-        </div>
-        <div class="col-4">
+        </label>
+        <div class="col-md-6 col-xl-4">
           <span class="ps-switch">
             <input id="is-gift_0" class="js-is-gift-switch" name="is_gift" value="0" checked="" type="radio">
             <label for="is-gift_0">{{ 'No'|trans({}, 'Admin.Global') }}</label>
@@ -99,12 +89,10 @@
 
       </div>
       <div class="form-group row type-text {% if not giftSettingsEnabled %}d-none{% endif %}">
-        <div class="col-3">
-        <label class="float-right">
+        <label class="col-md-6 col-xl-3 text-md-right col-form-label" for="cart_gift_message">
           {{ 'Gift message'|trans({}, 'Admin.Orderscustomers.Feature') }}
         </label>
-        </div>
-        <div class="col-4">
+        <div class="col-md-6 col-xl-4">
           <textarea id="cart_gift_message" name="cart_gift_message" class="form-control" cols="40" rows="4"></textarea>
         </div>
       </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -34,42 +34,40 @@
     <div class="alert alert-danger d-none" id="js-summary-error-block">
       <div class="alert-text"></div>
     </div>
-    <div class="row">
-      <div class="col">
         <div class="card">
           <div class="card-body">
             <div class="row">
-              <div class="col text-center">
+              <div class="col-6 col-md-4 col-xl-2 mb-2 mb-xl-0 text-center">
                 <p class="mb-0 text-muted">
                   <strong>{{ 'Total products'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                 </p>
                 <strong class="js-total-products"></strong>
               </div>
-              <div class="col text-center">
+              <div class="col-6 col-md-4 col-xl-2 mb-2 mb-xl-0 text-center">
                 <p class="mb-0 text-muted">
                   <strong>{{ 'Total vouchers (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                 </p>
                 <strong class="js-total-discounts"></strong>
               </div>
-              <div class="col text-center">
+              <div class="col-6 col-md-4 col-xl-2 mb-2 mb-xl-0 text-center">
                 <p class="mb-0 text-muted">
                   <strong>{{ 'Total shipping (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                 </p>
                 <strong class="js-total-shipping"></strong>
               </div>
-              <div class="col text-center">
+              <div class="col-6 col-md-4 col-xl-2 mb-2 mb-md-0 text-center">
                 <p class="mb-0 text-muted">
                   <strong>{{ 'Total taxes'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                 </p>
                 <strong class="js-total-taxes"></strong>
               </div>
-              <div class="col text-center">
+              <div class="col-6 col-md-4 col-xl-2 mb-2 mb-md-0 text-center">
                 <p class="mb-0 text-muted">
                   <strong>{{ 'Total (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                 </p>
                 <strong class="js-total-without-tax"></strong>
               </div>
-              <div class="col text-center">
+              <div class="col-6 col-md-4 col-xl-2 mb-2 mb-md-0 text-center">
                 <p class="mb-0 text-muted">
                   <strong>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
                 </p>
@@ -78,12 +76,10 @@
             </div>
           </div>
         </div>
-      </div>
-    </div>
 
     {{ form_start(summaryForm, {'action': path('admin_orders_place')}) }}
-      <div class="row mt-3">
-        <div class="col col-11">
+      <div class="mt-4 row">
+        <div class="col-lg-11">
 
           <div id="js-order-message-wrap">
             {{ ps.form_group_row(summaryForm.order_message, {}, {
@@ -99,15 +95,15 @@
             'label': 'Order status'|trans({}, 'Admin.Orderscustomers.Feature'),
           }) }}
 
-          <div class="form-group row mt-4">
-            <div class="col-sm offset-sm-4">
-              <button class="btn btn-primary" type="submit" id="create-order-button">
+          <div class="form-group row mt-2 mb-2">
+            <div class="col offset-sm-4">
+              <button class="btn btn-primary my-1" type="submit" id="create-order-button">
                 {{ 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
 
               <div class="btn-group">
                 <button
-                  class="btn btn-outline-primary dropdown-toggle"
+                  class="btn btn-outline-primary dropdown-toggle my-1"
                   type="button"
                   id="dropdown-menu-actions"
                   data-toggle="dropdown"

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/create.html.twig
@@ -33,37 +33,13 @@
 
 {% block content %}
   <div id="order-creation-container">
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig' %}
     <div id="js-cart-info-wrapper">
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart_rules.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig' %}
-        </div>
-      </div>
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart_rules.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig' %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Completely fixes responsivity of backoffice order create page. Improves look of the forms by centering labels and using proper boostrap classes. Removes some nonsense code like `<div class="row"><div class="col">` etc.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25040
| How to test?      | Compare the page before and after my change
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25056)
<!-- Reviewable:end -->
