### PR TITLE
Fix develop tests crashing because of outdated translation wordings

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -118,9 +118,9 @@ Feature: Duplicate product from Back Office (BO).
     And product "copy_of_product1" should be disabled
     And product "copy_of_product1" type should be standard
     And product "copy_of_product1" localized "name" should be:
-      | locale | value                      |
-      | en-US  | copy of smart sunglasses   |
-      | fr-FR  | copy of lunettes de soleil |
+      | locale | value                       |
+      | en-US  | copy of smart sunglasses    |
+      | fr-FR  | copie de lunettes de soleil |
     And product "copy_of_product1" localized "description" should be:
       | locale | value           |
       | en-US  | nice sunglasses |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since 1.7.8.x wordings have been pushed on crowdin, a behat test was failing because the test was checking a not-yet translated string. Also, Since some tests have been migrated from tests-legacy to tests, one of them was re-downloading a lot of localization pack for each test. This PR solves both issues.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25266)
<!-- Reviewable:end -->
