### PR TITLE
Fill file name and line when exporting translation catalogues

### DIFF
--- a/src/Core/Translation/Builder/Map/Message.php
+++ b/src/Core/Translation/Builder/Map/Message.php
@@ -52,6 +52,11 @@ class Message
      */
     private $userTranslation;
 
+    /**
+     * @var array
+     */
+    private $metadata;
+
     public function __construct(string $defaultTranslation)
     {
         $this->defaultTranslation = $defaultTranslation;
@@ -72,6 +77,18 @@ class Message
     public function setUserTranslation(string $userTranslation): self
     {
         $this->userTranslation = $userTranslation;
+
+        return $this;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function setMetadata(array $metadata): self
+    {
+        $this->metadata = $metadata;
 
         return $this;
     }

--- a/src/Core/Translation/Builder/Map/Message.php
+++ b/src/Core/Translation/Builder/Map/Message.php
@@ -55,7 +55,7 @@ class Message
     /**
      * @var array
      */
-    private $metadata;
+    private $metadata = [];
 
     public function __construct(string $defaultTranslation)
     {

--- a/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
+++ b/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
@@ -190,6 +190,7 @@ class TranslationCatalogueBuilder
             foreach ($messages as $translationKey => $translationValue) {
                 $translationKey = (string) $translationKey;
                 $message = new Message($translationKey);
+                $message->setMetadata($defaultCatalogue->getMetadata($translationKey, $domainName) ?? []);
                 if ($fileTranslatedCatalogue->defines($translationKey, $domainName)) {
                     $message->setFileTranslation($fileTranslatedCatalogue->get($translationKey, $domainName));
                 }

--- a/src/Core/Translation/Export/TranslationCatalogueExporter.php
+++ b/src/Core/Translation/Export/TranslationCatalogueExporter.php
@@ -184,7 +184,8 @@ class TranslationCatalogueExporter
             $domainName = $domain->getDomainName();
             foreach ($domain->getMessages() as $message) {
                 $messageCatalogue->set($message->getKey(), $message->getTranslation(), $domainName);
-                $messageCatalogue->setMetadata($message->getKey(), ['file' => '', 'line' => ''], $domainName);
+                $metadata = $message->getMetadata();
+                $messageCatalogue->setMetadata($message->getKey(), ['file' => $metadata['file'] ?? '', 'line' => $metadata['line'] ?? ''], $domainName);
             }
         }
 

--- a/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
+++ b/src/Core/Translation/Storage/Extractor/LegacyModuleExtractor.php
@@ -139,6 +139,22 @@ final class LegacyModuleExtractor implements LegacyModuleExtractorInterface
 
         unset($allWordings[$defaultDomain]);
 
-        return new MessageCatalogue($extractedCatalogue->getLocale(), $allWordings);
+        $newMessageCatalogue = new MessageCatalogue($extractedCatalogue->getLocale(), $allWordings);
+        foreach ($allWordings as $domain => $messages) {
+            foreach ($messages as $key => $message) {
+                $metadata = $extractedCatalogue->getMetadata($key, $domain);
+                if (null === $metadata && $domain === $newDomain) {
+                    $metadata = $extractedCatalogue->getMetadata($key, $defaultDomain);
+                }
+
+                $newMessageCatalogue->setMetadata(
+                    $key,
+                    $metadata,
+                    $domain
+                );
+            }
+        }
+
+        return $newMessageCatalogue;
     }
 }

--- a/src/Core/Translation/Storage/Finder/TranslationFinder.php
+++ b/src/Core/Translation/Storage/Finder/TranslationFinder.php
@@ -132,6 +132,8 @@ class TranslationFinder
                 $messageCatalogue->addCatalogue(
                     $this->removeTrailingLocaleFromDomains($fileCatalogue)
                 );
+
+                $messageCatalogue = $this->updateCatalogueMetadata($messageCatalogue, $fileCatalogue);
             }
         }
 
@@ -154,5 +156,80 @@ class TranslationFinder
         }
 
         return $domain;
+    }
+
+    /**
+     * Get metadata from original catalogue, parse them to extract filename and line and add them to the updated catalogue
+     *
+     * @param MessageCatalogue $catalogue
+     * @param MessageCatalogue $originalCatalogue
+     *
+     * @return MessageCatalogue
+     */
+    private function updateCatalogueMetadata(MessageCatalogue $catalogue, MessageCatalogue $originalCatalogue): MessageCatalogue
+    {
+        $locale = $originalCatalogue->getLocale();
+        $localeSuffix = '.' . $locale;
+        $suffixLength = strlen($localeSuffix);
+
+        foreach ($originalCatalogue->all() as $domain => $messages) {
+            $originalDomain = $domain;
+            // Remove locale suffix from domain name
+            if (substr($domain, -$suffixLength) === $localeSuffix) {
+                $domain = substr($domain, 0, -$suffixLength);
+            }
+            foreach (array_keys($messages) as $translationKey) {
+                $metadata = $originalCatalogue->getMetadata($translationKey, $originalDomain);
+                if ($this->shouldAddFileMetadata($metadata) && $this->metadataContainNotes($metadata)) {
+                    $catalogue->setMetadata($translationKey, $this->parseMetadataNotes($metadata), $domain);
+                }
+            }
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * @param array|null $metadata
+     *
+     * @return bool
+     */
+    private function metadataContainNotes(array $metadata = null): bool
+    {
+        return isset($metadata['notes'][0]['content']);
+    }
+
+    /**
+     * @param array|null $metadata
+     *
+     * @return bool
+     */
+    private function shouldAddFileMetadata(array $metadata = null): bool
+    {
+        return null === $metadata || !isset($metadata['file']) || !isset($metadata['line']);
+    }
+
+    /**
+     * @param array|null $metadata
+     *
+     * @return array
+     */
+    private function parseMetadataNotes(array $metadata = null): array
+    {
+        $defaultMetadata = ['file' => '', 'line' => ''];
+
+        if (!isset($metadata['file']['original'])) {
+            return $defaultMetadata;
+        }
+
+        $notes = $metadata['notes'][0]['content'];
+        if (1 !== preg_match('/Line: (?<line>\d+)/', $notes, $matches)) {
+            return $defaultMetadata;
+        }
+
+        return [
+            'file' => $metadata['file']['original'],
+            'line' => (int) $matches['line'],
+        ];
     }
 }

--- a/src/Core/Translation/Storage/Finder/TranslationFinder.php
+++ b/src/Core/Translation/Storage/Finder/TranslationFinder.php
@@ -223,13 +223,26 @@ class TranslationFinder
         }
 
         $notes = $metadata['notes'][0]['content'];
-        if (1 !== preg_match('/Line: (?<line>\d+)/', $notes, $matches)) {
-            return $defaultMetadata;
+        $originalFile = $metadata['file']['original'];
+        /*
+         * We have 2 different cases :
+         * When it's a PHP file, the notes contains "Line: XX", where XX is the line number
+         * When it's a template file, the notes contains "Context:\nFile: the-template-file-name:XX" , where XX is the line number
+         */
+        if (
+            1 === preg_match('/Line: (?<line>\d+)/', $notes, $matches)
+            || 1 === preg_match(
+                '/Context:\nFile: ' . preg_quote($originalFile, DIRECTORY_SEPARATOR) . ':(?<line>\d+)/',
+                $notes,
+                $matches
+            )
+        ) {
+            return [
+                'file' => $originalFile,
+                'line' => (int) $matches['line'],
+            ];
         }
 
-        return [
-            'file' => $metadata['file']['original'],
-            'line' => (int) $matches['line'],
-        ];
+        return $defaultMetadata;
     }
 }

--- a/src/Core/Translation/Storage/Provider/Finder/DefaultCatalogueFinder.php
+++ b/src/Core/Translation/Storage/Provider/Finder/DefaultCatalogueFinder.php
@@ -90,9 +90,7 @@ class DefaultCatalogueFinder extends AbstractCatalogueFinder
             $defaultCatalogue->addCatalogue($filteredCatalogue);
         }
 
-        $defaultCatalogue = $this->emptyCatalogue($defaultCatalogue);
-
-        return $defaultCatalogue;
+        return $this->emptyCatalogue($defaultCatalogue);
     }
 
     /**

--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
@@ -395,10 +395,20 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
             // only add if the domain is relevant to this module
             foreach ($this->filenameFilters as $pattern) {
                 if (preg_match($pattern, $newDomain)) {
+                    $messages = $catalogue->all($domain);
                     $newCatalogue->add(
-                        $catalogue->all($domain),
+                        $messages,
                         $newDomain
                     );
+
+                    foreach ($messages as $key => $message) {
+                        $newCatalogue->setMetadata(
+                            $key,
+                            $catalogue->getMetadata($key, $domain),
+                            $newDomain
+                        );
+                    }
+
                     break;
                 }
             }

--- a/tests/Unit/Core/Translation/Builder/TranslationCatalogueBuilderTest.php
+++ b/tests/Unit/Core/Translation/Builder/TranslationCatalogueBuilderTest.php
@@ -90,10 +90,8 @@ class TranslationCatalogueBuilderTest extends TestCase
             foreach ($messages as $messageKey => $messageValue) {
                 $catalogue->setMetadata($messageKey, [
                     'file' => 'someFakeFile.xlf',
-                    'line' => $i,
+                    'line' => $i++,
                 ], $domain);
-
-                ++$i;
             }
         }
         $provider->method('getDefaultCatalogue')->willReturn($catalogue);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add raw metadata to Message Map class so we can include them into the exported built catalogue
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24716
| How to test?      | Follow the step described in the related issue.<br>Before this PR, you will have file set to 'admin-dev' and line not filled.<br>After you will have the correct file and the line filled <br>[BEFORE_translations_export_fr-FR.zip](https://github.com/PrestaShop/PrestaShop/files/6740941/BEFORE_translations_export_fr-FR.zip)<br>[AFTER_translations_export_fr-FR.zip](https://github.com/PrestaShop/PrestaShop/files/6740943/AFTER_translations_export_fr-FR.zip)

| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25176)
<!-- Reviewable:end -->
