### PR TITLE
Display customer groups in order detail

### DIFF
--- a/admin-dev/themes/new-theme/scss/config/_settings.scss
+++ b/admin-dev/themes/new-theme/scss/config/_settings.scss
@@ -15,7 +15,7 @@ $background-info: #dcf4f9;
 $purple: #34219e;
 $bright-status-text: #383838;
 $local-font: true;
-$info-block-background: #f8f8f8;
+$info-block-background: #f3f3f3;
 
 // Multishop
 $multishop-header-default-color: #383c43;

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -183,11 +183,11 @@
     .customer-groups .badge {
       padding: 0.45rem 0.6rem;
       margin: 0.1rem 0;
-      color: #6c868e;
       font-size: 0.875rem;
       font-weight: 600;
-      background: #fff;
       white-space: normal;
+      color: #6c868e;
+      background: #fff;
       @include border-radius(1000px);
       box-shadow: 1px 1px 2px #00000014;
     }

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -189,7 +189,6 @@
       white-space: normal;
       background: #fff;
       @include border-radius(1000px);
-      box-shadow: 1px 1px 2px #00000014;
     }
   }
 

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -179,6 +179,18 @@
     .badge-dark {
       font-size: 100%;
     }
+
+    .customer-groups .badge {
+      padding: 0.45rem 0.6rem;
+      margin: 0.1rem 0;
+      color: #6c868e;
+      font-size: 0.875rem;
+      font-weight: 600;
+      background: #fff;
+      white-space: normal;
+      @include border-radius(1000px);
+      box-shadow: 1px 1px 2px #00000014;
+    }
   }
 
   .order {

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -185,8 +185,8 @@
       margin: 0.1rem 0;
       font-size: 0.875rem;
       font-weight: 600;
-      white-space: normal;
       color: #6c868e;
+      white-space: normal;
       background: #fff;
       @include border-radius(1000px);
       box-shadow: 1px 1px 2px #00000014;

--- a/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderCustomerForViewing.php
@@ -96,6 +96,11 @@ class OrderCustomerForViewing
     private $languageId;
 
     /**
+     * @var array
+     */
+    private $groups;
+
+    /**
      * @param int $id
      * @param string $firstName
      * @param string $lastName
@@ -109,6 +114,7 @@ class OrderCustomerForViewing
      * @param int $languageId
      * @param string $ape
      * @param string $siret
+     * @param array $groups
      */
     public function __construct(
         int $id,
@@ -123,7 +129,8 @@ class OrderCustomerForViewing
         bool $isGuest,
         int $languageId,
         string $ape = '',
-        string $siret = ''
+        string $siret = '',
+        array $groups = []
     ) {
         $this->id = $id;
         $this->firstName = $firstName;
@@ -138,6 +145,7 @@ class OrderCustomerForViewing
         $this->languageId = $languageId;
         $this->ape = $ape;
         $this->siret = $siret;
+        $this->groups = $groups;
     }
 
     /**
@@ -242,5 +250,13 @@ class OrderCustomerForViewing
     public function getLanguageId(): int
     {
         return $this->languageId;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -44,9 +44,7 @@
 
               <strong class="text-muted ml-2">#{{ orderForViewing.customer.id }}</strong>
             </h2>
-            {% if orderForViewing.customer.isGuest %}
-              <strong class="text-muted">Guest</strong>
-            {% endif %}
+
           </div>
           <div id="viewFullDetails" class="col-xxl-5 text-xxl-right">
             <a class="d-print-none" href="{{ path('admin_customers_view', {'customerId': orderForViewing.customer.id }) }}">
@@ -59,6 +57,15 @@
           </div>
         {% endif %}
       </div>
+
+      {% if orderForViewing.customer.groups %}
+        <div class="customer-groups mt-2">
+          {% for group in orderForViewing.customer.groups %}
+            <span class="badge">{{ group }}</span>
+          {% endfor %}
+        </div>
+      {% endif %}
+
     </div>
     {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
       <div class="row mt-3">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR displays the customer groups on order page. In the same spot as "Guest" was displayed, under customer's name.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23116
| How to test?      | Make an order with registered customer and see order page in backoffice, with and without a PR.
| Possible impacts? | no

**Screenshot**
![customer groups](https://user-images.githubusercontent.com/6097524/143945733-9246a2e4-91af-417e-8817-4339caa2f5e4.JPG)

**Design spec**
Default group suffixed by (default), no group IDs.
https://github.com/PrestaShop/PrestaShop/issues/23116#issuecomment-883444007

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25080)
<!-- Reviewable:end -->
