### PR TITLE
Fix category create in product page

### DIFF
--- a/src/Core/Domain/Product/Command/AssignProductToCategoryCommand.php
+++ b/src/Core/Domain/Product/Command/AssignProductToCategoryCommand.php
@@ -24,8 +24,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-declare(strict_types=1);
-
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryConstraintException;

--- a/src/PrestaShopBundle/Controller/Admin/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CategoryController.php
@@ -99,7 +99,7 @@ class CategoryController extends FrameworkBundleAdminController
                     if ($request->query->has('id_product')) {
                         $assignProductToCategoryCommand = new AssignProductToCategoryCommand(
                             $categoryId->getValue(),
-                            $request->query->get('id_product')
+                            $request->query->getInt('id_product')
                         );
                         $commandBus->handle($assignProductToCategoryCommand);
                     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | See issue ticket. Issues comes from 2 things: 1) a type mismatch and 2) a `declare(strict_types=1);` added to a 1.7.7 file (=> BC break). The PR fixes the type mismatch and remove the `declare(strict_types=1);`
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25081 & Fixes #22144
| How to test?      | see issue ticket.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25082)
<!-- Reviewable:end -->
