### PR TITLE
1.7.7.x

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4960,7 +4960,7 @@ class ProductCore extends ObjectModel
             (int) $row['id_product'],
             false,
             $id_product_attribute,
-            (self::$_taxCalculationMethod == PS_TAX_EXC ? 2 : 6),
+            (self::$_taxCalculationMethod == PS_TAX_EXC ? Context::getContext()->getComputingPrecision() : 6),
             null,
             false,
             true,

--- a/install-dev/upgrade/sql/1.7.7.6.sql
+++ b/install-dev/upgrade/sql/1.7.7.6.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8';
+
+ALTER TABLE `PREFIX_currency` MODIFY COLUMN `numeric_iso_code` varchar(3) DEFAULT NULL NULL;

--- a/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/UpdateProductQuantityInCartHandler.php
@@ -30,6 +30,7 @@ use Attribute;
 use Cart;
 use Context;
 use Customer;
+use Pack;
 use PrestaShop\PrestaShop\Adapter\Cart\AbstractCartHandler;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\UpdateProductQuantityInCartCommand;
@@ -37,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\UpdateProductQuantityI
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
@@ -177,18 +179,31 @@ final class UpdateProductQuantityInCartHandler extends AbstractCartHandler imple
      * @param UpdateProductQuantityInCartCommand $command
      *
      * @throws ProductOutOfStockException
+     * @throws PackOutOfStockException
      */
-    private function assertProductIsInStock(Product $product, UpdateProductQuantityInCartCommand $command)
+    private function assertProductIsInStock(Product $product, UpdateProductQuantityInCartCommand $command): void
     {
+        $isAvailableWhenOutOfStock = Product::isAvailableWhenOutOfStock($product->out_of_stock);
         if (null !== $command->getCombinationId()) {
-            $isAvailableWhenOutOfStock = Product::isAvailableWhenOutOfStock($product->out_of_stock);
             $isEnoughQuantity = Attribute::checkAttributeQty(
                 $command->getCombinationId()->getValue(),
                 $command->getNewQuantity()
             );
 
             if (!$isAvailableWhenOutOfStock && !$isEnoughQuantity) {
-                throw new ProductOutOfStockException(sprintf('Product with id "%s" is out of stock, thus cannot be added to cart', $product->id));
+                throw new ProductOutOfStockException(
+                    sprintf('Product with id "%s" is out of stock, thus cannot be added to cart', $product->id)
+                );
+            }
+
+            return;
+        } elseif (Pack::isPack($product->id)) {
+            $hasPackEnoughQuantity = Pack::isInStock($product->id, $command->getNewQuantity());
+
+            if (!$isAvailableWhenOutOfStock && !$hasPackEnoughQuantity) {
+                throw new PackOutOfStockException(
+                    sprintf('Product with id "%s" is out of stock, thus cannot be added to cart', $product->id)
+                );
             }
 
             return;

--- a/src/Core/Domain/Product/Exception/PackOutOfStockException.php
+++ b/src/Core/Domain/Product/Exception/PackOutOfStockException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Exception;
+
+/**
+ * Is thrown when using pack (e.g. adding to cart) which is out of stock
+ */
+class PackOutOfStockException extends ProductOutOfStockException
+{
+}

--- a/src/Core/Localization/Number/Formatter.php
+++ b/src/Core/Localization/Number/Formatter.php
@@ -121,7 +121,7 @@ class Formatter
 
         // Assemble the final number
         $formattedNumber = $majorDigits;
-        if ($minorDigits) {
+        if (strlen($minorDigits)) {
             $formattedNumber .= self::DECIMAL_SEPARATOR_PLACEHOLDER . $minorDigits;
         }
 

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_int($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
+            is_int(intval($currency->getDecimalPrecision())) ? intval($currency->getDecimalPrecision()) : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            $this->getMinFractionDigits($positivePattern),
+            is_int($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            ctype_digit($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            is_numeric($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_int((int)$currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            (int)$currency->getDecimalPrecision() ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_int(intval($currency->getDecimalPrecision())) ? intval($currency->getDecimalPrecision()) : $this->getMinFractionDigits($positivePattern),
+            is_int((int)$currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            (int)$currency->getDecimalPrecision() ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            ctype_digit($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/Core/Localization/Specification/Factory.php
+++ b/src/Core/Localization/Specification/Factory.php
@@ -113,7 +113,7 @@ class Factory
             $this->getNegativePattern($currencyPattern),
             $this->computeNumberSymbolLists($numbersSymbols),
             $maxFractionDigits ?? $this->getMaxFractionDigits($positivePattern),
-            is_numeric($currency->getDecimalPrecision()) ? (int)$currency->getDecimalPrecision(): $this->getMinFractionDigits($positivePattern),
+            is_numeric($currency->getDecimalPrecision()) ? (int) $currency->getDecimalPrecision() : $this->getMinFractionDigits($positivePattern),
             $numberGroupingUsed && $this->getPrimaryGroupSize($positivePattern) > 1,
             $this->getPrimaryGroupSize($positivePattern),
             $this->getSecondaryGroupSize($positivePattern),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -51,6 +51,7 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\FileUploadException;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\SpecificPrice\Command\AddSpecificPriceCommand;
@@ -592,6 +593,10 @@ class CartController extends FrameworkBundleAdminController
             ],
             ProductCustomizationNotFoundException::class => $this->trans(
                 'Product customization could not be found. Go to Catalog > Products to customize the product.',
+                'Admin.Catalog.Notification'
+            ),
+            PackOutOfStockException::class => $this->trans(
+                'There are not enough products in stock.',
                 'Admin.Catalog.Notification'
             ),
             ProductOutOfStockException::class => $this->trans(

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -294,7 +294,7 @@ class FactoryTest extends TestCase
                 $expected,
                 $specification->toArray()
             );
-            $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+            self::assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
         }
     }
 

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -27,10 +27,10 @@
 namespace LegacyTests\Unit\Core\Localization\Specification;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Localization\Currency;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\Locale;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleData;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\NumberSymbolsData;
+use PrestaShop\PrestaShop\Core\Localization\Currency;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Factory as FactorySpecification;
 
 class FactoryTest extends TestCase
@@ -221,85 +221,50 @@ class FactoryTest extends TestCase
      * Given an integer to specify max fraction digits
      * Then calling buildPriceSpecification() should return an NumberSpecification
      *
-     * @dataProvider getPriceData
+     * @dataProvider getPriceDataWithPrecisions
      */
     public function testBuildPriceSpecificationWithPrecisionFallback(array $data, array $expected): void
+    {
+        $currencyPrecision = $data[4]['currencyPrecision'];
+        $maxFractionDigits = $data[4]['maxFractionDigits'];
+        $expectedMinFractionDigits = $data[4]['expectedMinFractionDigits'];
+
+        $specification = $this->factory->buildPriceSpecification(
+            $data[0],
+            $this->createLocale(
+                ...$data
+            ),
+            new Currency(
+                null,
+                null,
+                'EUR',
+                '978',
+                [
+                    $data[0] => '€',
+                ],
+                $currencyPrecision,
+                [
+                    $data[0] => 'Euro',
+                ]
+            ),
+            3,
+            true,
+            $maxFractionDigits
+        );
+        $expected['maxFractionDigits'] = $maxFractionDigits;
+        $expected['minFractionDigits'] = $expectedMinFractionDigits;
+        self::assertEquals(
+            $expected,
+            $specification->toArray()
+        );
+        self::assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+    }
+
+    public function getPriceDataWithPrecisions()
     {
         // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
         // see PrestaShop\PrestaShop\Core\Localization\Specification\Number
         // The dataProvider provides minFractionDigits === 2
-        $precisions = [
-            [
-                'currencyPrecision' => 6,
-                'maxFractionDigits' => 3,
-                'expectedMinFractionDigits' => 3,
-            ], //minFractionDigits will be equal to 3
-            [
-                'currencyPrecision' => 6,
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 6,
-            ], //minFractionDigits will be equal to 6
-            [
-                'currencyPrecision' => 1,
-                'maxFractionDigits' => 3,
-                'expectedMinFractionDigits' => 1,
-            ], //minFractionDigits will be equal to 1
-            [
-                'currencyPrecision' => '4',
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 4,
-            ], //minFractionDigits will be equal to 4 because precision is numeric
-            [
-                'currencyPrecision' => null,
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 2,
-            ], //minFractionDigits will be equal to 2
-            [
-                'currencyPrecision' => [],
-                'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 2,
-            ], //minFractionDigits will be equal to 2
-        ];
-
-        foreach ($precisions as $expectedPrecisions) {
-            $currencyPrecision = $expectedPrecisions['currencyPrecision'];
-            $maxFractionDigits = $expectedPrecisions['maxFractionDigits'];
-            $expectedMinFractionDigits = $expectedPrecisions['expectedMinFractionDigits'];
-
-            $specification = $this->factory->buildPriceSpecification(
-                $data[0],
-                $this->createLocale(
-                    ...$data
-                ),
-                new Currency(
-                    null,
-                    null,
-                    'EUR',
-                    '978',
-                    [
-                        $data[0] => '€',
-                    ],
-                    $currencyPrecision,
-                    [
-                        $data[0] => 'Euro',
-                    ]
-                ),
-                3,
-                true,
-                $maxFractionDigits
-            );
-            $expected['maxFractionDigits'] = $maxFractionDigits;
-            $expected['minFractionDigits'] = $expectedMinFractionDigits;
-            self::assertEquals(
-                $expected,
-                $specification->toArray()
-            );
-            self::assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
-        }
-    }
-
-    public function getPriceData()
-    {
         return [
             [
                 [
@@ -307,6 +272,11 @@ class FactoryTest extends TestCase
                     '¤ #,##0.00;¤ -#,##0.00',
                     '#,##0%',
                     '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 3,
+                    ],
                 ],
                 [
                     'positivePattern' => '¤ #,##0.00',
@@ -339,6 +309,381 @@ class FactoryTest extends TestCase
                     '#,##0.00 ¤',
                     '#,##0 %',
                     '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 3,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 6,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 6,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 6,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 1,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 1,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => 1,
+                        'maxFractionDigits' => 3,
+                        'expectedMinFractionDigits' => 1,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => '4',
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 4,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => '4',
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 4,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => null,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => null,
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
+                ],
+                [
+                    'positivePattern' => '#,##0.00 ¤',
+                    'negativePattern' => '-#,##0.00 ¤',
+                    'maxFractionDigits' => 5,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'nl-NL',
+                    '¤ #,##0.00;¤ -#,##0.00',
+                    '#,##0%',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => [],
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
+                ],
+                [
+                    'positivePattern' => '¤ #,##0.00',
+                    'negativePattern' => '¤ -#,##0.00',
+                    'maxFractionDigits' => 2,
+                    'minFractionDigits' => 2,
+                    'groupingUsed' => true,
+                    'primaryGroupSize' => 3,
+                    'secondaryGroupSize' => 3,
+                    'currencyCode' => 'EUR',
+                    'currencySymbol' => '€',
+                    'numberSymbols' => [
+                        ',',
+                        '.',
+                        ';',
+                        '%',
+                        '-',
+                        '+',
+                        'E',
+                        "\u{00d7}",
+                        "\u{2030}",
+                        "\u{221e}",
+                        'NaN',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fr-FR',
+                    '#,##0.00 ¤',
+                    '#,##0 %',
+                    '#,##0.###',
+                    [
+                        'currencyPrecision' => [],
+                        'maxFractionDigits' => 6,
+                        'expectedMinFractionDigits' => 2,
+                    ],
                 ],
                 [
                     'positivePattern' => '#,##0.00 ¤',

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -223,7 +223,7 @@ class FactoryTest extends TestCase
      *
      * @dataProvider getPriceData
      */
-    public function testBuildPriceSpecificationWithPrecisionFallback($data, $expected)
+    public function testBuildPriceSpecificationWithPrecisionFallback(array $data, array $expected): void
     {
         // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
         // see PrestaShop\PrestaShop\Core\Localization\Specification\Number

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -214,6 +214,90 @@ class FactoryTest extends TestCase
         $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
     }
 
+    /**
+     * Given a valid CLDR locale
+     * Given a Max Fractions digits to display in a number's decimal
+     * Given a boolean to define if we should group digits in a number's integer part
+     * Given an integer to specify max fraction digits
+     * Then calling buildPriceSpecification() should return an NumberSpecification
+     *
+     * @dataProvider getPriceData
+     */
+    public function testBuildPriceSpecificationWithPrecisionFallback($data, $expected)
+    {
+        // if maxFractionDigits < minFractionDigits, minFractionDigits = maxFractionDigits
+        // see PrestaShop\PrestaShop\Core\Localization\Specification\Number
+        // The dataProvider provides minFractionDigits === 2
+        $precisions = [
+            [
+                'currencyPrecision' => 6,
+                'maxFractionDigits' => 3,
+                'expectedMinFractionDigits' => 3,
+            ], //minFractionDigits will be equal to 3
+            [
+                'currencyPrecision' => 6,
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 6,
+            ], //minFractionDigits will be equal to 6
+            [
+                'currencyPrecision' => 1,
+                'maxFractionDigits' => 3,
+                'expectedMinFractionDigits' => 1,
+            ], //minFractionDigits will be equal to 1
+            [
+                'currencyPrecision' => '4',
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+            [
+                'currencyPrecision' => null,
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+            [
+                'currencyPrecision' => [],
+                'maxFractionDigits' => 6,
+                'expectedMinFractionDigits' => 2,
+            ], //minFractionDigits will be equal to 2
+        ];
+
+        foreach ($precisions as $expectedPrecisions) {
+            $currencyPrecision = $expectedPrecisions['currencyPrecision'];
+            $maxFractionDigits = $expectedPrecisions['maxFractionDigits'];
+            $expectedMinFractionDigits = $expectedPrecisions['expectedMinFractionDigits'];
+
+            $specification = $this->factory->buildPriceSpecification(
+                $data[0],
+                $this->createLocale(
+                    ...$data
+                ),
+                new Currency(
+                    null,
+                    null,
+                    'EUR',
+                    '978',
+                    [
+                        $data[0] => '€',
+                    ],
+                    $currencyPrecision,
+                    [
+                        $data[0] => 'Euro',
+                    ]
+                ),
+                3,
+                true,
+                $maxFractionDigits
+            );
+            $expected['maxFractionDigits'] = $maxFractionDigits;
+            $expected['minFractionDigits'] = $expectedMinFractionDigits;
+            $this->assertEquals(
+                $expected,
+                $specification->toArray()
+            );
+            $this->assertEquals($specification->getMaxFractionDigits(), $maxFractionDigits);
+        }
+    }
+
     public function getPriceData()
     {
         return [

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -247,8 +247,8 @@ class FactoryTest extends TestCase
             [
                 'currencyPrecision' => '4',
                 'maxFractionDigits' => 6,
-                'expectedMinFractionDigits' => 2,
-            ], //minFractionDigits will be equal to 2
+                'expectedMinFractionDigits' => 4,
+            ], //minFractionDigits will be equal to 4 because precision is numeric
             [
                 'currencyPrecision' => null,
                 'maxFractionDigits' => 6,

--- a/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
+++ b/tests-legacy/Unit/Core/Localization/Specification/FactoryTest.php
@@ -290,7 +290,7 @@ class FactoryTest extends TestCase
             );
             $expected['maxFractionDigits'] = $maxFractionDigits;
             $expected['minFractionDigits'] = $expectedMinFractionDigits;
-            $this->assertEquals(
+            self::assertEquals(
                 $expected,
                 $specification->toArray()
             );

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -56,6 +56,7 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForOrderCreation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation;
 use PrestaShop\PrestaShop\Core\Domain\Cart\ValueObject\CartId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
@@ -281,6 +282,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
             Cart::resetStaticCache();
         } catch (MinimalQuantityException $e) {
             $this->lastException = $e;
+        } catch (PackOutOfStockException $e) {
+            $this->lastException = $e;
         }
     }
 
@@ -384,7 +387,7 @@ class CartFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @When I select :countryIsoCode address as delivery and invoice address for customer :customerReference in cart :cartReference
-     * @Given cart :cartReference delivery and invoice address country for customer :customeReferenceis is :countryIsoCode
+     * @Given cart :cartReference delivery and invoice address country for customer :customerReference is :countryIsoCode
      *
      * @param string $countryIsoCode
      * @param string $customerReference
@@ -975,12 +978,20 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then I should get error that carrier is invalid
      */
-    public function assertLastErrorIsInvalidCarrier()
+    public function assertLastErrorIsInvalidCarrier(): void
     {
         $this->assertLastErrorIs(
             CartConstraintException::class,
             CartConstraintException::INVALID_CARRIER
         );
+    }
+
+    /**
+     * @Then I should get an error that you have the maximum quantity available for this pack
+     */
+    public function assertLastErrorMaxQuantityAvailableForThisProduct(): void
+    {
+        $this->assertLastErrorIs(PackOutOfStockException::class);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
@@ -1,9 +1,11 @@
+#./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags calculation-cartrule-percent-multiple
+
 @reset-database-before-feature
+@calculation-cartrule-percent-multiple
 Feature: Cart rule (percent) calculation with multiple cart rules
   As a customer
   I must be able to have correct cart total when adding cart rules
 
-  @cumulative-percent-reduction
   Scenario: Empty cart, 2 cartRules
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -20,7 +22,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Then my cart total should be 0.0 tax included
     Then my cart total using previous calculation method should be 0.0 tax included
 
-  @cumulative-percent-reduction
   Scenario: one product in cart, quantity 1, 2x % global cartRules
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -39,7 +40,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     #known to fail on previous
     #Then my cart total using previous calculation method should be 15.9154 tax included
 
-  @cumulative-percent-reduction
   Scenario: one product in cart, quantity 3, one 50% global cartRule
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -56,7 +56,6 @@ Feature: Cart rule (percent) calculation with multiple cart rules
       | cartrule3        | 2.972 |
     Then my cart total should be precisely 33.75 tax included
 
-  @cumulative-percent-reduction
   Scenario: 3 products in cart, several quantities, 2x % global cartRules
     Given I have an empty default cart
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -78,3 +77,17 @@ Feature: Cart rule (percent) calculation with multiple cart rules
     Then my cart total should be 76.93 tax included
     #known to fail on previous
     #Then my cart total using previous calculation method should be 76.93 tax included
+
+  Scenario: one product in cart, one cart rule free shipping, one cart rule 10%
+    Given I have an empty default cart
+    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    And there is a cart rule named "freeshipping" that applies no discount with priority 1, quantity of 1000 and quantity per user 1000
+    And cart rule "freeshipping" offers free shipping
+    And there is a cart rule named "10percent" that applies a percent discount of 10.0% with priority 2, quantity of 1000 and quantity per user 1000
+    When I add 1 items of product "product1" in my cart
+    Then the current cart should have the following contextual reductions:
+      | freeshipping     | 7     |
+      | 10percent        | 1.981 |
+    And my cart total should be precisely 17.83 tax included
+    And cart shipping fees should be 0.00 tax included

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Updating/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Updating/Product/update_pack.feature
@@ -1,0 +1,133 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-updating-product-pack
+@reset-database-before-feature
+@cart-updating-product-pack
+Feature: Add product pack in cart
+  As a customer
+  I must be able to correctly update product packs in my cart
+
+  Background:
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And country "US" is enabled
+    Given I create an empty cart "cart_pack" for customer "testCustomer"
+    And there is a product in the catalog named "product_in_pack_1" with a price of 12.34 and 10 items in stock
+    And there is a product in the catalog named "product_in_pack_2" with a price of 56.78 and 10 items in stock
+    And there is a product in the catalog named "product_pack" with a price of 90.12 and 10 items in stock
+    And product "product_pack" is a pack containing 1 items of product "product_in_pack_1"
+    And product "product_pack" is a pack containing 2 items of product "product_in_pack_2"
+    Then the available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to deny order and only pack is decremented
+    # As I check pack stock 10 is the limit
+    Given the product "product_pack" denies order if out of stock
+    And the pack "product_pack" decrements pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 11
+    Then I should get an error that you have the maximum quantity available for this pack
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 10
+    Then I should get no error
+    And the remaining available stock for product "product_pack" should be 0
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    And cart "cart_pack" should contain product "product_pack"
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to deny order and only products in pack is decremented
+    # As I check products stock, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" denies order if out of stock
+    And the pack "product_pack" decrements products in pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 6
+    Then I should get an error that you have the maximum quantity available for this pack
+    And cart "cart_pack" should not contain product "product_pack"
+    ## The stock of pack is calculated from the stock of its unit
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 5
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 0
+    And the remaining available stock for product "product_in_pack_1" should be 5
+    And the remaining available stock for product "product_in_pack_2" should be 0
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to deny order and both packs and products are decremented
+    # As I check both, the products stock is limiting, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" denies order if out of stock
+    And the pack "product_pack" decrements both packs and products
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 6
+    Then I should get an error that you have the maximum quantity available for this pack
+    And cart "cart_pack" should not contain product "product_pack"
+    ## The stock of pack is calculated from the stock of its unit
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 5
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to allow order and only pack is decremented
+    # As I check pack stock 10 is the limit
+    Given the product "product_pack" allows order if out of stock
+    And the pack "product_pack" decrements pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 11
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be -1
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 10
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to allow order and only products in pack is decremented
+    # As I check products stock, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" allows order if out of stock
+    And the pack "product_pack" decrements products in pack only
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 6
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be -1
+    And the remaining available stock for product "product_in_pack_1" should be 4
+    And the remaining available stock for product "product_in_pack_2" should be -2
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10
+
+  Scenario: If the pack has availability preferences to allow order and both packs and products are decremented
+    # As I check both, the products stock is limiting, 5 is the limit (5 product_in_pack_1 & 10 product_in_pack_2)
+    Given the product "product_pack" allows order if out of stock
+    And the pack "product_pack" decrements both packs and products
+    When I update quantity of product "product_pack" in the cart "cart_pack" to 11
+    Then I should get no error
+    And cart "cart_pack" should contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be -6
+    And the remaining available stock for product "product_in_pack_1" should be -1
+    And the remaining available stock for product "product_in_pack_2" should be -12
+    When I delete product "product_pack" from cart "cart_pack"
+    And cart "cart_pack" should not contain product "product_pack"
+    And the remaining available stock for product "product_pack" should be 5
+    And the remaining available stock for product "product_in_pack_1" should be 10
+    And the remaining available stock for product "product_in_pack_2" should be 10

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -54,10 +54,11 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\OrderFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\EmployeeFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CartRuleFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
         order:
             paths:
                 - %paths.base%/Features/Scenario/Order


### PR DESCRIPTION
Hello I am trying to install PrestaShop 1.7.7.5 a new installation and during the installation process I get an error where it tells me that the facebook module could not be downloaded from addons.
use version PHP 7.3
![instalacionPR](https://user-images.githubusercontent.com/42347565/124473071-28dc5900-dd9f-11eb-8500-bc5be0b75102.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25235)
<!-- Reviewable:end -->
