### PR TITLE
Fix selectors map not being set in experimental product combinations page

### DIFF
--- a/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
+++ b/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
@@ -116,34 +116,6 @@ export default class DynamicPaginator {
   }
 
   /**
-   * Initiates the pagination component
-   *
-   * @private
-   */
-  private init(): void {
-    this.$paginationContainer.on('click', this.selectorsMap.pageLink, (e) => {
-      this.paginate(Number($(e.currentTarget).data('page')));
-    });
-    this.$paginationContainer
-      .find(this.selectorsMap.jumpToPageInput)
-      .keypress((e) => {
-        if (e.which === 13) {
-          e.preventDefault();
-          const input = <HTMLInputElement>e.currentTarget;
-          const page = this.getValidPageNumber(Number(input.value));
-          this.paginate(page);
-        }
-      });
-    this.$paginationContainer.on(
-      'change',
-      this.selectorsMap.limitSelect,
-      () => {
-        this.paginate(1);
-      },
-    );
-  }
-
-  /**
    * @param {Number} page
    */
   async paginate(page: number): Promise<void> {
@@ -179,12 +151,42 @@ export default class DynamicPaginator {
   }
 
   /**
+   * Initiates the pagination component
+   *
+   * @private
+   */
+  private init(): void {
+    this.$paginationContainer.on('click', this.selectorsMap.pageLink, (e) => {
+      this.paginate(Number($(e.currentTarget).data('page')));
+    });
+    this.$paginationContainer
+      .find(this.selectorsMap.jumpToPageInput)
+      .keypress((e) => {
+        if (e.which === 13) {
+          e.preventDefault();
+          const input = <HTMLInputElement>e.currentTarget;
+          const page = this.getValidPageNumber(Number(input.value));
+          this.paginate(page);
+        }
+      });
+    this.$paginationContainer.on(
+      'change',
+      this.selectorsMap.limitSelect,
+      () => {
+        this.paginate(1);
+      },
+    );
+  }
+
+  /**
    * @param page
    * @param limit
    *
    * @returns {Number}
+   *
+   * @private
    */
-  calculateOffset(page: number, limit: number): number {
+  private calculateOffset(page: number, limit: number): number {
     return (page - 1) * limit;
   }
 
@@ -193,7 +195,7 @@ export default class DynamicPaginator {
    *
    * @private
    */
-  refreshButtonsData(page: number): void {
+  private refreshButtonsData(page: number): void {
     this.$paginationContainer
       .find(this.selectorsMap.nextPageBtn)
       .data('page', page + 1);
@@ -208,8 +210,10 @@ export default class DynamicPaginator {
   /**
    * @param {Number} page
    * @param {Number} total
+   *
+   * @private
    */
-  refreshInfoLabel(page: number, total: number): void {
+  private refreshInfoLabel(page: number, total: number): void {
     const infoLabel = this.$paginationContainer.find(
       this.selectorsMap.paginationInfoLabel,
     );
@@ -272,12 +276,13 @@ export default class DynamicPaginator {
   }
 
   /**
-   *
    * @param page
    *
    * @returns {Number}
+   *
+   * @private
    */
-  getValidPageNumber(page: number): number {
+  private getValidPageNumber(page: number): number {
     if (page > this.pagesCount) {
       return this.pagesCount;
     }
@@ -291,14 +296,10 @@ export default class DynamicPaginator {
 
   /**
    * @param {Object} selectorsMap
+   *
+   * @private
    */
-  setSelectorsMap(selectorsMap: Record<string, string>): void {
-    if (selectorsMap) {
-      this.selectorsMap = selectorsMap;
-
-      return;
-    }
-
+  private setSelectorsMap(selectorsMap: Record<string, string>): void {
     this.selectorsMap = {
       jumpToPageInput: 'input[name="paginator-jump-page"]',
       firstPageBtn: 'button.page-link.first',
@@ -312,6 +313,8 @@ export default class DynamicPaginator {
       pageLink: 'button.page-link',
       limitSelect: '#paginator-limit',
       paginationInfoLabel: '#pagination-info',
+      //override with custom selectors if any provided
+      ...selectorsMap,
     };
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When refactored js to typescript, one little bug was introduced. Selectors map was not set, this caused combinations page not loading at all (see screenshots before after)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Go to experimental product page -> combinations tab -> you should see combinations page loaded as expected. (refer to screenshots bellow)
| Possible impacts? |

Screenshots:
**before:** 
![Screenshot from 2021-06-29 11-59-14](https://user-images.githubusercontent.com/31609858/123775298-edd9b180-d8d6-11eb-82d3-99ccb3b22a5f.png)
![Screenshot from 2021-06-29 12-18-22](https://user-images.githubusercontent.com/31609858/123775309-f03c0b80-d8d6-11eb-9f34-a84f04bcd5ef.png)

**After:**
![Screenshot from 2021-06-29 12-22-07](https://user-images.githubusercontent.com/31609858/123775355-faf6a080-d8d6-11eb-93b7-be2225bfaa87.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25152)
<!-- Reviewable:end -->
