### PR TITLE
Make searchbar full width on md and xs

### DIFF
--- a/themes/classic/_dev/css/components/search-widget.scss
+++ b/themes/classic/_dev/css/components/search-widget.scss
@@ -4,7 +4,22 @@
 }
 
 .header-top {
-  .search-widget {
+  &-right {
+    @include media-breakpoint-down(md) {
+      padding-right: 0;
+    }
+
+    @include media-breakpoint-down(xs) {
+      width: 100%;
+      padding-right: 15px;
+    }
+  }
+
+  .search-widgets {
+    @include media-breakpoint-down(md) {
+      width: 100%;
+    }
+
     form {
       input[type="text"] {
         width: 100%;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Searchbar was full width on 1.7.7, it's a regression
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25133.
| How to test?      | Go on FO and see if searchbar is full width on tablet and mobiles
| Possible impacts? | FO Searchbar style

⚠️ Should probably be merged after 1.7.8 release

# How does it looks?
![image](https://user-images.githubusercontent.com/14963751/124079524-8e4fe300-da49-11eb-8f51-dbc4a414ea07.png)
![image](https://user-images.githubusercontent.com/14963751/124079563-990a7800-da49-11eb-9c13-4d7e62c2f1eb.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25192)
<!-- Reviewable:end -->
