### PR TITLE
Fix isCatalogMode condition and Remove the price-drop link from the the best seller display condition

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -151,12 +151,15 @@ class SitemapControllerCore extends FrontController
             ],
         ];
 
-        if (Configuration::isCatalogMode() && Configuration::get('PS_DISPLAY_BEST_SELLERS')) {
-            $links[] = [
-                'id' => 'best-sales-page',
-                'label' => $this->trans('Best sellers', [], 'Shop.Theme.Catalog'),
-                'url' => $this->context->link->getPageLink('best-sales'),
-            ];
+        if (!Configuration::isCatalogMode()) {
+            if (Configuration::get('PS_DISPLAY_BEST_SELLERS')) {
+                $links[] = [
+                    'id' => 'best-sales-page',
+                    'label' => $this->trans('Best sellers', [], 'Shop.Theme.Catalog'),
+                    'url' => $this->context->link->getPageLink('best-sales'),
+                ];
+            }
+
             $links[] = [
                 'id' => 'prices-drop-page',
                 'label' => $this->trans('Price drop', [], 'Shop.Theme.Catalog'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | On the sitemap page, until now, the condition `isCatalogueMode` was reversed. So if you were not in catalogue mode, the best sellers + price drops page was not displayed. Also, I moved the link to the price drop from the `PS_DISPLAY_BEST_SELLERS` condition.  Indeed, on the `PricesDropController`, there is no `init()` method which, as for `BestSalesController`, checks the `PS_DISPLAY_BEST_SELLERS` condition. So to standardize, I unlinked the 2 here.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fix issue ? | Fixes #25277 
| How to test?      | On the sitemap page, the prices drop & best sellers page should appear when we are not in catalogue mode. For the best sellers, it also appears if the condition PS_DISPLAY_BEST_SELLERS is valid 
| Possible impacts? | I don't see any


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25268)
<!-- Reviewable:end -->
