### PR TITLE
In case multiple payment options are available

### DIFF
--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -71,7 +71,7 @@
           {if $option.form}
             {$option.form nofilter}
           {else}
-            <form id="payment-form" method="POST" action="{$option.action nofilter}">
+            <form id="payment-{$option.id}-form" method="POST" action="{$option.action nofilter}">
               {foreach from=$option.inputs item=input}
                 <input type="{$input.type}" name="{$input.name}" value="{$input.value}">
               {/foreach}


### PR DESCRIPTION
In case multiple payment options are available

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In case multiple payment options are available, the page will contain duplicate `payment-form` ID. Modify the ID name to make it different.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | 
| Fixed ticket?     | 
| How to test?      | Use multiple payment options, open FO checkout process, verify page contains multiple `payment-form` IDs
| Possible impacts? | If a module relies on this ID, it could not work anymore

## BC Break

Change of HTML ID `payment-form` to `payment-{$option.id}-form`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25069)
<!-- Reviewable:end -->
