### PR TITLE
Fix cart rule that can be used more than once per user when it shouldn't

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -674,7 +674,7 @@ class CartRuleCore extends ObjectModel
                 // in for example), these cart rules are not taken into account by the query above:
                 // so we count cart rules that are already linked to the current cart but not attached to an order yet.
                 $quantityUsed += (int) Db::getInstance()->getValue('
-                    select count(*)
+                    SELECT count(*)
                     from ps_cart_cart_rule ccr
                     LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
                     where c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . '

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -677,7 +677,7 @@ class CartRuleCore extends ObjectModel
                     SELECT count(*)
                     FROM ps_cart_cart_rule ccr
                     LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
-                    where c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . '
+                    WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . '
                     AND NOT EXISTS (SELECT null FROM ps_orders o where o.id_cart = ccr.id_cart)'
                 );
             } else {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -668,20 +668,21 @@ class CartRuleCore extends ObjectModel
 			AND ocr.`id_cart_rule` = ' . (int) $this->id . '
 			AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.`current_state`
 			');
-            // also count cart rules that are linked to a cart that is not attached to an order yet
+
             if ($alreadyInCart) {
-                $quantityUsedWithoutOrder = Db::getInstance()->getValue('
+                // sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
+                // in for example), these cart rules are not taken into account buy the query above:
+                // so we count cart rules that are already linked to the current cart but not attached to an order yet.
+                $quantityUsed += (int) Db::getInstance()->getValue('
                     select count(*)
                     from ps_cart_cart_rule ccr
                     LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
-                    where c.id_customer = ' . $cart->id_customer . '
+                    where c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . '
                     AND NOT EXISTS (SELECT null FROM ps_orders o where o.id_cart = ccr.id_cart)'
                 );
-                $quantityUsed += $quantityUsedWithoutOrder;
-            }
-            // When checking the cart rules present in that cart the request result is accurate
-            // When we check if using the cart rule one more time is valid then we increment this value
-            if (!$alreadyInCart) {
+            } else {
+                // When checking the cart rules present in that cart the request result is accurate
+                // When we check if using the cart rule one more time is valid then we increment this value
                 ++$quantityUsed;
             }
             if ($quantityUsed > $this->quantity_per_user) {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -673,13 +673,14 @@ class CartRuleCore extends ObjectModel
                 // Sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
                 // in for example), these cart rules are not taken into account by the query above:
                 // so we count cart rules that are already linked to the current cart but not attached to an order yet.
+
                 $quantityUsed += (int) Db::getInstance()->getValue('
                     SELECT count(*)
                     FROM ps_cart_cart_rule ccr
-                    LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
-                    WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . '
-                    AND NOT EXISTS (SELECT null FROM ps_orders o where o.id_cart = ccr.id_cart)'
-                );
+                    INNER JOIN ps_cart c ON c.id_cart = ccr.id_cart
+                    LEFT JOIN ps_orders o ON o.id_cart = c.id_cart
+                    WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
+                ');
             } else {
                 // When checking the cart rules present in that cart the request result is accurate
                 // When we check if using the cart rule one more time is valid then we increment this value

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -677,7 +677,7 @@ class CartRuleCore extends ObjectModel
                     select count(*)
                     from ps_cart_cart_rule ccr
                     LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
-                    where c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . '
+                    where c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . '
                     AND NOT EXISTS (SELECT null FROM ps_orders o where o.id_cart = ccr.id_cart)'
                 );
             } else {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -675,7 +675,7 @@ class CartRuleCore extends ObjectModel
                 // so we count cart rules that are already linked to the current cart but not attached to an order yet.
                 $quantityUsed += (int) Db::getInstance()->getValue('
                     SELECT count(*)
-                    from ps_cart_cart_rule ccr
+                    FROM ps_cart_cart_rule ccr
                     LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
                     where c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . '
                     AND NOT EXISTS (SELECT null FROM ps_orders o where o.id_cart = ccr.id_cart)'

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -670,7 +670,7 @@ class CartRuleCore extends ObjectModel
 			');
 
             if ($alreadyInCart) {
-                // sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
+                // Sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
                 // in for example), these cart rules are not taken into account buy the query above:
                 // so we count cart rules that are already linked to the current cart but not attached to an order yet.
                 $quantityUsed += (int) Db::getInstance()->getValue('

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -668,6 +668,17 @@ class CartRuleCore extends ObjectModel
 			AND ocr.`id_cart_rule` = ' . (int) $this->id . '
 			AND ' . (int) Configuration::get('PS_OS_ERROR') . ' != o.`current_state`
 			');
+            // also count cart rules that are linked to a cart that is not attached to an order yet
+            if ($alreadyInCart) {
+                $quantityUsedWithoutOrder = Db::getInstance()->getValue('
+                    select count(*)
+                    from ps_cart_cart_rule ccr
+                    LEFT JOIN ps_cart c on c.id_cart = ccr.id_cart
+                    where c.id_customer = ' . $cart->id_customer . '
+                    AND NOT EXISTS (SELECT null FROM ps_orders o where o.id_cart = ccr.id_cart)'
+                );
+                $quantityUsed += $quantityUsedWithoutOrder;
+            }
             // When checking the cart rules present in that cart the request result is accurate
             // When we check if using the cart rule one more time is valid then we increment this value
             if (!$alreadyInCart) {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -671,7 +671,7 @@ class CartRuleCore extends ObjectModel
 
             if ($alreadyInCart) {
                 // Sometimes a cart rule is already in a cart, but the cart is not yet attached to an order (when logging
-                // in for example), these cart rules are not taken into account buy the query above:
+                // in for example), these cart rules are not taken into account by the query above:
                 // so we count cart rules that are already linked to the current cart but not attached to an order yet.
                 $quantityUsed += (int) Db::getInstance()->getValue('
                     select count(*)

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -485,7 +485,6 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @When I create an order for current cart
      * @When /^I create an order with discount "(.+)" for current cart$/
      *
      * @param string $cartRuleName

--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -485,34 +485,6 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @When /^I create an order with discount "(.+)" for current cart$/
-     *
-     * @param string $cartRuleName
-     */
-    public function createOrderForCurrentCart(string $cartRuleName)
-    {
-        $cart = $this->getCurrentCart();
-        $order = new Order();
-        $order->id_address_invoice = 4;
-        $order->id_address_delivery = 4;
-        $order->id_cart = $cart->id;
-        $order->id_currency = 1;
-        $order->id_customer = $cart->id_customer;
-        $order->id_carrier = 1;
-        $order->id_shop = 1;
-        $order->id_shop_group = 1;
-        $order->payment = 'Payment by check';
-        $order->module = 'ps_checkpayment';
-        $order->total_paid = 42;
-        $order->total_products = 42;
-        $order->conversion_rate = 1.0;
-        $order->total_paid_real = 42;
-        $order->total_products_wt = 42;
-        $order->save();
-        $order->addCartRule($this->cartRules[$cartRuleName]->id, $cartRuleName, ['tax_excl' => 1, 'tax_incl' => 1.2]);
-    }
-
-    /**
      * @Then usage limit per user for cart rule :cartRuleReference is detected
      *
      * @param string $cartRuleReference

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -1118,4 +1118,34 @@ class CartFeatureContext extends AbstractDomainFeatureContext
             throw new \RuntimeException(sprintf('Expects %s, got %s instead', $expectedTotal, $cartTotal));
         }
     }
+
+    /**
+     * @When I create an empty anonymous cart :cartReference
+     */
+    public function createEmptyAnonymousCart(string $cartReference)
+    {
+        $cart = new Cart();
+        $cart->id_currency = 1;
+        $cart->id_guest = 1;
+        $cart->save();
+        SharedStorage::getStorage()->set($cartReference, (int) $cart->id);
+    }
+
+    /**
+     * @When I assign customer :customerReference to cart :cartReference
+     *
+     * @param string $customerReference
+     * @param string $cartReference
+     */
+    public function assignCustomerToCart(string $customerReference, string $cartReference)
+    {
+        $cartId = (int) SharedStorage::getStorage()->get($cartReference);
+        $customerId = (int) SharedStorage::getStorage()->get($customerReference);
+
+        $cart = new Cart($cartId);
+        $cart->id_guest = null;
+        $cart->id_customer = $customerId;
+        $cart->save();
+        Context::getContext()->cart = $cart;
+    }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -1121,6 +1121,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @When I create an empty anonymous cart :cartReference
+     *
+     * @param string $cartReference
      */
     public function createEmptyAnonymousCart(string $cartReference)
     {

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
@@ -8,20 +8,27 @@ Feature: A cart rule's usage limit per user is detected
     Given country "US" is enabled
     And there is customer "testCustomer" with email "pub@prestashop.com"
     And customer "testCustomer" has address in "US" country
-
-  Scenario: Cart rule usage limit is detected when the cart rule is created anonymously then assigned to a customer who already used it
-    Given I create an empty cart "dummy_cart" for customer "testCustomer"
+    And I am logged in as "test@prestashop.com" employee
     And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And the module "dummy_payment" is installed
     And there is a cart rule named "limitedCartRule" that applies an amount discount of 1.0 with priority 1, quantity of 2 and quantity per user 1
     And cart rule "limitedCartRule" has a discount code "foo1"
     And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+
+  Scenario: Cart rule usage limit is detected when the cart rule is created anonymously then assigned to a customer who already used it
+    Given I create an empty cart "dummy_cart" for customer "testCustomer"
     When I add 1 items of product "product1" in my cart
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
     Then I should have 1 different products in my cart
     And cart rule "limitedCartRule" can be applied to my cart
     When I use the discount "limitedCartRule"
     Then at least one cart rule applies today for customer with id 0
     And I should have 1 products in my cart
-    When I create an order with discount "limitedCartRule" for current cart
+    When I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
     And I create an empty anonymous cart "anonymousDummyCart"
     And I add 1 product "product1" to the cart "anonymousDummyCart"
     And I use a voucher "foo1" on the cart "anonymousDummyCart"

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
@@ -1,0 +1,29 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --tags remove-cart-rule
+@reset-database-before-feature
+@cart-rule-usage-limit
+
+Feature: Remove cart rule from a cart if it's not valid
+
+  Background:
+    Given country "US" is enabled
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+
+  Scenario: Cart rule usage limit is detected when the cart rule is created anonymously then assigned to a customer who already used it
+    Given I create an empty cart "dummy_cart" for customer "testCustomer"
+    And shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a cart rule named "limitedCartRule" that applies an amount discount of 1.0 with priority 1, quantity of 2 and quantity per user 1
+    And cart rule "limitedCartRule" has a discount code "foo1"
+    And there is a product in the catalog named "product1" with a price of 19.812 and 1000 items in stock
+    When I add 1 items of product "product1" in my cart
+    Then I should have 1 different products in my cart
+    And cart rule "limitedCartRule" can be applied to my cart
+    When I use the discount "limitedCartRule"
+    Then at least one cart rule applies today for customer with id 0
+    And I should have 1 products in my cart
+    When I create an order with discount "limitedCartRule" for current cart
+    And I create an empty anonymous cart "anonymousDummyCart"
+    And I add 1 product "product1" to the cart "anonymousDummyCart"
+    And I use a voucher "foo1" on the cart "anonymousDummyCart"
+    And I assign customer "testCustomer" to cart "anonymousDummyCart"
+    Then usage limit per user for cart rule "limitedCartRule" is detected

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
@@ -2,7 +2,7 @@
 @reset-database-before-feature
 @cart-rule-usage-limit
 
-Feature: Remove cart rule from a cart if it's not valid
+Feature: A cart rule's usage limit per user is detected
 
   Background:
     Given country "US" is enabled

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -60,6 +60,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ModuleFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
         order:
             paths:
                 - %paths.base%/Features/Scenario/Order


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | 
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25203
| How to test?      | See issue #25203
| Possible impacts? | See issues  #19949 and #19960 for possible regressions :/

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25286)
<!-- Reviewable:end -->
