### PR TITLE
Fixed translated order messages in Order View

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -261,6 +261,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $customerStats['nb_orders'],
             $customer->note,
             (bool) $customer->is_guest,
+            (int) $customer->id_lang,
             $isB2BEnabled ? ($customer->ape ?: '') : '',
             $isB2BEnabled ? ($customer->siret ?: '') : ''
         );

--- a/src/Adapter/OrderMessage/OrderMessageProvider.php
+++ b/src/Adapter/OrderMessage/OrderMessageProvider.php
@@ -46,10 +46,15 @@ class OrderMessageProvider
         $this->contextLanguageId = $contextLanguageId;
     }
 
-    public function getMessages(): array
+    /**
+     * @param int|null $langId
+     *
+     * @return array
+     */
+    public function getMessages(int $langId = null): array
     {
-        $result = OrderMessage::getOrderMessages($this->contextLanguageId);
+        $result = OrderMessage::getOrderMessages($langId ?? $this->contextLanguageId);
 
-        return \is_array($result) ? $result : [];
+        return is_array($result) ? $result : [];
     }
 }

--- a/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
@@ -91,6 +91,11 @@ class OrderCustomerForViewing
     private $siret;
 
     /**
+     * @var int
+     */
+    private $languageId;
+
+    /**
      * @param int $id
      * @param string $firstName
      * @param string $lastName
@@ -101,6 +106,7 @@ class OrderCustomerForViewing
      * @param int $validOrdersPlaced
      * @param string|null $privateNote
      * @param bool $isGuest
+     * @param int $languageId
      * @param string $ape
      * @param string $siret
      */
@@ -115,6 +121,7 @@ class OrderCustomerForViewing
         int $validOrdersPlaced,
         ?string $privateNote,
         bool $isGuest,
+        int $languageId,
         string $ape = '',
         string $siret = ''
     ) {
@@ -128,6 +135,7 @@ class OrderCustomerForViewing
         $this->validOrdersPlaced = $validOrdersPlaced;
         $this->privateNote = $privateNote;
         $this->isGuest = $isGuest;
+        $this->languageId = $languageId;
         $this->ape = $ape;
         $this->siret = $siret;
     }
@@ -226,5 +234,13 @@ class OrderCustomerForViewing
     public function getSiret(): string
     {
         return $this->siret;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLanguageId(): int
+    {
+        return $this->languageId;
     }
 }

--- a/src/Core/Form/ChoiceProvider/CustomerServiceOrderMessagesChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CustomerServiceOrderMessagesChoiceProvider.php
@@ -26,31 +26,32 @@
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Adapter\OrderMessage\OrderMessageProvider;
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 
 /**
  * Selects order messages itself.
  */
-final class CustomerServiceOrderMessagesChoiceProvider implements FormChoiceProviderInterface
+final class CustomerServiceOrderMessagesChoiceProvider implements ConfigurableFormChoiceProviderInterface
 {
     /**
-     * @var array
+     * @var OrderMessageProvider
      */
-    private $orderMessages;
+    private $orderMessageProvider;
 
-    public function __construct(array $orderMessages)
+    public function __construct(OrderMessageProvider $orderMessageProvider)
     {
-        $this->orderMessages = $orderMessages;
+        $this->orderMessageProvider = $orderMessageProvider;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getChoices(): array
+    public function getChoices(array $options): array
     {
         $result = [];
 
-        foreach ($this->orderMessages as $orderMessage) {
+        foreach ($this->orderMessageProvider->getMessages($options['lang_id']) as $orderMessage) {
             $result[$orderMessage['id_order_message']] = $orderMessage['message'];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -433,7 +433,9 @@ class OrderController extends FrameworkBundleAdminController
             'id_order' => $orderId,
         ]);
 
-        $orderMessageForm = $this->createForm(OrderMessageType::class, [], [
+        $orderMessageForm = $this->createForm(OrderMessageType::class, [
+            'lang_id' => $orderForViewing->getCustomer()->getLanguageId(),
+        ], [
             'action' => $this->generateUrl('admin_orders_send_message', ['orderId' => $orderId]),
         ]);
         $orderMessageForm->handleRequest($request);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CleanHtml;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\OrderMessageConstraint;
+use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TextWithLengthCounterType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
@@ -53,13 +54,13 @@ class OrderMessageType extends AbstractType
     private $orderMessageNameChoiceProvider;
 
     /**
-     * @var FormChoiceProviderInterface
+     * @var ConfigurableFormChoiceProviderInterface
      */
     private $orderMessageChoiceProvider;
 
     public function __construct(
         FormChoiceProviderInterface $orderMessageNameChoiceProvider,
-        FormChoiceProviderInterface $orderMessageChoiceProvider
+        ConfigurableFormChoiceProviderInterface $orderMessageChoiceProvider
     ) {
         $this->orderMessageNameChoiceProvider = $orderMessageNameChoiceProvider;
         $this->orderMessageChoiceProvider = $orderMessageChoiceProvider;
@@ -111,6 +112,8 @@ class OrderMessageType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['messages'] = $this->orderMessageChoiceProvider->getChoices();
+        $view->vars['messages'] = $this->orderMessageChoiceProvider->getChoices([
+            'lang_id' => $options['data']['lang_id'] ?? null,
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -244,4 +244,4 @@ services:
   prestashop.core.form.choice_provider.customer_service_order_messages:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\CustomerServiceOrderMessagesChoiceProvider'
     arguments:
-      - '@=service("prestashop.adapter.order_message.order_message_provider").getMessages()'
+      - '@prestashop.adapter.order_message.order_message_provider'

--- a/tests/Unit/Core/Domain/Order/QueryResult/OrderCustomerForViewingTest.php
+++ b/tests/Unit/Core/Domain/Order/QueryResult/OrderCustomerForViewingTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Domain\Order\QueryResult;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderCustomerForViewing;
+
+class OrderCustomerForViewingTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $mockCreatedAt = $this->createMock(DateTimeImmutable::class);
+
+        $instance = new OrderCustomerForViewing(
+            0,
+            'a',
+            'b',
+            'c',
+            'd',
+            $mockCreatedAt,
+            'e',
+            1,
+            'f',
+            true,
+            2
+        );
+
+        self::assertSame(0, $instance->getId());
+        self::assertSame('a', $instance->getFirstName());
+        self::assertSame('b', $instance->getLastName());
+        self::assertSame('c', $instance->getGender());
+        self::assertSame('d', $instance->getEmail());
+        self::assertSame($mockCreatedAt, $instance->getAccountRegistrationDate());
+        self::assertSame('e', $instance->getTotalSpentSinceRegistration());
+        self::assertSame(1, $instance->getValidOrdersPlaced());
+        self::assertSame('f', $instance->getPrivateNote());
+        self::assertSame(true, $instance->isGuest());
+        self::assertSame(2, $instance->getLanguageId());
+        self::assertSame('', $instance->getApe());
+        self::assertSame('', $instance->getSiret());
+    }
+
+    public function testConstructWithApe(): void
+    {
+        $mockCreatedAt = $this->createMock(DateTimeImmutable::class);
+
+        $instance = new OrderCustomerForViewing(
+            0,
+            'a',
+            'b',
+            'c',
+            'd',
+            $mockCreatedAt,
+            'e',
+            1,
+            'f',
+            true,
+            2,
+            'g'
+        );
+
+        self::assertSame(0, $instance->getId());
+        self::assertSame('a', $instance->getFirstName());
+        self::assertSame('b', $instance->getLastName());
+        self::assertSame('c', $instance->getGender());
+        self::assertSame('d', $instance->getEmail());
+        self::assertSame($mockCreatedAt, $instance->getAccountRegistrationDate());
+        self::assertSame('e', $instance->getTotalSpentSinceRegistration());
+        self::assertSame(1, $instance->getValidOrdersPlaced());
+        self::assertSame('f', $instance->getPrivateNote());
+        self::assertSame(true, $instance->isGuest());
+        self::assertSame(2, $instance->getLanguageId());
+        self::assertSame('g', $instance->getApe());
+        self::assertSame('', $instance->getSiret());
+    }
+
+    public function testConstructWithSiret(): void
+    {
+        $mockCreatedAt = $this->createMock(DateTimeImmutable::class);
+
+        $instance = new OrderCustomerForViewing(
+            0,
+            'a',
+            'b',
+            'c',
+            'd',
+            $mockCreatedAt,
+            'e',
+            1,
+            'f',
+            true,
+            2,
+            'g',
+            'h'
+        );
+
+        self::assertSame(0, $instance->getId());
+        self::assertSame('a', $instance->getFirstName());
+        self::assertSame('b', $instance->getLastName());
+        self::assertSame('c', $instance->getGender());
+        self::assertSame('d', $instance->getEmail());
+        self::assertSame($mockCreatedAt, $instance->getAccountRegistrationDate());
+        self::assertSame('e', $instance->getTotalSpentSinceRegistration());
+        self::assertSame(1, $instance->getValidOrdersPlaced());
+        self::assertSame('f', $instance->getPrivateNote());
+        self::assertSame(true, $instance->isGuest());
+        self::assertSame(2, $instance->getLanguageId());
+        self::assertSame('g', $instance->getApe());
+        self::assertSame('h', $instance->getSiret());
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Fixed translated order messages in Order View
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #24499
| How to test?      | Cf. #24499

**BC Breaks :**
* `src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php` : Added parameter `int $languageId` before optional
* `src/PrestaShopBundle/Form/Admin/Sell/Order/OrderMessageType.php` : Changed the type of the parameter `$orderMessageChoiceProvider` from `PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface` to `PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25059)
<!-- Reviewable:end -->
