### PR TITLE
add bootstrap colorpicker helper to prestashop component

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -38,6 +38,7 @@ import PreviewOpener from '@components/form/preview-opener';
 import MultistoreConfigField from '@js/components/form/multistore-config-field';
 import {EventEmitter} from '@components/event-emitter';
 import Router from '@components/router';
+import ColorPicker from '@js/app/utils/colorpicker';
 
 const initPrestashopComponents = () => {
   window.prestashop = {...window.prestashop};
@@ -95,6 +96,7 @@ const initPrestashopComponents = () => {
     MultistoreConfigField,
     PreviewOpener,
     Router,
+    ColorPicker,
   };
 };
 export default initPrestashopComponents;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Makes bootstrap color picker helper available from `window.prestashop.component` 
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25129
| How to test?      | See steps in the issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25130)
<!-- Reviewable:end -->
