### PR TITLE
[POC] Improved Memcached support

### DIFF
--- a/.dev/database/004-ps_memcached.sql
+++ b/.dev/database/004-ps_memcached.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `ps_memcached` (
+  `table_name` varchar(255) NOT NULL,
+  `expiry` int NOT NULL,
+  PRIMARY KEY (`table_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/override/classes/cache/Cache.php
+++ b/override/classes/cache/Cache.php
@@ -143,6 +143,6 @@ abstract class Cache extends CacheCore
         if (class_exists('Profiling', false)) {
             Profiling::queryStat('memcached', 'cmd_purge', [$table]);
         }
-        $this->table_expiry_dates[$table] = time();
+        $this->table_expiry_dates[$table] = time() + 1;
     }
 }

--- a/override/classes/cache/Cache.php
+++ b/override/classes/cache/Cache.php
@@ -1,0 +1,148 @@
+<?php
+
+abstract class Cache extends CacheCore
+{
+    public $table_expiry_dates = [];
+    protected $blacklist = [
+        'ps_cart',
+        'ps_cart_cart_rule',
+        'ps_cart_product',
+        'ps_connections',
+        'ps_customer',
+        'ps_customer_group',
+        'ps_guest',
+        'ps_referrer',
+        'ps_smarty_lazy_cache',
+        'ps_statssearch',
+    ];
+
+    /**
+     * Save the query result. Hash the query to get the key.
+     *
+     * @param string $query
+     * @param array $result
+     * @param null $row_id
+     *
+     * @return bool
+     */
+    public function setQuery($query, $result, $row_id = null)
+    {
+        $tables = $this->getTables($query);
+        if ($this->isBlacklist($tables)) {
+            return false;
+        }
+        if (class_exists('Profiling', false)) {
+            Profiling::queryStat('memcached', 'cmd_set', $tables);
+        }
+        $key = $this->getQueryHash($query) . (isset($row_id) ? "_$row_id" : '');
+        $this->set($key, $result);
+    }
+
+    /**
+     * @param $query
+     * @param $key
+     * @param null $row_id
+     *
+     * @return bool|mixed
+     */
+    public function getQuery($query, $key, $row_id = null)
+    {
+        $tables = $this->getTables($query);
+        if ($this->isBlacklist($tables)) {
+            return false;
+        }
+        if (isset($row_id)) {
+            $key .= "_$row_id";
+        }
+        $data = $this->_get($key);
+        if ($data === false) {
+            if (class_exists('Profiling', false)) {
+                Profiling::queryStat('memcached', 'get_miss', $tables);
+            }
+
+            return false;
+        }
+        if (!is_array($data) || count($data) != 1) {
+            if (class_exists('Profiling', false)) {
+                Profiling::queryStat('memcached', 'get_fail', $tables);
+            }
+
+            return false;
+        }
+        if ($this->isOutdated($query, key($data))) {
+            if (class_exists('Profiling', false)) {
+                Profiling::queryStat('memcached', 'get_fail', $tables);
+            }
+
+            return false;
+        }
+        if (class_exists('Profiling', false)) {
+            Profiling::queryStat('memcached', 'get_ok', $tables);
+        }
+
+        return current($data);
+    }
+
+    /**
+     * We invalidate all queries using these tables.
+     *
+     * @param string $query
+     */
+    public function deleteQuery($query)
+    {
+        $tables = $this->getTables($query);
+        if (is_array($tables)) {
+            foreach ($tables as $table) {
+                if (in_array($table, $this->blacklist)) {
+                    continue;
+                }
+                $this->expireTable($table);
+            }
+        }
+    }
+
+    /**
+     * Optimized version. Do not store query results if any blacklisted table is mentioned
+     *
+     * @param string[] $tables
+     *
+     * @return bool
+     */
+    protected function isBlacklist($tables)
+    {
+        if (empty($tables)) {
+            return false;
+        }
+
+        return count(array_intersect($this->blacklist, $tables)) > 0;
+    }
+
+    protected function isOutdated($query, $timestamp)
+    {
+        $tables = $this->getTables($query);
+        if (empty($tables)) {
+            return false;
+        }
+        foreach ($tables as $table) {
+            if (in_array($table, $this->blacklist)) {
+                continue;
+            }
+            if (isset($this->table_expiry_dates[$table])) {
+                $expiry = $this->table_expiry_dates[$table];
+            }
+            if (!empty($expiry) && $timestamp < $expiry) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function expireTable($table)
+    {
+        if (class_exists('Profiling', false)) {
+            Profiling::queryStat('memcached', 'cmd_purge', [$table]);
+        }
+        $this->table_expiry_dates[$table] = time();
+    }
+}

--- a/override/classes/cache/CacheMemcached.php
+++ b/override/classes/cache/CacheMemcached.php
@@ -1,0 +1,158 @@
+<?php
+
+class CacheMemcached extends CacheMemcachedCore
+{
+    public function __construct()
+    {
+        $this->connect();
+        if ($this->is_connected) {
+            if (php_sapi_name() === 'cli') {
+                $key = 'maisonb';
+            } else {
+                $pos = strpos($_SERVER['SERVER_ADMIN'], '@') + 1;
+                $len = min(7, strpos($_SERVER['SERVER_ADMIN'], '.', $pos) - $pos);
+                $key = substr($_SERVER['SERVER_ADMIN'], $pos, $len);
+            }
+            $this->memcached->setOption(Memcached::OPT_PREFIX_KEY, 'ps' . $key);
+            if ($this->memcached->getOption(Memcached::HAVE_IGBINARY)) {
+                $this->memcached->setOption(Memcached::OPT_SERIALIZER, Memcached::SERIALIZER_IGBINARY);
+            }
+        }
+        $tables = Db::getInstance()->executeS('select * from ps_memcached', true, false);
+        foreach ($tables as $table) {
+            if (empty($table['expiry'])) {
+                $this->blacklist[] = $table['table_name'];
+            } else {
+                $this->table_expiry_dates[$table['table_name']] = $table['expiry'];
+            }
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->saveExpiry();
+        parent::__destruct();
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @param float|int $ttl
+     *
+     * @return bool
+     */
+    protected function _set($key, $value, $ttl = 3600 * 24)
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+        if (class_exists('Profiling', false)) {
+            Profiling::beforeQuery();
+            $result = $this->memcached->set($key, $value, $ttl);
+            Profiling::afterQuery('memcached');
+        } else {
+            $result = $this->memcached->set($key, $value, $ttl);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @see Cache::_get()
+     */
+    protected function _get($key)
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+        if (class_exists('Profiling', false)) {
+            Profiling::beforeQuery();
+            $result = $this->memcached->get($key);
+            Profiling::afterQuery('memcached');
+        } else {
+            $result = $this->memcached->get($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @see Cache::_exists()
+     */
+    protected function _exists($key)
+    {
+        return $this->_get($key) !== false;
+    }
+
+    /**
+     * @see Cache::_delete()
+     */
+    protected function _delete($key)
+    {
+        if (!$this->is_connected) {
+            return false;
+        }
+        if (class_exists('Profiling', false)) {
+            Profiling::beforeQuery();
+            $result = $this->memcached->delete($key);
+            Profiling::afterQuery('memcached');
+        } else {
+            $result = $this->memcached->delete($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Always save the timestamp with the data
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param int $ttl
+     *
+     * @return bool
+     */
+    public function set($key, $value, $ttl = 0)
+    {
+        $value = [time() => $value];
+
+        return $this->_set($key, $value, $ttl);
+    }
+
+    /**
+     * Simply get the key
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function get($key)
+    {
+        $data = $this->_get($key);
+        if ($data === false) {
+            return false;
+        }
+        if (!is_array($data) || count($data) != 1) {
+            return false;
+        }
+
+        return current($data);
+    }
+
+    public function saveExpiry()
+    {
+        static $saved = false;
+        if (!$saved && count($this->table_expiry_dates)) {
+            $dsn = 'mysql:dbname=' . _DB_NAME_ . ';host=' . _DB_SERVER_;
+            $dbo = new PDO($dsn, _DB_USER_, _DB_PASSWD_, [PDO::ATTR_TIMEOUT => 5, PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true]);
+            $dbo->exec("SET NAMES 'utf8'");
+            $inserts = [];
+            foreach ($this->table_expiry_dates as $table => $date) {
+                $inserts[] = '(' . $dbo->quote($table) . ', ' . (int) $date . ')';
+            }
+            $query = 'insert into ps_memcached (table_name, expiry) values ' . implode(', ', $inserts) . ' on duplicate key update expiry = greatest(expiry, values(expiry));';
+            $dbo->exec($query);
+        }
+        $saved = true;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This override implements a working implementation of memcached database cache. 5 years + in production environment with PS 1.6.1.1, currently in dev and pre-prod environment PS 1.7.7.5.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes. The class `cache` is overridden. These changes are not intended to work with the other cache implementations.
| Deprecations?     | no
| Fixed ticket?     | Fixes #25185. Probably also fixes #21318 and #18171. #13389 would no longer be relevant.
| How to test?      | Enable memcached and test on a shop instance with frequent database updates
| Possible impacts? | Improves performance. Thanks to a working cache invalidation system, there is no adverse impact whatsoever.

This is how cache invalidation is designed:
- Every DML query is scanned for table names. Cache is invalidated for all tables contained in the query.
- Every query result is stored alongside its timestamp in a key that consist of `md5($query)`and a prefix (to differentiate between different instances of PS (e.g. prod and dev environment).
- The cache is expired using a mysql table (`PREFIX_memcached`), that contains the table name and the timestamp of the last update. (I have chosen mysql for this, because each query is atomic, the order of execution is guaranteed and the operation is guaranteed to succeed. memcached does not guarantee any of these three requirements for a working cache invalidation).
- When a result is retrieved, its timestamp is compared to the expiry stamp stored in `PREFIX_memcached`. If the result proves to be outdated, the query is rerun and the cache is updated.
- Stale records in the memcached storage heap are not actively deleted, bu as they age they may be garbage collected by memcached.
- Expiry dates are loaded at the beginning of execution (`__construct`), and cache invalidation is written to the db at the end of execution (`__destruct`). Thus changes made to the DB in a script take effect only when the script is finished. This simplifies and speeds up the cache invalidation, but it let's the door open for inconsitencies when a script takes long time to execute. On the other hand, concurrency is handled correctly (two scripts that update the same table at the same time.

There are the following missing pieces in this PR:
- In the BO, we need a separate button to flush memcached cache (currently ther is just one button `Clear cache`. For the use case, that we update a specific table directly in mysql, we need an option to invalidate only the cache of that table. I have this working in PS 1.6, but I did not yet have the time to port it to PS 1.7
- The table prefix is hardcoded to `ps_`
- The class `Profiling` referenced stores statistics, that are graphed with cacti. This is out of scope, so I'll leave it out anyway.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25217)
<!-- Reviewable:end -->
