### PR TITLE
Fix the path of the "form_warehouse_combination"

### DIFF
--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -153,7 +153,7 @@
 <div class="col-md-12">
   <div id="warehouse_combination_collection" class="col-md-12 form-group" data-url="{{ path('admin_warehouse_refresh_product_warehouse_combination_form') }}">
     {% if asm_globally_activated and isNotVirtual and isChecked %}
-      {{ include('@PrestaShop/Admin:Product/ProductPage/Forms/form_warehouse_combination.html.twig', { 'warehouses': warehouses, 'form': form }) }}
+      {{ include('@PrestaShop/Admin/Product/ProductPage/Forms/form_warehouse_combination.html.twig', { 'warehouses': warehouses, 'form': form }) }}
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Repair the path of the "form_warehouse_combination" template twig
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/16695
| How to test?      | The template is displayed and no more back-office crashes
| Possible impacts? | Stock product with warehouses


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25139)
<!-- Reviewable:end -->
