### PR TITLE
Link improvements, mainly for customers not logged in

### DIFF
--- a/themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -64,6 +64,7 @@
         <li><a href="{$urls.pages.guest_tracking}" title="{l s='Order tracking' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Order tracking' d='Shop.Theme.Customeraccount'}</a></li>
         <li><a href="{$urls.pages.my_account}" title="{l s='Log in to your customer account' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Sign in' d='Shop.Theme.Actions'}</a></li>
         <li><a href="{$urls.pages.register}" title="{l s='Create account' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Create account' d='Shop.Theme.Customeraccount'}</a></li>
+        {hook h='displayMyAccountBlock'}
       {/if} 
 	</ul>
 </div>

--- a/themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
+++ b/themes/classic/modules/ps_customeraccountlinks/ps_customeraccountlinks.tpl
@@ -39,13 +39,31 @@
     </span>
   </div>
   <ul class="account-list collapse" id="footer_account_list">
-    {foreach from=$my_account_urls item=my_account_url}
-        <li>
-          <a href="{$my_account_url.url}" title="{$my_account_url.title}" rel="nofollow">
-            {$my_account_url.title}
-          </a>
-        </li>
-    {/foreach}
-    {hook h='displayMyAccountBlock'}
+    {if $customer.is_logged}
+        <li><a href="{$urls.pages.identity}" title="{l s='Information' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Information' d='Shop.Theme.Customeraccount'}</a></li>
+        {if $customer.addresses|count}
+          <li><a href="{$urls.pages.addresses}" title="{l s='Addresses' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Addresses' d='Shop.Theme.Customeraccount'}</a></li>
+        {else}
+          <li><a href="{$urls.pages.address}" title="{l s='Add first address' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Add first address' d='Shop.Theme.Customeraccount'}</a></li>
+        {/if}
+        {if !$configuration.is_catalog}
+          <li><a href="{$urls.pages.history}" title="{l s='Orders' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Orders' d='Shop.Theme.Customeraccount'}</a></li>
+        {/if}
+        {if !$configuration.is_catalog}
+          <li><a href="{$urls.pages.order_slip}" title="{l s='Credit slips' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Credit slips' d='Shop.Theme.Customeraccount'}</a></li>
+        {/if}
+        {if $configuration.voucher_enabled && !$configuration.is_catalog}
+          <li><a href="{$urls.pages.discount}" title="{l s='Vouchers' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Vouchers' d='Shop.Theme.Customeraccount'}</a></li>
+        {/if}
+        {if $configuration.return_enabled && !$configuration.is_catalog}
+          <li><a href="{$urls.pages.order_follow}" title="{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Merchandise returns' d='Shop.Theme.Customeraccount'}</a></li>
+        {/if}
+        {hook h='displayMyAccountBlock'}
+        <li><a href="{$urls.actions.logout}" title="{l s='Log me out' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Sign out' d='Shop.Theme.Actions'}</a></li>
+      {else}
+        <li><a href="{$urls.pages.guest_tracking}" title="{l s='Order tracking' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Order tracking' d='Shop.Theme.Customeraccount'}</a></li>
+        <li><a href="{$urls.pages.my_account}" title="{l s='Log in to your customer account' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Sign in' d='Shop.Theme.Actions'}</a></li>
+        <li><a href="{$urls.pages.register}" title="{l s='Create account' d='Shop.Theme.Customeraccount'}" rel="nofollow">{l s='Create account' d='Shop.Theme.Customeraccount'}</a></li>
+      {/if} 
 	</ul>
 </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  I provided some useful links to customers that either do not have an account or are not logged in. Linked to https://github.com/PrestaShop/ps_customeraccountlinks/pull/34.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24999
| How to test?      | Install related PR, install this PR and see footer.
| Possible impacts? | None, no variables deleted.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25064)
<!-- Reviewable:end -->
