### PR TITLE
Cart rule category selection : display categories in a hierarchical way

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -525,7 +525,7 @@ class AdminCartRulesControllerCore extends AdminController
         return $this->createTemplate('product_rule.tpl')->fetch();
     }
 
-    public function populateCategories($flatCategories, $currentCategoryTree, $currentPath = ''): array
+    public function populateCategories(array $flatCategories, array $currentCategoryTree, string $currentPath = ''): array
     {
         if (!$currentCategoryTree) {
             return $flatCategories;

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -505,10 +505,9 @@ class AdminCartRulesControllerCore extends AdminController
                 break;
             case 'categories':
                 $categories = ['selected' => [], 'unselected' => []];
-                $flatCategories = [];
                 $categoryTree = Category::getNestedCategories(Category::getRootCategory()->id, (int) Context::getContext()->language->id, false);
 
-                $flatCategories = $this->populateCategories($flatCategories, $categoryTree);
+                $flatCategories = $this->populateCategories([], $categoryTree);
 
                 foreach ($flatCategories as $row) {
                     $categories[in_array($row['id'], $selected) ? 'selected' : 'unselected'][] = $row;

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -508,7 +508,7 @@ class AdminCartRulesControllerCore extends AdminController
                 $flatCategories = [];
                 $categoryTree = Category::getNestedCategories(Category::getRootCategory()->id, (int) Context::getContext()->language->id, false);
 
-                $this->populateCategories($flatCategories, $categoryTree);
+                $flatCategories = $this->populateCategories($flatCategories, $categoryTree);
 
                 foreach ($flatCategories as $row) {
                     $categories[in_array($row['id'], $selected) ? 'selected' : 'unselected'][] = $row;
@@ -526,10 +526,10 @@ class AdminCartRulesControllerCore extends AdminController
         return $this->createTemplate('product_rule.tpl')->fetch();
     }
 
-    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = ''): void
+    public function populateCategories($flatCategories, $currentCategoryTree, $currentPath = ''): array
     {
         if (!$currentCategoryTree) {
-            return;
+            return $flatCategories;
         }
 
         $separator = ' > ';
@@ -538,9 +538,11 @@ class AdminCartRulesControllerCore extends AdminController
             $flatCategories[] = ['id' => $categoryArray['id_category'], 'name' => $fullName];
             // recursive call for childrens
             if (!empty($categoryArray['children'])) {
-                $this->populateCategories($flatCategories, $categoryArray['children'], $fullName);
+                $flatCategories = $this->populateCategories($flatCategories, $categoryArray['children'], $fullName);
             }
         }
+
+        return $flatCategories;
     }
 
     public function ajaxProcess()

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -531,7 +531,7 @@ class AdminCartRulesControllerCore extends AdminController
         if (!$currentCategoryTree) {
             return;
         }
-        
+
         $separator = ' > ';
         foreach ($currentCategoryTree as $categoryArray) {
             $fullName = ($currentPath ? $currentPath . $separator : '') . $categoryArray['name'];

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -528,8 +528,11 @@ class AdminCartRulesControllerCore extends AdminController
 
     public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = '')
     {
-        $separator = ' > ';
         if ($currentCategoryTree) {
+            return;
+        }
+        
+        $separator = ' > ';
             foreach ($currentCategoryTree as $categoryArray) {
                 $fullName = ($currentPath ? $currentPath . $separator : '') . $categoryArray['name'];
                 $flatCategories[] = ['id' => $categoryArray['id_category'], 'name' => $fullName];

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -526,10 +526,11 @@ class AdminCartRulesControllerCore extends AdminController
         return $this->createTemplate('product_rule.tpl')->fetch();
     }
 
-    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = '') {
+    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = '') 
+    {
         $separator = ' > ';
         if ($currentCategoryTree) {
-            foreach($currentCategoryTree as $categoryArray) {
+            foreach ($currentCategoryTree as $categoryArray) {
                 $fullName = ($currentPath?$currentPath.$separator:''). $categoryArray['name'];
                 $flatCategories[] = ['id' => $categoryArray['id_category'], 'name' => $fullName];
                 // reccursive call for childrens

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -526,12 +526,12 @@ class AdminCartRulesControllerCore extends AdminController
         return $this->createTemplate('product_rule.tpl')->fetch();
     }
 
-    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = '') 
+    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = '')
     {
         $separator = ' > ';
         if ($currentCategoryTree) {
             foreach ($currentCategoryTree as $categoryArray) {
-                $fullName = ($currentPath?$currentPath.$separator:''). $categoryArray['name'];
+                $fullName = ($currentPath ? $currentPath . $separator : '') . $categoryArray['name'];
                 $flatCategories[] = ['id' => $categoryArray['id_category'], 'name' => $fullName];
                 // reccursive call for childrens
                 if (!empty($categoryArray['children'])) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -526,20 +526,19 @@ class AdminCartRulesControllerCore extends AdminController
         return $this->createTemplate('product_rule.tpl')->fetch();
     }
 
-    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = '')
+    public function populateCategories(&$flatCategories, $currentCategoryTree, $currentPath = ''): void
     {
-        if ($currentCategoryTree) {
+        if (!$currentCategoryTree) {
             return;
         }
         
         $separator = ' > ';
-            foreach ($currentCategoryTree as $categoryArray) {
-                $fullName = ($currentPath ? $currentPath . $separator : '') . $categoryArray['name'];
-                $flatCategories[] = ['id' => $categoryArray['id_category'], 'name' => $fullName];
-                // reccursive call for childrens
-                if (!empty($categoryArray['children'])) {
-                    $this->populateCategories($flatCategories, $categoryArray['children'], $fullName);
-                }
+        foreach ($currentCategoryTree as $categoryArray) {
+            $fullName = ($currentPath ? $currentPath . $separator : '') . $categoryArray['name'];
+            $flatCategories[] = ['id' => $categoryArray['id_category'], 'name' => $fullName];
+            // recursive call for childrens
+            if (!empty($categoryArray['children'])) {
+                $this->populateCategories($flatCategories, $categoryArray['children'], $fullName);
             }
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In cart rule page, in product restriction, the categories are now displayed in a hierarchical way : <br>Wines > White, Biers > White. Actually you have 2 White categories and no way to figure it out.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25168
| How to test?      | add a category restriction
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25169)
<!-- Reviewable:end -->

Here is how it's displayed
![image](https://user-images.githubusercontent.com/16720275/123935717-c3e6c480-d994-11eb-996b-ae82689dfadb.png)
