### PR TITLE
Fixed replaced image in product page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -494,7 +494,8 @@
           const imageElement = document.querySelector(
             DropzoneMap.savedImage(newImage.image_id),
           );
-          imageElement.src = newImage.image_url;
+          const imageUpdateTime = new Date();
+          imageElement.src = `${newImage.image_url}?${imageUpdateTime.getTime()}`;
 
           $.growl({message: this.$t('window.imageReplaced')});
           this.buttonLoading = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | with this small code trick ,we can change the replaced image to the newest one immediately the time after the image ajax replaced without the page refresh or reload. **This pull request have been discussed here https://github.com/PrestaShop/PrestaShop/pull/24983, but because I have pull to a wrong version, so I submit this pull request here to develop version.**
| Type?             | improvement
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #20035.
| How to test?      | Just clear your caches and refresh your product v2 page, and try to replace an image.
| Possible impacts? | small change, no other impact.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25089)
<!-- Reviewable:end -->
