### PR TITLE
Make color picker global in back office

### DIFF
--- a/admin-dev/themes/new-theme/js/app/utils/init-components.js
+++ b/admin-dev/themes/new-theme/js/app/utils/init-components.js
@@ -39,6 +39,7 @@ import MultistoreConfigField from '@js/components/form/multistore-config-field';
 import {EventEmitter} from '@components/event-emitter';
 import Grid from '@components/grid/grid';
 import Router from '@components/router';
+import ColorPicker from '@js/app/utils/colorpicker';
 
 // Grid extensions
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
@@ -137,6 +138,7 @@ const initPrestashopComponents = () => {
     Grid,
     GridExtensions,
     Router,
+    ColorPicker,
   };
 };
 export default initPrestashopComponents;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make colorpicker globally accessible through prestashop component
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes: #25129
| How to test?      | to be tested by a developer: see below 
| Possible impacts? | none
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

# How to test (by a developer):

- In a form type, add a field of type `ColorPickerType`
- Check that the field appears on the page
- In js, call the color picker via `window.prestashop.component.initComponents`:

```
window.prestashop.component.initComponents(
    [
        'ColorPicker'
    ],
);
new window.prestashop.component.ColorPicker();

```

- Then check that the color picker appears when you click on the field

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25153)
<!-- Reviewable:end -->
