### PR TITLE
Use jquery pseudo selector for inputs in "add address" form in "My account" area

### DIFF
--- a/themes/_core/js/address.js
+++ b/themes/_core/js/address.js
@@ -14,7 +14,7 @@ function handleCountryChange(selectors) {
       id_address: $(`${selectors.address} form`).data('id-address'),
     };
     const getFormViewUrl = $(`${selectors.address} form`).data('refresh-url');
-    const formFieldsSelector = `${selectors.address} input`;
+    const formFieldsSelector = `${selectors.address} :input`;
 
     $.post(getFormViewUrl, requestData).then((resp) => {
       const inputs = [];


### PR DESCRIPTION
I'm not sure whether this is a general problem, but in the theme I am using, the country is in a `select`.
This is not picked up by the current selector, meaning that the country is reset each time it is selected. This means clients cannot add addresses from their account page.
This PR fixes the problem.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See above.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | Use a theme with a `select` for the country dropdown in the address page in "My account". When you select a country, the dropdown will automatically reset itself to unselected.
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25280)
<!-- Reviewable:end -->
