### PR TITLE
Automatic update of rewrite url only on creation

### DIFF
--- a/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
+++ b/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const {$} = window;
+const { $ } = window;
 
 interface TextToLinkParams {
   sourceElementSelector: string;
@@ -66,12 +66,14 @@ interface TextToLinkParams {
 const textToLinkRewriteCopier = ({
   sourceElementSelector,
   destinationElementSelector,
-  options = {eventName: 'input'},
+  options = { eventName: 'input' },
 }: TextToLinkParams): void => {
   $(document).on(options.eventName, `${sourceElementSelector}`, (event) => {
-    $(destinationElementSelector).val(
-      window.str2url($(event.currentTarget).val(), 'UTF-8'),
-    );
+    if (!$(event.currentTarget).closest('form').data('id')) {
+      $(destinationElementSelector).val(
+        window.str2url($(event.currentTarget).val(), 'UTF-8'),
+      );
+    }
   });
 };
 

--- a/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
+++ b/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
@@ -69,7 +69,7 @@ const textToLinkRewriteCopier = ({
   options = {eventName: 'input'},
 }: TextToLinkParams): void => {
   $(document).on(options.eventName, `${sourceElementSelector}`, (event) => {
-    if (!$(event.currentTarget).closest('form').data('id')) {
+    if (!$(event.currentTarget).closest('form').data('objectId')) {
       $(destinationElementSelector).val(
         window.str2url($(event.currentTarget).val(), 'UTF-8'),
       );

--- a/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
+++ b/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
@@ -66,7 +66,7 @@ interface TextToLinkParams {
 const textToLinkRewriteCopier = ({
   sourceElementSelector,
   destinationElementSelector,
-  options = { eventName: 'input' },
+  options = {eventName: 'input'},
 }: TextToLinkParams): void => {
   $(document).on(options.eventName, `${sourceElementSelector}`, (event) => {
     if (!$(event.currentTarget).closest('form').data('id')) {

--- a/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
+++ b/admin-dev/themes/new-theme/js/components/text-to-link-rewrite-copier.ts
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const { $ } = window;
+const {$} = window;
 
 interface TextToLinkParams {
   sourceElementSelector: string;

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -225,7 +225,6 @@ class CmsPageController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Improve/Design/Cms/add.html.twig',
             [
-                'cmsPageId' => 0,
                 'cmsPageForm' => $form->createView(),
                 'cmsCategoryParentId' => $categoryParentId,
                 'enableSidebar' => true,

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -225,6 +225,7 @@ class CmsPageController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Improve/Design/Cms/add.html.twig',
             [
+                'cmsPageId' => 0,
                 'cmsPageForm' => $form->createView(),
                 'cmsCategoryParentId' => $categoryParentId,
                 'enableSidebar' => true,
@@ -300,6 +301,7 @@ class CmsPageController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Improve/Design/Cms/edit.html.twig',
             [
+                'cmsPageId' => $cmsPageId,
                 'cmsPageForm' => $form->createView(),
                 'cmsCategoryParentId' => $request->get('id_cms_category'),
                 'enableSidebar' => true,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -186,6 +186,7 @@ class CategoryController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/create.html.twig',
             [
+                'categoryId' => 0,
                 'allowMenuThumbnailsUpload' => true,
                 'categoryForm' => $categoryForm->createView(),
                 'defaultGroups' => $defaultGroups,
@@ -309,6 +310,7 @@ class CategoryController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/edit.html.twig',
             [
+                'categoryId' => $categoryId,
                 'allowMenuThumbnailsUpload' => $editableCategory->canContainMoreMenuThumbnails(),
                 'maxMenuThumbnails' => count(MenuThumbnailId::ALLOWED_ID_VALUES),
                 'contextLangId' => $this->getContextLangId(),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -186,7 +186,6 @@ class CategoryController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/create.html.twig',
             [
-                'categoryId' => 0,
                 'allowMenuThumbnailsUpload' => true,
                 'categoryForm' => $categoryForm->createView(),
                 'defaultGroups' => $defaultGroups,
@@ -236,7 +235,6 @@ class CategoryController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/create_root.html.twig',
             [
-                'categoryId' => 0,
                 'allowMenuThumbnailsUpload' => true,
                 'rootCategoryForm' => $rootCategoryForm->createView(),
                 'defaultGroups' => $defaultGroups,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -236,6 +236,7 @@ class CategoryController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/create_root.html.twig',
             [
+                'categoryId' => 0,
                 'allowMenuThumbnailsUpload' => true,
                 'rootCategoryForm' => $rootCategoryForm->createView(),
                 'defaultGroups' => $defaultGroups,
@@ -383,6 +384,7 @@ class CategoryController extends FrameworkBundleAdminController
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/edit_root.html.twig',
             [
+                'categoryId' => $categoryId,
                 'allowMenuThumbnailsUpload' => $editableCategory->canContainMoreMenuThumbnails(),
                 'maxMenuThumbnails' => count(MenuThumbnailId::ALLOWED_ID_VALUES),
                 'contextLangId' => $this->getContextLangId(),

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -25,7 +25,7 @@
 
 {% form_theme cmsPageForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
-{{ form_start(cmsPageForm, {'attr': {'data-id': cmsPageId}}) }}
+{{ form_start(cmsPageForm, {'attr': {'data-id': cmsPageId|default(0)}}) }}
   <div class="card">
     <div class="card-header">
       {{ 'Page'|trans({}, 'Admin.Shopparameters.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -25,7 +25,7 @@
 
 {% form_theme cmsPageForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
-{{ form_start(cmsPageForm) }}
+{{ form_start(cmsPageForm, {'attr': {'data-id': cmsPageId}}) }}
   <div class="card">
     <div class="card-header">
       {{ 'Page'|trans({}, 'Admin.Shopparameters.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -25,7 +25,7 @@
 
 {% form_theme cmsPageForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
-{{ form_start(cmsPageForm, {'attr': {'data-id': cmsPageId|default(0)}}) }}
+{{ form_start(cmsPageForm, {'attr': {'data-object-id': cmsPageId|default(0)}}) }}
   <div class="card">
     <div class="card-header">
       {{ 'Page'|trans({}, 'Admin.Shopparameters.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -26,7 +26,7 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block category_form_block %}
-{{ form_start(categoryForm) }}
+{{ form_start(categoryForm, {'attr': {'data-id': categoryId}}) }}
 <div class="card">
   <h3 class="card-header">
     {{ 'Category'|trans({}, 'Admin.Catalog.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -26,7 +26,7 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block category_form_block %}
-{{ form_start(categoryForm, {'attr': {'data-id': categoryId}}) }}
+{{ form_start(categoryForm, {'attr': {'data-id': categoryId|default(0)}}) }}
 <div class="card">
   <h3 class="card-header">
     {{ 'Category'|trans({}, 'Admin.Catalog.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -26,7 +26,7 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block category_form_block %}
-{{ form_start(categoryForm, {'attr': {'data-id': categoryId|default(0)}}) }}
+{{ form_start(categoryForm, {'attr': {'data-object-id': categoryId|default(0)}}) }}
 <div class="card">
   <h3 class="card-header">
     {{ 'Category'|trans({}, 'Admin.Catalog.Feature') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Automatic update of rewrite url only on creation to avoid SEO penalty of redirections on category and cms page
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25065
| How to test?      | Create a new category or cms page: rewrite is updated on every name change. Update a new category or cms page: the rewrite is not updated.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25075)
<!-- Reviewable:end -->
