### PR TITLE
Remove id_tax_rules_group in carrier table

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -601,7 +601,7 @@ class CarrierCore extends ObjectModel
             'SELECT id_tax_rules_group
             FROM (
                 SELECT COUNT(*) n, c.id_tax_rules_group
-                FROM ' . _DB_PREFIX_ . 'carrier c
+                FROM ' . _DB_PREFIX_ . 'carrier_tax_rules_group_shop c
                 JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON (c.id_tax_rules_group = trg.id_tax_rules_group)
                 WHERE trg.active = 1 AND trg.deleted = 0
                 GROUP BY c.id_tax_rules_group

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -95,7 +95,6 @@ CREATE TABLE `PREFIX_attribute_impact` (
 CREATE TABLE `PREFIX_carrier` (
   `id_carrier` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `id_reference` int(10) unsigned NOT NULL,
-  `id_tax_rules_group` int(10) unsigned DEFAULT '0',
   `name` varchar(64) NOT NULL,
   `url` varchar(255) DEFAULT NULL,
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
@@ -116,7 +115,6 @@ CREATE TABLE `PREFIX_carrier` (
   `grade` int(10) DEFAULT '0',
   PRIMARY KEY (`id_carrier`),
   KEY `deleted` (`deleted`, `active`),
-  KEY `id_tax_rules_group` (`id_tax_rules_group`),
   KEY `reference` (
     `id_reference`, `deleted`, `active`
   )

--- a/install-dev/data/xml/carrier.xml
+++ b/install-dev/data/xml/carrier.xml
@@ -2,7 +2,6 @@
 <entity_carrier>
   <fields id="name" class="Carrier" sql="a.id_carrier = 1">
     <field name="id_reference"/>
-    <field name="id_tax_rules_group"/>
     <field name="name"/>
     <field name="url"/>
     <field name="active"/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | id_tax_rules_group is not used anymore.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  Fixes https://github.com/PrestaShop/PrestaShop/issues/25208
| How to test?      | remove column in database without this pr and test an order and stock changes. 
| Possible impacts? | none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25207)
<!-- Reviewable:end -->
