### PR TITLE
Fix form label alignment, switch precision and alignment

### DIFF
--- a/admin-dev/themes/default/scss/partials/_switch-btn.scss
+++ b/admin-dev/themes/default/scss/partials/_switch-btn.scss
@@ -3,7 +3,7 @@
   position: relative;
   display: block;
   width: 100%;
-  height: 21px;
+  height: 22px;
   margin-top: 7px;
 
   &-nolabel {
@@ -18,6 +18,7 @@
     left: 0;
     z-index: 1;
     padding-left: 45px;
+    margin: 0;
     font-size: 14px;
     font-weight: 500;
     opacity: 0;
@@ -25,27 +26,25 @@
   }
 
   .slide-button {
-    position: relative;
     position: absolute;
-    top: 50%;
+    top: 0;
     z-index: 0;
     display: block;
-    width: 35px;
-    height: 21px;
+    width: 36px;
+    height: 22px;
     background: #b3c7cd;
-    transform: translateY(-50%);
+    border: 0;
     @include transition(0.25s ease-out);
     @include border-radius(1000px);
 
     &::after {
       position: absolute;
-      top: 50%;
-      left: 0;
-      width: 50%;
-      height: calc(100% - 2px);
+      top: 2px;
+      left: 2px;
+      width: 18px;
+      height: 18px;
       content: "";
       background: #fff;
-      transform: translate(1px, -48%);
       @include border-radius(50%);
       @include transition(0.25s ease-out);
     }
@@ -64,6 +63,7 @@
     z-index: 3;
     width: 100%;
     height: 100%;
+    margin: 0;
     cursor: pointer;
     opacity: 0;
 
@@ -106,7 +106,7 @@
         background: $brand-success;
 
         &::after {
-          transform: translate(15px, -48%);
+          transform: translateX(14px);
         }
       }
     }

--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -63,9 +63,6 @@
         text-align: right;
       }
 
-      @include media-breakpoint-down("sm") {
-        padding-left: 0;
-      }
     }
 
     &.type-hidden {
@@ -84,9 +81,9 @@
   }
 
   // make ps-switch align with label
-  .ps-switch:not(.ps-switch-lg) {
+  span.ps-switch:not(.ps-switch-lg) {
     @include media-breakpoint-up("sm") {
-      margin-top: 5px;
+      margin-top: 7px;
     }
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes #25063 - do not close
| How to test?      | Apply PR and check the difference in forms.
| Possible impacts? | None.

Switches in modern forms are done in related PR for UI Kit- https://github.com/PrestaShop/prestashop-ui-kit/pull/162.

**Desktop symfony form**
Fixed switch alignment with the label.
![desktop_symfony](https://user-images.githubusercontent.com/6097524/122956254-22061d00-d381-11eb-80b5-4490d51c3309.JPG)

**Mobile symfony form**
Fixed overflowing label.
![mobile_symfony](https://user-images.githubusercontent.com/6097524/122956286-29c5c180-d381-11eb-945e-64e391b529f2.JPG)

**Legacy form switches**
Fixed switch alignment and an issue where top few pixels in all switches were not clickable, due to input behind being moved down.
![switch_legacy](https://user-images.githubusercontent.com/6097524/122956351-364a1a00-d381-11eb-9f98-56ae238c5c13.JPG)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25087)
<!-- Reviewable:end -->
