### PR TITLE
Fix compiled legacy container

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -134,6 +134,11 @@ class ContainerBuilder
         if (null === $container) {
             $container = $this->compileContainer();
         }
+
+        // synthetic definitions can't be compiled
+        $container->set('shop', $container->get('context')->shop);
+        $container->set('employee', $container->get('context')->employee);
+
         $this->loadModulesAutoloader($container);
 
         return $container;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The way the front container is build makes services unavailable once the container is cached. This PR fixes it.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25112
| How to test?      | See below
| Possible impacts? | 

### How to test

In a front controller (`IndexController.php` for instance), try to get one of the following services: 
- `configuration`
- `context`
- `db`
- `shop`
- `employee`

```php
$container = ContainerBuilder::getContainer('front', true);
$entityManager = $container->get('shop');
```

With the cache cleared (`rm -rf var/cache/*`), you shouldn't have an exception, if you refresh the page, you shouldn't have an exception either.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25111)
<!-- Reviewable:end -->
