### PR TITLE
Display customer group when searching for a customer

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-map.ts
@@ -47,6 +47,7 @@ export default {
   notSelectedCustomerSearchResults: '.js-customer-search-result:not(.border-success)',
   customerSearchResultName: '.js-customer-name',
   customerSearchResultEmail: '.js-customer-email',
+  customerSearchResultGroups: '.js-customer-groups',
   customerSearchResultId: '.js-customer-id',
   customerSearchResultBirthday: '.js-customer-birthday',
   customerSearchResultCompany: '.js-customer-company',

--- a/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
@@ -97,7 +97,7 @@ export default class CustomerRenderer {
 
         Object.values(customerResult.groups).forEach((customerGroup) => {
           if (customerGroup.default === true) {
-            output.push(`${customerGroup.name} -  ${window.translate_javascripts['Customer search - group default']}`);
+            output.push(`${customerGroup.name} - ${window.translate_javascripts['Customer search - group default']}`);
           } else {
             output.push(customerGroup.name);
           }

--- a/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/customer-renderer.ts
@@ -97,7 +97,7 @@ export default class CustomerRenderer {
 
         Object.values(customerResult.groups).forEach((customerGroup) => {
           if (customerGroup.default === true) {
-            output.push(`${customerGroup.name} - ${window.translate_javascripts['Customer search - group default']}`);
+            output.push(`${customerGroup.name} (${window.translate_javascripts['Customer search - group default']})`);
           } else {
             output.push(customerGroup.name);
           }

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -868,13 +868,15 @@ class CustomerCore extends ObjectModel
      */
     public static function searchByName($query, $limit = null)
     {
-        $sql = 'SELECT *
-                FROM `' . _DB_PREFIX_ . 'customer`
+        $sql = "SELECT c.*, 
+                GROUP_CONCAT(cg.id_group SEPARATOR ',') AS group_ids 
+                FROM `" . _DB_PREFIX_ . 'customer` c
+                LEFT JOIN `' . _DB_PREFIX_ . 'customer_group` cg ON c.id_customer = cg.id_customer
                 WHERE 1';
         $search_items = explode(' ', $query);
-        $research_fields = ['id_customer', 'firstname', 'lastname', 'email'];
+        $research_fields = ['c.id_customer', 'c.firstname', 'c.lastname', 'c.email'];
         if (Configuration::get('PS_B2B_ENABLE')) {
-            $research_fields[] = 'company';
+            $research_fields[] = 'c.company';
         }
 
         $items = [];
@@ -889,6 +891,8 @@ class CustomerCore extends ObjectModel
         }
 
         $sql .= Shop::addSqlRestriction(Shop::SHARE_CUSTOMER);
+
+        $sql .= ' GROUP BY c.id_customer ';
 
         if ($limit) {
             $sql .= ' LIMIT 0, ' . (int) $limit;

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -868,9 +868,9 @@ class CustomerCore extends ObjectModel
      */
     public static function searchByName($query, $limit = null)
     {
-        $sql = "SELECT c.*, 
-                GROUP_CONCAT(cg.id_group SEPARATOR ',') AS group_ids 
-                FROM `" . _DB_PREFIX_ . 'customer` c
+        $sql = 'SELECT c.*, 
+                GROUP_CONCAT(cg.id_group SEPARATOR \',\') AS group_ids 
+                FROM `' . _DB_PREFIX_ . 'customer` c
                 LEFT JOIN `' . _DB_PREFIX_ . 'customer_group` cg ON c.id_customer = cg.id_customer
                 WHERE 1';
         $search_items = explode(' ', $query);

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -121,8 +121,8 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
                     foreach ($group_ids as $id_group) {
                         $customerArray['groups'][$id_group] = [
                             'id_group' => $id_group,
-                            'name' => (isset($groupNames[$id_group]) ? $groupNames[$id_group] : ''),
-                            'default' => ($id_group == $customerArray['id_default_group'] ? true : false),
+                            'name' => $groupNames[$id_group]) ?? '',
+                            'default' => $id_group == $customerArray['id_default_group'],
                         ];
                     }
                 }

--- a/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
+++ b/src/Adapter/Customer/QueryHandler/SearchCustomersHandler.php
@@ -121,7 +121,7 @@ final class SearchCustomersHandler implements SearchCustomersHandlerInterface
                     foreach ($group_ids as $id_group) {
                         $customerArray['groups'][$id_group] = [
                             'id_group' => $id_group,
-                            'name' => $groupNames[$id_group]) ?? '',
+                            'name' => $groupNames[$id_group] ?? '',
                             'default' => $id_group == $customerArray['id_default_group'],
                         ];
                     }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
@@ -87,6 +87,8 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\QueryHandler\SearchCustomersHandler'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@translator'
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -155,6 +155,7 @@
         {% if isB2BEnabled %}
           <p class="mb-0 js-customer-company"></p>
         {% endif %}
+        <p class="mb-0 js-customer-groups"></p>
       </div>
       <div class="card-footer">
         <a class="btn btn-outline-secondary js-details-customer-btn">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
@@ -49,3 +49,10 @@
 
   <script src="{{ asset('themes/new-theme/public/order_create.bundle.js') }}"></script>
 {% endblock %}
+
+{% set js_translatable = {
+  "Customer search - group default": 'default'|trans({}, 'Admin.Orderscustomers.Feature'),
+  "Customer search - group label single": 'Group'|trans({}, 'Admin.Orderscustomers.Feature'),
+  "Customer search - group label multiple": 'Groups'|trans({}, 'Admin.Orderscustomers.Feature'),
+}|merge(js_translatable)
+%}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR displays customer groups when searching for a customer on create order page. Allows to better distinguish between customer accounts. Default group is suffixed with " - default".
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23116 - do not close, still work to do
| How to test?      | Apply PR and go make a new order, you will see customer group under his email.
| Possible impacts? | -

**Screenshot:**
![Výstřižek](https://user-images.githubusercontent.com/6097524/140312423-7e54e06f-7d9b-450a-8414-ed076a290685.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25091)
<!-- Reviewable:end -->
