### PR TITLE
Remove precision type for currency

### DIFF
--- a/src/Core/Localization/Currency.php
+++ b/src/Core/Localization/Currency.php
@@ -89,7 +89,7 @@ class Currency implements CurrencyInterface
     /**
      * Number of decimal digits to use with this currency.
      *
-     * @var int
+     * @var int|null
      */
     protected $precision;
 
@@ -137,7 +137,7 @@ class Currency implements CurrencyInterface
         $this->isoCode = $isoCode;
         $this->numericIsoCode = $numericIsoCode;
         $this->symbols = $symbols;
-        $this->precision = $precision;
+        $this->precision = (int) $precision;
         $this->names = $names;
         $this->patterns = $patterns;
     }

--- a/src/Core/Localization/Currency.php
+++ b/src/Core/Localization/Currency.php
@@ -89,7 +89,7 @@ class Currency implements CurrencyInterface
     /**
      * Number of decimal digits to use with this currency.
      *
-     * @var int|null
+     * @var int
      */
     protected $precision;
 

--- a/src/Core/Localization/Currency/CurrencyData.php
+++ b/src/Core/Localization/Currency/CurrencyData.php
@@ -242,7 +242,7 @@ class CurrencyData
      */
     public function setPrecision($precision)
     {
-        $this->precision = $precision;
+        $this->precision = (int) $precision;
     }
 
     /**

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -107,7 +107,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            $this->getMinFractionDigits($positivePattern),
+            $currency->getDecimalPrecision() ?: $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because $precision is not typehinted, you can pass whatever value you like. So we remove the attribute type to reflect this
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | Retest https://github.com/PrestaShop/PrestaShop/pull/24320


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25098)
<!-- Reviewable:end -->
