### PR TITLE
In upgrade, fixed configuration update on multi store

### DIFF
--- a/install-dev/upgrade/upgrade.php
+++ b/install-dev/upgrade/upgrade.php
@@ -96,9 +96,9 @@ if (isset($_GET['action']) && method_exists($upgrade, 'do'.$_GET['action'])) {
 $result = '<?xml version="1.0" encoding="UTF-8"?>';
 if (!$upgrade->hasFailure()) {
     if (!isset($_GET['action']) || 'UpgradeComplete' === $_GET['action']) {
-        Configuration::updateValue('PS_HIDE_OPTIMIZATION_TIPS', 0);
-        Configuration::updateValue('PS_NEED_REBUILD_INDEX', 1);
-        Configuration::updateValue('PS_VERSION_DB', _PS_INSTALL_VERSION_);
+        Configuration::updateGlobalValue('PS_HIDE_OPTIMIZATION_TIPS', 0);
+        Configuration::updateGlobalValue('PS_NEED_REBUILD_INDEX', 1);
+        Configuration::updateGlobalValue('PS_VERSION_DB', _PS_INSTALL_VERSION_);
     }
 
     $result .= '<action result="ok" id="">'."\n";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.8.x
| Description?      | Manual upgrade is broken when multi store is enabled.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25303.
| How to test?      | Please follow test instructions from https://github.com/PrestaShop/PrestaShop/issues/25303
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

When multi store is enabled the [manual upgrade](https://devdocs.prestashop.com/1.7/basics/keeping-up-to-date/upgrade/#manual-upgrade--process-details) procedure is not properly handling [database upgrade](https://devdocs.prestashop.com/1.7/basics/keeping-up-to-date/upgrade/#database-upgrade).

After running the `php install/upgrade/upgrade.php` command, a new line is created in `ps_configuration` to save the `PS_VERSION_DB` (with `ship_id = 1`) instead of updating the existing line (with `shop_id = NULL`).

![image](https://user-images.githubusercontent.com/915273/125158617-6f192a00-e19c-11eb-8c55-1b7a4ecab32f.png)

This is a problem because if we run the upgrade script again, Prestashop will read the value from the 1st line and will try to run all the database upgrade scripts again.

In order to fix the issue, this PR use `Configuration::updateGlobalValue` instead of `Configuration::updateValue` in the upgrade script to be consistent with install script and 1 click upgrade module:

- In the install script, the `Configuration::updateGlobalValue` method is used:
https://github.com/PrestaShop/PrestaShop/blob/1453353fa9ddca4250c41b44bef77e9be8b0d15c/src/PrestaShopBundle/Install/Install.php#L445-L447

- In the 1 click upgrade module, the update query is generic and doesn't target the shop id:
https://github.com/PrestaShop/autoupgrade/blob/261dea41b4f82416c0d28e1b2bc96df75e57da59/classes/UpgradeTools/CoreUpgrader/CoreUpgrader.php#L465-L467

This PR solves the issue on our projects. (we built an automatic tool using the manual upgrade to upgrade our Prestashop projects)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25311)
<!-- Reviewable:end -->
