### PR TITLE
Do not display a voucher if its total is zero, tax incl - Cart page and Order page

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -32,6 +32,7 @@ use Configuration;
 use Context;
 use Country;
 use Hook;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
@@ -585,7 +586,7 @@ class CartPresenter implements PresenterInterface
             }
 
             // Avoid display of a voucher if its total is equal to zero tax included
-            if (0 == $totalCartVoucherReduction) {
+            if ((new DecimalNumber((string) $totalCartVoucherReduction))->equalsZero()) {
                 unset($vouchers[$cartVoucher['id_cart_rule']]);
                 continue;
             }

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -584,6 +584,12 @@ class CartPresenter implements PresenterInterface
                 $totalCartVoucherReduction = $this->includeTaxes() ? $cartVoucher['value_real'] : $cartVoucher['value_tax_exc'];
             }
 
+            // Avoid display of a voucher if its total is equal to zero tax included
+            if (0 == $totalCartVoucherReduction) {
+                unset($vouchers[$cartVoucher['id_cart_rule']]);
+                continue;
+            }
+
             // when a voucher has only a shipping reduction, the value displayed must be "Free Shipping"
             if ($freeShippingOnly) {
                 $cartVoucher['reduction_formatted'] = $this->translator->trans(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See paragraph below.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no 
| Deprecations?     | no
| Fixed ticket?     | Fixes #15224
| How to test?      | See paragraph below
| Possible impacts? | I don't see any.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25122)
<!-- Reviewable:end -->

**Description**
In FO cart page and FO order page, if a voucher total is equal to zero, then the voucher line is displayed with "-0.00 $" value.

This can happen for many reasons. For instance, when the product selected as gift is deleted (the case described by #15224)

To avoid this, in `Presenter`, I unset the voucher from the list of vouchers if its total is equal to zero.

**How to test:** ( @Hlavtox wrote a part of this)
    Make a cart rule with following specs:
    * Cart rule with unlimited users, unlimited groups.
    * Cart rule without a code
    * Cart rule that gives a free product to every order above X amount, select any product.
    Go to BO > Products. Delete the product you gave free as a gift.
    Go to front office.
    Buy on shop products with amount > X
    See that there is no gift product but also NO VOUCHER displayed (Before there were "-0.00 $" )



