### PR TITLE
Show error delete product on order page admin

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-manager.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-manager.js
@@ -58,8 +58,8 @@ export default class OrderProductManager {
         orderId,
       });
     }, (response) => {
-      if (response.message) {
-        $.growl.error({message: response.message});
+      if (response.responseJSON && response.responseJSON.message) {
+        $.growl.error({message: response.responseJSON.message});
       }
     });
   }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The errors on action delete product in the admin page of an order were not showing. It's OK on update & add action.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Fixed ticket?        | Fixes #25298
| Deprecations?     | no
| How to test?      | Create an `actionObjectOrderDetailDeleteBefore` and throw an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25291)
<!-- Reviewable:end -->
