### PR TITLE
Kick border radius of the middle button of search bar

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -2,7 +2,7 @@ $header-text-color: #4e6167 !default;
 
 .main-header {
   position: fixed;
-  z-index: 1040; // modal backdrop's z-index is 1050, so this must be just below that
+  z-index: 1040; // modal backdrop"s z-index is 1050, so this must be just below that
   display: flex;
   align-items: stretch;
   width: 100%;
@@ -155,6 +155,12 @@ $header-text-color: #4e6167 !default;
         @include transition(all 0.5s);
       }
 
+      .input-group-append {
+        .btn:first-of-type {
+          @include border-radius(0);
+        }
+      }
+
       // behavior when the search form is collapsed
       &.collapsed {
         width: 15.625rem;
@@ -178,7 +184,7 @@ $header-text-color: #4e6167 !default;
           padding: 0;
           overflow: hidden;
           border: 0;
-          // we can't use display:none or else the transition doesn't work
+          // we can"t use display:none or else the transition doesn"t work
           opacity: 0;
         }
       }
@@ -264,7 +270,7 @@ $header-text-color: #4e6167 !default;
   #header-search-container {
     .dropdown-toggle {
       &::after {
-        font-size: 1.6em; // use of em so that the size is relative to the component's font size
+        font-size: 1.6em; // use of em so that the size is relative to the component"s font size
         content: "arrow_drop_down";
       }
     }

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -2,7 +2,7 @@ $header-text-color: #4e6167 !default;
 
 .main-header {
   position: fixed;
-  z-index: 1040; // modal backdrop"s z-index is 1050, so this must be just below that
+  z-index: 1040; // modal backdrop's z-index is 1050, so this must be just below that
   display: flex;
   align-items: stretch;
   width: 100%;
@@ -184,7 +184,7 @@ $header-text-color: #4e6167 !default;
           padding: 0;
           overflow: hidden;
           border: 0;
-          // we can"t use display:none or else the transition doesn"t work
+          // we can't use display:none or else the transition doesn't work
           opacity: 0;
         }
       }
@@ -270,7 +270,7 @@ $header-text-color: #4e6167 !default;
   #header-search-container {
     .dropdown-toggle {
       &::after {
-        font-size: 1.6em; // use of em so that the size is relative to the component"s font size
+        font-size: 1.6em; // use of em so that the size is relative to the component's font size
         content: "arrow_drop_down";
       }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There was an unwanted border radius on the middle button of the search bar when it's opened
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go on a migrated page, open the search bar at the top and see if the dropdown button don't have any border radius on right side
| Possible impacts? | search bar

# Before
![image](https://user-images.githubusercontent.com/14963751/122948965-95a52b80-d37b-11eb-84ad-f792bf40b24f.png)

# After
![image](https://user-images.githubusercontent.com/14963751/122949331-dbfa8a80-d37b-11eb-94d4-757a6a82c6e3.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25085)
<!-- Reviewable:end -->
