### PR TITLE
Add search for newsletter module before going to module configuration on tests

### DIFF
--- a/tests/UI/campaigns/functional/FO/04_newsletter/01_subscribeNewsletter.js
+++ b/tests/UI/campaigns/functional/FO/04_newsletter/01_subscribeNewsletter.js
@@ -18,9 +18,8 @@ const foLoginPage = require('@pages/FO/login');
 const foMyAccountPage = require('@pages/FO/myAccount');
 const foAccountIdentityPage = require('@pages/FO/myAccount/identity');
 
-// Import datas
+// Import data
 const {DefaultCustomer} = require('@data/demo/customer');
-
 
 // Import test context
 const testContext = require('@utils/testContext');
@@ -30,8 +29,11 @@ const baseContext = 'functional_FO_newsletter_subscribeNewsletter';
 
 let browserContext;
 let page;
-const moduleName = 'Newsletter subscription';
 
+const moduleInformation = {
+  tag: 'ps_emailsubscription',
+  name: 'Newsletter subscription',
+};
 
 /*
 Go to the FO homepage
@@ -40,7 +42,7 @@ Go to BO in newsletter module
 Check if correctly subscribed
 Go back to the FO homepage
 Try to subscribe again with the same email
-Go to back to BO and delete subsbcription
+Go to back to BO and delete subscription
  */
 describe('FO Subscribe to Newsletter', async () => {
   // before and after functions
@@ -129,10 +131,11 @@ describe('FO Subscribe to Newsletter', async () => {
     it('should go to newsletter subscription module configuration page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToNewsletterModuleConfigPage', baseContext);
 
-      await moduleManagerPage.goToConfigurationPage(page, moduleName);
+      await moduleManagerPage.searchModule(page, moduleInformation.tag, moduleInformation.name);
+      await moduleManagerPage.goToConfigurationPage(page, moduleInformation.name);
 
       const moduleConfigurationPageSubtitle = await moduleConfigurationPage.getPageSubtitle(page);
-      await expect(moduleConfigurationPageSubtitle).to.contains(moduleName);
+      await expect(moduleConfigurationPageSubtitle).to.contains(moduleInformation.name);
     });
 
     it('should check if user is unsubscribed from newsletter', async function () {
@@ -187,10 +190,11 @@ describe('FO Subscribe to Newsletter', async () => {
     it('should go to newsletter subscription module configuration page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goBackToNewsletterModuleConfig', baseContext);
 
-      await moduleManagerPage.goToConfigurationPage(page, moduleName);
+      await moduleManagerPage.searchModule(page, moduleInformation.tag, moduleInformation.name);
+      await moduleManagerPage.goToConfigurationPage(page, moduleInformation.name);
 
       const moduleConfigurationPageSubtitle = await moduleConfigurationPage.getPageSubtitle(page);
-      await expect(moduleConfigurationPageSubtitle).to.contains(moduleName);
+      await expect(moduleConfigurationPageSubtitle).to.contains(moduleInformation.name);
     });
 
     it('should check if previous customer subscription is visible in table', async function () {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add search for newsletter module before going to module configuration on tests
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | no
| How to test?      | no tests needed
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25285)
<!-- Reviewable:end -->
