### PR TITLE
Clean Back-office templates

### DIFF
--- a/admin-dev/themes/default/template/content.tpl
+++ b/admin-dev/themes/default/template/content.tpl
@@ -26,10 +26,6 @@
 {* ajaxBox allows*}
 <div id="ajaxBox" style="display:none"></div>
 
-<div class="row">
-	<div class="col-lg-12">
-		{if isset($content)}
-			{$content}
-		{/if}
-	</div>
-</div>
+{if isset($content)}
+	{$content}
+{/if}

--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-renderer.ts
@@ -106,7 +106,7 @@ export default class OrderProductRenderer {
     $(OrderViewPageMap.productsPanel)
       .detach()
       .appendTo($modificationPosition);
-    $modificationPosition.closest('.row').removeClass('d-none');
+    $modificationPosition.removeClass('d-none');
 
     // Show column location & refunded
     this.toggleColumn(OrderViewPageMap.productsCellLocation);
@@ -131,7 +131,6 @@ export default class OrderProductRenderer {
   moveProductPanelToOriginalPosition(): void {
     $(OrderViewPageMap.productAddNewInvoiceInfo).addClass('d-none');
     $(OrderViewPageMap.productModificationPosition)
-      .closest('.row')
       .addClass('d-none');
 
     $(OrderViewPageMap.productsPanel)

--- a/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Blocks/pagination.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Blocks/pagination.html.twig
@@ -25,24 +25,19 @@
 
 {% block grid_pagination %}
   {% if grid.data.records_total > 10 or grid.pagination.offset %}
-    <div class="row">
-      <div class="col-md-12">
-        {% set route_params = {} %}
+    {% set route_params = {} %}
 
-        {% for param_name, param_value in app.request.attributes.get('_route_params') %}
-          {% set route_params = route_params|merge({ (param_name) : (param_value) }) %}
-        {% endfor %}
+    {% for param_name, param_value in app.request.attributes.get('_route_params') %}
+      {% set route_params = route_params|merge({ (param_name) : (param_value) }) %}
+    {% endfor %}
 
-        {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
-          'limit': grid.pagination.limit,
-          'offset': grid.pagination.offset,
-          'total': grid.data.records_total,
-          'prefix': grid.form_prefix,
-          'caller_route': app.request.attributes.get('_route'),
-          'caller_parameters': route_params
-        })) }}
-      </div>
-    </div>
+    {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
+      'limit': grid.pagination.limit,
+      'offset': grid.pagination.offset,
+      'total': grid.data.records_total,
+      'prefix': grid.form_prefix,
+      'caller_route': app.request.attributes.get('_route'),
+      'caller_parameters': route_params
+    })) }}
   {% endif %}
 {% endblock %}
-

--- a/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Columns/Content/toggle.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Columns/Content/toggle.html.twig
@@ -33,9 +33,13 @@
     class="ps-switch ps-switch-sm ps-switch-nolabel ps-switch-center ps-togglable-row"
     data-toggle-url="{{ path(column.options.route, {(column.options.route_param_name) : id_primary_key})}}"
   >
-  <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" id="input-false-{{ column.options.route }}-{{ id_primary_key }}" value="0" {% if not isValid %}checked{% endif %}>
+  <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" 
+         id="input-false-{{ column.options.route }}-{{ id_primary_key }}" 
+         value="0" {% if not isValid %}checked{% endif %}>
       <label for="input-false-{{ column.options.route }}-{{ id_primary_key }}">Off</label>
-      <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" id="input-true-{{ column.options.route }}-{{ id_primary_key }}" value="1" {% if isValid %}checked{% endif %}>
+      <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" 
+             id="input-true-{{ column.options.route }}-{{ id_primary_key }}" 
+             value="1" {% if isValid %}checked{% endif %}>
       <label for="input-true-{{ column.options.route }}-{{ id_primary_key }}">On</label>
       <span class="slide-button"></span>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Common/Grid/grid.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Common/Grid/grid.html.twig
@@ -23,38 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div class="row grid js-grid" id="{{ grid.id }}_grid" data-grid-id="{{ grid.id }}">
-  <div class="col-sm">
-    {% block grid_header_row %}
-      <div class="row">
-        {% block grid_bulk_actions_block %}
-          <div class="col-sm">
-            <div class="row">
-              <div class="col-sm">
-                {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions.html.twig', {'grid': grid}) }}
-              </div>
-            </div>
-          </div>
-        {% endblock %}
-      </div>
+<div class="grid js-grid" id="{{ grid.id }}_grid" data-grid-id="{{ grid.id }}">
+  {% block grid_header_row %}
+    {% block grid_bulk_actions_block %}
+      {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions.html.twig', {'grid': grid}) }}
     {% endblock %}
+  {% endblock %}
 
-    {% block grid_table_row %}
-      <div class="row">
-        <div class="col-sm">
-          {{ include('@PrestaShop/Admin/Common/Grid/Blocks/table.html.twig', {'grid': grid}) }}
-        </div>
-      </div>
-    {% endblock %}
+  {% block grid_table_row %}
+    {{ include('@PrestaShop/Admin/Common/Grid/Blocks/table.html.twig', {'grid': grid}) }}
+  {% endblock %}
 
-    {% block grid_footer_row %}
-      <div class="row">
-        <div class="col">
-          {{ include('@PrestaShop/Admin/Common/Grid/Blocks/pagination.html.twig', {'grid': grid}) }}
-        </div>
-      </div>
-    {% endblock %}
-  </div>
+  {% block grid_footer_row %}
+    {{ include('@PrestaShop/Admin/Common/Grid/Blocks/pagination.html.twig', {'grid': grid}) }}
+  {% endblock %}
 </div>
 
 {% block grid_extra_content %}{% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Backup/download_view.html.twig
@@ -27,34 +27,28 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block content %}
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col">
-        <div class="card">
-          <h3 class="card-header">
-            <i class="material-icons">cloud_download</i>
-            {{ 'Download'|trans({}, 'Admin.Actions') }}
-          </h3>
-          <div class="card-body">
-            <div class="alert alert-success" role="alert">
-              <p class="alert-text">
-                {{ 'Beginning the download ...'|trans({}, 'Admin.Advparameters.Notification') }}
-              </p>
-            </div>
-            <p>
-              {{ 'Backup files should automatically start downloading.'|trans({}, 'Admin.Advparameters.Notification') }}
-              {{ 'If not,[1][2] please click here[/1]!'|trans({'[1]': ' <a href="'~ downloadFile.url ~'" class="btn btn-outline-primary btn-sm">', '[/1]': '</a> ', '[2]': '<i class="icon-download"></i>'}, 'Admin.Advparameters.Notification')|raw }}
-          </p>
-          <p class="mb-0">
-            <a class="btn btn-outline-primary btn-sm" href="{{ path('admin_backups_index') }}">
-              <i class="material-icons">keyboard_backspace</i>
-              {{ 'Back to list'|trans({}, 'Admin.Actions') }}
-            </a>
-          </p>
-            <iframe src="{{ downloadFile.url }}" class="d-none"></iframe>
-          </div>
-        </div>
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">cloud_download</i>
+      {{ 'Download'|trans({}, 'Admin.Actions') }}
+    </h3>
+    <div class="card-body">
+      <div class="alert alert-success" role="alert">
+        <p class="alert-text">
+          {{ 'Beginning the download ...'|trans({}, 'Admin.Advparameters.Notification') }}
+        </p>
       </div>
+      <p>
+        {{ 'Backup files should automatically start downloading.'|trans({}, 'Admin.Advparameters.Notification') }}
+        {{ 'If not,[1][2] please click here[/1]!'|trans({'[1]': ' <a href="'~ downloadFile.url ~'" class="btn btn-outline-primary btn-sm">', '[/1]': '</a> ', '[2]': '<i class="icon-download"></i>'}, 'Admin.Advparameters.Notification')|raw }}
+      </p>
+      <p class="mb-0">
+        <a class="btn btn-outline-primary btn-sm" href="{{ path('admin_backups_index') }}">
+          <i class="material-icons">keyboard_backspace</i>
+          {{ 'Back to list'|trans({}, 'Admin.Actions') }}
+        </a>
+      </p>
+      <iframe src="{{ downloadFile.url }}" class="d-none"></iframe>
     </div>
   </div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Backup/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Backup/index.html.twig
@@ -34,39 +34,24 @@
   {% endblock %}
 
   {% block backup_alerts %}
-    {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig' %}
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig' %}
-      </div>
-    </div>
+    {% if multistoreIsUsed %}
+      {{ ps.infotip(multistoreInfoTip, true) }}
+    {% endif %}
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_warning.html.twig' %}
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/backup_info.html.twig' %}
   {% endblock %}
 
   {% block backup_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': backupGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': backupGrid} %}
   {% endblock %}
 
   {% block backup_options %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig' %}
   {% endblock %}
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }}
+  {{ parent() }}
 
   <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/backup.bundle.js') }}"></script>

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
@@ -26,38 +26,37 @@
 {% form_theme emailConfigurationForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block email_configuration %}
-  <div class="col-12">
-    <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">mail</i> {{ 'Email'|trans({}, 'Admin.Global') }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          {{ form_row(emailConfigurationForm.send_emails_to) }}
-          {{ form_row(emailConfigurationForm.mail_method) }}
-          <div class="js-smtp-configuration{% if emailConfigurationForm.mail_method.vars.value != smtpMailMethod %} d-none{% endif %}">
-            {{ form_widget(emailConfigurationForm.smtp_config) }}
-          </div>
-          {{ form_row(emailConfigurationForm.mail_type) }}
-          {{ form_row(emailConfigurationForm.log_emails) }}
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'Fill in the fields below to set up DKIM signing of outgoing emails. This will reduce the likelihood of your emails being marked as spam.
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">mail</i>
+      {{ 'Email'|trans({}, 'Admin.Global') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_row(emailConfigurationForm.send_emails_to) }}
+        {{ form_row(emailConfigurationForm.mail_method) }}
+        <div class="js-smtp-configuration{% if emailConfigurationForm.mail_method.vars.value != smtpMailMethod %} d-none{% endif %}">
+          {{ form_widget(emailConfigurationForm.smtp_config) }}
+        </div>
+        {{ form_row(emailConfigurationForm.mail_type) }}
+        {{ form_row(emailConfigurationForm.log_emails) }}
+        <div class="alert alert-info" role="alert">
+          <p class="alert-text">
+            {{ 'Fill in the fields below to set up DKIM signing of outgoing emails. This will reduce the likelihood of your emails being marked as spam.
               You can get the data below from your server administrator or generate it yourself by using one of the freely available tools, such as dkimcore.org.
               Also, make sure that your server is registered as an authorized sender in your SPF record. '|trans({}, 'Admin.Advparameters.Help') }}
-            </p>
-          </div>
-          {{ form_row(emailConfigurationForm.dkim_enable) }}
-          <div class="js-dkim-configuration{% if emailConfigurationForm.dkim_enable.vars.value == 0 %} d-none{% endif %}">
-            {{ form_widget(emailConfigurationForm.dkim_config) }}
-          </div>
-          {{ form_rest(emailConfigurationForm) }}
+          </p>
         </div>
+        {{ form_row(emailConfigurationForm.dkim_enable) }}
+        <div class="js-dkim-configuration{% if emailConfigurationForm.dkim_enable.vars.value == 0 %} d-none{% endif %}">
+          {{ form_widget(emailConfigurationForm.dkim_config) }}
+        </div>
+        {{ form_rest(emailConfigurationForm) }}
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="form-log-email-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-        </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-log-email-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
@@ -27,34 +27,27 @@
 
 {% block test_email_sending %}
   {{ form_start(testEmailSendingForm, {'action': path('admin_emails_send_test')}) }}
-  <div class="row justify-content-center">
-    <div class="col">
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">settings</i> {{ 'Test your email configuration'|trans }}
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            {{ form_widget(testEmailSendingForm) }}
-            <div class="row">
-              <div class="col">
-                <div class="alert alert-danger d-none js-test-email-errors" role="alert"></div>
-                <div class="alert alert-success d-none js-test-email-success" role="alert">
-                  <p class="alert-text">{{ 'A test email has been sent to the email address you provided.'|trans({}, 'Admin.Advparameters.Feature') }}</p>
-                </div>
-              </div>
-            </div>
-          </div>
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'Test your email configuration'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(testEmailSendingForm) }}
+        <div class="alert alert-danger d-none js-test-email-errors" role="alert"></div>
+        <div class="alert alert-success d-none js-test-email-success" role="alert">
+          <p class="alert-text">{{ 'A test email has been sent to the email address you provided.'|trans({}, 'Admin.Advparameters.Feature') }}</p>
         </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <div class="spinner d-none js-test-email-loader"></div>
-            <button type="button" class="btn btn-primary js-send-test-email-btn">
-              <i class="material-icons">email</i>
-              {{ 'Send a test email'|trans }}
-            </button>
-          </div>
-        </div>
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <div class="spinner d-none js-test-email-loader"></div>
+        <button type="button" class="btn btn-primary js-send-test-email-btn">
+          <i class="material-icons">email</i>
+          {{ 'Send a test email'|trans }}
+        </button>
       </div>
     </div>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Email/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Email/index.html.twig
@@ -27,21 +27,15 @@
 
 {% block content %}
   {% if isEmailLogsEnabled %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Email/Blocks/email_logs_grid.html.twig' %}
-    </div>
-  </div>
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Email/Blocks/email_logs_grid.html.twig' %}
   {% endif %}
 
   {{ form_start(emailConfigurationForm, {'action': path('admin_emails_save_options')}) }}
-  <div class="row justify-content-center">
-    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig' %}
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig' %}
 
-    {% block email_configuration_form_rest %}
-      {{ form_rest(emailConfigurationForm) }}
-    {% endblock %}
-  </div>
+  {% block email_configuration_form_rest %}
+    {{ form_rest(emailConfigurationForm) }}
+  {% endblock %}
   {{ form_end(emailConfigurationForm) }}
 
   {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig' %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/create.html.twig
@@ -28,9 +28,8 @@
 {% set layoutTitle = 'Add new'|trans({}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig' with {
+
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig' with {
         employeeForm: employeeForm,
         level: level,
         errorMessage: errorMessage,
@@ -39,8 +38,7 @@
         getTabsUrl: getTabsUrl,
         avatarUrl: employeeForm.vars.defaultAvatarUrl
       } %}
-    </div>
-  </div>
+
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
@@ -40,9 +40,7 @@
     </div>
   {% endif %}
 
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig' with {
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig' with {
         employeeForm: employeeForm,
         level: level,
         errorMessage: errorMessage,
@@ -52,8 +50,7 @@
         getTabsUrl: getTabsUrl,
         avatarUrl: editableEmployee.avatarUrl
       } %}
-    </div>
-  </div>
+
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/index.html.twig
@@ -36,19 +36,11 @@
 
 {% block content %}
   {% block employee_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block employee_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with { 'grid': employeeGrid } %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with { 'grid': employeeGrid } %}
   {% endblock %}
 
   {% block employee_options %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig
@@ -28,43 +28,45 @@
 {% form_theme featureFlagsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block content %}
-  {% if displayAllShopsContextForced %}{{ ps.infotip(multistoreForcedContextInfoTip, true) }}{% endif %}
-  <div class="row justify-content-center">
-    {{ form_start(featureFlagsForm, {attr : {class: 'form col', id:'feature-flag-form'}, action: path('admin_feature_flags_index') }) }}
-    {% block feature_flag_form %}
-      <div class="card" id="configuration_fieldset_general">
-        <h3 class="card-header">
-          <i class="material-icons">settings</i> {{ 'Experimental features'|trans }}
-        </h3>
+  {% if displayAllShopsContextForced %}
+    {{ ps.infotip(multistoreForcedContextInfoTip, true) }}
+  {% endif %}
+  {{ form_start(featureFlagsForm, {attr : {class: 'form', id:'feature-flag-form'}, action: path('admin_feature_flags_index') }) }}
+  {% block feature_flag_form %}
+    <div class="card" id="configuration_fieldset_general">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'Experimental features'|trans }}
+      </h3>
 
-        <div class="card-block row">
-          <div class="card-text">
-            <div class="alert medium-alert alert-warning" role="alert">
-              {{ 'Testing a feature before its official release can be exciting. However, you must be aware of the potential risks of such experiments:'|trans({}, 'Admin.Advparameters.Notification') }}
-              <ul>
-                <li>{{ 'Experimental features are still under development. Enabling them could therefore have unintended consequences and cause data loss.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
-                <li>{{ 'In any case, you should never experiment in production.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
-              </ul>
-            </div>
-            {{ form_widget(featureFlagsForm) }}
+      <div class="card-block row">
+        <div class="card-text">
+          <div class="alert medium-alert alert-warning" role="alert">
+            {{ 'Testing a feature before its official release can be exciting. However, you must be aware of the potential risks of such experiments:'|trans({}, 'Admin.Advparameters.Notification') }}
+            <ul>
+              <li>{{ 'Experimental features are still under development. Enabling them could therefore have unintended consequences and cause data loss.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
+              <li>{{ 'In any case, you should never experiment in production.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
+            </ul>
+          </div>
+          {{ form_widget(featureFlagsForm) }}
+        </div>
+      </div>
+      {% if featureFlagsForm.vars.data is not empty %}
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button type="submit" id="submit-btn-feature-flag" class="btn btn-primary" 
+                    data-modal-title="{{ 'Are you sure you want to enable this experimental feature?'|trans({}, 'Admin.Advparameters.Notification') }}" 
+                    data-modal-message="{{ 'You are about to enable a feature that is not stable yet. This should only be done in a test environment or in full knowledge of the potential risks.'|trans({}, 'Admin.Advparameters.Notification') }}" 
+                    data-modal-apply="{{ 'Enable'|trans({}, 'Admin.Actions') }}" 
+                    data-modal-cancel="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
           </div>
         </div>
-        {% if featureFlagsForm.vars.data is not empty %}
-          <div class="card-footer">
-            <div class="d-flex justify-content-end">
-              <button type="submit" id="submit-btn-feature-flag" class="btn btn-primary"
-                      data-modal-title="{{ 'Are you sure you want to enable this experimental feature?'|trans({}, 'Admin.Advparameters.Notification') }}"
-                      data-modal-message="{{ 'You are about to enable a feature that is not stable yet. This should only be done in a test environment or in full knowledge of the potential risks.'|trans({}, 'Admin.Advparameters.Notification') }}"
-                      data-modal-apply="{{ 'Enable'|trans({}, 'Admin.Actions') }}"
-                      data-modal-cancel="{{ 'Cancel'|trans({}, 'Admin.Actions') }}"
-              >{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-            </div>
-          </div>
-        {% endif %}
-      </div>
-    {% endblock %}
-    {{ form_end(featureFlagsForm) }}
-  </div>
+      {% endif %}
+    </div>
+  {% endblock %}
+  {{ form_end(featureFlagsForm) }}
 
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_data_configuration.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_data_configuration.html.twig
@@ -28,19 +28,18 @@
 {{ form_start(importDataConfigurationForm, {attr: {class: 'import-data-configuration-form'}}) }}
 <div class="card">
   <h3 class="card-header">
-    <i class="material-icons">list</i> {{ 'Match your data'|trans }}
+    <i class="material-icons">list</i>
+    {{ 'Match your data'|trans }}
   </h3>
   <div class="card-block row">
     <div class="card-text">
-      <div class="row">
-        <div class="col">
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'Please match each column of your source file to one of the destination columns.'|trans }}
-            </p>
-          </div>
-        </div>
+
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {{ 'Please match each column of your source file to one of the destination columns.'|trans }}
+        </p>
       </div>
+
       <div class="form-group row">
         <label class="form-control-label">
           {{ 'Load a data matching configuration'|trans }}
@@ -51,17 +50,13 @@
               {{ form_widget(importDataConfigurationForm.matches) }}
             </div>
             <div class="col">
-              <button
-                class="btn btn-outline-primary js-load-import-match"
-                data-url="{{ path('admin_import_data_configuration_get') }}"
-              >
-                <i class="material-icons">settings</i> {{ 'Load'|trans({}, 'Admin.Actions') }}
+              <button class="btn btn-outline-primary js-load-import-match" data-url="{{ path('admin_import_data_configuration_get') }}">
+                <i class="material-icons">settings</i>
+                {{ 'Load'|trans({}, 'Admin.Actions') }}
               </button>
-              <button
-                class="btn btn-outline-primary js-delete-import-match"
-                data-url="{{ path('admin_import_data_configuration_delete') }}"
-              >
-                <i class="material-icons">delete</i> {{ 'Delete'|trans({}, 'Admin.Actions') }}
+              <button class="btn btn-outline-primary js-delete-import-match" data-url="{{ path('admin_import_data_configuration_delete') }}">
+                <i class="material-icons">delete</i>
+                {{ 'Delete'|trans({}, 'Admin.Actions') }}
               </button>
             </div>
           </div>
@@ -77,11 +72,9 @@
               {{ form_widget(importDataConfigurationForm.match_name, {'attr': {'class': 'js-import-match-input', 'type': 'button'}}) }}
             </div>
             <div class="col">
-              <button
-                class="btn btn-outline-primary js-save-import-match"
-                data-url="{{ path('admin_import_data_configuration_create') }}"
-              >
-                <i class="material-icons">save</i> {{ 'Save'|trans({}, 'Admin.Actions') }}
+              <button class="btn btn-outline-primary js-save-import-match" data-url="{{ path('admin_import_data_configuration_create') }}">
+                <i class="material-icons">save</i>
+                {{ 'Save'|trans({}, 'Admin.Actions') }}
               </button>
             </div>
           </div>
@@ -92,51 +85,45 @@
           {{ 'Rows to skip'|trans }}
         </label>
         <div class="col-sm">
-          {{ form_widget(importDataConfigurationForm.skip, {'attr': {'class': 'col-xs-12 col-md-4 js-rows-skip', 'min': 0}}) }}
+          {{ form_widget(importDataConfigurationForm.skip, {'attr': {'class': 'col-md-4 js-rows-skip', 'min': 0}}) }}
           <small class="form-text">{{ 'Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.'|trans }}</small>
         </div>
       </div>
-      <div class="row">
-        <div class="col">
-          <div class="alert alert-warning js-validation-error js-duplicate-columns-warning d-none" role="alert">
-            <p class="alert-text">
-              {{ 'Two columns cannot have the same type of values'|trans({}, 'Admin.Advparameters.Feature') }}
-            </p>
-          </div>
-          <div class="alert alert-warning js-validation-error js-missing-column-warning d-none" role="alert">
-            <p class="alert-text">
-              {{ 'This column must be set:'|trans({}, 'Admin.Advparameters.Feature') }}
-              <span class="js-missing-column">&nbsp;</span>
-            </p>
-          </div>
-        </div>
+
+      <div class="alert alert-warning js-validation-error js-duplicate-columns-warning d-none" role="alert">
+        <p class="alert-text">
+          {{ 'Two columns cannot have the same type of values'|trans({}, 'Admin.Advparameters.Feature') }}
+        </p>
       </div>
-      <div class="row">
-        <table
-          class="table table-bordered js-import-data-table"
-          data-required-fields="{{ requiredFields|json_encode }}"
-        >
-          <thead>
+      <div class="alert alert-warning js-validation-error js-missing-column-warning d-none" role="alert">
+        <p class="alert-text">
+          {{ 'This column must be set:'|trans({}, 'Admin.Advparameters.Feature') }}
+          <span class="js-missing-column">&nbsp;</span>
+        </p>
+      </div>
+
+      <table class="table table-bordered js-import-data-table" data-required-fields="{{ requiredFields|json_encode }}">
+        <thead>
+          <tr>
+            {% for importEntityField in importDataConfigurationForm.type_value %}
+              <th class="js-entity-field {% if loop.index > maxVisibleColumns %} d-none{% endif %}">
+                {{ form_errors(importEntityField) }}
+                {{ form_widget(importEntityField) }}
+              </th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in dataRowCollection.rows %}
             <tr>
-              {% for importEntityField in importDataConfigurationForm.type_value %}
-                <th class="js-entity-field {% if loop.index > maxVisibleColumns %} d-none{% endif %}">
-                  {{ form_errors(importEntityField) }}
-                  {{ form_widget(importEntityField) }}
-                </th>
+              {% for cell in row %}
+                <td {% if loop.index > maxVisibleColumns %} class="d-none" {% endif %}>{{ cell.value }}</td>
               {% endfor %}
             </tr>
-          </thead>
-          <tbody>
-            {% for row in dataRowCollection.rows %}
-              <tr>
-                {% for cell in row %}
-                  <td{% if loop.index > maxVisibleColumns %} class="d-none"{% endif %}>{{ cell.value }}</td>
-                {% endfor %}
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
+          {% endfor %}
+        </tbody>
+      </table>
+
       <div class="row">
         <div class="col text-left">
           <button class="btn btn-outline-primary js-import-previous-page d-none" type="button">
@@ -144,10 +131,7 @@
           </button>
         </div>
         <div class="col text-right">
-          <button
-            class="btn btn-outline-primary js-import-next-page{% if not showPagingArrows %} d-none{% endif %}"
-            type="button"
-          >
+          <button class="btn btn-outline-primary js-import-next-page{% if not showPagingArrows %} d-none{% endif %}" type="button">
             <i class="material-icons">arrow_forward</i>
           </button>
         </div>
@@ -157,10 +141,7 @@
   </div>
   <div class="card-footer">
     <div class="d-flex justify-content-between">
-      <a class="btn btn-outline-secondary js-import-process-button"
-         href="{{ path('admin_import') }}"
-              data-import_url="{{ path('admin_import_process') }}"
-      >
+      <a class="btn btn-outline-secondary js-import-process-button" href="{{ path('admin_import') }}" data-import_url="{{ path('admin_import_process') }}">
         <i class="material-icons">cancel</i>
         {{ 'Cancel'|trans({}, 'Admin.Actions') }}
       </a>

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/ImportPage/import.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/ImportPage/import.html.twig
@@ -28,25 +28,21 @@
 
 {% block content %}
   {% if importForm is defined %}
-    <div class="row row justify-content-center">
-      <div class="col">
-        <div class="row">
-          <div class="col-12 col-md-8">
-            {% block import_panel %}
-              {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig' %}
-            {% endblock %}
-          </div>
+    <div class="row">
+      <div class="col-md-8">
+        {% block import_panel %}
+          {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig' %}
+        {% endblock %}
+      </div>
 
-          <div class="col-12 col-md-4">
-            {% block import_available_fields %}
-              {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_available_fields.html.twig' %}
-            {% endblock %}
+      <div class="col-md-4">
+        {% block import_available_fields %}
+          {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_available_fields.html.twig' %}
+        {% endblock %}
 
-            {% block import_sample_files %}
-              {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_sample_files.html.twig' %}
-            {% endblock %}
-          </div>
-        </div>
+        {% block import_sample_files %}
+          {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_sample_files.html.twig' %}
+        {% endblock %}
       </div>
     </div>
   {% endif %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig
@@ -23,37 +23,36 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 {% trans_default_domain "Admin.Advparameters.Feature" %}
-<div class="col">
-  <div class="card">
-    <h3 class="card-header">
-      <i class="material-icons">warning</i> {{ 'Severity levels'|trans({}, 'Admin.Advparameters.Help') }}
-    </h3>
-    <div class="card-block">
-      <div class="card-text">
-        <p>{{ 'Meaning of severity levels:'|trans }}</p>
-        <ol>
-          <li>
-            <span class="badge badge-pill badge-success">
-              {{ 'Informative only'|trans({}, 'Admin.Advparameters.Help') }}
-            </span>
-          </li>
-          <li>
-            <span class="badge badge-pill badge-warning">
-              {{ 'Warning'|trans({}, 'Admin.Advparameters.Help') }}
-            </span>
-          </li>
-          <li>
-            <span class="badge badge-pill badge-danger">
-              {{ 'Error'|trans({}, 'Admin.Advparameters.Help') }}
-            </span>
-          </li>
-          <li>
-            <span class="badge badge-pill badge-dark">
-              {{ 'Major issue (crash)!'|trans({}, 'Admin.Advparameters.Help') }}
-            </span>
-          </li>
-        </ol>
-      </div>
+<div class="card">
+  <h3 class="card-header">
+    <i class="material-icons">warning</i>
+    {{ 'Severity levels'|trans({}, 'Admin.Advparameters.Help') }}
+  </h3>
+  <div class="card-block">
+    <div class="card-text">
+      <p>{{ 'Meaning of severity levels:'|trans }}</p>
+      <ol>
+        <li>
+          <span class="badge badge-pill badge-success">
+            {{ 'Informative only'|trans({}, 'Admin.Advparameters.Help') }}
+          </span>
+        </li>
+        <li>
+          <span class="badge badge-pill badge-warning">
+            {{ 'Warning'|trans({}, 'Admin.Advparameters.Help') }}
+          </span>
+        </li>
+        <li>
+          <span class="badge badge-pill badge-danger">
+            {{ 'Error'|trans({}, 'Admin.Advparameters.Help') }}
+          </span>
+        </li>
+        <li>
+          <span class="badge badge-pill badge-dark">
+            {{ 'Major issue (crash)!'|trans({}, 'Admin.Advparameters.Help') }}
+          </span>
+        </li>
+      </ol>
     </div>
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
@@ -28,37 +28,28 @@
 
 {% block content %}
   {% block logs_severity_level_meaning %}
-    <div class="row">
-      {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig') }}
-    </div>
+    {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig') }}
   {% endblock %}
 
   {% block logs_main_panel %}
-    <div class="row">
-      <div class="col">
-        {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
-      </div>
-    </div>
+    {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
   {% endblock %}
 
   {% block logs_by_mail %}
     {{ form_start(logsByEmailForm, {'action': path('admin_logs_save_settings')}) }}
-    <div class="row justify-content-center">
-      <div class="col">
-        <div class="card">
-          <h3 class="card-header">
-            <i class="material-icons">business_center</i> {{ 'Logs by email'|trans }}
-          </h3>
-          <div class="card-block row">
-            <div class="card-text">
-                {{ form_widget(logsByEmailForm) }}
-            </div>
-          </div>
-          <div class="card-footer">
-            <div class="d-flex justify-content-end">
-              <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-            </div>
-          </div>
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">business_center</i>
+        {{ 'Logs by email'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {{ form_widget(logsByEmailForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
         </div>
       </div>
     </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Profiles/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Profiles/create.html.twig
@@ -26,12 +26,10 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Profiles/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Profiles/edit.html.twig
@@ -26,13 +26,9 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' with {
-        avatarUrl: editableProfile.avatarUrl
-      } %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' with {
+    avatarUrl: editableProfile.avatarUrl
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Profiles/index.html.twig
@@ -26,13 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
   {% block profiles_list_panel %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': grid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': grid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig
@@ -26,7 +26,7 @@
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 <div class="row">
-  <div class="col-12 col-md-4">
+  <div class="col-md-4">
     <div class="card">
       <h3 class="card-header">
           {{ 'List of MySQL Tables'|trans }}
@@ -56,7 +56,7 @@
       </div>
     </div>
   </div>
-  <div class="col-12 col-md-8">
+  <div class="col-md-8">
     <div class="card">
       <h3 class="card-header">
           {{ 'List of attributes for this MySQL table'|trans }}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/create.html.twig
@@ -27,7 +27,9 @@
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
   {% if requestSqlForm.vars.errors is not empty %}
     <div class="alert alert-danger">
       {% for error in requestSqlForm.vars.errors %}
@@ -36,15 +38,12 @@
     </div>
   {% endif %}
 
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig' %}
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig' %}
 
-      {% block sql_manager_db_tables_panel %}
-        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig' %}
-      {% endblock %}
-    </div>
-  </div>
+  {% block sql_manager_db_tables_panel %}
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig' %}
+  {% endblock %}
+
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/edit.html.twig
@@ -35,15 +35,11 @@
     </div>
   {% endif %}
 
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig' %}
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig' %}
 
-      {% block sql_manager_db_tables_panel %}
-        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig' %}
-      {% endblock %}
-    </div>
-  </div>
+  {% block sql_manager_db_tables_panel %}
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig' %}
+  {% endblock %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/index.html.twig
@@ -27,52 +27,40 @@
 {% trans_default_domain "Admin.Advparameters.Feature" %}
 
 {% block content %}
-    {% block sql_manager_info_block %}
-        <div class="row">
-            <div class="col">
-                <div class="alert alert-info" role="alert">
-                    <p class="alert-text">{{ 'How do I create a new SQL query?'|trans({}, 'Admin.Advparameters.Help') }}</p>
-                    <ul>
-                        <li>{{ 'Click "%add_new_label%".'|trans({'%add_new_label%': 'Add new SQL query'|trans({}, 'Admin.Advparameters.Feature')}, 'Admin.Advparameters.Help') }}</li>
-                        <li>{{ 'Fill in the fields and click "%save_label%".'|trans({'%save_label%': 'Save'|trans({}, 'Admin.Actions')}, 'Admin.Advparameters.Help') }}</li>
-                        <li>{{ 'You can then view the query results by clicking on the "%view_label%" action in the dropdown menu'|trans({'%view_label%': 'View'|trans({}, 'Admin.Global')}, 'Admin.Advparameters.Help') }}</li>
-                        <li>{{ 'You can also export the query results as a CSV file by clicking on the "%export_label%" button'|trans({'%export_label%': 'Export'|trans({}, 'Admin.Actions')}, 'Admin.Advparameters.Help') }}</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-    {% endblock %}
+  {% block sql_manager_info_block %}
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">{{ 'How do I create a new SQL query?'|trans({}, 'Admin.Advparameters.Help') }}</p>
+      <ul>
+        <li>{{ 'Click "%add_new_label%".'|trans({'%add_new_label%': 'Add new SQL query'|trans({}, 'Admin.Advparameters.Feature')}, 'Admin.Advparameters.Help') }}</li>
+        <li>{{ 'Fill in the fields and click "%save_label%".'|trans({'%save_label%': 'Save'|trans({}, 'Admin.Actions')}, 'Admin.Advparameters.Help') }}</li>
+        <li>{{ 'You can then view the query results by clicking on the "%view_label%" action in the dropdown menu'|trans({'%view_label%': 'View'|trans({}, 'Admin.Global')}, 'Admin.Advparameters.Help') }}</li>
+        <li>{{ 'You can also export the query results as a CSV file by clicking on the "%export_label%" button'|trans({'%export_label%': 'Export'|trans({}, 'Admin.Actions')}, 'Admin.Advparameters.Help') }}</li>
+      </ul>
+    </div>
+  {% endblock %}
 
-    {% block sql_manager_warning_block %}
-        <div class="row">
-            <div class="col">
-                <div class="alert alert-warning" role="alert">
-                    <p class="alert-text">{{ 'When saving the query, only the "SELECT" SQL statement is allowed.'|trans({}, 'Admin.Advparameters.Notification') }}</p>
-                </div>
-            </div>
-        </div>
-    {% endblock %}
+  {% block sql_manager_warning_block %}
+    <div class="alert alert-warning" role="alert">
+      <p class="alert-text">{{ 'When saving the query, only the "SELECT" SQL statement is allowed.'|trans({}, 'Admin.Advparameters.Notification') }}</p>
+    </div>
+  {% endblock %}
 
-    {% block sql_manager_list_panel %}
-        <div class="row">
-            <div class="col">
-                {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': requestSqlGrid} %}
-            </div>
-        </div>
-    {% endblock %}
+  {% block sql_manager_list_panel %}
 
-    {% block sql_manager_settings_panel %}
-        <div class="row justify-content-center">
-            <div class="col">
-                {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig' %}
-            </div>
-        </div>
-    {% endblock %}
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': requestSqlGrid} %}
+
+  {% endblock %}
+
+  {% block sql_manager_settings_panel %}
+
+    {% include '@PrestaShop/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig' %}
+
+  {% endblock %}
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }}
+  {{ parent() }}
 
-    <script src="{{ asset('themes/new-theme/public/sql_manager.bundle.js') }}"></script>
-    <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
+  <script src="{{ asset('themes/new-theme/public/sql_manager.bundle.js') }}"></script>
+  <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/RequestSql/view.html.twig
@@ -28,50 +28,47 @@
 
 {% block content %}
   {% block request_sql_view_block %}
-    <div class="row">
-      <div class="col">
-        <div class="card">
-          <div class="card-header">
-            <h3>
-              <i class="material-icons">list</i>
-              {{ 'SQL query result'|trans }} ({{ sqlRequestResult.rows|length }})
-            </h3>
-          </div>
-            <div class="card-block">
-              {% if sqlRequestResult.rows is not empty %}
-              <div class="table-responsive">
-                <table class="table">
-                  <thead>
-                    <tr>
-                      {% for column in sqlRequestResult.columns %}
-                        <th>{{ column }}</th>
-                      {% endfor %}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for row in sqlRequestResult.rows %}
-                    <tr>
-                      {% for column in sqlRequestResult.columns %}
-                        {% if requestSqlView.attributes[column] is defined %}
-                          <td>{{ requestSqlView.attributes[column] }}</td>
-                        {% else %}
-                          <td>{{ row[column] }}</td>
-                        {% endif %}
-                      {% endfor %}
-                    </tr>
+    <div class="card">
+      <div class="card-header">
+        <h3>
+          <i class="material-icons">list</i>
+          {{ 'SQL query result'|trans }}
+          ({{ sqlRequestResult.rows|length }})
+        </h3>
+      </div>
+      <div class="card-block">
+        {% if sqlRequestResult.rows is not empty %}
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
+                <tr>
+                  {% for column in sqlRequestResult.columns %}
+                    <th>{{ column }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in sqlRequestResult.rows %}
+                  <tr>
+                    {% for column in sqlRequestResult.columns %}
+                      {% if requestSqlView.attributes[column] is defined %}
+                        <td>{{ requestSqlView.attributes[column] }}</td>
+                      {% else %}
+                        <td>{{ row[column] }}</td>
+                      {% endif %}
                     {% endfor %}
-                  </tbody>
-                </table>
-              </div>
-              {% else %}
-                <div class="alert alert-warning">
-                  <p class="alert-text">
-                    {{ 'This SQL query has no result.'|trans({}, 'Admin.Advparameters.Notification') }}
-                  </p>
-                </div>
-              {% endif %}
-            </div>
-        </div>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <div class="alert alert-warning">
+            <p class="alert-text">
+              {{ 'This SQL query has no result.'|trans({}, 'Admin.Advparameters.Notification') }}
+            </p>
+          </div>
+        {% endif %}
       </div>
     </div>
   {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Webservice/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Webservice/create.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Webservice/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Webservice/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -40,37 +40,28 @@
 
   {% block webservice_list_notifications %}
     {% if configurationWarnings is not empty  %}
-      <div class="row">
-        <div class="col">
-          <div class="alert alert-warning" role="alert">
-            {% for warning in configurationWarnings %}
-              <p class="alert-text">{{ warning }}</p>
-            {% endfor %}
-          </div>
-        </div>
+      <div class="alert alert-warning" role="alert">
+        {% for warning in configurationWarnings %}
+          <p class="alert-text">{{ warning }}</p>
+        {% endfor %}
       </div>
     {% endif %}
   {% endblock %}
 
-  <div class="row">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
-    </div>
-  </div>
 
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ form_start(webserviceConfigurationForm, {'action': path('admin_webservice_save_settings') ,'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
+  {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid }) }}
 
-        {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
 
-        {% block webservice_configuration_form_rest %}
-          {{ form_rest(webserviceConfigurationForm) }}
-        {% endblock %}
+  {{ form_start(webserviceConfigurationForm, {'action': path('admin_webservice_save_settings') ,'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
 
-      {{ form_end(webserviceConfigurationForm) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig') }}
+
+  {% block webservice_configuration_form_rest %}
+    {{ form_rest(webserviceConfigurationForm) }}
+  {% endblock %}
+
+  {{ form_end(webserviceConfigurationForm) }}
+
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -29,82 +29,77 @@
 {% form_theme notificationsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    {{ form_start(generalForm, {attr : {class: 'form col'}, action: path('admin_administration_general_save') }) }}
-      {% block administration_form_general %}
-        <div class="card" id="configuration_fieldset_general">
-          <h3 class="card-header">
-            <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
-          </h3>
-          <div class="card-block row">
-            <div class="card-text">
-              {{ form_widget(generalForm) }}
-            </div>
-          </div>
-          <div class="card-footer">
-            <div class="d-flex justify-content-end">
-              <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-            </div>
+  {{ form_start(generalForm, {attr : {class: 'form'}, action: path('admin_administration_general_save') }) }}
+  {% block administration_form_general %}
+    <div class="card" id="configuration_fieldset_general">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'General'|trans({}, 'Admin.Global') }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {{ form_widget(generalForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+  {% endblock %}
+  {{ form_end(generalForm) }}
+
+  {{ form_start(uploadQuotaForm, {attr : {class: 'form'}, action: path('admin_administration_upload_quota_save') }) }}
+  {% block administration_form_upload_quota %}
+    <div class="card" id="configuration_fieldset_upload">
+      <h3 class="card-header">
+        <i class="material-icons">file_upload</i>
+        {{ 'Upload quota'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {{ form_widget(uploadQuotaForm) }}
+        </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
+    </div>
+  {% endblock %}
+  {{ form_end(uploadQuotaForm) }}
+
+  {{ form_start(notificationsForm, {attr : {class: 'form'}, action: path('admin_administration_notifications_save') }) }}
+  {% block administration_form_notifications %}
+    <div class="card" id="configuration_fieldset_notifications">
+      <h3 class="card-header">
+        <i class="material-icons">priority_high</i>
+        {{ 'Notifications'|trans }}
+
+        <span class="help-box" 
+              data-container="body" 
+              data-toggle="popover" 
+              data-trigger="hover" 
+              data-placement="right" 
+              data-content="{{ "Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them."|trans({}, 'Admin.Advparameters.Help') }}" 
+              title="">
+        </span>
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          <div class="card-text">
+            {{ form_widget(notificationsForm) }}
           </div>
         </div>
-      {% endblock %}
-    {{ form_end(generalForm) }}
-  </div>
-
-  <div class="row justify-content-center">
-    {{ form_start(uploadQuotaForm, {attr : {class: 'form col'}, action: path('admin_administration_upload_quota_save') }) }}
-      {% block administration_form_upload_quota %}
-        <div class="card" id="configuration_fieldset_upload">
-          <h3 class="card-header">
-            <i class="material-icons">file_upload</i> {{ 'Upload quota'|trans }}
-          </h3>
-          <div class="card-block row">
-            <div class="card-text">
-              {{ form_widget(uploadQuotaForm) }}
-            </div>
-          </div>
-          <div class="card-footer">
-            <div class="d-flex justify-content-end">
-              <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-            </div>
-          </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
         </div>
-      {% endblock %}
-    {{ form_end(uploadQuotaForm) }}
-  </div>
-
-  <div class="row justify-content-center">
-    {{ form_start(notificationsForm, {attr : {class: 'form col'}, action: path('admin_administration_notifications_save') }) }}
-      {% block administration_form_notifications %}
-        <div class="card" id="configuration_fieldset_notifications">
-          <h3 class="card-header">
-            <i class="material-icons">priority_high</i> {{ 'Notifications'|trans }}
-
-            <span
-              class="help-box"
-              data-container="body"
-              data-toggle="popover"
-              data-trigger="hover"
-              data-placement="right"
-              data-content="{{ "Notifications are numbered bubbles displayed at the very top of your back office, right next to the shop's name. They display the number of new items since you last clicked on them."|trans({}, 'Admin.Advparameters.Help') }}"
-              title=""
-            >
-            </span>
-          </h3>
-          <div class="card-block row">
-            <div class="card-text">
-              <div class="card-text">
-                {{ form_widget(notificationsForm) }}
-              </div>
-            </div>
-          </div>
-          <div class="card-footer">
-            <div class="d-flex justify-content-end">
-              <button type="submit" class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-            </div>
-          </div>
-        </div>
-      {% endblock %}
-    {{ form_end(notificationsForm) }}
-  </div>
+      </div>
+    </div>
+  {% endblock %}
+  {{ form_end(notificationsForm) }}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/memcache_servers.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/memcache_servers.html.twig
@@ -67,7 +67,10 @@
                     <td>{{ server.weight }}</td>
                     <td>
                         {% set removeMsg = 'Do you really want to remove the server %serverIp%:%serverPort% ?'|trans({'%serverIp%': server.ip, '%serverPort%': server.port}, 'Admin.Advparameters.Notification')|json_encode|raw  %}
-                        <a class="btn btn-default" href="" onclick="app.removeServer({{ server.id_memcached_server }}, {{ removeMsg }});"><i class="material-icons">remove_circle</i> {{ 'Remove'|trans({}, 'Admin.Actions') }}</a>
+                        <a class="btn btn-default" href="" 
+                           onclick="app.removeServer({{ server.id_memcached_server }}, {{ removeMsg }});">
+                          <i class="material-icons">remove_circle</i> {{ 'Remove'|trans({}, 'Admin.Actions') }}
+                        </a>
                     </td>
                 </tr>
             {% endfor %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -33,197 +33,174 @@
 {% form_theme cachingForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
   {{ form_start(smartyForm, {attr : {class: 'form'}, action: path('admin_performance_smarty_save') }) }}
-    <div class="row justify-content-center">
-      {% block perfs_form_smarty_cache %}
-        <div class="col">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">business_center</i> {{ 'Smarty'|trans }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {% block perfs_form_smarty_cache_form %}
-                  {{ form_widget(smartyForm) }}
-                {% endblock %}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+  {% block perfs_form_smarty_cache %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">business_center</i>
+        {{ 'Smarty'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% block perfs_form_smarty_cache_form %}
+            {{ form_widget(smartyForm) }}
+          {% endblock %}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(smartyForm) }}
 
   {{ form_start(debugModeForm, {attr : {class: 'form'}, action: path('admin_performance_debug_mode_save') }) }}
-    <div class="row justify-content-center">
-      {% block perfs_form_debug_mode %}
-        <div class="col">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">bug_report</i> {{ 'Debug mode'|trans }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {% block perfs_form_debug_mode_form %}
-                  {{ form_widget(debugModeForm) }}
-                {% endblock %}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+  {% block perfs_form_debug_mode %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">bug_report</i>
+        {{ 'Debug mode'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% block perfs_form_debug_mode_form %}
+            {{ form_widget(debugModeForm) }}
+          {% endblock %}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(debugModeForm) }}
 
   {{ form_start(optionalFeaturesForm, {attr : {class: 'form'}, action: path('admin_performance_optional_features_save') }) }}
-    <div class="row justify-content-center">
-      {% block perfs_form_optional_features %}
-        <div class="col">
-          <div class="card" id="optional_features">
-            <h3 class="card-header">
-              <i class="material-icons">extension</i> {{ 'Optional features'|trans }}
+  {% block perfs_form_optional_features %}
+    <div class="card" id="optional_features">
+      <h3 class="card-header">
+        <i class="material-icons">extension</i>
+        {{ 'Optional features'|trans }}
 
-              <span
-                class="help-box"
-                data-container="body"
-                data-toggle="popover"
-                data-trigger="hover"
-                data-placement="right"
-                data-content="{{ 'Some features can be disabled in order to improve performance.'|trans({}, 'Admin.Advparameters.Help') }}"
-                title=""
-              >
-              </span>
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {% block perfs_form_optional_features_form %}
-                  {{ form_widget(optionalFeaturesForm) }}
-                {% endblock %}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+        <span class="help-box" 
+              data-container="body" 
+              data-toggle="popover" 
+              data-trigger="hover" 
+              data-placement="right" 
+              data-content="{{ 'Some features can be disabled in order to improve performance.'|trans({}, 'Admin.Advparameters.Help') }}" 
+              title="">
+        </span>
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% block perfs_form_optional_features_form %}
+            {{ form_widget(optionalFeaturesForm) }}
+          {% endblock %}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(optionalFeaturesForm) }}
 
   {{ form_start(combineCompressCacheForm, {attr : {class: 'form'}, action: path('admin_performance_combine_compress_cache_save') }) }}
-    <div class="row justify-content-center">
-      {% block perfs_form_ccc %}
-        <div class="col">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">zoom_out_map</i> {{ 'CCC (Combine, Compress and Cache)'|trans }}
+  {% block perfs_form_ccc %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">zoom_out_map</i>
+        {{ 'CCC (Combine, Compress and Cache)'|trans }}
 
-
-            <span
-              class="help-box"
-              data-container="body"
-              data-toggle="popover"
-              data-trigger="hover"
-              data-placement="right"
-              data-content="{{ 'CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.7+. Otherwise, CCC will cause problems.'|trans({}, 'Admin.Advparameters.Help') }}"
-              title=""
-            >
-            </span>
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {% block perfs_form_ccc_form %}
-                  {{ form_widget(combineCompressCacheForm) }}
-                {% endblock %}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+        <span class="help-box" 
+              data-container="body" 
+              data-toggle="popover" 
+              data-trigger="hover" 
+              data-placement="right" 
+              data-content="{{ 'CCC allows you to reduce the loading time of your page. With these settings you will gain performance without even touching the code of your theme. Make sure, however, that your theme is compatible with PrestaShop 1.7+. Otherwise, CCC will cause problems.'|trans({}, 'Admin.Advparameters.Help') }}" 
+              title="">
+        </span>
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% block perfs_form_ccc_form %}
+            {{ form_widget(combineCompressCacheForm) }}
+          {% endblock %}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(combineCompressCacheForm) }}
 
   {{ form_start(mediaServersForm, {attr : {class: 'form'}, action: path('admin_performance_media_servers_save') }) }}
-    <div class="row justify-content-center">
-      {% block perfs_form_media_servers %}
-        <div class="col">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">link</i> {{ 'Media servers (use only with CCC)'|trans }}
+  {% block perfs_form_media_servers %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">link</i>
+        {{ 'Media servers (use only with CCC)'|trans }}
 
-              <span
-                class="help-box"
-                data-container="body"
-                data-toggle="popover"
-                data-trigger="hover"
-                data-placement="right"
-                data-content="{{ 'You must enter another domain, or subdomain, in order to use cookieless static content.'|trans({}, 'Admin.Advparameters.Feature') }}"
-                title=""
-              >
-              </span>
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {% block perfs_form_media_servers_form %}
-                  {{ form_widget(mediaServersForm) }}
-                {% endblock %}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+        <span class="help-box" 
+              data-container="body" 
+              data-toggle="popover" 
+              data-trigger="hover" 
+              data-placement="right" 
+              data-content="{{ 'You must enter another domain, or subdomain, in order to use cookieless static content.'|trans({}, 'Admin.Advparameters.Feature') }}" 
+              title="">
+        </span>
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% block perfs_form_media_servers_form %}
+            {{ form_widget(mediaServersForm) }}
+          {% endblock %}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(mediaServersForm) }}
 
   {{ form_start(cachingForm, {attr : {class: 'form'}, action: path('admin_performance_caching_save') }) }}
-    <div class="row justify-content-center">
-      {% block perfs_form_caching %}
-        <div class="col">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">link</i> {{ 'Caching'|trans }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {% block perfs_form_caching_form %}
-                  {{ form_widget(cachingForm) }}
-                {% endblock %}
+  {% block perfs_form_caching %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">link</i>
+        {{ 'Caching'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% block perfs_form_caching_form %}
+            {{ form_widget(cachingForm) }}
+          {% endblock %}
 
-                {{ include('@AdvancedParameters/memcache_servers.html.twig', {'form': memcacheForm}) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+          {{ include('@AdvancedParameters/memcache_servers.html.twig', {'form': memcacheForm}) }}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(cachingForm) }}
 {% endblock %}
 
@@ -236,22 +213,18 @@
       'removeServerUrl': '{{ url('admin_servers_delete')|e('js') }}',
       'testServerUrl': '{{ url('admin_servers_test')|e('js') }}'
     };
-    var app = new PerformancePage(
-      configuration.addServerUrl,
-      configuration.removeServerUrl,
-      configuration.testServerUrl
-    );
+    var app = new PerformancePage(configuration.addServerUrl, configuration.removeServerUrl, configuration.testServerUrl);
 
-    window.addEventListener('load', function() {
+    window.addEventListener('load', function () {
       var addServerBtn = document.getElementById('add-server-btn');
       var testServerBtn = document.getElementById('test-server-btn');
 
-      addServerBtn.addEventListener('click', function(event) {
+      addServerBtn.addEventListener('click', function (event) {
         event.preventDefault();
         app.addServer();
       });
 
-      testServerBtn.addEventListener('click', function(event) {
+      testServerBtn.addEventListener('click', function (event) {
         event.preventDefault();
         app.testServer();
       });

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -27,23 +27,22 @@
 {% form_theme generalForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block customer_preferences_general %}
-<div class="row justify-content-center">
-  <div class="col">
-      <div class="card">
-          <h3 class="card-header">
-              <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
-          </h3>
-          <div class="card-block row">
-              <div class="card-text">
-                {{ form_widget(generalForm) }}
-              </div>
-          </div>
-          <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                  <button class="btn btn-primary" id="form-general-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-          </div>
+
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'General'|trans({}, 'Admin.Global') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(generalForm) }}
       </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-general-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
   </div>
-</div>
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -27,78 +27,76 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block product_preferences_general %}
-<div class="row justify-content-center">
-  <div class="col">
-    <div class="card" id="configuration_fieldset_products">
-      <h3 class="card-header">
-        <i class="material-icons">settings</i> {{ 'Products (general)'|trans }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Catalog mode'|trans), ('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.catalog_mode) }}
-              {{ form_widget(generalForm.catalog_mode) }}
-              <small class="form-text">{{ 'Have specific needs? Edit particular groups to let them see prices or not.'|trans({}, 'Admin.Shopparameters.Help') }}</small>
-            </div>
-          </div>
-          <div class="form-group row catalog-mode-option">
-            {{ ps.label_with_help(('Show prices'|trans), ('Display product prices when in catalog mode.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.catalog_mode_with_prices) }}
-              {{ form_widget(generalForm.catalog_mode_with_prices) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Number of days for which the product is considered \'new\''|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generalForm.new_days_number) }}
-              {{ form_widget(generalForm.new_days_number) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Max size of product summary'|trans), ('Set the maximum size of the summary of your product description (in characters).'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.short_description_limit) }}
-              {{ form_widget(generalForm.short_description_limit) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Quantity discounts based on'|trans), ('How to calculate quantity discounts.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.quantity_discount) }}
-              {{ form_widget(generalForm.quantity_discount) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Force update of friendly URL'|trans), ('When active, friendly URL will be updated on every save.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.force_friendly_url) }}
-              {{ form_widget(generalForm.force_friendly_url) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default activation status'|trans), ('When active, new products will be activated by default during creation.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generalForm.default_status) }}
-              {{ form_widget(generalForm.default_status) }}
-            </div>
-          </div>
 
-          {% block product_general_preferences_form_rest %}
-            {{ form_rest(generalForm) }}
-          {% endblock %}
+  <div class="card" id="configuration_fieldset_products">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'Products (general)'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          {{ ps.label_with_help(('Catalog mode'|trans), ('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generalForm.catalog_mode) }}
+            {{ form_widget(generalForm.catalog_mode) }}
+            <small class="form-text">{{ 'Have specific needs? Edit particular groups to let them see prices or not.'|trans({}, 'Admin.Shopparameters.Help') }}</small>
+          </div>
         </div>
+        <div class="form-group row catalog-mode-option">
+          {{ ps.label_with_help(('Show prices'|trans), ('Display product prices when in catalog mode.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generalForm.catalog_mode_with_prices) }}
+            {{ form_widget(generalForm.catalog_mode_with_prices) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Number of days for which the product is considered \'new\''|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(generalForm.new_days_number) }}
+            {{ form_widget(generalForm.new_days_number) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Max size of product summary'|trans), ('Set the maximum size of the summary of your product description (in characters).'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generalForm.short_description_limit) }}
+            {{ form_widget(generalForm.short_description_limit) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Quantity discounts based on'|trans), ('How to calculate quantity discounts.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generalForm.quantity_discount) }}
+            {{ form_widget(generalForm.quantity_discount) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Force update of friendly URL'|trans), ('When active, friendly URL will be updated on every save.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generalForm.force_friendly_url) }}
+            {{ form_widget(generalForm.force_friendly_url) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Default activation status'|trans), ('When active, new products will be activated by default during creation.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generalForm.default_status) }}
+            {{ form_widget(generalForm.default_status) }}
+          </div>
+        </div>
+
+        {% block product_general_preferences_form_rest %}
+          {{ form_rest(generalForm) }}
+        {% endblock %}
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="form-general-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-        </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-general-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -27,75 +27,72 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block product_preferences_page %}
-<div class="row justify-content-center">
-  <div class="col">
-    <div class="card" id="configuration_fieldset_fo_product_page">
-      <h3 class="card-header">
-        <i class="material-icons">shopping_basket</i> {{ 'Product page'|trans }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Display available quantities on the product page'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_quantities) }}
-              {{ form_widget(pageForm.display_quantities) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Display remaining quantities when the quantity is lower than'|trans), ('Set to "0" to disable this feature.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_last_quantities) }}
-              {{ form_widget(pageForm.display_last_quantities) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Display unavailable attributes on the product page'|trans), ('If an attribute is not available in every product combination, it will not be displayed.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_unavailable_attributes) }}
-              {{ form_widget(pageForm.display_unavailable_attributes) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Display the "%add_to_cart_label%" button when a product has attributes'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help')), ('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pageForm.allow_add_variant_to_cart_from_listing) }}
-              {{ form_widget(pageForm.allow_add_variant_to_cart_from_listing) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Separator of attribute anchor on the product links'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(pageForm.attribute_anchor_separator) }}
-              {{ form_widget(pageForm.attribute_anchor_separator) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Display discounted price'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(pageForm.display_discount_price) }}
-              {{ form_widget(pageForm.display_discount_price) }}
-              <small class="form-text">{{ 'In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").'|trans({}, 'Admin.Shopparameters.Help') }}</small>
-            </div>
+  <div class="card" id="configuration_fieldset_fo_product_page">
+    <h3 class="card-header">
+      <i class="material-icons">shopping_basket</i>
+      {{ 'Product page'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Display available quantities on the product page'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(pageForm.display_quantities) }}
+            {{ form_widget(pageForm.display_quantities) }}
           </div>
         </div>
-
-        {% block product_page_preferences_form_rest %}
-          {{ form_rest(pageForm) }}
-        {% endblock %}
+        <div class="form-group row">
+          {{ ps.label_with_help(('Display remaining quantities when the quantity is lower than'|trans), ('Set to "0" to disable this feature.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(pageForm.display_last_quantities) }}
+            {{ form_widget(pageForm.display_last_quantities) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Display unavailable attributes on the product page'|trans), ('If an attribute is not available in every product combination, it will not be displayed.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(pageForm.display_unavailable_attributes) }}
+            {{ form_widget(pageForm.display_unavailable_attributes) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Display the "%add_to_cart_label%" button when a product has attributes'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help')), ('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(pageForm.allow_add_variant_to_cart_from_listing) }}
+            {{ form_widget(pageForm.allow_add_variant_to_cart_from_listing) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Separator of attribute anchor on the product links'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(pageForm.attribute_anchor_separator) }}
+            {{ form_widget(pageForm.attribute_anchor_separator) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Display discounted price'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(pageForm.display_discount_price) }}
+            {{ form_widget(pageForm.display_discount_price) }}
+            <small class="form-text">{{ 'In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").'|trans({}, 'Admin.Shopparameters.Help') }}</small>
+          </div>
+        </div>
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="form-page-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-        </div>
+
+      {% block product_page_preferences_form_rest %}
+        {{ form_rest(pageForm) }}
+      {% endblock %}
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-page-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -27,47 +27,46 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block product_preferences_pagination %}
-<div class="row justify-content-center">
-  <div class="col">
-    <div class="card" id="configuration_fieldset_order_by_pagination">
-      <h3 class="card-header">
-        <i class="material-icons">view_headline</i> {{ 'Pagination'|trans }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Products per page'|trans), ('Number of products displayed per page. Default is 10.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(paginationForm.products_per_page) }}
-              {{ form_widget(paginationForm.products_per_page) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default order by'|trans), ('The order in which products are displayed in the product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(paginationForm.default_order_by) }}
-              {{ form_widget(paginationForm.default_order_by) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default order method'|trans), ('Default order method for product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(paginationForm.default_order_way) }}
-              {{ form_widget(paginationForm.default_order_way) }}
-            </div>
-          </div>
 
-          {% block product_pagination_preferences_form_rest %}
-            {{ form_rest(paginationForm) }}
-          {% endblock %}
+  <div class="card" id="configuration_fieldset_order_by_pagination">
+    <h3 class="card-header">
+      <i class="material-icons">view_headline</i>
+      {{ 'Pagination'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          {{ ps.label_with_help(('Products per page'|trans), ('Number of products displayed per page. Default is 10.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(paginationForm.products_per_page) }}
+            {{ form_widget(paginationForm.products_per_page) }}
+          </div>
         </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Default order by'|trans), ('The order in which products are displayed in the product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(paginationForm.default_order_by) }}
+            {{ form_widget(paginationForm.default_order_by) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Default order method'|trans), ('Default order method for product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(paginationForm.default_order_way) }}
+            {{ form_widget(paginationForm.default_order_way) }}
+          </div>
+        </div>
+
+        {% block product_pagination_preferences_form_rest %}
+          {{ form_rest(paginationForm) }}
+        {% endblock %}
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="form-pagination-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-        </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-pagination-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>
-</div>
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -27,92 +27,91 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block product_preferences_stock %}
-<div class="row justify-content-center">
-  <div class="col">
-    <div class="card" id="configuration_fieldset_stock">
-      <h3 class="card-header">
-        <i class="material-icons">shop</i> {{ 'Products stock'|trans }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Allow ordering of out-of-stock products'|trans), ('By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.allow_ordering_oos) }}
-              {{ form_widget(stockForm.allow_ordering_oos) }}
-            </div>
+
+  <div class="card" id="configuration_fieldset_stock">
+    <h3 class="card-header">
+      <i class="material-icons">shop</i>
+      {{ 'Products stock'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          {{ ps.label_with_help(('Allow ordering of out-of-stock products'|trans), ('By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(stockForm.allow_ordering_oos) }}
+            {{ form_widget(stockForm.allow_ordering_oos) }}
           </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Enable stock management'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.stock_management) }}
-              {{ form_widget(stockForm.stock_management) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Label of in-stock products'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.stock_management) }}
-              {{ form_widget(stockForm.in_stock_label) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Label of out-of-stock products with allowed backorders'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.oos_allowed_backorders) }}
-              {{ form_widget(stockForm.oos_allowed_backorders) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Label of out-of-stock products with denied backorders'|trans }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(stockForm.oos_denied_backorders) }}
-              {{ form_widget(stockForm.oos_denied_backorders) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Delivery time of in-stock products'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.delivery_time) }}
-              {{ form_widget(stockForm.delivery_time) }}
-              <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Delivery time of out-of-stock products with allowed backorders'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.oos_delivery_time) }}
-              {{ form_widget(stockForm.oos_delivery_time) }}
-              <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Default pack stock management'|trans), ('When selling packs of products, how do you want your stock to be calculated?'|trans({}, 'Admin.Shopparameters.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(stockForm.pack_stock_management) }}
-              {{ form_widget(stockForm.pack_stock_management) }}
-            </div>
-          </div>
-          {{ form_row(stockForm.oos_show_label_listing_pages) }}
-          {% block product_stock_preferences_form_rest %}
-            {{ form_rest(stockForm) }}
-          {% endblock %}
         </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Enable stock management'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(stockForm.stock_management) }}
+            {{ form_widget(stockForm.stock_management) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Label of in-stock products'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(stockForm.stock_management) }}
+            {{ form_widget(stockForm.in_stock_label) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Label of out-of-stock products with allowed backorders'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(stockForm.oos_allowed_backorders) }}
+            {{ form_widget(stockForm.oos_allowed_backorders) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Label of out-of-stock products with denied backorders'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(stockForm.oos_denied_backorders) }}
+            {{ form_widget(stockForm.oos_denied_backorders) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Delivery time of in-stock products'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(stockForm.delivery_time) }}
+            {{ form_widget(stockForm.delivery_time) }}
+            <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Delivery time of out-of-stock products with allowed backorders'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(stockForm.oos_delivery_time) }}
+            {{ form_widget(stockForm.oos_delivery_time) }}
+            <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help(('Default pack stock management'|trans), ('When selling packs of products, how do you want your stock to be calculated?'|trans({}, 'Admin.Shopparameters.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(stockForm.pack_stock_management) }}
+            {{ form_widget(stockForm.pack_stock_management) }}
+          </div>
+        </div>
+        {{ form_row(stockForm.oos_show_label_listing_pages) }}
+        {% block product_stock_preferences_form_rest %}
+          {{ form_rest(stockForm) }}
+        {% endblock %}
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="form-stock-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-        </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-stock-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>
-</div>
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Contact/Contacts/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Contact/Contacts/create.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Contact/Contacts/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Contact/Contacts/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/Contact/Contacts/index.html.twig
@@ -27,11 +27,7 @@
 
 {% block content %}
   {% block contacts_list_panel %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': contactGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': contactGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -27,23 +27,20 @@
 {% form_theme generalForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block order_preferences_general %}
-<div class="row justify-content-center">
-  <div class="col">
-      <div class="card">
-          <h3 class="card-header">
-              <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
-          </h3>
-          <div class="card-block row">
-              <div class="card-text">
-                {{ form_widget(generalForm) }}
-              </div>
-          </div>
-          <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                  <button class="btn btn-primary" id="form-general-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-          </div>
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'General'|trans({}, 'Admin.Global') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(generalForm) }}
       </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-general-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
@@ -27,23 +27,20 @@
 {% form_theme giftOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block order_preferences_gift_options %}
-<div class="row justify-content-center">
-  <div class="col">
-      <div class="card">
-          <h3 class="card-header">
-              <i class="material-icons">cake</i> {{ 'Gift options'|trans({}, 'Admin.Shopparameters.Feature') }}
-          </h3>
-          <div class="card-block row">
-              <div class="card-text">
-                {{ form_widget(giftOptionsForm) }}
-              </div>
-          </div>
-          <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                  <button class="btn btn-primary" id="form-gift-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-          </div>
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">cake</i>
+      {{ 'Gift options'|trans({}, 'Admin.Shopparameters.Feature') }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(giftOptionsForm) }}
       </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="form-gift-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderReturnStates/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderReturnStates/create.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderReturnStates/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderReturnStates/edit.html.twig
@@ -31,11 +31,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderStates/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderStates/create.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderStates/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderStates/edit.html.twig
@@ -31,11 +31,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderStates/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/OrderStates/index.html.twig
@@ -43,21 +43,11 @@
 {% block content %}
 
   {% block order_states_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderStatesGrid} %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderStatesGrid} %}{% endembed %}
   {% endblock %}
 
   {% block order_return_states_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderReturnStatesGrid} %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderReturnStatesGrid} %}{% endembed %}
   {% endblock %}
 
 {% endblock %}
@@ -68,4 +58,3 @@
   <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/order_states.bundle.js') }}"></script>
 {% endblock %}
-

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig
@@ -29,19 +29,18 @@
   {% if isHostMode %}
     <div class="card">
       <h3 class="card-header">
-        <i class="material-icons">settings</i> {{ 'Manage domain name'|trans }}
+        <i class="material-icons">settings</i>
+        {{ 'Manage domain name'|trans }}
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="row">
-            <div class="col-sm">
-              <div class="alert alert-info" role="alert">
-                <div class="alert-text">
-                  {{ 'You can search for a new domain name or add a domain name that you already own. You will be redirected to your PrestaShop account.'|trans({}, 'Admin.Shopparameters.Help') }}
-                </div>
-              </div>
+
+          <div class="alert alert-info" role="alert">
+            <div class="alert-text">
+              {{ 'You can search for a new domain name or add a domain name that you already own. You will be redirected to your PrestaShop account.'|trans({}, 'Admin.Shopparameters.Help') }}
             </div>
           </div>
+
         </div>
       </div>
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig
@@ -26,29 +26,26 @@
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
 
 {% block keyword %}
-  <div class="card">
-    <h3 class="card-header">
-      <i class="material-icons">settings</i> {{ 'Robots file generation'|trans }}
-    </h3>
+<div class="card">
+  <h3 class="card-header">
+    <i class="material-icons">settings</i>
+    {{ 'Robots file generation'|trans }}
+  </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
-        <div class="row">
-          <div class="col-sm">
-            <div class="alert alert-info" role="alert">
-              <div class="alert-text">
-                {% set defaultDescription = 'Your robots.txt file MUST be in your website\'s root directory and nowhere else (e.g. http://www.example.com/robots.txt).'|trans({}, 'Admin.Shopparameters.Notification') %}
-                {% if isRobotsTextFileValid %}
-                  {{ defaultDescription }} <br>
-                  {{ 'Generate your "robots.txt" file by clicking on the following button (this will erase the old robots.txt file)'|trans({}, 'Admin.Shopparameters.Notification') }}
-                {% else %}
-                  {{ defaultDescription }} <br>
-                  {{ 'Before you can use this tool, you need to:'|trans({}, 'Admin.Shopparameters.Notification') }} <br>
-                  {{ '1) Create a blank robots.txt file in your root directory.'|trans({}, 'Admin.Shopparameters.Notification') }} <br>
-                  {{ '2) Give it write permissions (CHMOD 666 on Unix system).'|trans({}, 'Admin.Shopparameters.Notification') }}
-                {% endif %}
-              </div>
-            </div>
+  <div class="card-block row">
+    <div class="card-text">
+      <div class="alert alert-info" role="alert">
+        <div class="alert-text">
+          {% set defaultDescription = 'Your robots.txt file MUST be in your website\'s root directory and nowhere else (e.g. http://www.example.com/robots.txt).'|trans({}, 'Admin.Shopparameters.Notification') %}
+            {% if isRobotsTextFileValid %}
+              {{ defaultDescription }} <br>
+              {{ 'Generate your "robots.txt" file by clicking on the following button (this will erase the old robots.txt file)'|trans({}, 'Admin.Shopparameters.Notification') }}
+            {% else %}
+              {{ defaultDescription }} <br>
+              {{ 'Before you can use this tool, you need to:'|trans({}, 'Admin.Shopparameters.Notification') }} <br>
+              {{ '1) Create a blank robots.txt file in your root directory.'|trans({}, 'Admin.Shopparameters.Notification') }} <br>
+              {{ '2) Give it write permissions (CHMOD 666 on Unix system).'|trans({}, 'Admin.Shopparameters.Notification') }}
+            {% endif %}
           </div>
         </div>
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -32,19 +32,18 @@
   {% if isShopFeatureActive and not isHostMode %}
     <div class="card">
       <h3 class="card-header">
-        <i class="material-icons">settings</i> {{ cardHeaderLabel }}
+        <i class="material-icons">settings</i>
+        {{ cardHeaderLabel }}
       </h3>
       <div class="card-block row">
         <div class="card-text">
-          <div class="row">
-            <div class="col-sm">
-              <div class="alert alert-info" role="alert">
-                <div class="alert-text">
-                  {{ 'The multistore option is enabled. If you want to change the URL of your shop, you must go to the "Multistore" page under the "Advanced Parameters" menu.'|trans({}, 'Admin.Shopparameters.Notification') }}
-                </div>
-              </div>
+
+          <div class="alert alert-info" role="alert">
+            <div class="alert-text">
+              {{ 'The multistore option is enabled. If you want to change the URL of your shop, you must go to the "Multistore" page under the "Advanced Parameters" menu.'|trans({}, 'Admin.Shopparameters.Notification') }}
             </div>
           </div>
+
         </div>
       </div>
     </div>
@@ -52,31 +51,30 @@
 
   {% if not isShopFeatureActive and not isHostMode and doesMainShopUrlExist %}
     <div class="card">
-    <h3 class="card-header">
-      <i class="material-icons">settings</i> {{ cardHeaderLabel }}
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ cardHeaderLabel }}
 
-      <span
-        class="help-box"
-        data-container="body"
-        data-toggle="popover"
-        data-trigger="hover"
-        data-placement="right"
-        data-content="{{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}"
-        title=""
-      >
+        <span class="help-box" 
+              data-container="body" 
+              data-toggle="popover" 
+              data-trigger="hover" 
+              data-placement="right" 
+              data-content="{{ 'Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.'|trans({}, 'Admin.Shopparameters.Notification') }}" 
+              title="">
         </span>
-    </h3>
-    <div class="card-block row">
-      <div class="card-text">
-        {{ form_widget(shopUrlsForm) }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {{ form_widget(shopUrlsForm) }}
+        </div>
       </div>
-    </div>
 
-    <div class="card-footer">
-      <div class="d-flex justify-content-end">
-        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
       </div>
     </div>
-  </div>
   {% endif %}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/create.html.twig
@@ -26,12 +26,10 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig', {'metaForm': meta_form}) }}
-    </div>
-  </div>
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
+  {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig', {'metaForm': meta_form}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig', {'metaForm': meta_form}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig', {'metaForm': meta_form}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/Meta/index.html.twig
@@ -27,57 +27,42 @@
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-sm">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/meta_showcase_card.html.twig' %}
   {% if not isGridDisplayed %}
-    <div class="row">
-      <div class="col-sm">
-        <div class="alert alert-info" role="alert">
-          <div class="alert-text">
-            {{ 'You can only display the page list in a shop context.'|trans({}, 'Admin.Shopparameters.Notification') }}
-          </div>
-        </div>
+    <div class="alert alert-info" role="alert">
+      <div class="alert-text">
+        {{ 'You can only display the page list in a shop context.'|trans({}, 'Admin.Shopparameters.Notification') }}
       </div>
     </div>
   {% else %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': grid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': grid} %}
   {% endif %}
 
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ form_start(setUpUrlsForm, {attr : {class: 'form'}, action: path('admin_metas_set_up_urls_save') }) }}
-        {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig' %}
-      {{ form_end(setUpUrlsForm) }}
 
-      {{ form_start(shopUrlsForm, {attr : {class: 'form'}, action: path('admin_metas_shop_urls_save') }) }}
-        {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig' %}
-      {{ form_end(shopUrlsForm) }}
+  {{ form_start(setUpUrlsForm, {attr : {class: 'form'}, action: path('admin_metas_set_up_urls_save') }) }}
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig' %}
+  {{ form_end(setUpUrlsForm) }}
 
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig' %}
+  {{ form_start(shopUrlsForm, {attr : {class: 'form'}, action: path('admin_metas_shop_urls_save') }) }}
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig' %}
+  {{ form_end(shopUrlsForm) }}
 
-      {% if urlSchemaForm is not empty %}
-        {{ form_start(urlSchemaForm, {attr : {class: 'form'}, action: path('admin_metas_url_schema_save') }) }}
-          {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig' %}
-        {{ form_end(urlSchemaForm) }}
-      {% endif %}
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/domain_name_management.html.twig' %}
 
-      {{ form_start(seoOptionsForm, {attr : {class: 'form'}, action: path('admin_metas_seo_options_save') }) }}
-        {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig' %}
-      {{ form_end(seoOptionsForm) }}
+  {% if urlSchemaForm is not empty %}
+    {{ form_start(urlSchemaForm, {attr : {class: 'form'}, action: path('admin_metas_url_schema_save') }) }}
+    {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig' %}
+    {{ form_end(urlSchemaForm) }}
+  {% endif %}
+
+  {{ form_start(seoOptionsForm, {attr : {class: 'form'}, action: path('admin_metas_seo_options_save') }) }}
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig' %}
+  {{ form_end(seoOptionsForm) }}
 
 
-      {{ form_start(robotsForm, {'action': path('admin_metas_generate_robots_text_file')}) }}
-        {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig' %}
-      {{ form_end(robotsForm) }}
-    </div>
-  </div>
+  {{ form_start(robotsForm, {'action': path('admin_metas_generate_robots_text_file')}) }}
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig' %}
+  {{ form_end(robotsForm) }}
 
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/create.html.twig
@@ -26,11 +26,8 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/Blocks/form.html.twig' with {'searchEngineForm': searchEngineForm} %}
-    </div>
-  </div>
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/Blocks/form.html.twig' with {'searchEngineForm': searchEngineForm} %}
 {% endblock %}
-

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/edit.html.twig
@@ -28,9 +28,5 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': searchEngineServer}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/Blocks/form.html.twig' with {'searchEngineForm': searchEngineForm} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/Blocks/form.html.twig' with {'searchEngineForm': searchEngineForm} %}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/index.html.twig
@@ -34,11 +34,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': searchEnginesGrid} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': searchEnginesGrid} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/maintenance.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/maintenance.html.twig
@@ -29,28 +29,25 @@
 
 {% block content %}
   {{ form_start(generalForm, {'attr' : {'class': 'form', 'id': 'form-maintenance'} }) }}
-    <div class="row justify-content-center">
-      {% block maintenance_form_general %}
-        <div class="col-xl-12">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">business_center</i> {{ 'General'|trans({}, 'Admin.Global') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_widget(generalForm) }}
-                {{ form_rest(generalForm) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" id="form-maintenance-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+  {% block maintenance_form_general %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">business_center</i>
+        {{ 'General'|trans({}, 'Admin.Global') }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {{ form_widget(generalForm) }}
+          {{ form_rest(generalForm) }}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary" id="form-maintenance-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(generalForm) }}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/ShopParameters/preferences.html.twig
@@ -28,45 +28,42 @@
 
 {% block content %}
   {{ form_start(generalForm, {'attr' : {'class': 'form', 'id': 'configuration_form'} }) }}
-    <div class="row justify-content-center">
-      {% block preferences_form_general %}
-        <div class="col">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">settings</i> {{ 'General'|trans({}, 'Admin.Global') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                  {% if not app.request.isSecure() %}
-                    <div class="form-group row">
-                        <label class="form-control-label ">
-                          {{ 'Enable SSL'|trans({}, 'Admin.Shopparameters.Feature') }}
-                        </label>
-                      <div class="col-sm">
-                        <div class="input-group">
-                          <div class="form-control-plaintext">
-                            <a class="d-block" href="{{ sslUri }}">
-                              {{ 'Please click here to check if your shop supports HTTPS.'|trans({}, 'Admin.Shopparameters.Feature') }}
-                            </a>
-                          </div>
-                        </div>
-                        <small class="form-text">
-                          {{ 'If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.'|trans({}, 'Admin.Shopparameters.Help') }}
-                        </small>
-                      </div>
-                    </div>
-                  {% endif %}
-                {{ form_widget(generalForm) }}
+  {% block preferences_form_general %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'General'|trans({}, 'Admin.Global') }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          {% if not app.request.isSecure() %}
+            <div class="form-group row">
+              <label class="form-control-label ">
+                {{ 'Enable SSL'|trans({}, 'Admin.Shopparameters.Feature') }}
+              </label>
+              <div class="col-sm">
+                <div class="input-group">
+                  <div class="form-control-plaintext">
+                    <a class="d-block" href="{{ sslUri }}">
+                      {{ 'Please click here to check if your shop supports HTTPS.'|trans({}, 'Admin.Shopparameters.Feature') }}
+                    </a>
+                  </div>
+                </div>
+                <small class="form-text">
+                  {{ 'If you want to enable SSL on all the pages of your shop, activate the "Enable on all the pages" option below.'|trans({}, 'Admin.Shopparameters.Help') }}
+                </small>
               </div>
             </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" id="form-preferences-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
-            </div>
-          </div>
+          {% endif %}
+          {{ form_widget(generalForm) }}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary" id="form-preferences-save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(generalForm) }}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Exception/error.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Exception/error.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}"/>
 {% endblock %}
 
 {% block title %}
@@ -35,47 +35,45 @@
 
 {% block body %}
   <div class="container">
-    <div class="row mt-5">
-      <div class="col">
-        <div class="card">
-          <div class="card-body text-center">
-            <img class="img-responsive"
-                 src="{{ asset('themes/new-theme/img/error/500.svg') }}"
-                 alt="{{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}"
-            >
+    <div class="mt-5">
+      <div class="card">
+        <div class="card-body text-center">
+          <img class="img-responsive" 
+               src="{{ asset('themes/new-theme/img/error/500.svg') }}" 
+               alt="{{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}">
 
-            <div class="mt-3">
-              <p class="error-header">
-                {{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}
-              </p>
+          <div class="mt-3">
+            <p class="error-header">
+              {{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}
+            </p>
 
-              {% if exception %}
-                <div class="mx-auto">
-                  <p class="mb-0">{{ exception.message }}</p>
-                  <p class="mb-0">[{{ exception.class }} {{ exception.code }}]</p>
-                </div>
-              {% endif %}
-
-              <div class="mt-4">
-                <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
-                  <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
-
-                  <button class="btn btn-outline-secondary" type="submit">
-                    {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
-                  </button>
-                </form>
-                <button class="btn btn-primary js-go-back-btn ml-3" type="button">
-                  {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
-                </button>
+            {% if exception %}
+              <div class="mx-auto">
+                <p class="mb-0">{{ exception.message }}</p>
+                <p class="mb-0">[{{ exception.class }}
+                  {{ exception.code }}]</p>
               </div>
+            {% endif %}
 
-              <p class="mt-3">
-                <a href="{{ documentation_link('debug_mode') }}" target="_blank">
-                  {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
-                  <i class="material-icons">arrow_right_alt</i>
-                </a>
-              </p>
+            <div class="mt-4">
+              <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
+                <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
+
+                <button class="btn btn-outline-secondary" type="submit">
+                  {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
+                </button>
+              </form>
+              <button class="btn btn-primary js-go-back-btn ml-3" type="button">
+                {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
+              </button>
             </div>
+
+            <p class="mt-3">
+              <a href="{{ documentation_link('debug_mode') }}" target="_blank">
+                {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
+                <i class="material-icons">arrow_right_alt</i>
+              </a>
+            </p>
           </div>
         </div>
       </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Exception/not_found.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Exception/not_found.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}"/>
 {% endblock %}
 
 {% block title %}
@@ -35,55 +35,51 @@
 
 {% block body %}
   <div class="container">
-    <div class="row mt-5">
-      <div class="col">
-        <div class="card">
-          <div class="card-body text-center">
-            <img class="img-responsive"
-                 src="{{ asset('themes/new-theme/img/error/500.svg') }}"
-                 alt="{{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}"
-            >
+    <div class="mt-5">
+      <div class="card">
+        <div class="card-body text-center">
+          <img class="img-responsive" src="{{ asset('themes/new-theme/img/error/500.svg') }}" alt="{{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}">
 
-            <div class="mt-3">
-              <p class="error-header">
-                {{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}
-              </p>
+          <div class="mt-3">
+            <p class="error-header">
+              {{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}
+            </p>
 
-              {% if exception is defined and exception %}
-                <div class="mx-auto">
-                  <p class="mb-0">{{ exception.message }}</p>
-                  {% if exception.class is defined or exception.code is defined %}
-                    <p class="mb-0">[{{ exception.class|default('Exception') }} {{ exception.code|default(0) }}]</p>
-                  {% endif %}
-                </div>
-              {% endif %}
-
-              {% if errorMessage is defined %}
-                <div class="mx-auto">
-                  <p class="mb-0">{{ errorMessage }}</p>
-                </div>
-              {% endif %}
-
-              <div class="mt-4">
-                <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
-                  <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
-
-                  <button class="btn btn-outline-secondary" type="submit">
-                    {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
-                  </button>
-                </form>
-                <button class="btn btn-primary js-go-back-btn ml-3" type="button">
-                  {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
-                </button>
+            {% if exception is defined and exception %}
+              <div class="mx-auto">
+                <p class="mb-0">{{ exception.message }}</p>
+                {% if exception.class is defined or exception.code is defined %}
+                  <p class="mb-0">[{{ exception.class|default('Exception') }}
+                    {{ exception.code|default(0) }}]</p>
+                {% endif %}
               </div>
+            {% endif %}
 
-              <p class="mt-3">
-                <a href="{{ documentation_link('debug_mode') }}" target="_blank">
-                  {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
-                  <i class="material-icons">arrow_right_alt</i>
-                </a>
-              </p>
+            {% if errorMessage is defined %}
+              <div class="mx-auto">
+                <p class="mb-0">{{ errorMessage }}</p>
+              </div>
+            {% endif %}
+
+            <div class="mt-4">
+              <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
+                <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
+
+                <button class="btn btn-outline-secondary" type="submit">
+                  {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
+                </button>
+              </form>
+              <button class="btn btn-primary js-go-back-btn ml-3" type="button">
+                {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
+              </button>
             </div>
+
+            <p class="mt-3">
+              <a href="{{ documentation_link('debug_mode') }}" target="_blank">
+                {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
+                <i class="material-icons">arrow_right_alt</i>
+              </a>
+            </p>
           </div>
         </div>
       </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig
@@ -24,30 +24,25 @@
  *#}
 
 {% if cmsPageView.breadcrumb_tree is not empty %}
-  <div class="row">
-    <div class="col">
-      <div class="card">
-        <div class="card-block">
-          <nav>
-            <ol class="breadcrumb">
-              {% for category in cmsPageView.breadcrumb_tree %}
-                <li class="breadcrumb-item">
-                  {% set cmsPageRouteParameters = {} %}
+  <div class="card">
+    <div class="card-block">
+      <nav>
+        <ol class="breadcrumb">
+          {% for category in cmsPageView.breadcrumb_tree %}
+            <li class="breadcrumb-item">
+              {% set cmsPageRouteParameters = {} %}
 
-                  {% if category.cmsPageCategoryId.value != cmsPageView.root_category_id %}
-                    {% set cmsPageRouteParameters = {'id_cms_category' : category.cmsPageCategoryId.value} %}
-                  {% endif %}
+              {% if category.cmsPageCategoryId.value != cmsPageView.root_category_id %}
+                {% set cmsPageRouteParameters = {'id_cms_category' : category.cmsPageCategoryId.value} %}
+              {% endif %}
 
-                  <a href="{{ path('admin_cms_pages_index', cmsPageRouteParameters) }}">
-                    {{ category.name }}
-                  </a>
-                </li>
-              {% endfor %}
-            </ol>
-          </nav>
-        </div>
-      </div>
+              <a href="{{ path('admin_cms_pages_index', cmsPageRouteParameters) }}">
+                {{ category.name }}
+              </a>
+            </li>
+          {% endfor %}
+        </ol>
+      </nav>
     </div>
   </div>
 {% endif %}
-

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/add.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/add.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/create_category.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/create_category.html.twig
@@ -25,15 +25,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
-          'cmsPageCategoryForm': cmsPageCategoryForm,
-          'cmsCategoryParentId': app.request.query.get('id_cms_category')
-        })
-      }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
+      'cmsPageCategoryForm': cmsPageCategoryForm,
+      'cmsCategoryParentId': app.request.query.get('id_cms_category')
+    })
+  }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/edit.html.twig
@@ -26,12 +26,8 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
-      <span class="js-preview-url" data-preview-url="{{ previewUrl }}"></span>
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
+  <span class="js-preview-url" data-preview-url="{{ previewUrl }}"></span>
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/edit_category.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/edit_category.html.twig
@@ -26,15 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
-          'cmsPageCategoryForm': cmsPageCategoryForm,
-          'cmsCategoryParentId': cmsCategoryParentId
-        })
-      }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
+      'cmsPageCategoryForm': cmsPageCategoryForm,
+      'cmsCategoryParentId': cmsCategoryParentId
+    })
+  }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Cms/index.html.twig
@@ -41,37 +41,24 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="col-sm">
-      {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/showcase_card.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/showcase_card.html.twig' %}
 
   {% block cms_page_category_breadcrumb %}
     {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig' %}
   {% endblock %}
 
   {% block cms_category_grid %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsCategoryGrid} %}
-
-            {% block grid_panel_footer %}
-              {% if app.request.query.get('id_cms_category') and app.request.query.get('id_cms_category') != cmsPageView.root_category_id %}
-                {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/listing_panel_footer.html.twig' %}
-              {% endif %}
-            {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsCategoryGrid} %}
+      {% block grid_panel_footer %}
+        {% if app.request.query.get('id_cms_category') and app.request.query.get('id_cms_category') != cmsPageView.root_category_id %}
+          {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/listing_panel_footer.html.twig' %}
+        {% endif %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 
   {% block cms_grid %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
@@ -25,41 +25,35 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block mailThemeConfigurationFormBlock %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {{ form_start(mailThemeConfigurationForm, {'action': path('admin_mail_theme_save_configuration')}) }}
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">settings</i> {{ 'Configuration'|trans({}, 'Admin.Global') }}
-        </h3>
+{{ form_start(mailThemeConfigurationForm, {'action': path('admin_mail_theme_save_configuration')}) }}
+<div class="card">
+  <h3 class="card-header">
+    <i class="material-icons">settings</i>
+    {{ 'Configuration'|trans({}, 'Admin.Global') }}
+  </h3>
 
-        <div class="card-block row">
-          <div class="card-text">
-
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ ps.label_with_help(
-                  ('Select your default email theme'|trans({}, 'Admin.Design.Feature')),
-                  ('This won\'t regenerate email templates, it only sets the default email theme for future generation (when a language is installed for example).'|trans({}, 'Admin.Design.Help'))
-                ) }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(mailThemeConfigurationForm.defaultTheme) }}
-                {{ form_widget(mailThemeConfigurationForm.defaultTheme) }}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary" id="save-configuration-form">
-              <span>{{ 'Save'|trans({}, 'Admin.Actions') }}</span>
-            </button>
-          </div>
+  <div class="card-block row">
+    <div class="card-text">
+      <div class="form-group row">
+        {{ ps.label_with_help(
+          ('Select your default email theme'|trans({}, 'Admin.Design.Feature')),
+          ('This won\'t regenerate email templates, it only sets the default email theme for future generation (when a language is installed for example).'|trans({}, 'Admin.Design.Help'))
+        ) }}
+        <div class="col-sm">
+          {{ form_errors(mailThemeConfigurationForm.defaultTheme) }}
+          {{ form_widget(mailThemeConfigurationForm.defaultTheme) }}
         </div>
       </div>
-      {{ form_end(mailThemeConfigurationForm) }}
     </div>
   </div>
+
+  <div class="card-footer">
+    <div class="d-flex justify-content-end">
+      <button class="btn btn-primary" id="save-configuration-form">
+        <span>{{ 'Save'|trans({}, 'Admin.Actions') }}</span>
+      </button>
+    </div>
+  </div>
+</div>
+{{ form_end(mailThemeConfigurationForm) }}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
@@ -25,77 +25,74 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block generateMailsFormBlock %}
-<div class="row justify-content-center">
-  <div class="col-xl-12">
-    {{ form_start(generateMailsForm, {'action': path('admin_mail_theme_generate')}) }}
-    <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">email</i> {{ 'Generate emails'|trans({}, 'Admin.Design.Feature') }}
-      </h3>
 
-      <div class="card-block row">
-        <div class="card-text">
+  {{ form_start(generateMailsForm, {'action': path('admin_mail_theme_generate')}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'Generate emails'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
 
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Select your email theme'|trans({}, 'Admin.Design.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.mailTheme) }}
-              {{ form_widget(generateMailsForm.mailTheme) }}
-            </div>
+    <div class="card-block row">
+      <div class="card-text">
+
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Select your email theme'|trans({}, 'Admin.Design.Feature') }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.mailTheme) }}
+            {{ form_widget(generateMailsForm.mailTheme) }}
           </div>
+        </div>
 
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.language) }}
-              {{ form_widget(generateMailsForm.language) }}
-            </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.language) }}
+            {{ form_widget(generateMailsForm.language) }}
           </div>
+        </div>
 
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ ps.label_with_help(
-                ('Select the theme you want to overwrite'|trans({}, 'Admin.Design.Feature')),
-              ('PrestaShop\'s email templates are stored in the "mails" folder, but they can be overridden by your current theme\'s own "mails" folder. Using this option enables to overwrite emails from your current theme.'|trans({}, 'Admin.Design.Help'))
-              ) }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.theme) }}
-              {{ form_widget(generateMailsForm.theme) }}
-              {% if generateMailsForm.theme.vars.disabled %}
+        <div class="form-group row">
+          {{ ps.label_with_help(
+            ('Select the theme you want to overwrite'|trans({}, 'Admin.Design.Feature')),
+            ('PrestaShop\'s email templates are stored in the "mails" folder, but they can be overridden by your current theme\'s own "mails" folder. Using this option enables to overwrite emails from your current theme.'|trans({}, 'Admin.Design.Help'))
+          ) }}
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.theme) }}
+            {{ form_widget(generateMailsForm.theme) }}
+            {% if generateMailsForm.theme.vars.disabled %}
               <small class="form-text">{{ 'No emails were detected in any theme folder so this field is disabled.'|trans({}, 'Admin.Design.Help') }}</small>
-              {% endif %}
-            </div>
+            {% endif %}
           </div>
+        </div>
 
-          <div class="form-group row">
-            {{ ps.label_with_help(
-              ('Overwrite templates'|trans({}, 'Admin.Design.Feature')),
+        <div class="form-group row">
+          {{ ps.label_with_help(
+            ('Overwrite templates'|trans({}, 'Admin.Design.Feature')),
             ('By default, existing email template files are not modified to avoid deleting any modification you may have done. Enable this option to force the overwrite.'|trans({}, 'Admin.Design.Help'))
-            ) }}
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.overwrite) }}
-              {{ form_widget(generateMailsForm.overwrite) }}
-            </div>
+          ) }}
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.overwrite) }}
+            {{ form_widget(generateMailsForm.overwrite) }}
           </div>
-
         </div>
-      </div>
 
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
-            <i class="material-icons">email</i>
-            <span>{{ 'Generate emails'|trans({}, 'Admin.Actions') }}</span>
-          </button>
-        </div>
       </div>
     </div>
-    {{ form_end(generateMailsForm) }}
+
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">
+          <i class="material-icons">email</i>
+          <span>{{ 'Generate emails'|trans({}, 'Admin.Actions') }}</span>
+        </button>
+      </div>
+    </div>
   </div>
-</div>
+  {{ form_end(generateMailsForm) }}
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
@@ -24,98 +24,95 @@
  *#}
 
 {% block generateMailsFormBlock %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">email</i> {{ 'List %theme% layouts'|trans({'%theme%': mailTheme.name}, 'Admin.Design.Feature') }}
-        </h3>
 
-        <div class="card-block">
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'List %theme% layouts'|trans({'%theme%': mailTheme.name}, 'Admin.Design.Feature') }}
+    </h3>
 
-            <table class="grid-table table">
-              <thead class="thead-default">
-                <tr class="column-headers">
-                  <th scope="col">
-                    {{ 'Name'|trans({}, 'Admin.Global') }}
-                  </th>
-                  <th scope="col">
-                    {{ 'Module'|trans({}, 'Admin.Global') }}
-                  </th>
-                  <th scope="col">
-                    <div class="grid-actions-header-text">
-                      {{ 'Actions'|trans({}, 'Admin.Global') }}
+    <div class="card-block">
+
+      <table class="grid-table table">
+        <thead class="thead-default">
+          <tr class="column-headers">
+            <th scope="col">
+              {{ 'Name'|trans({}, 'Admin.Global') }}
+            </th>
+            <th scope="col">
+              {{ 'Module'|trans({}, 'Admin.Global') }}
+            </th>
+            <th scope="col">
+              <div class="grid-actions-header-text">
+                {{ 'Actions'|trans({}, 'Admin.Global') }}
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for mailLayout in mailTheme.layouts %}
+            <tr>
+              <td class="data-type">
+                {{ mailLayout.name }}
+              </td>
+              <td class="data-type">
+                {{ mailLayout.moduleName }}
+              </td>
+              <td class="action-type">
+                {% if mailLayout.moduleName is empty %}
+                  {% set previewUrl = path('admin_mail_theme_preview_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
+                  {% set rawUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
+                  {% set txtUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'txt'}) %}
+                  {% set mailUrl = path('admin_mail_theme_send_test_mail', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name}) %}
+                {% else %}
+                  {% set previewUrl = path('admin_mail_theme_preview_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
+                  {% set rawUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
+                  {% set txtUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'txt'}) %}
+                  {% set mailUrl = path('admin_mail_theme_send_test_module_mail', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name}) %}
+                {% endif %}
+
+                <div class="btn-group-action text-right">
+                  <div class="btn-group">
+                    <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ previewUrl }}">
+                      <i class="material-icons">http</i>
+                    </a>
+
+                    <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
+                       data-toggle="dropdown" 
+                       aria-haspopup="true" 
+                       aria-expanded="false">
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-right">
+                      <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
+                        <i class="material-icons">code</i>
+                        {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
+                      </a>
+                      <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
+                        <i class="material-icons">subject</i>
+                        {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
+                      </a>
+                      <a class="btn tooltip-link dropdown-item" href="{{ mailUrl }}">
+                        <i class="material-icons">email</i>
+                        {{ 'Send a test email'|trans({}, 'Admin.Advparameters.Feature') }}
+                      </a>
                     </div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for mailLayout in mailTheme.layouts %}
-                  <tr>
-                    <td class="data-type">
-                      {{ mailLayout.name }}
-                    </td>
-                    <td class="data-type">
-                      {{ mailLayout.moduleName }}
-                    </td>
-                    <td class="action-type">
-                      {% if mailLayout.moduleName is empty %}
-                        {% set previewUrl = path('admin_mail_theme_preview_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
-                        {% set rawUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
-                        {% set txtUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'txt'}) %}
-                        {% set mailUrl = path('admin_mail_theme_send_test_mail', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name}) %}
-                      {% else %}
-                        {% set previewUrl = path('admin_mail_theme_preview_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
-                        {% set rawUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
-                        {% set txtUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'txt'}) %}
-                        {% set mailUrl = path('admin_mail_theme_send_test_module_mail', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name}) %}
-                      {% endif %}
+                  </div>
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-                      <div class="btn-group-action text-right">
-                        <div class="btn-group">
-                          <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ previewUrl }}">
-                            <i class="material-icons">http</i>
-                          </a>
-
-                          <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
-                             data-toggle="dropdown"
-                             aria-haspopup="true"
-                             aria-expanded="false"
-                          >
-                          </a>
-
-                          <div class="dropdown-menu dropdown-menu-right">
-                            <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
-                              <i class="material-icons">code</i>
-                              {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
-                            </a>
-                            <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
-                              <i class="material-icons">subject</i>
-                              {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
-                            </a>
-                            <a class="btn tooltip-link dropdown-item" href="{{ mailUrl }}">
-                              <i class="material-icons">email</i>
-                              {{ 'Send a test email'|trans({}, 'Admin.Advparameters.Feature') }}
-                            </a>
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-
-        </div>
-
-        <div class="card-footer">
-          <a href="{{ path('admin_mail_theme_index', params|default({})) }}" class="btn btn-outline-secondary" id="back-to-configuration-link">
-            <i class="material-icons">arrow_back</i>
-            {{ 'Back to configuration'|trans({}, 'Admin.Actions') }}
-          </a>
-        </div>
-
-      </div>
     </div>
+
+    <div class="card-footer">
+      <a href="{{ path('admin_mail_theme_index', params|default({})) }}" class="btn btn-outline-secondary" id="back-to-configuration-link">
+        <i class="material-icons">arrow_back</i>
+        {{ 'Back to configuration'|trans({}, 'Admin.Actions') }}
+      </a>
+    </div>
+
   </div>
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig
@@ -24,48 +24,45 @@
  *#}
 
 {% block generateMailsFormBlock %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">email</i> {{ 'Email themes'|trans({}, 'Admin.Design.Feature') }}
-        </h3>
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'Email themes'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
 
-        <div class="card-block">
+    <div class="card-block">
 
-            <table class="grid-table table">
-              <thead class="thead-default">
-                <tr class="column-headers">
-                  <th scope="col">
-                    {{ 'Name'|trans({}, 'Admin.Global') }}
-                  </th>
-                  <th scope="col">
-                    <div class="grid-actions-header-text">
-                      {{ 'Actions'|trans({}, 'Admin.Global') }}
-                    </div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for theme in mailThemes %}
-                  <tr>
-                    <td class="data-type column-name">
-                      {{ theme.name }}
-                    </td>
-                    <td class="action-type">
-                      <div class="btn-group-action text-right">
-                        <a class="btn tooltip-link preview-link" href="{{ path('admin_mail_theme_preview', {'theme': theme.name}) }}">
-                          <i class="material-icons">search</i>
-                        </a>
-                      </div>
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+      <table class="grid-table table">
+        <thead class="thead-default">
+          <tr class="column-headers">
+            <th scope="col">
+              {{ 'Name'|trans({}, 'Admin.Global') }}
+            </th>
+            <th scope="col">
+              <div class="grid-actions-header-text">
+                {{ 'Actions'|trans({}, 'Admin.Global') }}
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for theme in mailThemes %}
+            <tr>
+              <td class="data-type column-name">
+                {{ theme.name }}
+              </td>
+              <td class="action-type">
+                <div class="btn-group-action text-right">
+                  <a class="btn tooltip-link preview-link" href="{{ path('admin_mail_theme_preview', {'theme': theme.name}) }}">
+                    <i class="material-icons">search</i>
+                  </a>
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-        </div>
-      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
@@ -24,38 +24,37 @@
  *#}
 
 {% block translateMailsBodyFormBlock %}
-<div class="row justify-content-center">
-  <div class="col-xl-12">
-    {{ form_start(translateMailsBodyForm, {'action': path('admin_mail_theme_translate_body')}) }}
-    <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">email</i> {{ 'Translate emails'|trans({}, 'Admin.Actions') }}
-      </h3>
 
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(translateMailsBodyForm.language) }}
-              {{ form_widget(translateMailsBodyForm.language) }}
-            </div>
+  {{ form_start(translateMailsBodyForm, {'action': path('admin_mail_theme_translate_body')}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'Translate emails'|trans({}, 'Admin.Actions') }}
+    </h3>
+
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(translateMailsBodyForm.language) }}
+            {{ form_widget(translateMailsBodyForm.language) }}
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
-            <i class="material-icons">email</i>
-            <span>{{ 'Translate emails'|trans({}, 'Admin.Actions') }}</span>
-          </button>
-        </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">
+          <i class="material-icons">email</i>
+          <span>{{ 'Translate emails'|trans({}, 'Admin.Actions') }}</span>
+        </button>
       </div>
     </div>
-    {{ form_end(translateMailsBodyForm) }}
   </div>
-</div>
+  {{ form_end(translateMailsBodyForm) }}
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
@@ -26,49 +26,45 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-12">
-      {{ form_start(pageLayoutCustomizationForm) }}
-        <div class="row justify-content-center">
-          <div class="col-xl-10">
-            <div class="card">
-              <h3 class="card-header">
-                <i class="material-icons">settings</i>
-                {{ 'Choose layouts'|trans({}, 'Admin.Actions') }}
-              </h3>
-              <div class="card-body">
-                <table class="table">
-                  <thead>
-                    <tr>
-                      <th>{{ 'Page'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Layout'|trans({}, 'Admin.Global') }}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for customizablePage in pages %}
-                      <tr>
-                        <td>{{ customizablePage.title|default(customizablePage.page) }}</td>
-                        <td>{{ customizablePage.description }}</td>
-                        <td>{{ form_widget(pageLayoutCustomizationForm['layouts'][customizablePage.page]) }}</td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
+  {{ form_start(pageLayoutCustomizationForm) }}
+  <div class="row justify-content-center">
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">settings</i>
+          {{ 'Choose layouts'|trans({}, 'Admin.Actions') }}
+        </h3>
+        <div class="card-body">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>{{ 'Page'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Layout'|trans({}, 'Admin.Global') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for customizablePage in pages %}
+                <tr>
+                  <td>{{ customizablePage.title|default(customizablePage.page) }}</td>
+                  <td>{{ customizablePage.description }}</td>
+                  <td>{{ form_widget(pageLayoutCustomizationForm['layouts'][customizablePage.page]) }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
 
-                {% block page_layout_customization_form_rest %}
-                  {{ form_rest(pageLayoutCustomizationForm) }}
-                {% endblock %}
-              </div>
-              <div class="card-footer">
-                <div class="d-flex justify-content-end">
-                  <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-                </div>
-              </div>
-            </div>
+          {% block page_layout_customization_form_rest %}
+            {{ form_rest(pageLayoutCustomizationForm) }}
+          {% endblock %}
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
           </div>
         </div>
-      {{ form_end(pageLayoutCustomizationForm) }}
+      </div>
     </div>
   </div>
+  {{ form_end(pageLayoutCustomizationForm) }}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Theme/import.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Theme/import.html.twig
@@ -41,83 +41,81 @@
 } %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {{ form_start(importThemeForm) }}
-      {{ form_errors(importThemeForm) }}
-      <div class="row justify-content-center">
-        <div class="col-xl-10">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">file_copy</i>
-              {{ 'Import from your computer'|trans({}, 'Admin.Design.Feature') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_row(importThemeForm.import_from_computer) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">
-                  <i class="material-icons">cloud_upload</i>
-                  {{ 'Save'|trans({}, 'Admin.Actions') }}
-                </button>
-              </div>
-            </div>
+
+  {{ form_start(importThemeForm) }}
+  {{ form_errors(importThemeForm) }}
+  <div class="row justify-content-center">
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">file_copy</i>
+          {{ 'Import from your computer'|trans({}, 'Admin.Design.Feature') }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_row(importThemeForm.import_from_computer) }}
           </div>
         </div>
-
-        <div class="col-xl-10">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">file_copy</i>
-              {{ 'Import from the web'|trans({}, 'Admin.Design.Feature') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_row(importThemeForm.import_from_web) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">
-                  <i class="material-icons">cloud_upload</i>
-                  {{ 'Save'|trans({}, 'Admin.Actions') }}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-xl-10">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">file_copy</i>
-              {{ 'Import from FTP'|trans({}, 'Admin.Design.Feature') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_row(importThemeForm.import_from_ftp) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">
-                  <i class="material-icons">cloud_upload</i>
-                  {{ 'Save'|trans({}, 'Admin.Actions') }}
-                </button>
-              </div>
-            </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">
+              <i class="material-icons">cloud_upload</i>
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
           </div>
         </div>
       </div>
+    </div>
 
-      {% block import_theme_form_rest %}
-        {{ form_rest(importThemeForm) }}
-      {% endblock %}
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">file_copy</i>
+          {{ 'Import from the web'|trans({}, 'Admin.Design.Feature') }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_row(importThemeForm.import_from_web) }}
+          </div>
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">
+              <i class="material-icons">cloud_upload</i>
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
 
-      {{ form_end(importThemeForm) }}
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">file_copy</i>
+          {{ 'Import from FTP'|trans({}, 'Admin.Design.Feature') }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_row(importThemeForm.import_from_ftp) }}
+          </div>
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">
+              <i class="material-icons">cloud_upload</i>
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
+
+  {% block import_theme_form_rest %}
+    {{ form_rest(importThemeForm) }}
+  {% endblock %}
+
+  {{ form_end(importThemeForm) }}
+
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Theme/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/Theme/index.html.twig
@@ -41,126 +41,124 @@
 
 {% block content %}
   <div id="themes-logo-page">
-    <div class="row">
-      <div class="col">
 
-        {% if not isSingleShopContext %}
-          <div class="alert alert-info">
-            <p class="alert-text">
-              {{ 'You must select a shop from the above list if you wish to choose a theme.'|trans({}, 'Admin.Design.Help') }}
-            </p>
-          </div>
-        {% endif %}
 
-        {% if isInstalledRtlLanguage %}
-          {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig' %}
-        {% endif %}
+    {% if not isSingleShopContext %}
+      <div class="alert alert-info">
+        <p class="alert-text">
+          {{ 'You must select a shop from the above list if you wish to choose a theme.'|trans({}, 'Admin.Design.Help') }}
+        </p>
+      </div>
+    {% endif %}
 
-        {{ form_start(shopLogosForm, {'action': path('admin_themes_upload_logos')}) }}
-          {% if not isInstalledRtlLanguage and isSingleShopContext and isMultiShopFeatureUsed %}
-            {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/multishop_switch.html.twig' %}
-          {% endif %}
-          <div class="card">
-            <div class="card-header">
-              {{ 'Logo'|trans({}, 'Admin.Global') }}
-            </div>
-            <div class="card-body logo-configuration-card-body">
-              {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/logo_configuration.html.twig' %}
-            </div>
-            <div class="card-footer">
-              <button class="btn btn-primary float-right">
-                {{ 'Save'|trans({}, 'Admin.Actions') }}
-              </button>
-              <div class="clearfix">&nbsp;</div>
-            </div>
-          </div>
-          {{ form_rest(shopLogosForm) }}
-        {{ form_end(shopLogosForm) }}
+    {% if isInstalledRtlLanguage %}
+      {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig' %}
+    {% endif %}
 
-        <div class="card">
-          <div class="card-header">
-            {{ 'My theme for %name% shop'|trans({'%name%': shopName}, 'Admin.Design.Feature') }}
-          </div>
-          <div class="card-body row">
-
-            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-              'themeName': currentlyUsedTheme.get('display_name'),
-              'themeVersion': currentlyUsedTheme.get('version'),
-              'themeAuthor': currentlyUsedTheme.get('author.name'),
-              'themeAuthorUrl': theme.get('author.url'),
-              'isActive': true
-              } %}
-              {% block image %}
-                <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name')   }}">
-              {% endblock %}
-              {% block button_container %}
-                <button class="btn action-button">
-                  <i class="material-icons icon-current-theme">done</i>
-                  {{ 'My current theme'|trans({}, 'Admin.Design.Feature') }}
-                </button>
-              {% endblock %}
-            {% endembed %}
-
-            {% if notUsedThemes is not empty %}
-              {% for theme in notUsedThemes %}
-                {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-                  'themeName': theme.get('display_name'),
-                  'themeVersion': theme.get('version'),
-                  'themeAuthor': theme.get('author.name'),
-                  'themeAuthorUrl': theme.get('author.url'),
-                  'isActive': false
-                  }  %}
-                  {% block image %}
-                    <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
-                  {% endblock %}
-                  {% block button_container %}
-                    <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">
-                      <input type="hidden" name="token" value="{{ csrf_token('enable-theme') }}" />
-                      <button type="button" class="btn action-button js-display-use-theme-modal" {{ (not isSingleShopContext) ? 'disabled' : '' }}>
-                        <i class="material-icons">
-                          present_to_all
-                        </i>
-                        <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
-                      </button>
-                    </form>
-                    <form action="{{ path('admin_themes_delete', {'themeName': theme.name}) }}" method="post" class="d-inline">
-                      <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}" />
-                      <button type="button" class="btn delete-button js-display-delete-theme-modal">
-                        <i class="material-icons">
-                          delete
-                        </i>
-                      </button>
-                    </form>
-                  {% endblock %}
-                {% endembed %}
-              {% endfor %}
-
-              {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig' %}
-              {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig' %}
-            {% endif %}
-
-            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_catalog_card.html.twig' %}
-              {% block image %}
-                <img src="{{ asset('themes/new-theme/public/pages/themes/icon_themes.png') }}" alt="{{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}">
-              {% endblock %}
-
-              {% block description %}
-                {{ 'Explore more than a thousand themes'|trans({}, 'Admin.Design.Feature') }}
-              {% endblock %}
-
-              {% block button_container %}
-                <a class="btn btn-primary" href="{{ themeCatalogUrl }}" target="_blank">
-                  {{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}
-                </a>
-              {% endblock %}
-
-            {% endembed %}
-
-            {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig' %}
-          </div>
-        </div>
+    {{ form_start(shopLogosForm, {'action': path('admin_themes_upload_logos')}) }}
+    {% if not isInstalledRtlLanguage and isSingleShopContext and isMultiShopFeatureUsed %}
+      {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/multishop_switch.html.twig' %}
+    {% endif %}
+    <div class="card">
+      <div class="card-header">
+        {{ 'Logo'|trans({}, 'Admin.Global') }}
+      </div>
+      <div class="card-body logo-configuration-card-body">
+        {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/logo_configuration.html.twig' %}
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-primary float-right">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+        <div class="clearfix">&nbsp;</div>
       </div>
     </div>
+    {{ form_rest(shopLogosForm) }}
+    {{ form_end(shopLogosForm) }}
+
+    <div class="card">
+      <div class="card-header">
+        {{ 'My theme for %name% shop'|trans({'%name%': shopName}, 'Admin.Design.Feature') }}
+      </div>
+      <div class="card-body row">
+
+        {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
+          'themeName': currentlyUsedTheme.get('display_name'),
+          'themeVersion': currentlyUsedTheme.get('version'),
+          'themeAuthor': currentlyUsedTheme.get('author.name'),
+          'themeAuthorUrl': theme.get('author.url'),
+          'isActive': true
+        } %}
+          {% block image %}
+            <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name') }}">
+          {% endblock %}
+          {% block button_container %}
+            <button class="btn action-button">
+              <i class="material-icons icon-current-theme">done</i>
+              {{ 'My current theme'|trans({}, 'Admin.Design.Feature') }}
+            </button>
+          {% endblock %}
+        {% endembed %}
+
+        {% if notUsedThemes is not empty %}
+          {% for theme in notUsedThemes %}
+            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
+              'themeName': theme.get('display_name'),
+              'themeVersion': theme.get('version'),
+              'themeAuthor': theme.get('author.name'),
+              'themeAuthorUrl': theme.get('author.url'),
+              'isActive': false
+            }  %}
+              {% block image %}
+                <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
+              {% endblock %}
+              {% block button_container %}
+                <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">
+                  <input type="hidden" name="token" value="{{ csrf_token('enable-theme') }}"/>
+                  <button type="button" class="btn action-button js-display-use-theme-modal" {{ (not isSingleShopContext) ? 'disabled' : '' }}>
+                    <i class="material-icons">
+                      present_to_all
+                    </i>
+                    <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
+                  </button>
+                </form>
+                <form action="{{ path('admin_themes_delete', {'themeName': theme.name}) }}" method="post" class="d-inline">
+                  <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
+                  <button type="button" class="btn delete-button js-display-delete-theme-modal">
+                    <i class="material-icons">
+                      delete
+                    </i>
+                  </button>
+                </form>
+              {% endblock %}
+            {% endembed %}
+          {% endfor %}
+
+          {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig' %}
+          {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig' %}
+        {% endif %}
+
+        {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_catalog_card.html.twig' %}
+          {% block image %}
+            <img src="{{ asset('themes/new-theme/public/pages/themes/icon_themes.png') }}" alt="{{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}">
+          {% endblock %}
+
+          {% block description %}
+            {{ 'Explore more than a thousand themes'|trans({}, 'Admin.Design.Feature') }}
+          {% endblock %}
+
+          {% block button_container %}
+            <a class="btn btn-primary" href="{{ themeCatalogUrl }}" target="_blank">
+              {{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}
+            </a>
+          {% endblock %}
+
+        {% endembed %}
+
+        {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig' %}
+      </div>
+    </div>
+
   </div>
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Design/positions.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Design/positions.html.twig
@@ -26,34 +26,58 @@
 {% trans_default_domain "Admin.Design.Feature" %}
 
 {% block content %}
-  <div class="row m-0">
+  <div class="row">
     {% if not canMove %}
       <p class="alert alert-warning alert-can-move">
         {{ 'If you want to order/move the following data, please select a shop from the shop list.' | trans({}, 'Admin.Design.Notification') }}
       </p>
     {% endif %}
 
-    <div class="card col-9">
-      <div class="card-body">
-        <div class="card">
-          <form class="mt-2" id="position-filters">
-            <div class="container">
-              <div class="row">
-                <div class="row col-md-12 col-lg-6">
-                  <label class="form-control-label col-4 text-left mt-1">{{ 'Show' | trans({}, 'Admin.Actions') }}</label>
-                  <div class="col-8">
+    <div class="col-md-3">
+      <div class="card" id="modules-position-selection-panel">
+        <h3 class="card-header">
+          <i class="material-icons">check</i>
+          {{ 'Selection' | trans({}, 'Admin.Global') }}</h3>
+        <div class="card-body">
+          <p>
+            <span id="modules-position-single-selection">{{ '1 module selected' | trans }}</span>
+            <span id="modules-position-multiple-selection">
+              <span id="modules-position-selection-count"></span>
+              {{ 'modules selected' | trans({}, 'Admin.Design.Feature') }}
+            </span>
+          </p>
+          <div>
+            <button class="btn btn-primary">
+              <i class="icon-remove"></i>
+              {{ 'Unhook the selection' | trans }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-9 order-md-first">
+      <div class="card card-body">
+        <div class="card bg-light p-3">
+          <form id="position-filters">
+            <div class="row">
+              <div class="col-lg-6 mb-2">
+                <div class="row align-items-center">
+                  <label class="form-control-label col-md-4 text-left text-lg-center">{{ 'Show' | trans({}, 'Admin.Actions') }}</label>
+                  <div class="col-md-8">
                     <select id="show-modules" class="filter">
                       <option value="all">{{ 'All modules' | trans }}&nbsp;</option>
                       {% for module in modules %}
-                        <option value="{{ module.id }}"{% if selectedModule == module.id %} selected="selected"{% endif %}>{{ module.displayName }}</option>
+                        <option value="{{ module.id }}" {% if selectedModule == module.id %} selected="selected" {% endif %}>{{ module.displayName }}</option>
                       {% endfor %}
                     </select>
                   </div>
                 </div>
+              </div>
 
-                <div class="row col-md-12 col-lg-6">
-                  <label class="form-control-label col-5 text-center mt-1">{{ 'Search for a hook' | trans }}</label>
-                  <div class="input-group col-7">
+              <div class="col-lg-6 mb-2">
+                <div class="row align-items-center">
+                  <label class="form-control-label col-md-4 text-left text-lg-center">{{ 'Search for a hook' | trans }}</label>
+                  <div class="input-group col-md-8">
                     <div class="input-group-prepend">
                       <div class="input-group-text">
                         <i class="material-icons">search</i>
@@ -65,42 +89,45 @@
               </div>
             </div>
 
-            <div class="container mt-3">
-              <div class="row">
-                <div class="col-lg-12">
-                  <p class="checkbox">
-                    <label class="form-control-label" for="hook-position">
-                      <input type="checkbox" id="hook-position" />
-                      <label class="selectbox" for="hook-position"><i class="material-icons done">done</i></label>
-                      {{ 'Display non-positionable hooks' | trans }}
-                    </label>
-                  </p>
-                </div>
-              </div>
-            </div>
+            <p class="checkbox mt-3 mb-0">
+              <label class="form-control-label" for="hook-position">
+                <input type="checkbox" id="hook-position"/>
+                <label class="selectbox" for="hook-position">
+                  <i class="material-icons done">done</i>
+                </label>
+                {{ 'Display non-positionable hooks' | trans }}
+              </label>
+            </p>
           </form>
         </div>
 
-        <form id="module-positions-form" method="post" action="{{ path('admin_modules_positions_unhook') }}" data-update-url="{{ path('api_improve_design_positions_update') }}" data-togglestatus-url="{{ path('admin_modules_positions_toggle_status') }}">
+        <form id="module-positions-form" method="post" 
+              action="{{ path('admin_modules_positions_unhook') }}" 
+              data-update-url="{{ path('api_improve_design_positions_update') }}" 
+              data-togglestatus-url="{{ path('admin_modules_positions_toggle_status') }}">
           {% for hook in hooks %}
-            <section class="hook-panel{% if not hook['position'] %} hook-position{% endif %}"{% if not hook['position'] %} style="display:none;"{% endif %}>
+            <section class="hook-panel{% if not hook['position'] %} hook-position{% endif %}" {% if not hook['position'] %} style="display:none;" {% endif %}>
               <a name="{{ hook['name'] }}"></a>
               <header class="hook-panel-header">
                 <span class="hook-status">
-                   <input
-                      class="switch-input-md hook-switch-action"
-                      data-toggle="switch"
-                      data-hook-id="{{ hook['id_hook'] }}"
-                      type="checkbox"
-                      value="{{ hook['active'] }}"
-                      {{ hook['active'] ? 'checked="checked"' : '' }}
-                    />
+                  <input class="switch-input-md hook-switch-action" 
+                         data-toggle="switch" 
+                         data-hook-id="{{ hook['id_hook'] }}" 
+                         type="checkbox" 
+                         value="{{ hook['active'] }}" 
+                         {{ hook['active'] ? 'checked="checked"' : '' }}
+                  />
                 </span>
                 <span class="hook-name">{{ hook['name'] }}</span>
                 <label class="badge badge-pill float-right">
                   {% if hook['modules_count'] and canMove %}
-                    <input type="checkbox" class="hook-checker" id="Ghook{{ hook['id_hook'] }}" data-hook-id="{{ hook['id_hook'] }}" />
-                    <label class="selectbox" for="Ghook{{ hook['id_hook'] }}"><i class="material-icons done">done</i></label>
+                    <input type="checkbox" class="hook-checker" 
+                           id="Ghook{{ hook['id_hook'] }}" 
+                           data-hook-id="{{ hook['id_hook'] }}"
+                    />
+                    <label class="selectbox" for="Ghook{{ hook['id_hook'] }}">
+                      <i class="material-icons done">done</i>
+                    </label>
                   {% endif %}
 
                   {{ hook['modules_count'] }}
@@ -117,17 +144,24 @@
                   <ul class="list-unstyled{% if hook['modules_count'] > 1 %} sortable{% endif %}">
                     {% for module in hook['modules'] if modules[module['id_module']] is defined %}
                       {% set moduleInstance = modules[module['id_module']] %}
-                      <li id="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"
-                        class="module-position-{{ moduleInstance.id }} module-item{% if canMove and hook['modules_count'] >= 2 %} draggable{% endif %}">
+                      <li id="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}" 
+                          class="module-position-{{ moduleInstance.id }} module-item{% if canMove and hook['modules_count'] >= 2 %} draggable{% endif %}">
 
                         <div class="module-column-select">
                           <i class="material-icons drag_indicator">drag_indicator</i>
-                          <input type="checkbox" id="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}" data-hook-id="{{ hook['id_hook'] }}" class="modules-position-checkbox hook{{ hook['id_hook'] }}" name="unhooks[]" value="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"/>
-                          <label class="selectbox" for="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"><i class="material-icons done">done</i></label>
+                          <input type="checkbox" id="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}" 
+                                 data-hook-id="{{ hook['id_hook'] }}" 
+                                 class="modules-position-checkbox hook{{ hook['id_hook'] }}" 
+                                 name="unhooks[]" 
+                                 value="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"
+                          />
+                          <label class="selectbox" for="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}">
+                            <i class="material-icons done">done</i>
+                          </label>
                         </div>
 
                         <div class="module-column-icon">
-                          <img src="{{ asset('../modules/' ~ moduleInstance.name ~ '/logo.png') }}" alt="{{ moduleInstance.displayName| escape }}" />
+                          <img src="{{ asset('../modules/' ~ moduleInstance.name ~ '/logo.png') }}" alt="{{ moduleInstance.displayName| escape }}"/>
                         </div>
 
                         <div class="module-column-infos">
@@ -144,7 +178,8 @@
                         </div>
 
                         {% if not selectedModule and hook['modules_count'] > 1 %}
-                          <div class="btn-toolbar text-center module-column-position{% if canMove and hook['modules_count'] >= 2 %} dragHandle{% endif %}" id="td_{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}">
+                          <div class="btn-toolbar text-center module-column-position{% if canMove and hook['modules_count'] >= 2 %} dragHandle{% endif %}" 
+                               id="td_{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}">
                             <div class="btn-group">
                               <span class="index-position">{{ loop.index }}</span>
                             </div>
@@ -162,13 +197,17 @@
                               {% set linkParams = linkParams|merge({'show_modules': selectedModule}) %}
                             {% endif %}
 
-                            <a class="btn tooltip-link" href="{{ getAdminLink('AdminModulesPositions', true, linkParams) }}" aria-label="{{ 'Edit' | trans({}, 'Admin.Actions') }}" title="{{ 'Edit' | trans({}, 'Admin.Actions') }}">
+                            <a class="btn tooltip-link" href="{{ getAdminLink('AdminModulesPositions', true, linkParams) }}" 
+                               aria-label="{{ 'Edit' | trans({}, 'Admin.Actions') }}" title="{{ 'Edit' | trans({}, 'Admin.Actions') }}">
                               <i class="material-icons">edit</i>
                             </a>
 
-                            <a class="btn tooltip-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-reference="parent">
+                            <a class="btn tooltip-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split" 
+                               data-toggle="dropdown" 
+                               aria-haspopup="true" 
+                               aria-expanded="false" 
+                               data-reference="parent">
                             </a>
-
                             <div class="dropdown-menu">
                               <a class="dropdown-item" href="{{ path('admin_modules_positions_unhook', {moduleId: moduleInstance.id, hookId: hook['id_hook']}) }}">
                                 <i class="material-icons">indeterminate_check_box</i>
@@ -196,23 +235,6 @@
             </button>
           </div>
         </form>
-      </div>
-    </div>
-
-    <div class="col-3">
-      <div class="card" id="modules-position-selection-panel">
-        <h3 class="card-header"><i class="material-icons">checked</i> {{ 'Selection' | trans({}, 'Admin.Global') }}</h3>
-        <div class="card-body">
-          <p>
-            <span id="modules-position-single-selection">{{ '1 module selected' | trans }}</span>
-            <span id="modules-position-multiple-selection">
-              <span id="modules-position-selection-count"></span> {{ 'modules selected' | trans({}, 'Admin.Design.Feature') }}
-            </span>
-          </p>
-          <div class="text-center">
-            <button class="btn btn-primary"><i class="icon-remove"></i> {{ 'Unhook the selection' | trans }}</button>
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Currency/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Currency/create.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': []}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': []}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Currency/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Currency/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': languages}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': languages}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Currency/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Currency/index.html.twig
@@ -36,11 +36,7 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': currencyGrid }) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': currencyGrid }) }}
 
   {% block exchange_rates_block %}
     <div class="row">

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Geolocation/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Geolocation/index.html.twig
@@ -28,36 +28,26 @@
 
 {% block content %}
   {% if not geolocationDatabaseAvailable %}
-    <div class="row">
-      <div class="col">
-        <div class="alert alert-warning" role="alert">
-          <span class="alert-text">
-            {{ 'Since December 30, 2019, you need to register for a [1]MaxMind[/1] account to get a license key to be able to download the geolocation data. Once downloaded, extract the data using Winrar or Gzip into the /app/Resources/geoip/ directory.'|trans({'[1]': '<a href="https://dev.maxmind.com/geoip/geoip2/geolite2" target="_blank">', '[/1]': '<a/>'}, 'Admin.Notifications.Warning')|raw }}
-          </span>
-        </div>
-      </div>
+
+    <div class="alert alert-warning" role="alert">
+      <span class="alert-text">
+        {{ 'Since December 30, 2019, you need to register for a [1]MaxMind[/1] account to get a license key to be able to download the geolocation data. Once downloaded, extract the data using Winrar or Gzip into the /app/Resources/geoip/ directory.'|trans({'[1]': '<a href="https://dev.maxmind.com/geoip/geoip2/geolite2" target="_blank">', '[/1]': '<a/>'}, 'Admin.Notifications.Warning')|raw }}
+      </span>
     </div>
+
   {% endif %}
 
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {{ form_start(geolocationByIpAddressForm, {'action': path('admin_geolocation_by_ip_address_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig' %}
-      {{ form_end(geolocationByIpAddressForm) }}
-    </div>
+  {{ form_start(geolocationByIpAddressForm, {'action': path('admin_geolocation_by_ip_address_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig' %}
+  {{ form_end(geolocationByIpAddressForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(geolocationOptionsForm, {'action': path('admin_geolocation_options_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig' %}
-      {{ form_end(geolocationOptionsForm) }}
-    </div>
+  {{ form_start(geolocationOptionsForm, {'action': path('admin_geolocation_options_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig' %}
+  {{ form_end(geolocationOptionsForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(geolocationIpAddressWhitelistForm, {'action': path('admin_geolocation_whitelist_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig' %}
-      {{ form_end(geolocationIpAddressWhitelistForm) }}
-    </div>
-  </div>
+  {{ form_start(geolocationIpAddressWhitelistForm, {'action': path('admin_geolocation_whitelist_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig' %}
+  {{ form_end(geolocationIpAddressWhitelistForm) }}
 
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Language/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Language/create.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Add new'|trans({}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Language/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Language/edit.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': editableLanguage.name}, 'Admin.Catalog.Feature') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Language/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Language/index.html.twig
@@ -36,27 +36,23 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-  <div class="row">
-    <div class="col">
-      <div class="alert alert-warning" role="alert">
-        <p class="alert-text">{{ 'When you delete a language, all related translations in the database will be deleted.'|trans({}, 'Admin.International.Notification') }}</p>
-      </div>
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
 
-      {% if not isHtaccessFileWriter %}
-        <div class="alert alert-info" role="alert">
-          <p class="alert-text">{{ 'Your .htaccess file must be writable.'|trans({}, 'Admin.International.Notification') }}</p>
-        </div>
-      {% endif %}
-    </div>
+  <div class="alert alert-warning" role="alert">
+    <p class="alert-text">{{ 'When you delete a language, all related translations in the database will be deleted.'|trans({}, 'Admin.International.Notification') }}</p>
   </div>
 
-  {% block language_listing %}
-    <div class="row">
-      <div class="col-sm">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with { 'grid': languageGrid } %}
-      </div>
+  {% if not isHtaccessFileWriter %}
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">{{ 'Your .htaccess file must be writable.'|trans({}, 'Admin.International.Notification') }}</p>
     </div>
+  {% endif %}
+
+
+  {% block language_listing %}
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with { 'grid': languageGrid } %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Localization/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Localization/index.html.twig
@@ -27,31 +27,19 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig' %}
 
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {{ form_start(configurationForm, {'action': path('admin_localization_configuration_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/configuration.html.twig' %}
-      {{ form_end(configurationForm) }}
-    </div>
+  {{ form_start(configurationForm, {'action': path('admin_localization_configuration_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/configuration.html.twig' %}
+  {{ form_end(configurationForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(localUnitsForm, {'action': path('admin_localization_local_units_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/local_units.html.twig' %}
-      {{ form_end(localUnitsForm) }}
-    </div>
+  {{ form_start(localUnitsForm, {'action': path('admin_localization_local_units_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/local_units.html.twig' %}
+  {{ form_end(localUnitsForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(advancedForm, {'action': path('admin_localization_advanced_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig' %}
-      {{ form_end(advancedForm) }}
-    </div>
-  </div>
+  {{ form_start(advancedForm, {'action': path('admin_localization_advanced_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig' %}
+  {{ form_end(advancedForm) }}
 
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Tax/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Tax/create.html.twig
@@ -26,12 +26,10 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-    </div>
-  </div>
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
+  {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Tax/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Tax/edit.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Tax/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Tax/index.html.twig
@@ -36,12 +36,8 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-lg-12">
-      {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxGrid} %}
-      {% include '@PrestaShop/Admin/Improve/International/Tax/Blocks/tax_options.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxGrid} %}
+  {% include '@PrestaShop/Admin/Improve/International/Tax/Blocks/tax_options.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/TaxRulesGroup/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/TaxRulesGroup/index.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-lg-12">
-      {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxRulesGroupGrid} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxRulesGroupGrid} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -31,7 +31,8 @@
 
   <div class="card">
     <h3 class="card-header">
-      <i class="material-icons">file_copy</i> {{ 'Copy'|trans({}, 'Admin.Actions') }}
+      <i class="material-icons">file_copy</i>
+      {{ 'Copy'|trans({}, 'Admin.Actions') }}
     </h3>
 
     <div class="card-block row">
@@ -48,9 +49,7 @@
           </div>
         </div>
         <div class="form-group row">
-          <label class="form-control-label">
-            {{ form_label(copyLanguageForm.from_language) }}
-          </label>
+          {{ form_label(copyLanguageForm.from_language) }}
           <div class="col-sm">
             <div class="input-group">
               {{ form_errors(copyLanguageForm.from_language) }}
@@ -66,9 +65,7 @@
         </div>
 
         <div class="form-group row">
-          <label class="form-control-label">
-            {{ form_label(copyLanguageForm.to_language) }}
-          </label>
+          {{ form_label(copyLanguageForm.to_language) }}
           <div class="col-sm">
             <div class="input-group">
               {{ form_errors(copyLanguageForm.to_language) }}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -27,36 +27,20 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div class="card card-kpis">
-        {% block translations_kpis_row %}
-          <div class="row">
-            {{ render(controller(
-              'PrestaShopBundle:Admin\\Common:renderKpiRow',
-              { 'kpiRow': kpiRow }
-            )) }}
-          </div>
-        {% endblock %}
-      </div>
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig' %}
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig' %}
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/export_language.html.twig' %}
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/copy_language.html.twig' %}
-    </div>
+  <div class="card card-kpis">
+    {% block translations_kpis_row %}
+      {{ render(controller(
+        'PrestaShopBundle:Admin\\Common:renderKpiRow',
+        { 'kpiRow': kpiRow }
+      )) }}
+    {% endblock %}
   </div>
+
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig' %}
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig' %}
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/export_language.html.twig' %}
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/copy_language.html.twig' %}
+
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Zone/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Zone/create.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig') }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig') }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/International/Zone/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/International/Zone/edit.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': zoneName}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig', {'zoneForm': zoneForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig', {'zoneForm': zoneForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
@@ -29,12 +29,12 @@
   <div class="module-item-list">
   {% for module in paymentModules %}
     <div class="row module-item-wrapper-list border-bottom mb-sm-3">
-      <div class="col-12 col-sm-2 col-md-1 col-lg-1">
+      <div class="col-sm-2 col-md-1 col-lg-1">
         <div class="module-logo-thumb-list text-center">
           <img src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}"/>
         </div>
       </div>
-      <div class="col-12 col-sm-6 col-md-8 col-lg-9 pl-0">
+      <div class="col-sm-6 col-md-8 col-lg-9 pl-0">
         <p class="mb-0">
           {{ module.attributes.displayName|raw }}
           <span class="text-muted">
@@ -46,7 +46,7 @@
         </p>
       </div>
       {% if module.attributes.is_configurable %}
-      <div class="col-12 col-sm-4 col-md-3 col-lg-2 mb-3">
+      <div class="col-sm-4 col-md-3 col-lg-2 mb-3">
         <div class="text-center">
           <a href="{{ path('admin_module_configure_action', {'module_name': module.attributes.name}) }}"
              class="btn btn-primary-reverse btn-outline-primary light-button"

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -26,41 +26,27 @@
 {% trans_default_domain 'Admin.Payment.Feature' %}
 
 {% block content %}
-  <div class="container">
-
-    {% if paymentModules|length < 2 %}
-      <div class="card-block row alert-block">
-        <div class="card-text">
-          <div class="row">
-            <div class="col-sm">
-              <div class="alert alert-info" role="alert">
-                <div class="alert-text">
-                  {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% endif %}
-
-    <div class="row">
-      <div class="col">
-        {% if isSingleShopContext %}
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">credit_card</i> {{ 'Active payment'|trans }}
-            </h3>
-            <div class="card-block">
-              {% include '@PrestaShop/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig' %}
-            </div>
-          </div>
-        {% else %}
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">{{ 'You have more than one shop and must select one to configure payment.'|trans({}, 'Admin.Payment.Notification') }}</p>
-          </div>
-        {% endif %}
+  {% if paymentModules|length < 2 %}
+    <div class="alert alert-info" role="alert">
+      <div class="alert-text">
+        {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
       </div>
     </div>
-  </div>
+  {% endif %}
+
+  {% if isSingleShopContext %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">credit_card</i>
+        {{ 'Active payment'|trans }}
+      </h3>
+      <div class="card-block">
+        {% include '@PrestaShop/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig' %}
+      </div>
+    </div>
+  {% else %}
+    <div class="alert alert-warning" role="alert">
+      <p class="alert-text">{{ 'You have more than one shop and must select one to configure payment.'|trans({}, 'Admin.Payment.Notification') }}</p>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Payment/Preferences/payment_preferences.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Payment/Preferences/payment_preferences.html.twig
@@ -27,35 +27,31 @@
 
 {% block content %}
   <div class="container">
-    <div class="row">
-      <div class="col">
-        {% if not isSingleShopContext %}
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">
-              {{ 'Note that this page is available in a single shop context only. Switch context to work on it.'|trans({}, 'Admin.Notifications.Info') }}
-            </p>
-          </div>
-        {% elseif paymentModulesCount == 0 %}
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">
-              {{ 'No payment module installed'|trans({}, 'Admin.Payment.Notification') }}
-            </p>
-          </div>
-        {% else %}
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'This is where you decide what payment modules are available for different variations like your customers\' currency, group, and country.'|trans({}, 'Admin.Payment.Help') }}
-            </p>
-            <p class="alert-text">
-              {{ 'A check mark indicates you want the payment module available.'|trans({}, 'Admin.Payment.Help') }}
-              {{ 'If it is not checked then this means that the payment module is disabled.'|trans({}, 'Admin.Payment.Help') }}
-            </p>
-          </div>
-
-          {% include '@PrestaShop/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig' %}
-        {% endif %}
+    {% if not isSingleShopContext %}
+      <div class="alert alert-warning" role="alert">
+        <p class="alert-text">
+          {{ 'Note that this page is available in a single shop context only. Switch context to work on it.'|trans({}, 'Admin.Notifications.Info') }}
+        </p>
       </div>
-    </div>
+    {% elseif paymentModulesCount == 0 %}
+      <div class="alert alert-warning" role="alert">
+        <p class="alert-text">
+          {{ 'No payment module installed'|trans({}, 'Admin.Payment.Notification') }}
+        </p>
+      </div>
+    {% else %}
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {{ 'This is where you decide what payment modules are available for different variations like your customers\' currency, group, and country.'|trans({}, 'Admin.Payment.Help') }}
+        </p>
+        <p class="alert-text">
+          {{ 'A check mark indicates you want the payment module available.'|trans({}, 'Admin.Payment.Help') }}
+          {{ 'If it is not checked then this means that the payment module is disabled.'|trans({}, 'Admin.Payment.Help') }}
+        </p>
+      </div>
+
+      {% include '@PrestaShop/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig' %}
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Carriers/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Carriers/index.html.twig
@@ -27,19 +27,11 @@
 
 {% block content %}
   {% block carrier_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Improve/Shipping/Carriers/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Improve/Shipping/Carriers/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% include '@PrestaShop/Admin/Improve/Shipping/Carriers/Blocks/information_block.html.twig' %}
-  <div class="row">
-    <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': carrierGrid} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': carrierGrid} %}
 
   {# Recommended modules will be attached to here. #}
   <div class="row">

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
@@ -27,22 +27,19 @@
 {% form_theme carrierOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block shipping_preferences_carrier_options %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div id="carrier-options" class="card">
-        <h3 class="card-header">
-          <i class="material-icons">local_shipping</i> {{ 'Carrier options'|trans }}
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            {{ form_widget(carrierOptionsForm) }}
-          </div>
-        </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary" id="save-carrier-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-          </div>
-        </div>
+  <div id="carrier-options" class="card">
+    <h3 class="card-header">
+      <i class="material-icons">local_shipping</i>
+      {{ 'Carrier options'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(carrierOptionsForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="save-carrier-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
@@ -27,33 +27,28 @@
 {% form_theme handlingForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block shipping_preferences_handling %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div id="handling" class="card">
-        <h3 class="card-header">
-          <i class="material-icons">filter_none</i> {{ 'Handling'|trans }}
+  <div id="handling" class="card">
+    <h3 class="card-header">
+      <i class="material-icons">filter_none</i>
+      {{ 'Handling'|trans }}
 
-          <span
-            class="help-box"
-            data-container="body"
-            data-toggle="popover"
-            data-trigger="hover"
-            data-placement="right"
-            data-content="{{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }} {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}"
-            title=""
-          >
-          </span>
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            {{ form_widget(handlingForm) }}
-          </div>
-        </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-          </div>
-        </div>
+      <span class="help-box" 
+            data-container="body" 
+            data-toggle="popover" 
+            data-trigger="hover" 
+            data-placement="right" 
+            data-content="{{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }} {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}" 
+            title="">
+      </span>
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(handlingForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/action_button.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/action_button.html.twig
@@ -33,7 +33,7 @@
 
 {% else %}
 
-    <form class='{{classes_form|default() }}' method="post" action="{{ url }}">
+    <form class="{{classes_form|default() }}" method="post" action="{{ url }}">
       <button type="submit" class="{{ classes }} module_action_menu_{{ action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ action }}">
         {{ displayAction }}
       </button>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_grid.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_grid.html.twig
@@ -25,7 +25,7 @@
 {% set isModuleActive = module.database.active %}
 
 <div
-  class="module-item module-item-grid col-md-12 col-lg-6 col-xl-3 {% if origin == 'manage' and isModuleActive == '0' %}module-item-grid-isNotActive{% endif %}"
+  class="module-item module-item-grid col-lg-6 col-xl-3 {% if origin == 'manage' and isModuleActive == '0' %}module-item-grid-isNotActive{% endif %}"
   data-id="{{ module.attributes.id }}"
   data-name="{{ module.attributes.displayName }}"
   data-scoring="{{ module.attributes.avgRate }}"

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_grid_addons.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_grid_addons.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div class="module-addons-item-grid col-md-12 col-lg-6 col-xl-3">
+<div class="module-addons-item-grid col-lg-6 col-xl-3">
   <div class="module-addons-item-wrapper-grid">
     <span class="module-icon-addons-exit-grid">
       <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}" />

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_list.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_list.html.twig
@@ -43,13 +43,13 @@
 >
   <div class="container-fluid">
     <div class="module-item-wrapper-list row">
-      <div class="col-sm-12 col-md-12 col-lg-1 text-sm-center">
+      <div class="col-lg-1 text-sm-center">
         <div class="module-logo-thumb-list">
           <img src="{{ module.attributes.img }}" class="text-md-center" alt="{{ module.attributes.displayName }}"/>
         </div>
       </div>
-      <div class="col-md-12 col-lg-11 row">
-        <div class="col-sm-12 col-md-10 col-lg-11">
+      <div class="col-lg-11 row">
+        <div class="col-md-10 col-lg-11">
           <h3
             class="text-ellipsis module-name-list"
             data-toggle="pstooltip"
@@ -69,7 +69,7 @@
             </span>
           </h3>
         </div>
-        <div class="col-sm-12 col-md-2">
+        <div class="col-md-2">
           <span class="text-ellipsis small-text">
             {% block addon_version %}
               {% if module.attributes.productType == "service" %}
@@ -80,7 +80,7 @@
             {% endblock %}
           </span>
         </div>
-        <div class="col-sm-12 col-md-8 col-lg-7">
+        <div class="col-md-8 col-lg-7">
           {% block addon_description %}
             {{ module.attributes.description|raw }}
             {% if module.attributes.description|length > 0 and module.attributes.description|length < module.attributes.fullDescription|length %}
@@ -93,7 +93,7 @@
             </span>
           {% endblock %}
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-3 text-md-right">
+        <div class="col-lg-3 text-md-right">
           {% block module_actions %}
             {% if requireBulkActions is defined and requireBulkActions == true %}
               <div class="module-checkbox-bulk-list md-checkbox">

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/grid_loader.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/grid_loader.html.twig
@@ -24,36 +24,32 @@
  *#}
 {#Simulate a bunch of module card #}
 <div class="module-placeholders-wrapper row">
-    {% for i in 0..8 %}
-
-      <div class="timeline-item col-xl-3 col-lg-6 col-md-12 col-sm-12">
-        <div class="timeline-item-wrapper">
-            <div class="animated-background">
-              <div class="background-masker header-top"></div>
-              <div class="background-masker header-left"></div>
-              <div class="background-masker header-right"></div>
-              <div class="background-masker header-bottom"></div>
-              <div class="background-masker subheader-left"></div>
-              <div class="background-masker subheader-right"></div>
-              <div class="background-masker subheader-bottom"></div>
-              <div class="background-masker content-top"></div>
-              <div class="background-masker content-first-end"></div>
-              <div class="background-masker content-second-line"></div>
-              <div class="background-masker content-second-end"></div>
-              <div class="background-masker content-third-line"></div>
-              <div class="background-masker content-third-end"></div>
-            </div>
-          </div>
+  {% for i in 0..8 %}
+    <div class="timeline-item col-lg-6 col-xl-3">
+      <div class="timeline-item-wrapper">
+        <div class="animated-background">
+          <div class="background-masker header-top"></div>
+          <div class="background-masker header-left"></div>
+          <div class="background-masker header-right"></div>
+          <div class="background-masker header-bottom"></div>
+          <div class="background-masker subheader-left"></div>
+          <div class="background-masker subheader-right"></div>
+          <div class="background-masker subheader-bottom"></div>
+          <div class="background-masker content-top"></div>
+          <div class="background-masker content-first-end"></div>
+          <div class="background-masker content-second-line"></div>
+          <div class="background-masker content-second-end"></div>
+          <div class="background-masker content-third-line"></div>
+          <div class="background-masker content-third-end"></div>
+        </div>
       </div>
-
-    {% endfor %}
+    </div>
+  {% endfor %}
 </div>
 
-<div class="module-placeholders-failure row">
-      <div class="module-placeholders-failure-wrapper col-md-12">
-          <div class='module-placeholders-failure-msg'>
-          </div>
-          <button id='module-placeholders-failure-retry' type="button" class="btn btn-primary">{{ 'Try again'|trans({}, 'Admin.Actions') }}</button>
-      </div>
-
+<div class="module-placeholders-failure">
+  <div class="module-placeholders-failure-wrapper">
+    <div class="module-placeholders-failure-msg"></div>
+    <button id="module-placeholders-failure-retry" type="button" class="btn btn-primary">{{ 'Try again'|trans({}, 'Admin.Actions') }}</button>
+  </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_addons_connect.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_addons_connect.html.twig
@@ -32,52 +32,43 @@
       </div>
       <div class="modal-body">
         {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
-          <div class="row">
-            <div class="col-md-12">
-              <div class="alert alert-danger" role="alert">
-                <p class="alert-text">
-                  {{ errorMessage }}
-                </p>
-              </div>
-            </div>
+          <div class="alert alert-danger" role="alert">
+            <p class="alert-text">
+              {{ errorMessage }}
+            </p>
           </div>
         {% else %}
-          <div class="row">
-              <div class="col-md-12">
-                  <p>
-                      {{ "Link your shop to your Addons account to automatically receive important updates for the modules you purchased. Don't have an account yet?"|trans({}, 'Admin.Modules.Feature') }}
-                      <a href="https://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules.Feature') }}</a>
-                  </p>
-                  <form id="addons-connect-form"
-                        action="{{ path('admin_addons_login') }}"
-                        method="POST"
-                        data-error-message="{{ 'An error occurred while processing your request.'|trans({}, 'Admin.Notifications.Error') }}"
-                  >
-                  <div class="form-group">
-                    <label for="module-addons-connect-email">{{ 'Email address'|trans({}, 'Admin.Global') }}</label>
-                    <input name="username_addons" type="email" class="form-control" id="module-addons-connect-email" placeholder="Email">
-                  </div>
-                  <div class="form-group">
-                    <label for="module-addons-connect-password">{{ 'Password'|trans({}, 'Admin.Global') }}</label>
-                    <input name="password_addons" type="password" class="form-control" id="module-addons-connect-password" placeholder="Password">
-                  </div>
-                  <div class="md-checkbox md-checkbox-inline">
-                    <label>
-                      <input type="checkbox" name="addons_remember_me">
-                      <i class="md-checkbox-control"></i>
-                      {{ 'Remember me'|trans({}, 'Admin.Global') }}
-                    </label>
-                  </div>
-                  <div class="text-center">
-                    <button type="submit" class="btn btn-primary">{{ "Let's go!"|trans({}, 'Admin.Actions') }}</button>
-                    <div id="addons_login_btn" class="spinner" style="display:none;"></div>
-                  </div>
-                </form>
-                <p class="text-center py-3">
-                    <a href="https://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password?'|trans({}, 'Admin.Global') }}</a>
-                </p>
-              </div>
-          </div>
+          <p>
+            {{ "Link your shop to your Addons account to automatically receive important updates for the modules you purchased. Don't have an account yet?"|trans({}, 'Admin.Modules.Feature') }}
+            <a href="https://addons.prestashop.com/authentication.php" target="_blank">{{ 'Sign up now'|trans({}, 'Admin.Modules.Feature') }}</a>
+          </p>
+          <form id="addons-connect-form" 
+                action="{{ path('admin_addons_login') }}" 
+                method="POST" 
+                data-error-message="{{ 'An error occurred while processing your request.'|trans({}, 'Admin.Notifications.Error') }}">
+            <div class="form-group">
+              <label for="module-addons-connect-email">{{ 'Email address'|trans({}, 'Admin.Global') }}</label>
+              <input name="username_addons" type="email" class="form-control" id="module-addons-connect-email" placeholder="Email">
+            </div>
+            <div class="form-group">
+              <label for="module-addons-connect-password">{{ 'Password'|trans({}, 'Admin.Global') }}</label>
+              <input name="password_addons" type="password" class="form-control" id="module-addons-connect-password" placeholder="Password">
+            </div>
+            <div class="md-checkbox md-checkbox-inline">
+              <label>
+                <input type="checkbox" name="addons_remember_me">
+                <i class="md-checkbox-control"></i>
+                {{ 'Remember me'|trans({}, 'Admin.Global') }}
+              </label>
+            </div>
+            <div class="text-center">
+              <button type="submit" class="btn btn-primary">{{ "Let's go!"|trans({}, 'Admin.Actions') }}</button>
+              <div id="addons_login_btn" class="spinner" style="display:none;"></div>
+            </div>
+          </form>
+          <p class="text-center py-3">
+            <a href="https://addons.prestashop.com/password.php" target="_blank">{{ 'Forgot your password?'|trans({}, 'Admin.Global') }}</a>
+          </p>
         {% endif %}
       </div>
     </div>
@@ -92,17 +83,13 @@
         <button type="button" class="close" data-dismiss="modal">&times;</button>
       </div>
       <div class="modal-body">
-          <div class="row">
-              <div class="col-md-12">
-                  <p>
-                    {{ "You are about to log out your Addons account. You might miss important updates of Addons you've bought."|trans({}, 'Admin.Modules.Notification') }}
-                  </p>
-              </div>
-          </div>
+        <p>
+          {{ "You are about to log out your Addons account. You might miss important updates of Addons you've bought."|trans({}, 'Admin.Modules.Notification') }}
+        </p>
       </div>
       <div class="modal-footer">
-          <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
-          <a class="btn btn-primary uppercase" href="{{ path('admin_addons_logout') }}" id="module-modal-addons-logout-ack">{{ 'Yes, log out'|trans({}, 'Admin.Modules.Feature') }}</a>
+        <input type="button" class="btn btn-default uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
+        <a class="btn btn-primary uppercase" href="{{ path('admin_addons_logout') }}" id="module-modal-addons-logout-ack">{{ 'Yes, log out'|trans({}, 'Admin.Modules.Feature') }}</a>
       </div>
 
     </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_confirm.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_confirm.html.twig
@@ -45,73 +45,60 @@
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>
-            <div class="modal-body row">
-              <div class="col-md-12">
-                <p>
-                  {% if module_action == 'disable' %}
-                    {{ "You are about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <br>
-                    {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules.Notification') }}
-                  {% endif %}
-                  {% if module_action == 'uninstall' %}
-                    {{ "You are about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
-                    <br>
-                    {{ module.attributes.confirmUninstall }}
-                    <br>
-                    <br>
-                    {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <label>
-                      <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
-                    </label>
-                    <br>
-                    <span class="italic red">
-                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
-                    </span>
-                  {% endif %}
-                  {% if module_action == 'reset' %}
-                    {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <br>
-                    {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <span class="italic red">
-                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
-                    </span>
-                  {% endif %}
-                </p>
-              </div>
+            <div class="modal-body">
+              <p>
+                {% if module_action == 'disable' %}
+                  {{ "You are about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <br>
+                  {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules.Notification') }}
+                {% endif %}
+                {% if module_action == 'uninstall' %}
+                  {{ "You are about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
+                  <br>
+                  {{ module.attributes.confirmUninstall }}
+                  <br>
+                  <br>
+                  {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <label>
+                    <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}">
+                    {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
+                  </label>
+                  <br>
+                  <span class="italic red">
+                    {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
+                  </span>
+                {% endif %}
+                {% if module_action == 'reset' %}
+                  {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <br>
+                  {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <span class="italic red">
+                    {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
+                  </span>
+                {% endif %}
+              </p>
             </div>
             <div class="modal-footer">
-              <input type="button" class="btn btn-outline-secondary" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'Admin.Actions') }}" />
+              <input type="button" class="btn btn-outline-secondary" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'Admin.Actions') }}"/>
               {% if module_action == 'disable' %}
-                <a
-                  class="btn btn-primary uppercase module_action_modal_{{ module_action }}"
-                  href="{{ module_url }}"
-                  data-dismiss="modal"
-                  data-tech-name="{{module.attributes.name}}"
-                >
+                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}" href="{{ module_url }}" 
+                data-dismiss="modal" data-tech-name="{{module.attributes.name}}">
                   {{ "Yes, disable it"|trans({}, 'Admin.Modules.Feature') }}
                 </a>
               {% endif %}
               {% if module_action == 'uninstall' %}
-                <a
-                  class="btn btn-primary uppercase module_action_modal_{{ module_action }}"
-                  href="{{ module_url }}"
-                  data-dismiss="modal"
-                  data-tech-name="{{module.attributes.name}}"
-                >
+                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}" href="{{ module_url }}" 
+                data-dismiss="modal" data-tech-name="{{module.attributes.name}}">
                   {{ "Yes, uninstall it"|trans({}, 'Admin.Modules.Feature') }}
                 </a>
               {% endif %}
               {% if module_action == 'reset' %}
-                <a
-                  class="btn btn-primary uppercase module_action_modal_{{ module_action }}"
-                  href="{{ module_url }}"
-                  data-dismiss="modal"
-                  data-tech-name="{{module.attributes.name}}"
-                >
+                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}" href="{{ module_url }}" 
+                data-dismiss="modal" data-tech-name="{{module.attributes.name}}">
                   {{ "Yes, reset it"|trans({}, 'Admin.Modules.Feature') }}
                 </a>
               {% endif %}

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -31,26 +31,23 @@
         <button type="button" class="close" data-dismiss="modal">&times;</button>
       </div>
       <div class="modal-body">
-          <div class="row">
-              <div class="col-md-12">
-                  <p>
-                    {{ "You are about to [1] the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">[Module Action]</span>'})|raw }}
-                  </p>
-                  <p id="module-modal-bulk-confirm-list">
-                      [Module List Up To 10 Max]
-                  </p>
+        <p>
+          {{ "You are about to [1] the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">[Module Action]</span>'})|raw }}
+        </p>
+        <p id="module-modal-bulk-confirm-list">
+          [Module List Up To 10 Max]
+        </p>
 
-                  <div id="module-modal-bulk-checkbox">
-                    <label>
-                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
-                    </label>
-                  </div>
-              </div>
-          </div>
+        <div id="module-modal-bulk-checkbox">
+          <label>
+            <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion">
+            {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
+          </label>
+        </div>
       </div>
       <div class="modal-footer">
-          <input type="button" class="btn btn-outline-secondary uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
-          <button class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</button>
+        <input type="button" class="btn btn-outline-secondary uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
+        <button class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</button>
       </div>
 
     </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_confirm_prestatrust.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_confirm_prestatrust.html.twig
@@ -34,38 +34,38 @@
       </div>
       <div class="modal-body">
         <div class="row">
-            <div class="col-md-2 text-sm-center">
-              <img id="pstrust-img" src="" alt=""/>
-            </div>
-            <div class="col-md-10">
-              <dl class="row">
-                <dt class="col-sm-3">{{ "Module"|trans({}, 'Admin.Global') }}</dt>
-                <dd class="col-sm-9">
-                    <strong id="pstrust-name"></strong>
-                </dd>
-                <dt class="col-sm-3">{{ "Author"|trans({}, 'Admin.Modules.Feature') }}</dt>
-                <dd class="col-sm-9" id="pstrust-author"></dd>
-                <dt class="col-sm-3">{{ "Status"|trans({}, 'Admin.Global') }}</dt>
-                <dd class="col-sm-9"><strong><span class="text-info" id="pstrust-label"></span></strong></dd>
-              </dl>
-            </div>
+          <div class="col-md-2 text-sm-center">
+            <img id="pstrust-img" src="" alt=""/>
+          </div>
+          <div class="col-md-10">
+            <dl class="row">
+              <dt class="col-sm-3">{{ "Module"|trans({}, 'Admin.Global') }}</dt>
+              <dd class="col-sm-9">
+                <strong id="pstrust-name"></strong>
+              </dd>
+              <dt class="col-sm-3">{{ "Author"|trans({}, 'Admin.Modules.Feature') }}</dt>
+              <dd class="col-sm-9" id="pstrust-author"></dd>
+              <dt class="col-sm-3">{{ "Status"|trans({}, 'Admin.Global') }}</dt>
+              <dd class="col-sm-9">
+                <strong>
+                  <span class="text-info" id="pstrust-label"></span>
+                </strong>
+              </dd>
+            </dl>
+          </div>
         </div>
-        <div class="row">
-            <div class="col-md-12">
-                <div class="alert alert-info" id="pstrust-message" role="alert">
-                    <p class="alert-text"></p>
-                </div>
-            </div>
+        <div class="alert alert-info" id="pstrust-message" role="alert">
+          <p class="alert-text"></p>
         </div>
       </div>
       <div class="modal-footer">
         <div id="pstrust-btn-property-ok">
-            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">{{"Back to modules list"|trans({}, 'Admin.Modules.Feature')}}</button>
-            <button type="submit" class="btn btn-primary pstrust-install">{{"Proceed with the installation"|trans({}, 'Admin.Modules.Feature')}}</button>
+          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">{{"Back to modules list"|trans({}, 'Admin.Modules.Feature')}}</button>
+          <button type="submit" class="btn btn-primary pstrust-install">{{"Proceed with the installation"|trans({}, 'Admin.Modules.Feature')}}</button>
         </div>
         <div id="pstrust-btn-property-nok">
-            <button type="submit" class="btn btn-outline-secondary pstrust-install">{{"Proceed with the installation"|trans({}, 'Admin.Modules.Feature')}}</button>
-            <a href="" class="btn btn-primary" id="pstrust-buy" target="_blank">{{"Buy module"|trans({}, 'Admin.Modules.Feature')}}</a>
+          <button type="submit" class="btn btn-outline-secondary pstrust-install">{{"Proceed with the installation"|trans({}, 'Admin.Modules.Feature')}}</button>
+          <a href="" class="btn btn-primary" id="pstrust-buy" target="_blank">{{"Buy module"|trans({}, 'Admin.Modules.Feature')}}</a>
         </div>
       </div>
     </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_import.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_import.html.twig
@@ -23,68 +23,59 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div id="module-modal-import" class="modal modal-vcenter fade" role="dialog" data-backdrop="static" data-keyboard="false">
-    <div class="modal-dialog">
-        <!-- Modal content-->
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
-                <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
+  <div class="modal-dialog">
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
+        <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
+      </div>
+      <div class="modal-body">
+        {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
+          <div class="alert alert-danger" role="alert">
+            <p class="alert-text">
+              {{ errorMessage }}
+            </p>
+          </div>
+        {% else %}
+          <form action="#" class="dropzone" id="importDropzone">
+            <div class="module-import-start">
+              <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
+              <p class="module-import-start-main-text">
+                {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
+              </p>
+              <p class="module-import-start-footer-text">
+                {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
+                {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
+              </p>
             </div>
-            <div class="modal-body">
-                {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="alert alert-danger" role="alert">
-                                <p class="alert-text">
-                                    {{ errorMessage }}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="row">
-                        <div class="col-md-12">
-                            <form action="#" class="dropzone" id="importDropzone">
-                                <div class="module-import-start">
-                                    <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
-                                    <p class=module-import-start-main-text>
-                                        {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
-                                    </p>
-                                    <p class=module-import-start-footer-text>
-                                        {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
-                                        {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
-                                    </p>
-                                </div>
-                                <div class='module-import-processing'>
-                                    <!-- Loader -->
-                                    <div class="spinner"></div>
-                                    <p class=module-import-processing-main-text>{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                    <p class=module-import-processing-footer-text>
-                                        {{ "It will close as soon as the module is installed. It won't be long!"|trans({}, 'Admin.Modules.Notification') }}
-                                    </p>
-                                </div>
-                                <div class='module-import-success'>
-                                    <i class="module-import-success-icon material-icons">done</i><br/>
-                                    <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                    <p class="module-import-success-details"></p>
-                                    <a class="module-import-success-configure btn btn-primary-reverse btn-outline-primary light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
-                                </div>
-                                <div class='module-import-failure'>
-                                    <i class="module-import-failure-icon material-icons">error</i><br/>
-                                    <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                    <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
-                                    <div class='module-import-failure-details'></div>
-                                    <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
-                                </div>
-                                <div class='module-import-confirm'>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                {% endif %}
+            <div
+              class="module-import-processing">
+              <!-- Loader -->
+              <div class="spinner"></div>
+              <p class="module-import-processing-main-text">{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>
+              <p class="module-import-processing-footer-text">
+                {{ "It will close as soon as the module is installed. It won't be long!"|trans({}, 'Admin.Modules.Notification') }}
+              </p>
             </div>
-            <div class="modal-footer">
+            <div class="module-import-success">
+              <i class="module-import-success-icon material-icons">done</i><br/>
+              <p class="module-import-success-msg">{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
+              <p class="module-import-success-details"></p>
+              <a class="module-import-success-configure btn btn-primary-reverse btn-outline-primary light-button" href="#">{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
             </div>
-        </div>
+            <div class="module-import-failure">
+              <i class="module-import-failure-icon material-icons">error</i><br/>
+              <p class="module-import-failure-msg">{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
+              <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
+              <div class="module-import-failure-details"></div>
+              <a class="module-import-failure-retry btn btn-tertiary" href="#">{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
+            </div>
+            <div class="module-import-confirm"></div>
+          </form>
+        {% endif %}
+      </div>
+      <div class="modal-footer"></div>
     </div>
+  </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -38,7 +38,8 @@
   ats.features,
   ats.badges is defined and ats.badges|length > 0 ? ats.badges : false
 %}
-<div class="modal-dialog module-modal-dialog">
+<div
+  class="modal-dialog module-modal-dialog">
   <!-- Modal content-->
   <div class="modal-content module-modal-content no-padding">
     <div class="modal-header module-modal-header">
@@ -69,12 +70,13 @@
       </button>
     </div>
 
-    <div class="modal-body row module-modal-body">
-      <div class="col-md-12 module-big-cover">
+    <div class="modal-body module-modal-body">
+      <div class="module-big-cover">
         <img src="{% if cover.big is defined %}{{ cover.big }}{% else %}{{ notFoundImg }}{% endif %}"/>
       </div>
-      <div class="col-md-12 module-menu-readmore">
-        <nav class="navbar navbar-light">
+      <div class="module-menu-readmore">
+        <nav
+          class="navbar navbar-light">
           {# tab list #}
           <ul class="nav nav-pills">
             <li class="nav-item">
@@ -108,7 +110,8 @@
             {# end tab list #}
           </ul>
         </nav>
-        <div class="tab-content">
+        <div
+          class="tab-content">
           {# tab content list #}
           <div id="overview-{{ name }}" class="tab-pane fade in active show">
             <p class="module-readmore-tab-content">

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/see_more.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/see_more.html.twig
@@ -22,13 +22,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div class="col-12">
-  <p class="text-center">
-    <button type="button" class="btn btn-link see-more" data-category="{{ id }}">
-      {{ 'See more' | trans({}, 'Admin.Actions') }}
-    </button>
-    <button type="button" class="btn btn-link see-less d-none" data-category="{{ id }}">
-      {{ 'See less' | trans({}, 'Admin.Actions') }}
-    </button>
-  </p>
-</div>
+<p class="text-center">
+  <button type="button" class="btn btn-link see-more" data-category="{{ id }}">
+    {{ 'See more' | trans({}, 'Admin.Actions') }}
+  </button>
+  <button type="button" class="btn btn-link see-less d-none" data-category="{{ id }}">
+    {{ 'See less' | trans({}, 'Admin.Actions') }}
+  </button>
+</p>

--- a/templates/bundles/PrestaShopBundle/Admin/Module/tab-modules-list.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/tab-modules-list.html.twig
@@ -24,47 +24,45 @@
  *#}
 {% set modulesListShouldBeDisplayed = (modulesList is defined and modulesList is not empty) %}
 {% if modulesListShouldBeDisplayed == true %}
-  <div class="row row-margin-bottom">
-  <div class="col-lg-12">
+  <div class="row-margin-bottom">
     <ul class="nav nav-pills">
       {% if modulesList.notInstalled|length > 0 %}
-      <li class="active">
-        <a href="#tab_modules_list_not_installed" data-toggle="tab">
-          {{ 'Not Installed'|trans({}) }}
-        </a>
-      </li>
+        <li class="active">
+          <a href="#tab_modules_list_not_installed" data-toggle="tab">
+            {{ 'Not Installed'|trans({}) }}
+          </a>
+        </li>
       {% endif %}
 
       {% if modulesList.installed|length > 0 %}
-        <li {% if modulesList.notInstalled|length == 0 %}class="active"{% endif %}>
-        <a href="#tab_modules_list_installed" data-toggle="tab">
-          {{ 'Installed'|trans({}) }}
-        </a>
+        <li {% if modulesList.notInstalled|length == 0 %} class="active" {% endif %}>
+          <a href="#tab_modules_list_installed" data-toggle="tab">
+            {{ 'Installed'|trans({}) }}
+          </a>
         </li>
       {% endif %}
     </ul>
   </div>
-</div>
-<div id="modules_list_container_content" class="tab-content modal-content-overflow">
-  {% if modulesList.notInstalled is defined and modulesList.notInstalled is not empty %}
-  <div class="tab-pane active" id="tab_modules_list_not_installed">
-    <table id="tab_modules_list_not_installed" class="table">
-      {% for module in modulesList.notInstalled %}
-        {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
-      {% endfor %}
-    </table>
+  <div id="modules_list_container_content" class="tab-content modal-content-overflow">
+    {% if modulesList.notInstalled is defined and modulesList.notInstalled is not empty %}
+      <div class="tab-pane active" id="tab_modules_list_not_installed">
+        <table id="tab_modules_list_not_installed" class="table">
+          {% for module in modulesList.notInstalled %}
+            {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
+          {% endfor %}
+        </table>
+      </div>
+    {% endif %}
+    {% if modulesList.installed|length > 0 %}
+      <div class="tab-pane {% if modulesList.notInstalled|length == 0 %}active{% endif %}" id="tab_modules_list_installed">
+        <table id="tab_modules_list_installed" class="table">
+          {% for module in modulesList.installed %}
+            {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
+          {% endfor %}
+        </table>
+      </div>
+    {% endif %}
   </div>
-  {% endif %}
-  {% if modulesList.installed|length > 0 %}
-  <div class="tab-pane {% if modulesList.notInstalled|length == 0 %}active{% endif %}" id="tab_modules_list_installed">
-    <table id="tab_modules_list_installed" class="table">
-      {% for module in modulesList.installed %}
-        {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
-      {% endfor %}
-    </table>
-  </div>
-  {% endif %}
-</div>
 {% endif %}
 <div class="alert alert-addons row-margin-top" role="alert">
   <p class="alert-text">

--- a/templates/bundles/PrestaShopBundle/Admin/Product/CatalogPage/Blocks/filters.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/CatalogPage/Blocks/filters.html.twig
@@ -23,66 +23,38 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div id="catalog-actions" class="col order-first">
-  <div class="row">
-    <div class="col">
-      {% block product_catalog_filter_by_categories %}
-        <div id="product_catalog_category_tree_filter" class="d-inline-block dropdown dropdown-clickable mr-2">
-          <button
-                  class="btn btn-outline-secondary dropdown-toggle"
-                  type="button"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-          >
-              {{ 'Filter by categories'|trans({}, 'Admin.Actions') }}
-              {% if selected_category is defined and selected_category is not null %}
-                  ({{ selected_category.getName() }})
-              {% endif %}
-          </button>
-          <div id="tree-categories" class="dropdown-menu">
-            <div class="categories-tree-actions">
-              <a
-                href="#"
-                name="product_catalog_category_tree_filter_expand"
-                onclick="productCategoryFilterExpand($('div#product_catalog_category_tree_filter'), this);"
-                id="product_catalog_category_tree_filter_expand"
-              >
-                <i class="material-icons">expand_more</i>
-                  {{ 'Expand'|trans({}, 'Admin.Actions') }}
-              </a>
-              <a
-                href="#"
-                name="product_catalog_category_tree_filter_collapse"
-                onclick="productCategoryFilterCollapse($('div#product_catalog_category_tree_filter'), this);"
-                id="product_catalog_category_tree_filter_collapse"
-              >
-                <i class="material-icons">expand_less</i>
-                  {{ 'Collapse'|trans({}, 'Admin.Actions') }}
-              </a>
-              <a
-                href="#"
-                name="product_catalog_category_tree_filter_reset"
-                onclick="productCategoryFilterReset($('div#product_catalog_category_tree_filter'));"
-                id="product_catalog_category_tree_filter_reset"
-              >
-                <i class="material-icons">radio_button_unchecked</i>
-                  {{ 'Unselect'|trans({}, 'Admin.Actions') }}
-              </a>
-            </div>
-              {{ form_widget(categories) }}
-          </div>
-        </div>
-      {% endblock %}
 
-      {% block product_catalog_filter_bulk_actions %}
-        <div
-            class="d-inline-block"
-            bulkurl="{{ path('admin_product_bulk_action', {'action': 'activate_all'}) }}"
-            massediturl="{{ path('admin_product_mass_edit_action', {'action': 'sort'}) }}"
-            redirecturl="{{ path('admin_product_catalog', {'limit': limit, 'offset': offset, 'orderBy': orderBy, 'sortOrder': sortOrder}) }}"
-            redirecturlnextpage="{{ path('admin_product_catalog', {'limit': limit, 'offset': offset+limit, 'orderBy': orderBy, 'sortOrder': sortOrder}) }}"
-        >
-          {% set buttons_action = [
+  {% block product_catalog_filter_by_categories %}
+    <div id="product_catalog_category_tree_filter" class="d-inline-block dropdown dropdown-clickable mr-2">
+      <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{ 'Filter by categories'|trans({}, 'Admin.Actions') }}
+        {% if selected_category is defined and selected_category is not null %}
+          ({{ selected_category.getName() }})
+        {% endif %}
+      </button>
+      <div id="tree-categories" class="dropdown-menu">
+        <div class="categories-tree-actions">
+          <a href="#" name="product_catalog_category_tree_filter_expand" onclick="productCategoryFilterExpand($('div#product_catalog_category_tree_filter'), this);" id="product_catalog_category_tree_filter_expand">
+            <i class="material-icons">expand_more</i>
+            {{ 'Expand'|trans({}, 'Admin.Actions') }}
+          </a>
+          <a href="#" name="product_catalog_category_tree_filter_collapse" onclick="productCategoryFilterCollapse($('div#product_catalog_category_tree_filter'), this);" id="product_catalog_category_tree_filter_collapse">
+            <i class="material-icons">expand_less</i>
+            {{ 'Collapse'|trans({}, 'Admin.Actions') }}
+          </a>
+          <a href="#" name="product_catalog_category_tree_filter_reset" onclick="productCategoryFilterReset($('div#product_catalog_category_tree_filter'));" id="product_catalog_category_tree_filter_reset">
+            <i class="material-icons">radio_button_unchecked</i>
+            {{ 'Unselect'|trans({}, 'Admin.Actions') }}
+          </a>
+        </div>
+        {{ form_widget(categories) }}
+      </div>
+    </div>
+  {% endblock %}
+
+  {% block product_catalog_filter_bulk_actions %}
+    <div class="d-inline-block" bulkurl="{{ path('admin_product_bulk_action', {'action': 'activate_all'}) }}" massediturl="{{ path('admin_product_mass_edit_action', {'action': 'sort'}) }}" redirecturl="{{ path('admin_product_catalog', {'limit': limit, 'offset': offset, 'orderBy': orderBy, 'sortOrder': sortOrder}) }}" redirecturlnextpage="{{ path('admin_product_catalog', {'limit': limit, 'offset': offset+limit, 'orderBy': orderBy, 'sortOrder': sortOrder}) }}">
+      {% set buttons_action = [
             {
               "onclick": "bulkProductAction(this, 'activate_all');",
               "icon": "radio_button_checked",
@@ -94,7 +66,7 @@
             }
           ] %}
 
-          {% set buttons_action = buttons_action|merge([
+      {% set buttons_action = buttons_action|merge([
             {
               "divider": true
             }, {
@@ -105,7 +77,7 @@
           ]) %}
 
 
-          {% set buttons_action = buttons_action|merge([
+      {% set buttons_action = buttons_action|merge([
             {
               "divider": true
             }, {
@@ -115,7 +87,7 @@
             }
           ]) %}
 
-          {% include '@PrestaShop/Admin/Helpers/dropdown_menu.html.twig' with {
+      {% include '@PrestaShop/Admin/Helpers/dropdown_menu.html.twig' with {
             'div_style': "btn-group dropdown bulk-catalog",
             'button_id': "product_bulk_menu",
             'disabled': true,
@@ -124,27 +96,16 @@
             'menu_icon': "icon-caret-up",
             'items': buttons_action
           } %}
-        </div>
-      {% endblock %}
     </div>
-  </div>
+  {% endblock %}
 
   {% block product_catalog_filter_select_all %}
-  <div class="row">
-    <div class="col">
-      <div class="md-checkbox">
-        <label>
-          <input
-            type="checkbox"
-            id="bulk_action_select_all"
-            onclick="$('#product_catalog_list').find('table td.checkbox-column input:checkbox').prop('checked', $(this).prop('checked')); updateBulkMenu();"
-            value=""
-          >
-          <i class="md-checkbox-control"></i>
-            {{ "Select all"|trans({}, 'Admin.Actions') }}
-        </label>
-      </div>
+    <div class="md-checkbox">
+      <label>
+        <input type="checkbox" id="bulk_action_select_all" onclick="$('#product_catalog_list').find('table td.checkbox-column input:checkbox').prop('checked', $(this).prop('checked')); updateBulkMenu();" value="">
+        <i class="md-checkbox-control"></i>
+        {{ "Select all"|trans({}, 'Admin.Actions') }}
+      </label>
     </div>
-  </div>
   {% endblock %}
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/CatalogPage/Forms/form_products.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/CatalogPage/Forms/form_products.html.twig
@@ -22,59 +22,44 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<form
-  name="product_catalog_list"
-  id="product_catalog_list"
-  method="post"
-  action="{{ path('admin_product_catalog', {'limit': limit, 'orderBy': orderBy, 'sortOrder': sortOrder}) }}"
-  orderingurl="{{ path('admin_product_catalog', {offset: 0, 'limit': 300, 'orderBy': 'position_ordering', 'sortOrder': sortOrder}) }}"
-  newproducturl="{{ path('admin_product_new') }}"
->
-  <div class="row">
-    <div class="col-md-12">
-      <input type="hidden" name="filter_category" value="{{ filter_category|default('') }}" />
-    </div>
-  </div>
+<form name="product_catalog_list" id="product_catalog_list" 
+      method="post" 
+      action="{{ path('admin_product_catalog', {'limit': limit, 'orderBy': orderBy, 'sortOrder': sortOrder}) }}" 
+      orderingurl="{{ path('admin_product_catalog', {offset: 0, 'limit': 300, 'orderBy': 'position_ordering', 'sortOrder': sortOrder}) }}" 
+      newproducturl="{{ path('admin_product_new') }}">
 
-  <div class="row">
-    <div class="col-md-12">
-      {% block product_catalog_form_table %}
-        {{ include('@Product/CatalogPage/Lists/products_table.html.twig', {
-          'limit': limit,
-          'orderBy': orderBy,
-          'offset': offset,
-          'sortOrder': sortOrder,
-          'filter_category': filter_category,
-          'filter_column_id_product': filter_column_id_product,
-          'filter_column_name': filter_column_name,
-          'filter_column_reference': filter_column_reference,
-          'filter_column_name_category': filter_column_name_category,
-          'filter_column_price': filter_column_price,
-          'filter_column_sav_quantity': filter_column_sav_quantity,
-          'filter_column_active':filter_column_active,
-          'has_category_filter': has_category_filter,
-          'activate_drag_and_drop': activate_drag_and_drop,
-          'products': products,
-          'last_sql': last_sql
-          })
-        }}
-      {% endblock %}
-    </div>
-  </div>
+  <input type="hidden" name="filter_category" value="{{ filter_category|default('') }}"/>
+
+  {% block product_catalog_form_table %}
+    {{ include('@Product/CatalogPage/Lists/products_table.html.twig', {
+      'limit': limit,
+      'orderBy': orderBy,
+      'offset': offset,
+      'sortOrder': sortOrder,
+      'filter_category': filter_category,
+      'filter_column_id_product': filter_column_id_product,
+      'filter_column_name': filter_column_name,
+      'filter_column_reference': filter_column_reference,
+      'filter_column_name_category': filter_column_name_category,
+      'filter_column_price': filter_column_price,
+      'filter_column_sav_quantity': filter_column_sav_quantity,
+      'filter_column_active':filter_column_active,
+      'has_category_filter': has_category_filter,
+      'activate_drag_and_drop': activate_drag_and_drop,
+      'products': products,
+      'last_sql': last_sql
+      })
+    }}
+  {% endblock %}
 
   {% if product_count_filtered > 20 %}
-    <div class="row">
-      <div class="col-md-12">
-
-        {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
-          'limit': limit,
-          'offset': offset,
-          'total': product_count_filtered,
-          'caller_route': app.request.attributes.get('_route'),
-          'caller_parameters': pagination_parameters,
-          'limit_choices': pagination_limit_choices
-          })) }}
-      </div>
-    </div>
+    {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
+      'limit': limit,
+      'offset': offset,
+      'total': product_count_filtered,
+      'caller_route': app.request.attributes.get('_route'),
+      'caller_parameters': pagination_parameters,
+      'limit_choices': pagination_limit_choices
+      })) }}
   {% endif %}
 </form>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/CatalogPage/catalog.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/CatalogPage/catalog.html.twig
@@ -46,18 +46,16 @@
     <div class="content container-fluid">
 
       {% if permission_error|length %}
-      <div class="row">
-        <div class="col-md-12">
-          <div class="alert alert-danger" role="alert">
-            <button type="button" class="close" data-dismiss="alert">
-              <span aria-hidden="true"><i class="material-icons">close</i></span>
-            </button>
-            <p class="alert-text">
-              {{ permission_error }}
-            </p>
-          </div>
+        <div class="alert alert-danger" role="alert">
+          <button type="button" class="close" data-dismiss="alert">
+            <span aria-hidden="true">
+              <i class="material-icons">close</i>
+            </span>
+          </button>
+          <p class="alert-text">
+            {{ permission_error }}
+          </p>
         </div>
-      </div>
       {% endif %}
 
       <div class="row align-items-start">
@@ -226,7 +224,7 @@
       <form method="post" action="{{ sql_manager_add_link }}" id="catalog_sql_query_modal_content">
         <div class="modal-body">
           <textarea name="sql" rows="20" cols="65"></textarea>
-          <input type="hidden" name="name" value="" />
+          <input type="hidden" name="name" value=""/>
         </div>
       </form>
     {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Blocks/header.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Blocks/header.html.twig
@@ -24,13 +24,13 @@
  *#}
 <div class="product-header col-md-12">
   <div class="row justify-content-md-center">
-  {% if is_multishop_context %}
-    <div class="col-xxl-10">
-      <div class="alert alert-warning" role="alert">
-        <p class="alert-text">{{ 'You are in a multistore context: any modification will impact all your shops, or each shop of the active group.'|trans({}, 'Admin.Catalog.Notification') }}</p>
+    {% if is_multishop_context %}
+      <div class="col-xxl-10">
+        <div class="alert alert-warning" role="alert">
+          <p class="alert-text">{{ 'You are in a multistore context: any modification will impact all your shops, or each shop of the active group.'|trans({}, 'Admin.Catalog.Notification') }}</p>
+        </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
 
     <div class="col-xxl-10">
       <div class="row">
@@ -39,56 +39,43 @@
         </div>
         <div class="col-sm-7 col-md-2 form_step1_type_product">
           {{ form_widget(formType) }}
-          <span class="help-box pull-xs-right" data-toggle="popover"
-            data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?"|trans({}, 'Admin.Catalog.Help') }}"></span>
+          <span class="help-box pull-xs-right" data-toggle="popover" 
+          data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?"|trans({}, 'Admin.Catalog.Help') }}"></span>
         </div>
         <div class="col-sm-2 col-md-1 form_switch_language">
           <div class="{{ languages|length == 1 ? 'hide' : '' }}">
             <select id="form_switch_language" class="custom-select">
               {% for language in languages %}
-                <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %}selected="selected"{% endif %}>{{ language.iso_code }}</option>
+                <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %} 
+                        selected="selected" {% endif %}>{{ language.iso_code }}</option>
               {% endfor %}
             </select>
           </div>
         </div>
         <div class="toolbar col-sm-3 col-md-2 text-md-right">
-          <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans({}, 'Admin.Global') }}"
-            id="product_form_go_to_sales">
+          <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans({}, 'Admin.Global') }}" id="product_form_go_to_sales">
             <i class="material-icons">assessment</i>
             <span class="title">{{ 'Sales'|trans({}, 'Admin.Global') }}</span>
           </a>
 
-          <a
-            class="toolbar-button btn-quicknav btn-sidebar"
-            href="#"
-            title="{{ 'Quick navigation'|trans({}, 'Admin.Global') }}"
-            data-toggle="sidebar"
-            data-target="#right-sidebar"
-            data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}"
-            id="product_form_open_quicknav"
-          >
+          <a class="toolbar-button btn-quicknav btn-sidebar" href="#" title="{{ 'Quick navigation'|trans({}, 'Admin.Global') }}" 
+             data-toggle="sidebar" data-target="#right-sidebar" 
+             data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}" id="product_form_open_quicknav">
             <i class="material-icons">list</i>
             <span class="title">{{ 'Product list'|trans({}, 'Admin.Catalog.Feature') }}</span>
           </a>
 
-          <a class="toolbar-button btn-help btn-sidebar" href="#"
-            title="{{ 'Help'|trans({}, 'Admin.Global') }}"
-            data-toggle="sidebar"
-            data-target="#right-sidebar"
-            data-url="{{ help_link }}"
-            id="product_form_open_help"
-          >
+          <a class="toolbar-button btn-help btn-sidebar" href="#" title="{{ 'Help'|trans({}, 'Admin.Global') }}" 
+             data-toggle="sidebar" data-target="#right-sidebar" 
+             data-url="{{ help_link }}" id="product_form_open_help">
             <i class="material-icons">help</i>
             <span class="title">{{ 'Help'|trans({}, 'Admin.Global') }}</span>
           </a>
         </div>
       </div>
-      <div class="row">
-        <div class="col-lg-12">
-          {{ form_errors(formName) }}
-          {{ form_errors(formType) }}
-        </div>
-      </div>
+      {{ form_errors(formName) }}
+      {{ form_errors(formType) }}
     </div>
   </div>
 </div>
+

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_categories.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_categories.html.twig
@@ -23,8 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <h2>{{ "Categories"|trans({}, 'Admin.Catalog.Feature') }}
-  <span class="help-box" data-toggle="popover"
-    data-content="{{ "Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+  <span class="help-box" 
+        data-toggle="popover"
+        data-content="{{ "Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics."|trans({}, 'Admin.Catalog.Help') }}" >
+  </span>
 </h2>
 <div class="categories-tree js-categories-tree">
   <fieldset class="form-group">
@@ -49,8 +51,10 @@
 <div id="add-categories">
   <h2>
     {{ "Create a new category"|trans({}, 'Admin.Catalog.Feature') }}
-    <span class="help-box" data-toggle="popover"
-      data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+    <span class="help-box" 
+          data-toggle="popover"
+          data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it."|trans({}, 'Admin.Catalog.Help') }}" >
+    </span>
   </h2>
   <div id="add-categories-content" class="hide">
     <div id="form_step1_new_category" data-action="{{ path('admin_category_simple_add_form', {'id_product': productId }) }}">

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_combination.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_combination.html.twig
@@ -49,13 +49,13 @@
         <div class="btn-group btn-group-sm" role="group">
             <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-open tooltip-link btn-sm"><i class="material-icons">mode_edit</i></a>
         </div>
-        <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide row">
-            <div class="col-sm-12 nav">
+        <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide">
+            <div class="nav">
                 {# "Prev." is short for "Previous" #}
                 <a class="btn-sensitive prev"><i class="material-icons">keyboard_arrow_left</i> {{ 'Prev. combination'|trans({}, 'Admin.Catalog.Feature') }}</a>
                 <a class="next btn-sensitive">{{ 'Next combination'|trans({}, 'Admin.Catalog.Feature') }} <i class="material-icons">keyboard_arrow_right</i></a>
             </div>
-            <div class="panel col-md-12 p-2">
+            <div class="panel p-2">
                 <div class="float-left">
                     <button type="button" class="back-to-product btn btn-outline-secondary btn-back"><i class="material-icons">arrow_back</i> {{ 'Back to product'|trans({}, 'Admin.Catalog.Feature') }}</button>
                 </div>
@@ -87,8 +87,10 @@
                       <fieldset class="form-group">
                           <label class="form-control-label">
                             {{ form.attribute_minimal_quantity.vars.label }}
-                            <span class="help-box" data-toggle="popover"
-                              data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                            <span class="help-box" 
+                                  data-toggle="popover"
+                                  data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" >
+                            </span>
                           </label>
                           {{ form_errors(form.attribute_minimal_quantity) }}
                           {{ form_widget(form.attribute_minimal_quantity) }}
@@ -126,7 +128,11 @@
                       <div class="widget-checkbox-inline">
                         {{ form_errors(form.attribute_low_stock_alert) }}
                         {{ form_widget(form.attribute_low_stock_alert) }}
-                        <span class="help-box" data-toggle="popover" data-html="true" data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" ></span>
+                        <span class="help-box" 
+                              data-toggle="popover" 
+                              data-html="true" 
+                              data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" >
+                        </span>
                       </div>
                     </fieldset>
                   </div>
@@ -146,8 +152,10 @@
                         <fieldset class="form-group">
                             <label class="form-control-label">
                               {{ form.attribute_price.vars.label }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "Does this combination have a different price? Is it cheaper or more expensive than the default retail price?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                              <span class="help-box" 
+                                    data-toggle="popover"
+                                    data-content="{{ "Does this combination have a different price? Is it cheaper or more expensive than the default retail price?"|trans({}, 'Admin.Catalog.Help') }}" >
+                              </span>
                             </label>
                             {{ form_errors(form.attribute_price) }}
                             {{ form_widget(form.attribute_price) }}
@@ -176,8 +184,10 @@
                         <fieldset class="form-group">
                             <label class="form-control-label">
                               {{ form.attribute_unity.vars.label }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "Does this combination have a different price per unit?"|trans({}, 'Admin.Catalog.Feature') }}" ></span>
+                              <span class="help-box" 
+                                    data-toggle="popover"
+                                    data-content="{{ "Does this combination have a different price per unit?"|trans({}, 'Admin.Catalog.Feature') }}" >
+                              </span>
                             </label>
                             {{ form_errors(form.attribute_unity) }}
                             {{ form_widget(form.attribute_unity) }}
@@ -211,8 +221,10 @@
                         <fieldset class="form-group">
                             <label class="form-control-label">
                               {{ form.attribute_ean13.vars.label }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                              <span class="help-box" 
+                                    data-toggle="popover"
+                                    data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}" >
+                              </span>
                             </label>
                             {{ form_errors(form.attribute_ean13) }}
                             {{ form_widget(form.attribute_ean13) }}
@@ -236,24 +248,17 @@
                 <h2 class="title">
                   {{ "Images"|trans({}, 'Admin.Catalog.Feature') }}
                 </h2>
-                <div class="row">
-                    <div class="col-md-12">
-                        <fieldset class="form-group js-combination-images">
-                            <label>
-                                <small class="form-control-label">{{ form.id_image_attr.vars.label }}</small>
-                                <small class="form-control-label number-of-images"></small>
-                            </label>
-                            {{ form_errors(form.id_image_attr) }}
-                            {{ form_widget(form.id_image_attr) }}
-                        </fieldset>
-                    </div>
-                </div>
 
-                <div class="row">
-                    <div class="col-md-12">
-                        {{ renderhook('displayAdminProductsCombinationBottom', { 'id_product': form.vars.value.id_product, 'id_product_attribute': form.vars.value.id_product_attribute }) }}
-                    </div>
-                </div>
+                <fieldset class="form-group js-combination-images">
+                    <label>
+                        <small class="form-control-label">{{ form.id_image_attr.vars.label }}</small>
+                        <small class="form-control-label number-of-images"></small>
+                    </label>
+                    {{ form_errors(form.id_image_attr) }}
+                    {{ form_widget(form.id_image_attr) }}
+                </fieldset>
+
+                {{ renderhook('displayAdminProductsCombinationBottom', { 'id_product': form.vars.value.id_product, 'id_product_attribute': form.vars.value.id_product_attribute }) }}
 
                 {{ form_widget(form.id_product_attribute) }}
             </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -54,24 +54,20 @@
     </div>
 
     <div id="combinations-bulk-form">
-      <div class="row">
-        <div class="col-md-12">
-          <p
-            class="form-control bulk-action"
-            data-toggle="collapse"
-            href="#bulk-combinations-container"
-            aria-expanded="false"
-            aria-controls="bulk-combinations-container"
-          >
-            {# First tag [1] is number of combinations selected. Second tag [2] is the total of combinations available. #}
-            <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span id="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
-            <i class="material-icons float-right">keyboard_arrow_down</i>
-          </p>
-        </div>
-        <div class="col-md-12 collapse js-collapse" id="bulk-combinations-container">
-          <div class="border p-3">
-            {{ include('@Product/ProductPage/Forms/form_combinations_bulk.html.twig', { 'form': form_combination_bulk }) }}
-          </div>
+      <p
+        class="form-control bulk-action"
+        data-toggle="collapse"
+        href="#bulk-combinations-container"
+        aria-expanded="false"
+        aria-controls="bulk-combinations-container"
+      >
+        {# First tag [1] is number of combinations selected. Second tag [2] is the total of combinations available. #}
+        <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span id="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
+        <i class="material-icons float-right">keyboard_arrow_down</i>
+      </p>
+      <div class="collapse js-collapse" id="bulk-combinations-container">
+        <div class="border p-3">
+          {{ include('@Product/ProductPage/Forms/form_combinations_bulk.html.twig', { 'form': form_combination_bulk }) }}
         </div>
       </div>
     </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
@@ -75,7 +75,10 @@
 
   <div class="col-lg-4 col-md-3 col-sm-6">
     <label class="form-control-label">{{ form.low_stock_threshold.vars.label }}
-      <span class="help-box" data-toggle="popover" data-content="{{ 'You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.'|trans({}, 'Admin.Catalog.Feature') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover" 
+            data-content="{{ 'You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.'|trans({}, 'Admin.Catalog.Feature') }}" >
+      </span>
     </label>
     {{ form_errors(form.low_stock_threshold) }}
     {{ form_widget(form.low_stock_threshold) }}
@@ -85,7 +88,10 @@
     <div class="widget-checkbox-inline">
       {{ form_errors(form.low_stock_alert) }}
       {{ form_widget(form.low_stock_alert) }}
-      <span class="help-box" data-toggle="popover" data-content="{{ 'The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team'|trans({}, 'Admin.Catalog.Feature') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover" 
+            data-content="{{ 'The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team'|trans({}, 'Admin.Catalog.Feature') }}" >
+      </span>
     </div>
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_feature.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_feature.html.twig
@@ -23,13 +23,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div class="row product-feature">
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
         <fieldset class="form-group mb-0">
             <label class="form-control-label">{{ form.feature.vars.label }}</label>
             {{ form_widget(form.feature) }}
         </fieldset>
     </div>
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
         <fieldset class="form-group mb-0">
             <label class="form-control-label">{{ form.value.vars.label }}</label>
             {{ form_widget(form.value) }}

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_related_products.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_related_products.html.twig
@@ -22,11 +22,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div  id="related-title" class="row">
-  <div class="col-md-12">
-    <h2>{{ "Related product"|trans({}, 'Admin.Catalog.Feature') }}</h2>
-  </div>
+<div id="related-title">
+  <h2>{{ "Related product"|trans({}, 'Admin.Catalog.Feature') }}</h2>
 </div>
+
 <div id="related-content" class="row {{ form.vars.value.data|length == 0 ? 'hide':'' }}">
   <div class="col-xl-8 col-lg-11">
     <fieldset class="form-group">
@@ -39,10 +38,7 @@
       </fieldset>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-4">
-    <button type="button" class="btn btn-outline-primary sensitive open {{ form.vars.value.data|length > 0 ? 'hide':'' }}" id="add-related-product-button">
-      <i class="material-icons">add_circle</i> {{ 'Add a related product'|trans({}, 'Admin.Catalog.Feature') }}
-    </button>
-  </div>
-</div>
+
+<button type="button" class="btn btn-outline-primary sensitive open {{ form.vars.value.data|length > 0 ? 'hide':'' }}" id="add-related-product-button">
+  <i class="material-icons">add_circle</i> {{ 'Add a related product'|trans({}, 'Admin.Catalog.Feature') }}
+</button>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_seo.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_seo.html.twig
@@ -22,114 +22,116 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div class="col-md-12">
 
-  <h2>{{ 'Search Engine Optimization'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-  <p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
+<h2>{{ 'Search Engine Optimization'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+<p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
 
-  {% block product_catalog_tool_serp %}
-    <p>{{ "Here is a preview of your search engine result, play with it!"|trans({}, 'Admin.Catalog.Feature') }}</p>
-    {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
-    <div id="serp-app"></div>
-  {% endblock %}
+{% block product_catalog_tool_serp %}
+  <p>{{ "Here is a preview of your search engine result, play with it!"|trans({}, 'Admin.Catalog.Feature') }}</p>
+  {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
+  <div id="serp-app"></div>
+{% endblock %}
 
-  <div class="row">
-    <div class="col-md-9">
-      <fieldset class="form-group">
-        {{ form_label(seoForm.meta_title) }}
-        {{ form_errors(seoForm.meta_title) }}
-        {{ form_widget(seoForm.meta_title) }}
-      </fieldset>
-    </div>
+<div class="row">
+  <div class="col-md-9">
+    <fieldset class="form-group">
+      {{ form_label(seoForm.meta_title) }}
+      {{ form_errors(seoForm.meta_title) }}
+      {{ form_widget(seoForm.meta_title) }}
+    </fieldset>
   </div>
-
-  <div class="row">
-    <div class="col-md-9">
-      <fieldset class="form-group">
-        {{ form_label(seoForm.meta_description) }}
-        {{ form_errors(seoForm.meta_description) }}
-        {{ form_widget(seoForm.meta_description) }}
-      </fieldset>
-    </div>
-  </div>
-  <fieldset class="form-group">
-    <label class="form-control-label">
-      {{ seoForm.link_rewrite.vars.label }}
-      <span class="help-box" data-toggle="popover"
-        data-content="{{ "This is the human-readable URL, as generated from the product's name. You can change it if you want."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-    </label>
-    {{ form_errors(seoForm.link_rewrite) }}
-    <div class="row">
-      <div class="col-md-7">
-        {{ form_widget(seoForm.link_rewrite) }}
-      </div>
-      <div class="col-md-2">
-        <button type="button" class="btn btn-block btn-outline-secondary" id="seo-url-regenerate">{{ 'Reset URL'|trans({}, 'Admin.Catalog.Feature') }}</button>
-      </div>
-    </div>
-  </fieldset>
-
-  <div class="row">
-    <div class="col-md-9">
-      <div class="alert alert-info" role="alert">
-        <p class="alert-text">
-          {% if configuration('PS_REWRITING_SETTINGS') == 0 %}
-            <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
-          {% else %}
-            <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
-          {% endif %}
-        </p>
-        <p class="alert-text">
-          {% if configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 %}
-            <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {# "It" refers to the option "Force update of friendly URL" #}
-            {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
-          {% endif %}
-        </p>
-      </div>
-    </div>
-  </div>
-
-  <h2 class="mt-4">
-    {{ 'Redirection page'|trans({}, 'Admin.Catalog.Feature') }}
-    <span class="help-box" data-toggle="popover"
-      data-content="{{ "When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-  </h2>
-
-  <div class="row">
-
-    <div class="col-md-4">
-      <fieldset class="form-group">
-        <label class="form-control-label">{{ seoForm.redirect_type.vars.label }}</label>
-        {{ form_errors(seoForm.redirect_type) }}
-        {{ form_widget(seoForm.redirect_type) }}
-      </fieldset>
-    </div>
-
-    <div class="col-md-5" id="id-product-redirected">
-      <fieldset class="form-group">
-        <label class="form-control-label">{{ seoForm.id_type_redirected.vars.label }}</label>
-        {{ form_errors(seoForm.id_type_redirected) }}
-        {{ form_widget(seoForm.id_type_redirected) }}
-      </fieldset>
-
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-9">
-      <div class="alert alert-info" role="alert">
-        <p class="alert-text">
-          {{ 'No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
-          {{ 'Permanent redirection (301) = Permanently display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}<br>
-          {{ 'Temporary redirection (302) = Temporarily display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}
-        </p>
-      </div>
-    </div>
-  </div>
-
-  {{ form_rest(seoForm) }}
-
-  {{ renderhook('displayAdminProductsSeoStepBottom', { 'id_product': productId }) }}
 </div>
+
+<div class="row">
+  <div class="col-md-9">
+    <fieldset class="form-group">
+      {{ form_label(seoForm.meta_description) }}
+      {{ form_errors(seoForm.meta_description) }}
+      {{ form_widget(seoForm.meta_description) }}
+    </fieldset>
+  </div>
+</div>
+<fieldset class="form-group">
+  <label class="form-control-label">
+    {{ seoForm.link_rewrite.vars.label }}
+    <span class="help-box" 
+          data-toggle="popover"
+          data-content="{{ "This is the human-readable URL, as generated from the product's name. You can change it if you want."|trans({}, 'Admin.Catalog.Help') }}" >
+    </span>
+  </label>
+  {{ form_errors(seoForm.link_rewrite) }}
+  <div class="row">
+    <div class="col-md-7">
+      {{ form_widget(seoForm.link_rewrite) }}
+    </div>
+    <div class="col-md-2">
+      <button type="button" class="btn btn-block btn-outline-secondary" id="seo-url-regenerate">{{ 'Reset URL'|trans({}, 'Admin.Catalog.Feature') }}</button>
+    </div>
+  </div>
+</fieldset>
+
+<div class="row">
+  <div class="col-md-9">
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">
+        {% if configuration('PS_REWRITING_SETTINGS') == 0 %}
+          <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+          {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+        {% else %}
+          <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+          {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+        {% endif %}
+      </p>
+      <p class="alert-text">
+        {% if configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 %}
+          <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+          {# "It" refers to the option "Force update of friendly URL" #}
+          {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
+        {% endif %}
+      </p>
+    </div>
+  </div>
+</div>
+
+<h2 class="mt-4">
+  {{ 'Redirection page'|trans({}, 'Admin.Catalog.Feature') }}
+  <span class="help-box" 
+        data-toggle="popover"
+        data-content="{{ "When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name."|trans({}, 'Admin.Catalog.Help') }}" >
+  </span>
+</h2>
+
+<div class="row">
+
+  <div class="col-md-4">
+    <fieldset class="form-group">
+      <label class="form-control-label">{{ seoForm.redirect_type.vars.label }}</label>
+      {{ form_errors(seoForm.redirect_type) }}
+      {{ form_widget(seoForm.redirect_type) }}
+    </fieldset>
+  </div>
+
+  <div class="col-md-5" id="id-product-redirected">
+    <fieldset class="form-group">
+      <label class="form-control-label">{{ seoForm.id_type_redirected.vars.label }}</label>
+      {{ form_errors(seoForm.id_type_redirected) }}
+      {{ form_widget(seoForm.id_type_redirected) }}
+    </fieldset>
+
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-9">
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">
+        {{ 'No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'Permanent redirection (301) = Permanently display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'Temporary redirection (302) = Temporarily display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}
+      </p>
+    </div>
+  </div>
+</div>
+
+{{ form_rest(seoForm) }}
+
+{{ renderhook('displayAdminProductsSeoStepBottom', { 'id_product': productId }) }}

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -82,8 +82,10 @@
   <div class="form-group">
     <h2>
       {{ form.additional_delivery_times.vars.label }}
-      <span class="help-box" data-toggle="popover"
-        data-content="{{ "Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover"
+            data-content="{{ "Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws."|trans({}, 'Admin.Catalog.Help') }}" >
+      </span>
     </h2>
     <div class="row">
        <div class="col-md-12" {% if block('widget_container_attributes') is defined %} {{ block('widget_container_attributes') }} {% endif %}>
@@ -123,8 +125,10 @@
   <div class="form-group">
     <h2>
       {{ form.additional_shipping_cost.vars.label }}
-      <span class="help-box" data-toggle="popover"
-        data-content="{{ "If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover"
+            data-content="{{ "If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping."|trans({}, 'Admin.Catalog.Help') }}" >
+      </span>
     </h2>
     <label class="form-control-label">{{ 'Does this product incur additional shipping costs?'|trans({}, 'Admin.Catalog.Feature') }}</label>
     <div class="row">

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
@@ -25,21 +25,19 @@
 {% if form.suppliers|length > 0 %}
   <div id="form_step6_suppliers_custom_fields">
     <h2>{{ form.suppliers.vars.label }}</h2>
-    <div class="row mb-1">
-      <div class="col-md-12">
-        <div class="alert expandable-alert alert-info" role="alert">
-          <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#suppliersInfo" aria-expanded="false" aria-controls="collapseDanger">
-            {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
-          </button>
-          <p class="alert-text">
-            {{ 'This interface allows you to specify the suppliers of the current product and its combinations, if any.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
-            {{ 'You can specify supplier references according to previously associated suppliers.'|trans({}, 'Admin.Catalog.Help')|raw }}
+    <div class="mb-1">
+      <div class="alert expandable-alert alert-info" role="alert">
+        <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#suppliersInfo" aria-expanded="false" aria-controls="collapseDanger">
+          {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
+        </button>
+        <p class="alert-text">
+          {{ 'This interface allows you to specify the suppliers of the current product and its combinations, if any.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
+          {{ 'You can specify supplier references according to previously associated suppliers.'|trans({}, 'Admin.Catalog.Help')|raw }}
+        </p>
+        <div class="alert-more collapse" id="suppliersInfo">
+          <p>
+            {{ 'When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.'|trans({}, 'Admin.Catalog.Help')|raw }}
           </p>
-          <div class="alert-more collapse" id="suppliersInfo">
-            <p>
-              {{ 'When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.'|trans({}, 'Admin.Catalog.Help')|raw }}
-            </p>
-          </div>
         </div>
       </div>
     </div>
@@ -50,18 +48,18 @@
           {{ form_errors(form.suppliers) }}
           <table class="table" id="form_step6_suppliers">
             <thead class="thead-default">
-            <tr>
-              <th width="70%">{{ 'Choose the suppliers associated with this product'|trans({}, 'Admin.Catalog.Feature') }}</th>
-              <th width="30%">{{ 'Default supplier'|trans({}, 'Admin.Catalog.Feature') }}</th>
-            </tr>
+              <tr>
+                <th width="70%">{{ 'Choose the suppliers associated with this product'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th width="30%">{{ 'Default supplier'|trans({}, 'Admin.Catalog.Feature') }}</th>
+              </tr>
             </thead>
             <tbody>
-            {% for key, supplier in form.suppliers %}
-              <tr>
-                <td>{{ form_widget(supplier) }}</td>
-                <td>{{ form_widget(form.default_supplier[key]) }}</td>
-              </tr>
-            {% endfor %}
+              {% for key, supplier in form.suppliers %}
+                <tr>
+                  <td>{{ form_widget(supplier) }}</td>
+                  <td>{{ form_widget(form.default_supplier[key]) }}</td>
+                </tr>
+              {% endfor %}
             </tbody>
           </table>
         </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig
@@ -24,27 +24,25 @@
  *#}
 {% if suppliers|length > 0 %}
   <h4>{{ 'Supplier reference(s)'|trans({}, 'Admin.Catalog.Feature') }}</h4>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="alert alert-info" role="alert">
-        <p class="alert-text">
-          {{ 'You can specify product reference(s) for each associated supplier. Click "%save_label%" after changing selected suppliers to display the associated product references.'|trans({'%save_label%': 'Save'|trans({}, 'Admin.Actions')}, 'Admin.Catalog.Help')|raw }}
-        </p>
-      </div>
-    </div>
+  <div class="alert alert-info" role="alert">
+    <p class="alert-text">
+      {{ 'You can specify product reference(s) for each associated supplier. Click "%save_label%" after changing selected suppliers to display the associated product references.'|trans({'%save_label%': 'Save'|trans({}, 'Admin.Actions')}, 'Admin.Catalog.Help')|raw }}
+    </p>
   </div>
 {% endif %}
 
 {% for supplierId in suppliers %}
   {% set collectionName = 'supplier_combination_' ~ supplierId %}
   <div class="panel panel-default">
-    <div class="panel-heading"><strong>{{ form[collectionName].vars.label }}</strong></div>
+    <div class="panel-heading">
+      <strong>{{ form[collectionName].vars.label }}</strong>
+    </div>
     <div class="panel-body" id="supplier_combination_{{ supplierId }}">
       <div>
         {{ form_errors(form[collectionName]) }}
         <table class="table">
           <thead class="thead-default">
-            <tr >
+            <tr>
               <th width="30%">{{ 'Product name'|trans({}, 'Admin.Catalog.Feature') }}</th>
               <th width="30%">{{ 'Supplier reference'|trans({}, 'Admin.Catalog.Feature') }}</th>
               <th width="20%">{{ 'Cost price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
@@ -52,18 +50,18 @@
             </tr>
           </thead>
           <tbody>
-          {% for supplier_combination in form[collectionName] %}
-            <tr>
-              <td>{{ supplier_combination.vars.value.label }}</td>
-              <td>{{ form_widget(supplier_combination.supplier_reference) }}</td>
-              <td>{{ form_widget(supplier_combination.product_price) }}</td>
-              <td>
-                {{ form_widget(supplier_combination.product_price_currency) }}
-                {{ form_widget(supplier_combination.id_product_attribute) }}
-                {{ form_widget(supplier_combination.supplier_id) }}
-              </td>
-            </tr>
-          {% endfor %}
+            {% for supplier_combination in form[collectionName] %}
+              <tr>
+                <td>{{ supplier_combination.vars.value.label }}</td>
+                <td>{{ form_widget(supplier_combination.supplier_reference) }}</td>
+                <td>{{ form_widget(supplier_combination.product_price) }}</td>
+                <td>
+                  {{ form_widget(supplier_combination.product_price_currency) }}
+                  {{ form_widget(supplier_combination.id_product_attribute) }}
+                  {{ form_widget(supplier_combination.supplier_id) }}
+                </td>
+              </tr>
+            {% endfor %}
           </tbody>
         </table>
       </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/combinations.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/combinations.html.twig
@@ -23,169 +23,181 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step3">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
+  <div class="container-fluid">
+
+    <div id="quantities" style="{% if has_combinations or formDependsOnStocks.vars.value != "0" %}display: none;{% endif %}">
+      <h2>{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+      <fieldset class="form-group">
         <div class="row">
-
-          <div class="col-md-12">
-
-            <div id="quantities" style="{% if has_combinations or formDependsOnStocks.vars.value != "0" %}display: none;{% endif %}">
-              <h2>{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-              <fieldset class="form-group">
-                <div class="row">
-                  {% if configuration('PS_STOCK_MANAGEMENT') %}
-                    <div class="col-md-4">
-                      <label class="form-control-label">{{ formStockQuantity.vars.label }}</label>
-                      {{ form_errors(formStockQuantity) }}
-                      {{ form_widget(formStockQuantity) }}
-                    </div>
-                  {% endif %}
-                  <div class="col-md-4">
-                    <label class="form-control-label">{{ formStockMinimalQuantity.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    {{ form_errors(formStockMinimalQuantity) }}
-                    {{ form_widget(formStockMinimalQuantity) }}
-                  </div>
-                </div>
-              </fieldset>
-
-              <h2>{{ 'Stock'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-              <fieldset class="form-group">
-                <div class="row">
-                  <div class="col-md-4">
-                    <label class="form-control-label">{{ formLocation.vars.label }}</label>
-                    {{ form_errors(formLocation) }}
-                    {{ form_widget(formLocation) }}
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-md-4">
-                    <label class="form-control-label">{{ formLowStockThreshold.vars.label }}</label>
-                    {{ form_errors(formLowStockThreshold) }}
-                    {{ form_widget(formLowStockThreshold) }}
-                  </div>
-                  <div class="col-md-8">
-                    <label class="form-control-label">&nbsp;</label>
-                    <div class="widget-checkbox-inline">
-                      {{ form_errors(formLowStockAlert) }}
-                      {{ form_widget(formLowStockAlert) }}
-                      <span class="help-box" data-toggle="popover" data-html="true" data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" ></span>
-                    </div>
-                  </div>
-                </div>
-              </fieldset>
+          {% if configuration('PS_STOCK_MANAGEMENT') %}
+            <div class="col-md-4">
+              <label class="form-control-label">{{ formStockQuantity.vars.label }}</label>
+              {{ form_errors(formStockQuantity) }}
+              {{ form_widget(formStockQuantity) }}
             </div>
+          {% endif %}
+          <div class="col-md-4">
+            <label class="form-control-label">{{ formStockMinimalQuantity.vars.label }}</label>
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+            {{ form_errors(formStockMinimalQuantity) }}
+            {{ form_widget(formStockMinimalQuantity) }}
+          </div>
+        </div>
+      </fieldset>
 
-            <div id="virtual_product" data-action="{{ path('admin_product_virtual_save_action', { 'idProduct': productId }) }}" data-action-remove="{{ path('admin_product_virtual_remove_action', {'idProduct': productId }) }}">
+      <h2>{{ 'Stock'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+      <fieldset class="form-group">
+        <div class="row">
+          <div class="col-md-4">
+            <label class="form-control-label">{{ formLocation.vars.label }}</label>
+            {{ form_errors(formLocation) }}
+            {{ form_widget(formLocation) }}
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-4">
+            <label class="form-control-label">{{ formLowStockThreshold.vars.label }}</label>
+            {{ form_errors(formLowStockThreshold) }}
+            {{ form_widget(formLowStockThreshold) }}
+          </div>
+          <div class="col-md-8">
+            <label class="form-control-label">&nbsp;</label>
+            <div class="widget-checkbox-inline">
+              {{ form_errors(formLowStockAlert) }}
+              {{ form_widget(formLowStockAlert) }}
+              <span class="help-box" 
+                    data-toggle="popover" 
+                    data-html="true" 
+                    data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}">
+              </span>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
 
-              <div class="row">
-                <div class="col-md-4">
-                  <h2>{{ formVirtualProduct.vars.label }}</h2>
-                </div>
-                <div class="col-md-8">
-                  <fieldset class="form-group">
-                    {{ form_widget(formVirtualProduct.is_virtual_file) }}
-                  </fieldset>
-                </div>
+    <div id="virtual_product" 
+         data-action="{{ path('admin_product_virtual_save_action', { 'idProduct': productId }) }}" 
+         data-action-remove="{{ path('admin_product_virtual_remove_action', {'idProduct': productId }) }}">
+        
+      <h2>{{ formVirtualProduct.vars.label }}</h2>
+      <fieldset class="form-group">
+        {{ form_widget(formVirtualProduct.is_virtual_file) }}
+      </fieldset>
+
+      <div class="row">
+        <div class="col-md-8">
+          <div id="virtual_product_content" class="bg-light p-3">
+            <div class="row">
+              {{ form_errors(formVirtualProduct) }}
+              <div class="col-md-12">
+                <fieldset class="form-group">
+                  <label class="form-control-label">{{ formVirtualProduct.file.vars.label }}</label>
+                  <span class="help-box" 
+                        data-toggle="popover" 
+                        data-content="{{ "Upload a file from your computer (%maxUploadSize% max.)"|trans({'%maxUploadSize%': max_upload_size}, 'Admin.Catalog.Help') }}">
+                  </span>
+                  <div id="form_step3_virtual_product_file_input" class="{{ formVirtualProduct.vars.value.filename is defined ? 'hide' : 'show' }}">
+                    {{ form_widget(formVirtualProduct.file) }}
+                  </div>
+                  <div id="form_step3_virtual_product_file_details" class="{{ formVirtualProduct.vars.value.filename is defined ? 'show' : 'hide' }}">
+                    <a href="{{ formVirtualProduct.vars.value.file_download_link is defined ? formVirtualProduct.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ 'Download file'|trans({}, 'Admin.Actions') }}</a>
+                    <a href="{{ path('admin_product_virtual_remove_file_action', {'idProduct': productId}) }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'Admin.Actions') }}</a>
+                  </div>
+                </fieldset>
               </div>
-
-              <div id="virtual_product_content" class="row col-md-8">
-                {{ form_errors(formVirtualProduct) }}
-                <div class="col-md-12">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.file.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Upload a file from your computer (%maxUploadSize% max.)"|trans({'%maxUploadSize%': max_upload_size}, 'Admin.Catalog.Help') }}" ></span>
-                    <div id="form_step3_virtual_product_file_input" class="{{ formVirtualProduct.vars.value.filename is defined ? 'hide' : 'show' }}">
-                      {{ form_widget(formVirtualProduct.file) }}
-                    </div>
-                    <div id="form_step3_virtual_product_file_details" class="{{ formVirtualProduct.vars.value.filename is defined ? 'show' : 'hide' }}">
-                      <a href="{{ formVirtualProduct.vars.value.file_download_link is defined ? formVirtualProduct.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ 'Download file'|trans({}, 'Admin.Actions') }}</a>
-                      <a href="{{ path('admin_product_virtual_remove_file_action', {'idProduct': productId}) }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'Admin.Actions') }}</a>
-                    </div>
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.name.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    {{ form_errors(formVirtualProduct.name) }}
-                    {{ form_widget(formVirtualProduct.name) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.nb_downloadable.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    {{ form_errors(formVirtualProduct.nb_downloadable) }}
-                    {{ form_widget(formVirtualProduct.nb_downloadable) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.expiration_date.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    {{ form_errors(formVirtualProduct.expiration_date) }}
-                    {{ form_widget(formVirtualProduct.expiration_date) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.nb_days.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    {{ form_errors(formVirtualProduct.nb_days) }}
-                    {{ form_widget(formVirtualProduct.nb_days) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-12">
-                  {{ form_widget(formVirtualProduct.save) }}
-                </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">{{ formVirtualProduct.name.vars.label }}</label>
+                  <span class="help-box" 
+                        data-toggle="popover" 
+                        data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}">
+                  </span>
+                  {{ form_errors(formVirtualProduct.name) }}
+                  {{ form_widget(formVirtualProduct.name) }}
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">{{ formVirtualProduct.nb_downloadable.vars.label }}</label>
+                  <span class="help-box" 
+                        data-toggle="popover" 
+                        data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}">
+                  </span>
+                  {{ form_errors(formVirtualProduct.nb_downloadable) }}
+                  {{ form_widget(formVirtualProduct.nb_downloadable) }}
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">{{ formVirtualProduct.expiration_date.vars.label }}</label>
+                  <span class="help-box" 
+                        data-toggle="popover" 
+                        data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}">
+                  </span>
+                  {{ form_errors(formVirtualProduct.expiration_date) }}
+                  {{ form_widget(formVirtualProduct.expiration_date) }}
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">{{ formVirtualProduct.nb_days.vars.label }}</label>
+                  <span class="help-box" 
+                        data-toggle="popover" 
+                        data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}">
+                  </span>
+                  {{ form_errors(formVirtualProduct.nb_days) }}
+                  {{ form_widget(formVirtualProduct.nb_days) }}
+                </fieldset>
+              </div>
+              <div class="col-md-12">
+                {{ form_widget(formVirtualProduct.save) }}
               </div>
             </div>
-
-            {% if asm_globally_activated and formType.vars.value != "2" %}
-              <div class="form-group" id="asm_quantity_management">
-                <label class="col-sm-2 control-label" for="form_step3_advanced_stock_management"></label>
-                <div class="col-sm-10">
-                  {{ form_errors(formAdvancedStockManagement) }}
-                  {{ form_widget(formAdvancedStockManagement) }}
-                  {% if form.step1.type_product.vars.value == "1" %}
-                    {{ 'When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.'|trans({}, 'Admin.Catalog.Notification') }}
-                  {% endif %}
-                </div>
-              </div>
-              <div class="form-group" id="depends_on_stock_div" style="{% if not(formAdvancedStockManagement.vars.checked) %}display: none;{% endif %}">
-                <label class="col-sm-2 control-label" for="form_step3_depends_on_stock"></label>
-                <div class="col-sm-10">
-                  {{ form_errors(formDependsOnStocks) }}
-                  {{ form_widget(formDependsOnStocks) }}
-                </div>
-              </div>
-            {% endif %}
-            {% if configuration('PS_STOCK_MANAGEMENT') %}
-              <div id="pack_stock_type">
-                <h2>{{ formPackStockType.vars.label }}</h2>
-                <div class="row col-md-4">
-                  <fieldset class="form-group">
-                    {{ form_errors(formPackStockType) }}
-                    {{ form_widget(formPackStockType) }}
-                  </fieldset>
-                </div>
-              </div>
-            {% endif %}
-            {{ include('@Product/ProductPage/Forms/form_combinations.html.twig', {'form': formStep3, 'form_combination_bulk': formCombinations}) }}
-
-            {{ renderhook('displayAdminProductsQuantitiesStepBottom', { 'id_product': productId }) }}
-
           </div>
         </div>
       </div>
+
     </div>
+
+    {% if asm_globally_activated and formType.vars.value != "2" %}
+      <div class="form-group" id="asm_quantity_management">
+        <label class="col-sm-2 control-label" for="form_step3_advanced_stock_management"></label>
+        <div class="col-sm-10">
+          {{ form_errors(formAdvancedStockManagement) }}
+          {{ form_widget(formAdvancedStockManagement) }}
+          {% if form.step1.type_product.vars.value == "1" %}
+            {{ 'When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.'|trans({}, 'Admin.Catalog.Notification') }}
+          {% endif %}
+        </div>
+      </div>
+      <div class="form-group" id="depends_on_stock_div" style="{% if not(formAdvancedStockManagement.vars.checked) %}display: none;{% endif %}">
+        <label class="col-sm-2 control-label" for="form_step3_depends_on_stock"></label>
+        <div class="col-sm-10">
+          {{ form_errors(formDependsOnStocks) }}
+          {{ form_widget(formDependsOnStocks) }}
+        </div>
+      </div>
+    {% endif %}
+    {% if configuration('PS_STOCK_MANAGEMENT') %}
+      <div id="pack_stock_type">
+        <h2>{{ formPackStockType.vars.label }}</h2>
+        <div class="row">
+          <div class="col-md-4">
+            <fieldset class="form-group">
+              {{ form_errors(formPackStockType) }}
+              {{ form_widget(formPackStockType) }}
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {{ include('@Product/ProductPage/Forms/form_combinations.html.twig', {'form': formStep3, 'form_combination_bulk': formCombinations}) }}
+
+    {{ renderhook('displayAdminProductsQuantitiesStepBottom', { 'id_product': productId }) }}
+
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/essentials.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/essentials.html.twig
@@ -23,247 +23,253 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane active" id="step1">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
-        <div class="row">
+  <div class="container-fluid">
+    <div
+      class="row">
 
-          {# LEFT #}
-          <div class="col-md-9 left-column">
+      {# LEFT #}
+      <div class="col-md-9 left-column">
 
-            <div id="js_form_step1_inputPackItems">
-              {{ form_errors(formPackItems) }}
-              {{ form_widget(formPackItems) }}
+        <div id="js_form_step1_inputPackItems">
+          {{ form_errors(formPackItems) }}
+          {{ form_widget(formPackItems) }}
+        </div>
+
+        <div id="product-images-container" class="mb-4">
+          <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12" 
+               url-upload="{{ path('admin_product_image_upload', {'idProduct': productId}) }}" 
+               url-position="{{ path('admin_product_image_positions') }}" 
+               data-max-size="{{ configuration('PS_LIMIT_UPLOAD_IMAGE_VALUE') }}">
+            <div id="product-images-dropzone-error" class="text-danger"></div>
+            <div class="dz-default dz-message openfilemanager">
+              <i class="material-icons">add_a_photo</i><br/>
+              {{js_translatable['Drop images here']}}<br/>
+              <a>{{js_translatable['or select files']}}</a><br/>
+              <small>
+                {{js_translatable['files recommandations']}}<br/>
+                {{js_translatable['files recommandations2']}}
+              </small>
             </div>
-
-            <div id="product-images-container" class="mb-4">
-              <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12"
-                  url-upload="{{ path('admin_product_image_upload', {'idProduct': productId}) }}"
-                  url-position="{{ path('admin_product_image_positions') }}"
-                  data-max-size="{{ configuration('PS_LIMIT_UPLOAD_IMAGE_VALUE') }}"
-              >
-                <div id="product-images-dropzone-error" class="text-danger"></div>
-                <div class="dz-default dz-message openfilemanager">
-                    <i class="material-icons">add_a_photo</i><br/>
-                    {{js_translatable['Drop images here']}}<br/>
-                    <a>{{js_translatable['or select files']}}</a><br/>
-                    <small>
-                        {{js_translatable['files recommandations']}}<br/>
-                        {{js_translatable['files recommandations2']}}
-                    </small>
+            {% if images is defined %}
+              {% if editable %}
+                <div class="dz-preview disabled openfilemanager">
+                  <div>
+                    <span>+</span>
+                  </div>
                 </div>
-                {% if images is defined %}
-                    {% if editable %}
-                        <div class="dz-preview disabled openfilemanager">
-                            <div><span>+</span></div>
-                        </div>
-                    {% endif %}
-                  {% for image in images %}
-                    <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle"
-                        data-id="{{ image.id }}"
-                        url-delete="{{ path('admin_product_image_delete', {'idImage': image.id}) }}"
-                        url-update="{{ path('admin_product_image_form', {'idImage': image.id}) }}"
-                    >
-                      <div class="dz-image bg" style="background-image: url('{{ image.base_image_url }}-home_default.{{ image.format }}');"></div>
-                      <div class="dz-details">
-                        <div class="dz-size"><span data-dz-size=""></span></div>
-                        <div class="dz-filename"><span data-dz-name=""></span></div>
-                      </div>
-                      <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress="" style="width: 100%;"></span></div>
-                      <div class="dz-error-message"><span data-dz-errormessage=""></span></div>
-                      <div class="dz-success-mark"></div>
-                      <div class="dz-error-mark"></div>
-                      {% if image.cover %}
-                        <div class="iscover">{{ 'Cover'|trans({}, 'Admin.Catalog.Feature') }}</div>
-                      {% endif %}
+              {% endif %}
+              {% for image in images %}
+                <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle" data-id="{{ image.id }}" 
+                     url-delete="{{ path('admin_product_image_delete', {'idImage': image.id}) }}" 
+                     url-update="{{ path('admin_product_image_form', {'idImage': image.id}) }}">
+                  <div class="dz-image bg" style="background-image: url('{{ image.base_image_url }}-home_default.{{ image.format }}');"></div>
+                  <div class="dz-details">
+                    <div class="dz-size">
+                      <span data-dz-size=""></span>
                     </div>
-                  {% endfor %}
-                {% endif %}
-              </div>
-              <div id="product-images-form-container" class="col-md-4">
-                <div id="product-images-form"></div>
-              </div>
-              <div class="dropzone-expander text-sm-center col-md-12">
-                <span class="expand">{{ 'View all images'|trans({}, 'Admin.Catalog.Feature') }}</span>
-                <span class="compress">{{ 'View less'|trans({}, 'Admin.Catalog.Feature') }}</span>
-              </div>
-
-            </div>
-
-            <div class="summary-description-container">
-              <h2>{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-              <div id="description_short" class="mb-3">
-                {{ form_widget(formShortDescription) }}
-              </div>
-
-              <h2>{{ 'Description'|trans({}, 'Admin.Global') }}</h2>
-              <div id="description" class="mb-3">
-                {{ form_widget(formDescription) }}
-              </div>
-            </div>
-
-            {{ renderhook('displayAdminProductsMainStepLeftColumnMiddle', { 'id_product': productId }) }}
-
-            <div id="features" class="mb-3">
-              <div id="features-content" class="content {{ formFeatures|length == 0 ? 'hide':'' }}">
-                <h2>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                {{ form_errors(formFeatures) }}
-                <div
-                  class="feature-collection nostyle"
-                  data-prototype="{% filter escape %}
-                    {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': formFeatures.vars.prototype }) }}
-                  {% endfilter %}"
-                >
-                  {% for feature in formFeatures %}
-                    {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': feature }) }}
-                  {% endfor %}
+                    <div class="dz-filename">
+                      <span data-dz-name=""></span>
+                    </div>
+                  </div>
+                  <div class="dz-progress">
+                    <span class="dz-upload" data-dz-uploadprogress="" style="width: 100%;"></span>
+                  </div>
+                  <div class="dz-error-message">
+                    <span data-dz-errormessage=""></span>
+                  </div>
+                  <div class="dz-success-mark"></div>
+                  <div class="dz-error-mark"></div>
+                  {% if image.cover %}
+                    <div class="iscover">{{ 'Cover'|trans({}, 'Admin.Catalog.Feature') }}</div>
+                  {% endif %}
                 </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <button type="button" class="btn btn-outline-primary sensitive add" id="add_feature_button"><i class="material-icons">add_circle</i> {{ 'Add a feature'|trans({}, 'Admin.Catalog.Feature') }}</button>
-                </div>
-              </div>
-            </div>
-
-            <div id="manufacturer" class="mb-3">
-              {{ include('@Product/ProductPage/Forms/form_manufacturer.html.twig', { 'form': formManufacturer }) }}
-            </div>
-
-            <div id="related-product" class="mb-3">
-              {{ include('@Product/ProductPage/Forms/form_related_products.html.twig', { 'form': formRelatedProducts }) }}
-            </div>
-
-            {{ renderhook('displayAdminProductsMainStepLeftColumnBottom', { 'id_product': productId }) }}
-
+              {% endfor %}
+            {% endif %}
+          </div>
+          <div id="product-images-form-container" class="col-md-4">
+            <div id="product-images-form"></div>
+          </div>
+          <div class="dropzone-expander text-sm-center col-md-12">
+            <span class="expand">{{ 'View all images'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="compress">{{ 'View less'|trans({}, 'Admin.Catalog.Feature') }}</span>
           </div>
 
-          {# RIGHT #}
-          <div class="col-md-3 right-column">
+        </div>
 
-              <div class="row">
-                <div class="col-md-12">
+        <div class="summary-description-container">
+          <h2>{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+          <div id="description_short" class="mb-3">
+            {{ form_widget(formShortDescription) }}
+          </div>
 
-                  {% if is_combination_active %}
-                    <div class="form-group mb-3" id="show_variations_selector">
-                      <h2>
-                        {{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}
-                        <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                      </h2>
-                      <div class="radio">
-                        <label>
-                          <input type="radio" name="show_variations" value="0" {% if not has_combinations %}checked="checked"{% endif %}>
-                          {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
-                        </label>
-                      </div>
-                      <div class="radio">
-                        <label>
-                          <input type="radio" name="show_variations" value="1" {% if has_combinations %}checked="checked"{% endif %}>
-                          {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
-                        </label>
-                        <div id="product_type_combinations_shortcut">
-                          <span class="small font-secondary">
-                            {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                            {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  {% endif %}
-
-                  <div class="form-group mb-4">
-                    <h2>
-                      {{ "Reference"|trans({}, 'Admin.Catalog.Feature') }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "Your reference code for this product. Allowed special characters: .-_#\."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </h2>
-                    {{ form_errors(formReference) }}
-                    <div class="row">
-                      <div class="col-xl-12 col-lg-12" id="product_reference_field">
-                          {{ form_widget(formReference) }}
-                      </div>
-                    </div>
-                  </div>
-
-                  {% if configuration('PS_STOCK_MANAGEMENT') %}
-                    <div class="form-group mb-4" id="product_qty_0_shortcut_div">
-                      <h2>
-                        {{ "Quantity"|trans({}, 'Admin.Catalog.Feature') }}
-                        <span class="help-box" data-toggle="popover"
-                          data-content="{{ "How many products should be available for sale?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                      </h2>
-                      {{ form_errors(formQuantityShortcut) }}
-                      <div class="row">
-                        <div class="col-xl-6 col-lg-12">
-                          {{ form_widget(formQuantityShortcut) }}
-                        </div>
-                      </div>
-                      <span class="small font-secondary">
-                        {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                        {{ "Advanced settings in [1][2]Quantities[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                      </span>
-                    </div>
-                  {% endif %}
-
-                  <div class="form-group mb-4">
-                    <h2>
-                      {{ "Price"|trans({}, 'Admin.Global') }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </h2>
-                    <div class="row">
-                      <div class="col-md-6">
-                        <label class="form-control-label">{{ "Tax excluded"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                        {{ form_widget(formPriceShortcut) }}
-                        {{ form_errors(formPriceShortcut) }}
-                      </div>
-                      <div class="col-md-6 col-offset-md-1">
-                        <label class="form-control-label">{{ "Tax included"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                        {{ form_widget(formPriceShortcutTTC) }}
-                        {{ form_errors(formPriceShortcutTTC) }}
-                      </div>
-                      <div class="col-md-12 mt-1">
-                        <label class="form-control-label">{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                        {{ render(
-                            controller('PrestaShopBundle:Admin/Common:renderField', {
-                              'formName': 'step2',
-                              'formType': 'PrestaShopBundle\\Form\\Admin\\Product\\ProductPrice',
-                              'fieldName': 'id_tax_rules_group',
-                              'fieldData' : form.step2.id_tax_rules_group.vars.value
-                              }
-                            )
-                          )
-                        }}
-                      </div>
-                      <div class="col-md-12">
-                        <span class="small font-secondary">
-                          {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                          {{ "Advanced settings in [1][2]Pricing[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                        </span>
-                      </div>
-                    </div>
-                    <div class="row hide">
-                      <div class="col-md-12">
-                        <label>{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                      </div>
-                      <div class="clearfix"></div>
-                      <div class="col-md-11" id="tax_rule_shortcut">
-                      </div>
-                      <a href="#" onclick="$(this).parent().hide()">&times;</a>
-                    </div>
-                  </div>
-
-                  <div class="form-group mb-4" id="categories">
-                    {{ include('@Product/ProductPage/Forms/form_categories.html.twig', { 'form': formCategories, 'productId': productId }) }}
-                  </div>
-
-                  {{ renderhook('displayAdminProductsMainStepRightColumnBottom', { 'id_product': productId }) }}
-
-                </div>
-              </div>
+          <h2>{{ 'Description'|trans({}, 'Admin.Global') }}</h2>
+          <div id="description" class="mb-3">
+            {{ form_widget(formDescription) }}
           </div>
         </div>
+
+        {{ renderhook('displayAdminProductsMainStepLeftColumnMiddle', { 'id_product': productId }) }}
+
+        <div id="features" class="mb-3">
+          <div id="features-content" class="content {{ formFeatures|length == 0 ? 'hide':'' }}">
+            <h2>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+            {{ form_errors(formFeatures) }}
+            <div class="feature-collection nostyle" data-prototype="{% filter escape %} {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': formFeatures.vars.prototype }) }} {% endfilter %}">
+              {% for feature in formFeatures %}
+                {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': feature }) }}
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-4">
+              <button type="button" class="btn btn-outline-primary sensitive add" id="add_feature_button">
+                <i class="material-icons">add_circle</i>
+                {{ 'Add a feature'|trans({}, 'Admin.Catalog.Feature') }}</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="manufacturer" class="mb-3">
+          {{ include('@Product/ProductPage/Forms/form_manufacturer.html.twig', { 'form': formManufacturer }) }}
+        </div>
+
+        <div id="related-product" class="mb-3">
+          {{ include('@Product/ProductPage/Forms/form_related_products.html.twig', { 'form': formRelatedProducts }) }}
+        </div>
+
+        {{ renderhook('displayAdminProductsMainStepLeftColumnBottom', { 'id_product': productId }) }}
+
+      </div>
+
+      {# RIGHT #}
+      <div class="col-md-3 right-column">
+
+        {% if is_combination_active %}
+          <div class="form-group mb-3" id="show_variations_selector">
+            <h2>
+              {{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}
+              <span class="help-box" 
+                    data-toggle="popover" 
+                    data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}">
+              </span>
+            </h2>
+            <div class="radio">
+              <label>
+                <input type="radio" name="show_variations" value="0" {% if not has_combinations %} checked="checked" {% endif %}>
+                {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="show_variations" value="1" {% if has_combinations %} checked="checked" {% endif %}>
+                {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
+              </label>
+              <div id="product_type_combinations_shortcut">
+                <span
+                  class="small font-secondary">
+                  {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+                  {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                </span>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="form-group mb-4">
+          <h2>
+            {{ "Reference"|trans({}, 'Admin.Catalog.Feature') }}
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "Your reference code for this product. Allowed special characters: .-_#\."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+          </h2>
+          {{ form_errors(formReference) }}
+          <div class="row">
+            <div class="col-lg-12" id="product_reference_field">
+              {{ form_widget(formReference) }}
+            </div>
+          </div>
+        </div>
+
+        {% if configuration('PS_STOCK_MANAGEMENT') %}
+          <div class="form-group mb-4" id="product_qty_0_shortcut_div">
+            <h2>
+              {{ "Quantity"|trans({}, 'Admin.Catalog.Feature') }}
+              <span class="help-box" 
+                    data-toggle="popover" 
+                    data-content="{{ "How many products should be available for sale?"|trans({}, 'Admin.Catalog.Help') }}">
+              </span>
+            </h2>
+            {{ form_errors(formQuantityShortcut) }}
+            <div class="row">
+              <div class="col-xl-6 col-lg-12">
+                {{ form_widget(formQuantityShortcut) }}
+              </div>
+            </div>
+            <span
+              class="small font-secondary">
+              {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+              {{ "Advanced settings in [1][2]Quantities[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+            </span>
+          </div>
+        {% endif %}
+
+        <div class="form-group mb-4">
+          <h2>
+            {{ "Price"|trans({}, 'Admin.Global') }}
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+          </h2>
+          <div class="row">
+            <div class="col-md-6">
+              <label class="form-control-label">{{ "Tax excluded"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(formPriceShortcut) }}
+              {{ form_errors(formPriceShortcut) }}
+            </div>
+            <div class="col-md-6 col-offset-md-1">
+              <label class="form-control-label">{{ "Tax included"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(formPriceShortcutTTC) }}
+              {{ form_errors(formPriceShortcutTTC) }}
+            </div>
+            <div class="col-md-12 mt-1">
+              <label class="form-control-label">{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ render(
+                      controller('PrestaShopBundle:Admin/Common:renderField', {
+                        'formName': 'step2',
+                        'formType': 'PrestaShopBundle\\Form\\Admin\\Product\\ProductPrice',
+                        'fieldName': 'id_tax_rules_group',
+                        'fieldData' : form.step2.id_tax_rules_group.vars.value
+                        }
+                      )
+                    )
+                  }}
+            </div>
+            <div class="col-md-12">
+              <span
+                class="small font-secondary">
+                {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+                {{ "Advanced settings in [1][2]Pricing[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+              </span>
+            </div>
+          </div>
+          <div class="row hide">
+            <div class="col-md-12">
+              <label>{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
+            </div>
+            <div class="clearfix"></div>
+            <div class="col-md-11" id="tax_rule_shortcut"></div>
+            <a href="#" onclick="$(this).parent().hide()">&times;</a>
+          </div>
+        </div>
+
+        <div class="form-group mb-4" id="categories">
+          {{ include('@Product/ProductPage/Forms/form_categories.html.twig', { 'form': formCategories, 'productId': productId }) }}
+        </div>
+
+        {{ renderhook('displayAdminProductsMainStepRightColumnBottom', { 'id_product': productId }) }}
+
       </div>
     </div>
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/options.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/options.html.twig
@@ -23,208 +23,192 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step6">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
+  <div class="container-fluid">
+
+    {{ renderhook('displayAdminProductsOptionsStepTop', { 'id_product': productId }) }}
+
+    <h2>{{ 'Visibility'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+    <p class="subtitle">{{ 'Where do you want your product to appear?'|trans({}, 'Admin.Catalog.Feature') }}</p>
+
+    <div class="row">
+      <div class="col-md-4 form-group">
+        {{ form_errors(optionsForm.visibility) }}
+        {{ form_widget(optionsForm.visibility) }}
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-7 form-group">
+        {{ form_errors(optionsForm.display_options) }}
         <div class="row">
-
-          <div class="col-md-12">
-
-            {{ renderhook('displayAdminProductsOptionsStepTop', { 'id_product': productId }) }}
-
-            <div class="row">
-              <div class="col-md-12">
-                <h2>{{ 'Visibility'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                <p class="subtitle">{{ 'Where do you want your product to appear?'|trans({}, 'Admin.Catalog.Feature') }}</p>
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="col-md-4 form-group">
-                {{ form_errors(optionsForm.visibility) }}
-                {{ form_widget(optionsForm.visibility) }}
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="col-md-7 form-group">
-                  {{ form_errors(optionsForm.display_options) }}
-                  <div class="row">
-                    <div class="col-md-4 js-available-for-order">
-                      {{ form_widget(optionsForm.display_options.available_for_order) }}
-                    </div>
-                    <div class="col-md-3 js-show-price">
-                      {{ form_widget(optionsForm.display_options.show_price) }}
-                    </div>
-                    <div class="col-md-5">
-                      {{ form_widget(optionsForm.display_options.online_only) }}
-                    </div>
-                  </div>
-              </div>
-            </div>
-            <div class="row form-group">
-              <div class="col-md-8">
-                <label class="form-control-label">{{ 'Tags'|trans({}, 'Admin.Catalog.Feature') }}</label>
-                {{ form_errors(optionsForm.tags) }}
-                {{ form_widget(optionsForm.tags) }}
-                <div class="alert expandable-alert alert-info mt-3" role="alert">
-                  <p class="alert-text">{{ 'Tags are meant to help your customers find your products via the search bar.'|trans({}, 'Admin.Catalog.Help')|raw }}</p>
-                  <div class="alert-more collapse" id="tagsInfo">
-                    <p>
-                      {{ 'Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
-                      {{ 'You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.'|trans({}, 'Admin.Catalog.Help')|
+          <div class="col-md-4 js-available-for-order">
+            {{ form_widget(optionsForm.display_options.available_for_order) }}
+          </div>
+          <div class="col-md-3 js-show-price">
+            {{ form_widget(optionsForm.display_options.show_price) }}
+          </div>
+          <div class="col-md-5">
+            {{ form_widget(optionsForm.display_options.online_only) }}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row form-group">
+      <div class="col-md-8">
+        <label class="form-control-label">{{ 'Tags'|trans({}, 'Admin.Catalog.Feature') }}</label>
+        {{ form_errors(optionsForm.tags) }}
+        {{ form_widget(optionsForm.tags) }}
+        <div class="alert expandable-alert alert-info mt-3" role="alert">
+          <p class="alert-text">{{ 'Tags are meant to help your customers find your products via the search bar.'|trans({}, 'Admin.Catalog.Help')|raw }}</p>
+          <div class="alert-more collapse" id="tagsInfo">
+            <p>
+              {{ 'Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
+              {{ 'You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.'|trans({}, 'Admin.Catalog.Help')|
                       replace({
                         '[1]' : '<a href="'~ getAdminLink("AdminSearchConf") ~'" target="_blank">',
                         '[/1]' : '</a>'
                       })|raw
                       }}
-                    </p>
-                  </div>
-                 <div class="read-more-container">
-                   <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#tagsInfo" aria-expanded="false" aria-controls="collapseDanger">
-                      {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
-                    </button>
-                 </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="col-md-12">
-                <h2>{{ 'Condition & References'|trans({}, 'Admin.Catalog.Feature')|raw }}</h2>
-              </div>
-            </div>
-
-            <div class="row">
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.condition.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.condition) }}
-                {{ form_widget(optionsForm.condition) }}
-              </fieldset>
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">&nbsp;</label>
-                {{ form_widget(optionsForm.show_condition) }}
-              </fieldset>
-            </div>
-            <div class="row">
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.isbn.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "ISBN is used internationally to identify books and their various editions."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.isbn) }}
-                {{ form_widget(optionsForm.isbn) }}
-              </fieldset>
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.ean13.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.ean13) }}
-                {{ form_widget(optionsForm.ean13) }}
-              </fieldset>
-            </div>
-            <div class="row">
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.upc.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.upc) }}
-                {{ form_widget(optionsForm.upc) }}
-              </fieldset>
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.mpn.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                        data-content="{{ "MPN is used internationally to identify the Manufacturer Part Number."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.mpn) }}
-                {{ form_widget(optionsForm.mpn) }}
-              </fieldset>
-            </div>
-
-            <div class="row">
-              <div class="col-md-12">
-                <div id="custom_fields" class="mt-3">
-                  <h2>{{ optionsForm.custom_fields.vars.label }}</h2>
-                  <p class="subtitle">{{ 'Customers can personalize the product by entering some text or by providing custom image files.'|trans({}, 'Admin.Catalog.Feature') }}</p>
-                  {{ form_errors(optionsForm.custom_fields) }}
-                  <ul class="customFieldCollection nostyle" data-prototype="
-                              {% filter escape %}
-                              {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': optionsForm.custom_fields.vars.prototype }) }}
-                              {% endfilter %}">
-                    {% for field in optionsForm.custom_fields %}
-                      <li>
-                        {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': field }) }}
-                      </li>
-                    {% endfor %}
-                  </ul>
-                  <a href="#" class="btn btn-outline-secondary add">
-                    <i class="material-icons">add_circle</i>
-                    {{ 'Add a customization field'|trans({}, 'Admin.Catalog.Feature') }}
-                  </a>
-                </div>
-              </div>
-            </div>
-
-            <div class="row mt-4">
-              <div class="col-md-8">
-                <h2>{{ 'Attached files'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                <p class="subtitle">{{ 'Select the files (instructions, documentation, recipes, etc.) your customers can directly download on this product page.'|trans({}, 'Admin.Catalog.Feature') }} <br/> {{ 'Need to browse all files? Go to [1]Catalog > Files[/1]'|trans({'[1]':'<a href="'~getAdminLink("AdminAttachments")~'">','[/1]':'</a>'}, 'Admin.Catalog.Feature')|raw }} </p>
-                {{ form_widget(optionsForm.attachments) }}
-              </div>
-            </div>
-            <div class="row mt-3">
-              <div class="col-md-8">
-                <a
-                  class="btn btn-outline-secondary mb-3"
-                  href="#collapsedForm"
-                  data-toggle="collapse"
-                  aria-expanded="false"
-                  aria-controls="collapsedForm"
-                >
-                  <i class="material-icons">add_circle</i>
-                  {{ 'Attach a new file'|trans({}, 'Admin.Catalog.Feature') }}
-                </a>
-                <fieldset class="form-group collapse" id="collapsedForm">
-                  {{ form_errors(optionsForm.attachment_product) }}
-                  <div id="form_step6_attachment_product" data-action="{{ optionsForm.attachment_product.vars.attr['data-action'] }}">
-                    <div class="form-group">{{ form_widget(optionsForm.attachment_product.file) }}</div>
-                    <div class="form-group">{{ form_widget(optionsForm.attachment_product.name) }}</div>
-                    <div class="form-group">{{ form_widget(optionsForm.attachment_product.description) }}</div>
-                    <div class="form-group">
-                      {{ form_widget(optionsForm.attachment_product.add) }}
-                      {{ form_widget(optionsForm.attachment_product.cancel) }}
-                    </div>
-                  </div>
-                </fieldset>
-              </div>
-            </div>
-
-            <div class="row mt-3">
-              <div class="col-md-8" id="supplier_collection">
-                {{ include('@Product/ProductPage/Forms/form_supplier_choice.html.twig', { 'form': optionsForm }) }}
-              </div>
-            </div>
-            <div class="row">
-              <div id="supplier_combination_collection" class="col-md-12" data-url="{{ path('admin_supplier_refresh_product_supplier_combination_form', { 'idProduct': productId, 'supplierIds': 1}) }}">
-                {{ include('@Product/ProductPage/Forms/form_supplier_combination.html.twig', { 'suppliers': optionsForm.suppliers.vars.value, 'form': optionsForm }) }}
-              </div>
-            </div>
-
-            {{ renderhook('displayAdminProductsOptionsStepBottom', { 'id_product': productId }) }}
-
+            </p>
+          </div>
+          <div class="read-more-container">
+            <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#tagsInfo" aria-expanded="false" aria-controls="collapseDanger">
+              {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
+            </button>
           </div>
         </div>
       </div>
     </div>
+
+    <h2>{{ 'Condition & References'|trans({}, 'Admin.Catalog.Feature')|raw }}</h2>
+
+    <div class="row">
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.condition.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.condition) }}
+        {{ form_widget(optionsForm.condition) }}
+      </fieldset>
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">&nbsp;</label>
+        {{ form_widget(optionsForm.show_condition) }}
+      </fieldset>
+    </div>
+    <div class="row">
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.isbn.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "ISBN is used internationally to identify books and their various editions."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.isbn) }}
+        {{ form_widget(optionsForm.isbn) }}
+      </fieldset>
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.ean13.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.ean13) }}
+        {{ form_widget(optionsForm.ean13) }}
+      </fieldset>
+    </div>
+    <div class="row">
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.upc.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.upc) }}
+        {{ form_widget(optionsForm.upc) }}
+      </fieldset>
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.mpn.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "MPN is used internationally to identify the Manufacturer Part Number."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.mpn) }}
+        {{ form_widget(optionsForm.mpn) }}
+      </fieldset>
+    </div>
+
+    <div id="custom_fields" class="mt-3">
+      <h2>{{ optionsForm.custom_fields.vars.label }}</h2>
+      <p class="subtitle">{{ 'Customers can personalize the product by entering some text or by providing custom image files.'|trans({}, 'Admin.Catalog.Feature') }}</p>
+      {{ form_errors(optionsForm.custom_fields) }}
+      <ul class="customFieldCollection nostyle" data-prototype="
+        {% filter escape %}
+          {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': optionsForm.custom_fields.vars.prototype }) }}
+        {% endfilter %}">
+        {% for field in optionsForm.custom_fields %}
+          <li>
+            {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': field }) }}
+          </li>
+        {% endfor %}
+      </ul>
+      <a href="#" class="btn btn-outline-secondary add">
+        <i class="material-icons">add_circle</i>
+        {{ 'Add a customization field'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-md-8">
+        <h2>{{ 'Attached files'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+        <p class="subtitle">{{ 'Select the files (instructions, documentation, recipes, etc.) your customers can directly download on this product page.'|trans({}, 'Admin.Catalog.Feature') }}
+          <br/>
+          {{ 'Need to browse all files? Go to [1]Catalog > Files[/1]'|trans({'[1]':'<a href="'~getAdminLink("AdminAttachments")~'">','[/1]':'</a>'}, 'Admin.Catalog.Feature')|raw }}
+        </p>
+        {{ form_widget(optionsForm.attachments) }}
+      </div>
+    </div>
+    <div class="row mt-3">
+      <div class="col-md-8">
+        <a class="btn btn-outline-secondary mb-3" href="#collapsedForm" data-toggle="collapse" aria-expanded="false" aria-controls="collapsedForm">
+          <i class="material-icons">add_circle</i>
+          {{ 'Attach a new file'|trans({}, 'Admin.Catalog.Feature') }}
+        </a>
+        <fieldset class="form-group collapse" id="collapsedForm">
+          {{ form_errors(optionsForm.attachment_product) }}
+          <div id="form_step6_attachment_product" data-action="{{ optionsForm.attachment_product.vars.attr['data-action'] }}">
+            <div class="form-group">{{ form_widget(optionsForm.attachment_product.file) }}</div>
+            <div class="form-group">{{ form_widget(optionsForm.attachment_product.name) }}</div>
+            <div class="form-group">{{ form_widget(optionsForm.attachment_product.description) }}</div>
+            <div class="form-group">
+              {{ form_widget(optionsForm.attachment_product.add) }}
+              {{ form_widget(optionsForm.attachment_product.cancel) }}
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-md-8" id="supplier_collection">
+        {{ include('@Product/ProductPage/Forms/form_supplier_choice.html.twig', { 'form': optionsForm }) }}
+      </div>
+    </div>
+    <div id="supplier_combination_collection" data-url="{{ path('admin_supplier_refresh_product_supplier_combination_form', { 'idProduct': productId, 'supplierIds': 1}) }}">
+      {{ include('@Product/ProductPage/Forms/form_supplier_combination.html.twig', { 'suppliers': optionsForm.suppliers.vars.value, 'form': optionsForm }) }}
+    </div>
+
+    {{ renderhook('displayAdminProductsOptionsStepBottom', { 'id_product': productId }) }}
+
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/pricing.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/pricing.html.twig
@@ -23,204 +23,192 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step2">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
-        <div class="row">
+  <div class="container-fluid">
 
-          <div class="col-md-12">
-            <h2>{{ 'Retail price'|trans({}, 'Admin.Catalog.Feature') }}
-              <span class="help-box" data-toggle="popover"
-                data-content="{{ "This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-            </h2>
-          </div>
+    <h2>{{ 'Retail price'|trans({}, 'Admin.Catalog.Feature') }}
+      <span class="help-box" 
+            data-toggle="popover" 
+            data-content="{{ "This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}">
+      </span>
+    </h2>
 
-          <div class="col-md-12 form-group">
-            <div class="row">
+    <div class="form-group">
+      <div class="row">
 
-              <div class="col-xl-2 col-lg-3">
-                <label class="form-control-label">{{ pricingForm.price.vars.label }}</label>
-                {{ form_errors(pricingForm.price) }}
-                {{ form_widget(pricingForm.price) }}
-              </div>
-              <div class="col-xl-2 col-lg-3">
-                <label class="form-control-label">{{ pricingForm.price_ttc.vars.label }}</label>
-                {{ form_errors(pricingForm.price_ttc) }}
-                {{ form_widget(pricingForm.price_ttc) }}
-              </div>
+        <div class="col-xl-2 col-lg-3">
+          <label class="form-control-label">{{ pricingForm.price.vars.label }}</label>
+          {{ form_errors(pricingForm.price) }}
+          {{ form_widget(pricingForm.price) }}
+        </div>
+        <div class="col-xl-2 col-lg-3">
+          <label class="form-control-label">{{ pricingForm.price_ttc.vars.label }}</label>
+          {{ form_errors(pricingForm.price_ttc) }}
+          {{ form_widget(pricingForm.price_ttc) }}
+        </div>
 
-              <div class="col-xl-4 col-lg-6 mx-auto">
-                <label class="form-control-label">
-                  {{ pricingForm.unit_price.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                <div class="row">
-                  <div class="col-md-6">
-                    {{ form_errors(pricingForm.unit_price) }}
-                    {{ form_widget(pricingForm.unit_price) }}
-                  </div>
-                  <div class="col-md-6">
-                    {{ form_errors(pricingForm.unity) }}
-                    {{ form_widget(pricingForm.unity) }}
-                  </div>
-                </div>
-              </div>
-              <div class="col-md-2 col-md-offset-1 {% if configuration('PS_USE_ECOTAX') != 1 %}hide{% endif %}">
-                <label class="form-control-label">{{ pricingForm.ecotax.vars.label }}</label>
-                {{ form_errors(pricingForm.ecotax) }}
-                {{ form_widget(pricingForm.ecotax) }}
-              </div>
+        <div class="col-xl-4 col-lg-6 mx-auto">
+          <label class="form-control-label">
+            {{ pricingForm.unit_price.vars.label }}
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "Some products can be purchased by unit (per bottle, per pound, etc.), and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+          </label>
+          <div class="row">
+            <div class="col-md-6">
+              {{ form_errors(pricingForm.unit_price) }}
+              {{ form_widget(pricingForm.unit_price) }}
+            </div>
+            <div class="col-md-6">
+              {{ form_errors(pricingForm.unity) }}
+              {{ form_widget(pricingForm.unity) }}
             </div>
           </div>
-
-          <div class="col-md-12">
-            <div class="row form-group">
-              <div class="col-md-4">
-                <label class="form-control-label">{{ pricingForm.id_tax_rules_group.vars.label }}</label>
-                {{ form_errors(pricingForm.id_tax_rules_group) }}
-                {{ form_widget(pricingForm.id_tax_rules_group) }}
-              </div>
-              <div class="col-md-8">
-                <label class="form-control-label">&nbsp;</label>
-                <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}" target="_blank">
-                  {{ 'Manage tax rules'|trans({}, 'Admin.Catalog.Feature') }}
-                </a>
-              </div>
-              <div class="col-md-12 pt-1">
-                {{ form_widget(pricingForm.on_sale) }}
-              </div>
-              <div class="col-md-12">
-                <div class="row">
-                  <div class="col-xl-5 col-lg-12">
-                    <div class="alert alert-info mt-2" role="alert">
-                      <p class="alert-text">
-                        {{ 'Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<strong>', '[/1]': '</strong>', '[2]': '<span id="final_retail_price_ti">', '[/2]': '</span>', '[3]': '<span id="final_retail_price_te">', '[/3]': '</span>', })|raw }}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="col-md-12">
-            <div class="row mb-3">
-              <div class="col-md-12">
-                <h2>
-                  {{ 'Cost price'|trans({}, 'Admin.Catalog.Feature') }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </h2>
-              </div>
-              <div class="col-xl-2 col-lg-3 form-group">
-                <label class="form-control-label">{{ pricingForm.wholesale_price.vars.label|raw }}</label>
-                {{ form_errors(pricingForm.wholesale_price) }}
-                {{ form_widget(pricingForm.wholesale_price) }}
-              </div>
-            </div>
-          </div>
-
-          <div class="col-md-12">
-            <div class="row mb-3">
-              <div class="col-md-12">
-                <h2>
-                  {{ 'Specific prices'|trans({}, 'Admin.Catalog.Feature') }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "You can set specific prices for customers belonging to different groups, different countries, etc."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </h2>
-              </div>
-              <div class="col-md-12">
-                <div id="specific-price" class="mb-2">
-                  <a id="js-open-create-specific-price-form" class="btn btn-outline-primary mb-3" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
-                    <i class="material-icons">add_circle</i>
-                    {{ 'Add a specific price'|trans({}, 'Admin.Catalog.Feature') }}
-                  </a>
-                  <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}">
-                      {{ include('@Product/ProductPage/Forms/form_specific_price.html.twig', {'form': pricingForm.specific_price, 'is_multishop_context': is_multishop_context}) }}
-                  </div>
-                  <table
-                      id="js-specific-price-list"
-                      class="table hide seo-table"
-                      data-listing-url="{{ path('admin_specific_price_list', { 'idProduct': 1 }) }}"
-                      data-action-delete="{{ path('admin_delete_specific_price', { 'idSpecificPrice': 1 }) }}"
-                      data-action-edit="{{ path('admin_get_specific_price_update_form', { 'idSpecificPrice': 1 }) }}">
-                    <thead class="thead-default">
-                    <tr>
-                      <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Rule'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Combination'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Currency'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Country'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Group'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Customer'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Fixed price'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Impact'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Period'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'From'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th></th>
-                      <th></th>
-                    </tr>
-                    </thead>
-                    <tbody></tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div>
-            {{ include('@Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig') }}
-          </div>
-
-
-          <div class="col-md-12">
-            <div class="row">
-              <div class="col-md-12">
-                <h2>
-                  {{ 'Priority management'|trans({}, 'Admin.Catalog.Feature') }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </h2>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>{{ 'Priorities'|trans({}, 'Admin.Catalog.Feature') }}</label>
-                  {{ form_errors(pricingForm.specificPricePriority_0) }}
-                  {{ form_widget(pricingForm.specificPricePriority_0) }}
-                </fieldset>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>&nbsp;</label>
-                  {{ form_errors(pricingForm.specificPricePriority_1) }}
-                  {{ form_widget(pricingForm.specificPricePriority_1) }}
-                </fieldset>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>&nbsp;</label>
-                  {{ form_errors(pricingForm.specificPricePriority_2) }}
-                  {{ form_widget(pricingForm.specificPricePriority_2) }}
-                </fieldset>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>&nbsp;</label>
-                  {{ form_errors(pricingForm.specificPricePriority_3) }}
-                  {{ form_widget(pricingForm.specificPricePriority_3) }}
-                </fieldset>
-              </div>
-              <div class="col-md-12">
-                {{ form_widget(pricingForm.specificPricePriorityToAll) }}
-              </div>
-            </div>
-          </div>
-
-          {{ renderhook('displayAdminProductsPriceStepBottom', { 'id_product': productId }) }}
-
+        </div>
+        <div class="col-md-2 col-md-offset-1 {% if configuration('PS_USE_ECOTAX') != 1 %}hide{% endif %}">
+          <label class="form-control-label">{{ pricingForm.ecotax.vars.label }}</label>
+          {{ form_errors(pricingForm.ecotax) }}
+          {{ form_widget(pricingForm.ecotax) }}
         </div>
       </div>
     </div>
+
+    <div class="row form-group">
+      <div class="col-md-4">
+        <label class="form-control-label">{{ pricingForm.id_tax_rules_group.vars.label }}</label>
+        {{ form_errors(pricingForm.id_tax_rules_group) }}
+        {{ form_widget(pricingForm.id_tax_rules_group) }}
+      </div>
+      <div class="col-md-8">
+        <label class="form-control-label">&nbsp;</label>
+        <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}" target="_blank">
+          {{ 'Manage tax rules'|trans({}, 'Admin.Catalog.Feature') }}
+        </a>
+      </div>
+      <div class="col-md-12 pt-1">
+        {{ form_widget(pricingForm.on_sale) }}
+      </div>
+      <div class="col-md-12">
+        <div class="row">
+          <div class="col-xl-5 col-lg-12">
+            <div class="alert alert-info mt-2" role="alert">
+              <p class="alert-text">
+                {{ 'Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<strong>', '[/1]': '</strong>', '[2]': '<span id="final_retail_price_ti">', '[/2]': '</span>', '[3]': '<span id="final_retail_price_te">', '[/3]': '</span>', })|raw }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-12">
+        <h2>
+          {{ 'Cost price'|trans({}, 'Admin.Catalog.Feature') }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </h2>
+      </div>
+      <div class="col-xl-2 col-lg-3 form-group">
+        <label class="form-control-label">{{ pricingForm.wholesale_price.vars.label|raw }}</label>
+        {{ form_errors(pricingForm.wholesale_price) }}
+        {{ form_widget(pricingForm.wholesale_price) }}
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-12">
+        <h2>
+          {{ 'Specific prices'|trans({}, 'Admin.Catalog.Feature') }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "You can set specific prices for customers belonging to different groups, different countries, etc."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </h2>
+      </div>
+      <div class="col-md-12">
+        <div id="specific-price" class="mb-2">
+          <a id="js-open-create-specific-price-form" class="btn btn-outline-primary mb-3" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
+            <i class="material-icons">add_circle</i>
+            {{ 'Add a specific price'|trans({}, 'Admin.Catalog.Feature') }}
+          </a>
+          <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}">
+            {{ include('@Product/ProductPage/Forms/form_specific_price.html.twig', {'form': pricingForm.specific_price, 'is_multishop_context': is_multishop_context}) }}
+          </div>
+          <table id="js-specific-price-list" class="table hide seo-table" data-listing-url="{{ path('admin_specific_price_list', { 'idProduct': 1 }) }}" data-action-delete="{{ path('admin_delete_specific_price', { 'idSpecificPrice': 1 }) }}" data-action-edit="{{ path('admin_get_specific_price_update_form', { 'idSpecificPrice': 1 }) }}">
+            <thead class="thead-default">
+              <tr>
+                <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Rule'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Combination'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Currency'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Country'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Group'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Customer'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Fixed price'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Impact'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Period'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'From'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      {{ include('@Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig') }}
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <h2>
+          {{ 'Priority management'|trans({}, 'Admin.Catalog.Feature') }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </h2>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>{{ 'Priorities'|trans({}, 'Admin.Catalog.Feature') }}</label>
+          {{ form_errors(pricingForm.specificPricePriority_0) }}
+          {{ form_widget(pricingForm.specificPricePriority_0) }}
+        </fieldset>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>&nbsp;</label>
+          {{ form_errors(pricingForm.specificPricePriority_1) }}
+          {{ form_widget(pricingForm.specificPricePriority_1) }}
+        </fieldset>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>&nbsp;</label>
+          {{ form_errors(pricingForm.specificPricePriority_2) }}
+          {{ form_widget(pricingForm.specificPricePriority_2) }}
+        </fieldset>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>&nbsp;</label>
+          {{ form_errors(pricingForm.specificPricePriority_3) }}
+          {{ form_widget(pricingForm.specificPricePriority_3) }}
+        </fieldset>
+      </div>
+      <div class="col-md-12">
+        {{ form_widget(pricingForm.specificPricePriorityToAll) }}
+      </div>
+    </div>
+
+    {{ renderhook('displayAdminProductsPriceStepBottom', { 'id_product': productId }) }}
+
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/seo.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/Panels/seo.html.twig
@@ -23,17 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step5">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
-        <div class="row">
-          {{ include('@Product/ProductPage/Forms/form_seo.html.twig', {
-            'seoForm' : seoForm,
-            'productId': productId
-            })
-          }}
-        </div>
-      </div>
-    </div>
+  <div class="container-fluid">
+    {{ include('@Product/ProductPage/Forms/form_seo.html.twig', {
+      'seoForm' : seoForm,
+      'productId': productId
+      })
+    }}
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/product.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Product/ProductPage/product.html.twig
@@ -113,8 +113,6 @@
         {# PANEL SHIPPING #}
         {% block product_panel_shipping %}
           <div role="tabpanel" class="form-contenttab tab-pane" id="step4">
-            <div class="row">
-              <div class="col-md-12">
                 <div class="container-fluid">
                   <div class="row">
                     {{ include('@Product/ProductPage/Forms/form_shipping.html.twig', {
@@ -126,8 +124,6 @@
                     }) }}
                   </div>
                 </div>
-              </div>
-            </div>
           </div>
         {% endblock %}
 
@@ -160,93 +156,73 @@
         {% block product_panel_modules %}
           {% if hooksarraycontent(hooks) is not empty %}
             <div role="tabpanel" class="form-contenttab tab-pane" id="hooks">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="container-fluid">
-                    <div class="row">
-
-                      {# LEFT #}
-                      <div class="col-md-12">
-                        <div class="row module-selection" style="display: none;">
-                          <div class="col-md-12 col-lg-7">
-                            {% for module in hooks %}
-                              <div class="module-render-container module-{{ module.attributes.name }}">
-                                <div>
-                                  <img class="top-logo" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
-                                  <h2 class="text-ellipsis module-name-grid">
-                                    {{ module.attributes.displayName }}
-                                  </h2>
-                                  <div class="text-ellipsis small-text module-version">
-                                    {{ module.attributes.version }} by {{ module.attributes.author }}
-                                  </div>
-                                </div>
-                                <div class="small no-padding">
-                                  {{ module.attributes.description }}
-                                </div>
-                              </div>
-                            {% endfor %}
-                          </div>
-                          <div class="col-md-12 col-lg-5">
-                            <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                            <select class="modules-list-select" data-toggle="select2">
-                              {% for module in hooks %}
-                                <option value="module-{{ module.attributes.name }}">{{ module.attributes.displayName }}</option>
-                              {% endfor %}
-                            </select>
-                          </div>
+              <div class="container-fluid">
+                <div class="row module-selection" style="display: none;">
+                  <div class="col-lg-7">
+                    {% for module in hooks %}
+                      <div class="module-render-container module-{{ module.attributes.name }}">
+                        <div>
+                          <img class="top-logo" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
+                          <h2 class="text-ellipsis module-name-grid">{{ module.attributes.displayName }}</h2>
+                          <div class="text-ellipsis small-text module-version">{{ module.attributes.version }} by {{ module.attributes.author }}</div>
                         </div>
-
-                        <div class="module-render-container all-modules">
-                          <p>
-                            <h2>{{ 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                            {{ 'These modules are relative to the product page of your shop.'|trans({}, 'Admin.Catalog.Feature') }}<br />
-                            {{ 'To manage all your modules go to the [1]Installed module page[/1]'|trans({}, 'Admin.Catalog.Feature')|replace({'[1]': '<a href="' ~ path("admin_module_manage") ~ '">', '[/1]': '</a>'})|raw }}
-                          </p>
-                          <div class="row">
-                            {% for module in hooks %}
-                              <div class="col-md-12 col-lg-6 col-xl-4">
-                                <div class="module-item-wrapper-grid">
-                                  <div class="module-item-heading-grid">
-                                    <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
-                                    <h3 class="text-ellipsis module-name-grid">
-                                      {{ module.attributes.displayName }}
-                                    </h3>
-                                    <div class="text-ellipsis small-text module-version-author-grid">
-                                      {{ module.attributes.version }} by {{ module.attributes.author }}
-                                    </div>
-                                  </div>
-                                  <div class="module-quick-description-grid small no-padding">
-                                    {{ module.attributes.description }}
-                                  </div>
-                                  <div class="module-container">
-                                    <div class="module-quick-action-grid clearfix">
-                                      <button class="modules-list-button btn btn-outline-primary pull-xs-right" data-target="module-{{ module.id }}">
-                                        {{ 'Configure'|trans({}, 'Admin.Actions') }}
-                                      </button>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            {% endfor %}
-                          </div>
+                        <div class="small no-padding">
+                          {{ module.attributes.description }}
                         </div>
-
-                        {% for module in hooks %}
-                          <div
-                            id="module_{{ module.id }}"
-                            class="module-render-container module-{{ module.attributes.name }}"
-                            style="display: none;"
-                          >
-                            <div>
-                              {{ module.content|raw }}
-                            </div>
-                          </div>
-                        {% endfor %}
                       </div>
-
-                    </div>
+                    {% endfor %}
+                  </div>
+                  <div class="col-lg-5">
+                    <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+                    <select class="modules-list-select" data-toggle="select2">
+                      {% for module in hooks %}
+                        <option value="module-{{ module.attributes.name }}">{{ module.attributes.displayName }}</option>
+                      {% endfor %}
+                    </select>
                   </div>
                 </div>
+
+                <div class="module-render-container all-modules">
+                  <div>
+                    <h2>{{ 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+                    <p>{{ 'These modules are relative to the product page of your shop.'|trans({}, 'Admin.Catalog.Feature') }}<br />
+                    {{ 'To manage all your modules go to the [1]Installed module page[/1]'|trans({}, 'Admin.Catalog.Feature')|replace({'[1]': '<a href="' ~ path("admin_module_manage") ~ '">', '[/1]': '</a>'})|raw }}</p>
+                  </div>
+                  <div class="row">
+                    {% for module in hooks %}
+                      <div class="col-lg-6 col-xl-4">
+                        <div class="module-item-wrapper-grid">
+                          <div class="module-item-heading-grid">
+                            <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
+                            <h3 class="text-ellipsis module-name-grid">
+                              {{ module.attributes.displayName }}
+                            </h3>
+                            <div class="text-ellipsis small-text module-version-author-grid">
+                              {{ module.attributes.version }} by {{ module.attributes.author }}
+                            </div>
+                          </div>
+                          <div class="module-quick-description-grid small no-padding">
+                            {{ module.attributes.description }}
+                          </div>
+                          <div class="module-container">
+                            <div class="module-quick-action-grid clearfix">
+                              <button class="modules-list-button btn btn-outline-primary pull-xs-right" data-target="module-{{ module.id }}">
+                                {{ 'Configure'|trans({}, 'Admin.Actions') }}
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+
+                {% for module in hooks %}
+                  <div id="module_{{ module.id }}" class="module-render-container module-{{ module.attributes.name }}" style="display: none;">
+                    <div>{{ module.content|raw }}</div>
+                  </div>
+                {% endfor %}
+
               </div>
             </div>
           {% endif %}

--- a/templates/bundles/PrestaShopBundle/Admin/ProductImage/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/ProductImage/form.html.twig
@@ -25,10 +25,10 @@
 <button type="button" class="float-right close" onclick="formImagesProduct.close()"><i class="material-icons">close</i></button>
 
 <div class="row">
-    <div class="col-lg-12 col-xl-7">
+    <div class="col-xl-7">
       {{ form_widget(form.cover) }}
     </div>
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
         <a href="{{ image.base_image_url }}.{{ image.format }}" class="btn btn-link btn-sm open-image" target="_blank">
           <i class="material-icons">zoom_in</i> {{ 'Zoom'|trans({}, 'Admin.Catalog.Feature') }}
         </a>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Address/add.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Address/add.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Sell/Address/Blocks/form.html.twig', {'addressForm': addressForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Sell/Address/Blocks/form.html.twig', {'addressForm': addressForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Address/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Address/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Sell/Address/Blocks/form.html.twig', {'addressForm': addressForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Sell/Address/Blocks/form.html.twig', {'addressForm': addressForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Address/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Address/index.html.twig
@@ -27,34 +27,18 @@
 
 {% block content %}
   {% block addresses_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': addressGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': addressGrid} %}
   {% endblock %}
 
   {% block address_required_fields_form %}
-    <div class="row">
-      <div class="col-md-12">
-        <p>
-          <button class="btn btn-primary"
-                  type="button"
-                  data-toggle="collapse"
-                  data-target="#addressRequiredFieldsContainer"
-                  aria-expanded="false"
-                  aria-controls="addressRequiredFieldsContainer"
-          >
-            <i class="material-icons">add_circle</i>
-            {{ 'Set required fields for this section'|trans({}, 'Admin.Orderscustomers.Feature') }}
-          </button>
-        </p>
-      </div>
+    <p>
+      <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#addressRequiredFieldsContainer" aria-expanded="false" aria-controls="addressRequiredFieldsContainer">
+        <i class="material-icons">add_circle</i>
+        {{ 'Set required fields for this section'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </button>
+    </p>
 
-      <div class="col-md-12">
-        {% include '@PrestaShop/Admin/Sell/Address/Blocks/required_fields.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Address/Blocks/required_fields.html.twig' %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attachment/add.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attachment/add.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attachment/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attachment/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' with {'attachmentId': attachmentId} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' with {'attachmentId': attachmentId} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attachment/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attachment/index.html.twig
@@ -27,11 +27,7 @@
 
 {% block content %}
   {% block attachments_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attachmentGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attachmentGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attribute/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Attribute/index.html.twig
@@ -35,21 +35,16 @@
 
 {% block content %}
   {% block attributes_listing %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGrid} %}
-          {% block grid_panel_footer %}
-            <div class="card-footer">
-              <a href="{{ path('admin_attribute_groups_index') }}"
-                 class="btn btn-outline-secondary">
-                <i class="material-icons">arrow_back</i>
-                {{ 'Back to list'|trans({}, 'Admin.Actions') }}
-              </a>
-            </div>
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGrid} %}
+      {% block grid_panel_footer %}
+        <div class="card-footer">
+          <a href="{{ path('admin_attribute_groups_index') }}" class="btn btn-outline-secondary">
+            <i class="material-icons">arrow_back</i>
+            {{ 'Back to list'|trans({}, 'Admin.Actions') }}
+          </a>
+        </div>
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/AttributeGroup/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/AttributeGroup/index.html.twig
@@ -36,19 +36,11 @@
 {% block content %}
 
   {% block attribute_group_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/AttributeGroup/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/AttributeGroup/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block attributes_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGroupGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGroupGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CartRule/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CartRule/index.html.twig
@@ -27,11 +27,7 @@
 
 {% block content %}
   {% block cart_rule_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cartRuleGrid} %}
-      </div>
-    </div>
+    {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cartRuleGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CatalogPriceRule/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CatalogPriceRule/create.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CatalogPriceRule/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CatalogPriceRule/edit.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CatalogPriceRule/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/CatalogPriceRule/index.html.twig
@@ -36,11 +36,7 @@
 
 {% block content %}
   {% block catalog_price_rule_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': catalogPriceRuleGrid} %}
-      </div>
-    </div>
+    {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': catalogPriceRuleGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/delete_block.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/Blocks/delete_block.html.twig
@@ -25,39 +25,31 @@
 
 {% if isDeleteSubmitted %}
   {{ form_start(deleteCategoriesForm) }}
-    <div class="col-md-12">
-      <div class="card">
-        <h3 class="card-header">
-          {{ 'What do you want to do with the products associated with this category?'|trans({}, 'Admin.Catalog.Notification') }}
-        </h3>
-        <div class="card-body">
-          <div class="row">
-            <div class="col">
-                <div class="form-group mb-0">
-                  {{ form_widget(deleteCategoriesForm.delete_mode) }}
-                </div>
-                <div class="d-none">
-                  {{ form_widget(deleteCategoriesForm.categories_to_delete) }}
-                </div>
-            </div>
-          </div>
+  <div class="col-md-12">
+    <div class="card">
+      <h3 class="card-header">
+        {{ 'What do you want to do with the products associated with this category?'|trans({}, 'Admin.Catalog.Notification') }}
+      </h3>
+      <div class="card-body">
+        <div class="form-group mb-0">
+          {{ form_widget(deleteCategoriesForm.delete_mode) }}
         </div>
-        <div class="card-footer">
-          <a class="btn btn-secondary btn-sm"
-             href="{{ path('admin_categories_index') }}"
-          >
-            <i class="material-icons">cancel</i>
-            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-          </a>
-
-          <button class="btn btn-danger btn-sm"
-                  type="submit"
-          >
-            <i class="material-icons">delete</i>
-            {{ 'Delete'|trans({}, 'Admin.Actions') }}
-          </button>
+        <div class="d-none">
+          {{ form_widget(deleteCategoriesForm.categories_to_delete) }}
         </div>
       </div>
+      <div class="card-footer">
+        <a class="btn btn-secondary btn-sm" href="{{ path('admin_categories_index') }}">
+          <i class="material-icons">cancel</i>
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </a>
+
+        <button class="btn btn-danger btn-sm" type="submit">
+          <i class="material-icons">delete</i>
+          {{ 'Delete'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
     </div>
+  </div>
   {{ form_end(deleteCategoriesForm) }}
 {% endif %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/create.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/create_root.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/create_root.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {'categoryForm': rootCategoryForm} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {'categoryForm': rootCategoryForm} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/edit.html.twig
@@ -28,16 +28,12 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
-        'categoryForm': editCategoryForm,
-        'thumbnailImage': editableCategory.thumbnailImage,
-        'coverImage': editableCategory.coverImage,
-        'menuThumbnailImages': editableCategory.menuThumbnailImages,
-      } %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
+    'categoryForm': editCategoryForm,
+    'thumbnailImage': editableCategory.thumbnailImage,
+    'coverImage': editableCategory.coverImage,
+    'menuThumbnailImages': editableCategory.menuThumbnailImages,
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/edit_root.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/edit_root.html.twig
@@ -28,16 +28,12 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
-        'categoryForm': editRootCategoryForm,
-        'thumbnailImage': editableCategory.thumbnailImage,
-        'coverImage': editableCategory.coverImage,
-        'menuThumbnailImages': editableCategory.menuThumbnailImages,
-      } %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
+    'categoryForm': editRootCategoryForm,
+    'thumbnailImage': editableCategory.thumbnailImage,
+    'coverImage': editableCategory.coverImage,
+    'menuThumbnailImages': editableCategory.menuThumbnailImages,
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Categories/index.html.twig
@@ -31,50 +31,34 @@
 
 {% block content %}
   {% block category_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block categories_kpis %}
-    <div class="row">
-      <div class="col">
-        <div class="card card-kpis">
-          <div class="row">
-            {{ render(controller(
+    <div class="card card-kpis">
+      <div class="row">
+        {{ render(controller(
               'PrestaShopBundle:Admin\\Common:renderKpiRow',
               { 'kpiRow': categoriesKpi }
             )) }}
-          </div>
-        </div>
       </div>
     </div>
   {% endblock %}
 
   {% block categories_breadcrumb %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig' %}
   {% endblock %}
 
   {% block categories_listing %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': categoriesGrid} %}
-          {% block grid_panel_footer %}
-            {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/listing_panel_footer.html.twig' %}
-          {% endblock %}
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': categoriesGrid} %}
+      {% block grid_panel_footer %}
+        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/listing_panel_footer.html.twig' %}
+      {% endblock %}
 
-          {% block grid_panel_extra_content %}
-            {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig' %}
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+      {% block grid_panel_extra_content %}
+        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig' %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Features/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Features/create.html.twig
@@ -31,14 +31,10 @@
   {% if showDisabledFeatureWarning is defined and showDisabledFeatureWarning %}
     {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' %}
   {% else %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
-          featureId: null,
-          featureForm: featureForm
-        } %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
+      featureId: null,
+      featureForm: featureForm
+    } %}
   {% endif %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Features/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Features/edit.html.twig
@@ -31,14 +31,10 @@
   {% if showDisabledFeatureWarning is defined and showDisabledFeatureWarning %}
     {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' %}
   {% else %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
-          featureId: editableFeature.featureId.getValue,
-          featureForm: featureForm
-        } %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
+      featureId: editableFeature.featureId.getValue,
+      featureForm: featureForm
+    } %}
   {% endif %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/Address/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/Address/create.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/Address/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/Address/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/add.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/add.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/edit.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/index.html.twig
@@ -42,19 +42,11 @@
 {% block content %}
   {% block manufacturers_listing %}
     {{ ps.infotip(settingsTipMessage, true) }}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
   {% endblock %}
 
   {% block manufacturers_address_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerAddressGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerAddressGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Manufacturer/view.html.twig
@@ -26,16 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/addresses.html.twig' %}
-    </div>
-  </div>
 
-  <div class="row mt-3">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig' %}
-    </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/addresses.html.twig' %}
+
+  <div class="mt-3">
+    {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig' %}
   </div>
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Monitoring/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Monitoring/index.html.twig
@@ -27,87 +27,55 @@
 
 {% block content %}
   {% block monitoring_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Monitoring/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Monitoring/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block empty_categories_listing %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': emptyCategoryGrid} %}
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': emptyCategoryGrid} %}
 
-          {% block grid_panel_body %}
-            <div class="card-body">
-              <div class="alert alert-info">
-                <div class="alert-text">
-                  {{ 'An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.'|trans({}, 'Admin.Catalog.Help') }}
-                </div>
-              </div>
-              {% block grid_view_block %}
-                {{ include('@PrestaShop/Admin/Common/Grid/grid.html.twig', {'grid': emptyCategoryGrid }) }}
-              {% endblock %}
+      {% block grid_panel_body %}
+        <div class="card-body">
+          <div class="alert alert-info">
+            <div class="alert-text">
+              {{ 'An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.'|trans({}, 'Admin.Catalog.Help') }}
             </div>
+          </div>
+          {% block grid_view_block %}
+            {{ include('@PrestaShop/Admin/Common/Grid/grid.html.twig', {'grid': emptyCategoryGrid }) }}
           {% endblock %}
+        </div>
+      {% endblock %}
 
-          {% block grid_panel_extra_content %}
-            {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig'
+      {% block grid_panel_extra_content %}
+        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig'
               with {'deleteCategoriesForm': deleteCategoryForm }
             %}
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 
   {% block no_qty_product_with_combinations_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithCombinationGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithCombinationGrid} %}
   {% endblock %}
 
   {% block no_qty_product_without_combinations_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithoutCombinationGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithoutCombinationGrid} %}
   {% endblock %}
 
   {% block disabled_product_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': disabledProductGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': disabledProductGrid} %}
   {% endblock %}
 
   {% block product_without_image_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutImageGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutImageGrid} %}
   {% endblock %}
 
   {% block product_without_description_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutDescriptionGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutDescriptionGrid} %}
   {% endblock %}
 
   {% block product_without_price_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutPriceGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutPriceGrid} %}
   {% endblock %}
 
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 <div class="row module-selection d-none">
-  <div class="col-md-12 col-lg-7">
+  <div class="col-lg-7">
     {% for module in extraModules %}
       <div class="module-render-container module-{{ module.attributes.name }}">
         <div>
@@ -43,7 +43,7 @@
     {% endfor %}
   </div>
 
-  <div class="col-md-12 col-lg-5">
+  <div class="col-lg-5">
     <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
     <select class="modules-list-select" data-toggle="select2">
       {% for module in extraModules %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig
@@ -32,7 +32,7 @@
 
   <div class="row">
     {% for module in extraModules %}
-      <div class="col-md-12 col-lg-6 col-xl-4">
+      <div class="col-lg-6 col-xl-4">
         <div class="module-item-wrapper-grid">
           <div class="module-item-heading-grid">
             <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -32,23 +32,20 @@
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-sm-12">
-    {{ form_start(combinationForm, {'attr': {'class': 'form-horizontal combination-page', 'novalidate': 'novalidate'}}) }}
-    <div class="card">
-      <div class="card-header">
-        {{ 'Combination details'|trans({}, 'Admin.Catalog.Feature') }} -
-        <span>{{ combinationForm.vars.value.name }}</span>
-      </div>
-      <div class="card-block row">
-        <div id="{{ combinationForm.vars.id }}">
-          {{ form_row(combinationForm) }}
-        </div>
+  {{ form_start(combinationForm, {'attr': {'class': 'form-horizontal combination-page', 'novalidate': 'novalidate'}}) }}
+  <div class="card">
+    <div class="card-header">
+      {{ 'Combination details'|trans({}, 'Admin.Catalog.Feature') }}
+      -
+      <span>{{ combinationForm.vars.value.name }}</span>
+    </div>
+    <div class="card-block row">
+      <div id="{{ combinationForm.vars.id }}">
+        {{ form_row(combinationForm) }}
       </div>
     </div>
-    {{ form_end(combinationForm) }}
   </div>
-</div>
+  {{ form_end(combinationForm) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Form/features_form_theme.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Product/Form/features_form_theme.html.twig
@@ -32,14 +32,14 @@
 
 {%- block feature_value_row -%}
   <div class="form-group row product-feature">
-    <div class="col-lg-12 col-xl-3">
+    <div class="col-xl-3">
       <fieldset class="form-group mb-0">
         <label class="form-control-label">{{ form.feature_id.vars.label }}</label>
         {{ form_widget(form.feature_id) }}
         {{ form_errors(form.feature_id) }}
       </fieldset>
     </div>
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
       <fieldset class="form-group mb-0">
         <label class="form-control-label">{{ form.feature_value_id.vars.label }}</label>
         {{ form_widget(form.feature_value_id) }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/add.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/add.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/edit.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -37,11 +37,7 @@
 {% block content %}
   {% block supplier_grid %}
     {{ ps.infotip(settingsTipMessage, true) }}
-    <div class="row">
-      <div class="col">
-        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
-      </div>
-    </div>
+    {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Catalog/Suppliers/view.html.twig
@@ -26,9 +26,5 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/View/products.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/View/products.html.twig' %}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/Blocks/View/addresses.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/Blocks/View/addresses.html.twig
@@ -29,24 +29,15 @@
     {{ 'Addresses'|trans({}, 'Admin.Global') }}
     <span class="badge badge-primary rounded">{{ customerInformation.addressesInformation|length }}</span>
 
-    <a href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}"
-       class="tooltip-link float-right"
-       data-toggle="pstooltip"
-       title=""
-       data-placement="top"
-       data-original-title="{{ 'Add'|trans({}, 'Admin.Actions') }}"
-    >
+    <a href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}" class="tooltip-link float-right" 
+    data-toggle="pstooltip" title="" data-placement="top" data-original-title="{{ 'Add'|trans({}, 'Admin.Actions') }}">
       <i class="material-icons">add_circle</i>
     </a>
   </h3>
 
   <div class="card-body">
     {% if customerAddressGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerAddressGrid} %}
-        </div>
-      </div>
+      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerAddressGrid} %}
     {% else %}
       <p class="text-muted text-center mb-0">
         {{ '%firstname% %lastname% has not registered any addresses yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/Blocks/View/discounts.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/Blocks/View/discounts.html.twig
@@ -31,11 +31,7 @@
   </h3>
   <div class="card-body">
     {% if customerDiscountGrid.data.records_total > 0 %}
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerDiscountGrid} %}
-        </div>
-      </div>
+      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerDiscountGrid} %}
     {% else %}
       <p class="text-muted text-center mb-0">
         {{ '%firstname% %lastname% has no discount vouchers'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -52,101 +52,85 @@
         </div>
       </div>
 
-      <div class="row">
-        <div class="col">
-          {% if validOrdersCount %}
-            <table class="table">
-              <thead>
-              <tr>
-                <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Total spent'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-                <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
+      {% if validOrdersCount %}
+        <table class="table">
+          <thead>
+            <tr>
+              <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Total spent'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for order in customerInformation.ordersInformation.validOrders %}
+              {% set orderViewUrl = getAdminLink('AdminOrders', true, {'id_order': order.orderId, 'vieworder': 1}) %}
+
+              <tr class="customer-valid-order">
+                <td class="customer-valid-order-id js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderId }}</td>
+                <td class="customer-valid-order-date js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderPlacedDate }}</td>
+                <td class="customer-valid-order-payment js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.paymentMethodName }}</td>
+                <td class="customer-valid-order-status js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderStatus }}</td>
+                <td class="customer-valid-order-products js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderProductsCount }}</td>
+                <td class="customer-valid-order-total js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.totalPaid }}</td>
+                <td class="customer-valid-order-actions text-right">
+                  <div class="btn-group-action">
+                    <div class="btn-group">
+                      <a href="{{ orderViewUrl }}" class="btn tooltip-link dropdown-item view-link" data-toggle="pstooltip" data-placement="top" data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}">
+                        <i class="material-icons">zoom_in</i>
+                      </a>
+                    </div>
+                  </div>
+                </td>
               </tr>
-              </thead>
-              <tbody>
-              {% for order in customerInformation.ordersInformation.validOrders %}
-                {% set orderViewUrl = getAdminLink('AdminOrders', true, {'id_order': order.orderId, 'vieworder': 1}) %}
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
 
-                <tr class="customer-valid-order">
-                  <td class="customer-valid-order-id js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderId }}</td>
-                  <td class="customer-valid-order-date js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderPlacedDate }}</td>
-                  <td class="customer-valid-order-payment js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.paymentMethodName }}</td>
-                  <td class="customer-valid-order-status js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderStatus }}</td>
-                  <td class="customer-valid-order-products js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderProductsCount }}</td>
-                  <td class="customer-valid-order-total js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.totalPaid }}</td>
-                  <td class="customer-valid-order-actions text-right">
-                    <div class="btn-group-action">
-                      <div class="btn-group">
-                        <a href="{{ orderViewUrl }}"
-                           class="btn tooltip-link dropdown-item view-link"
-                           data-toggle="pstooltip"
-                           data-placement="top"
-                           data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}"
-                        >
-                          <i class="material-icons">zoom_in</i>
-                        </a>
-                      </div>
+
+      {% if invalidOrdersCount %}
+        <table class="table">
+          <thead>
+            <tr>
+              <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
+              <th>{{ 'Total spent'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for order in customerInformation.ordersInformation.invalidOrders %}
+              {% set orderViewUrl = getAdminLink('AdminOrders', true, {'id_order': order.orderId, 'vieworder': 1}) %}
+
+              <tr class="customer-invalid-order">
+                <td class="customer-invalid-order-id js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderId }}</td>
+                <td class="customer-invalid-order-date js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderPlacedDate }}</td>
+                <td class="customer-invalid-order-payment js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.paymentMethodName }}</td>
+                <td class="customer-invalid-order-status js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderStatus }}</td>
+                <td class="customer-invalid-order-products js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderProductsCount }}</td>
+                <td class="customer-invalid-order-total js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.totalPaid }}</td>
+                <td class="text-right customer-invalid-order-actions">
+                  <div class="btn-group-action">
+                    <div class="btn-group">
+                      <a href="{{ orderViewUrl }}" class="btn tooltip-link dropdown-item grid-view-row-link" data-toggle="pstooltip" data-placement="top" data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}">
+                        <i class="material-icons">zoom_in</i>
+                      </a>
                     </div>
-                  </td>
-                </tr>
-              {% endfor %}
-              </tbody>
-            </table>
-          {% endif %}
-        </div>
-      </div>
+                  </div>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
 
-      <div class="row">
-        <div class="col">
-          {% if invalidOrdersCount %}
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Total spent'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-                  <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
-                </tr>
-              </thead>
-              <tbody>
-              {% for order in customerInformation.ordersInformation.invalidOrders %}
-                {% set orderViewUrl = getAdminLink('AdminOrders', true, {'id_order': order.orderId, 'vieworder': 1}) %}
-
-                <tr class="customer-invalid-order">
-                  <td class="customer-invalid-order-id js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderId }}</td>
-                  <td class="customer-invalid-order-date js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderPlacedDate }}</td>
-                  <td class="customer-invalid-order-payment js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.paymentMethodName }}</td>
-                  <td class="customer-invalid-order-status js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderStatus }}</td>
-                  <td class="customer-invalid-order-products js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderProductsCount }}</td>
-                  <td class="customer-invalid-order-total js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.totalPaid }}</td>
-                  <td class="text-right customer-invalid-order-actions">
-                    <div class="btn-group-action">
-                      <div class="btn-group">
-                        <a href="{{ orderViewUrl }}"
-                           class="btn tooltip-link dropdown-item grid-view-row-link"
-                           data-toggle="pstooltip"
-                           data-placement="top"
-                           data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}"
-                        >
-                          <i class="material-icons">zoom_in</i>
-                        </a>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              {% endfor %}
-              </tbody>
-            </table>
-          {% endif %}
-        </div>
-      </div>
     {% else %}
       <p class="text-muted text-center">
         {{ '%firstname% %lastname% has not placed any orders yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/create.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Customer/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Customer/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/edit.html.twig
@@ -30,11 +30,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Customer/Blocks/form.html.twig' with {'isGuest': customerInformation.personalInformation.guest} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Customer/Blocks/form.html.twig' with {'isGuest': customerInformation.personalInformation.guest} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/index.html.twig
@@ -30,73 +30,44 @@
 
 {% block content %}
   {% block employee_helper_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Customer/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Customer/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block customers_kpis %}
-    <div class="row">
-      <div class="col-md-12">
-        <div class="card card-kpis">
-          <div class="row">
-            {{ render(controller(
-              'PrestaShopBundle:Admin\\Common:renderKpiRow',
-              { 'kpiRow': customersKpi }
-            )) }}
-          </div>
-        </div>
+    <div class="card card-kpis">
+      <div class="row">
+        {{ render(controller(
+          'PrestaShopBundle:Admin\\Common:renderKpiRow',
+          { 'kpiRow': customersKpi }
+        )) }}
       </div>
     </div>
   {% endblock %}
 
   {% block customers_listing %}
     {% if not isSingleShopContext %}
-      <div class="row">
-        <div class="col-md-12">
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'You have to select a shop if you want to create a customer.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-            </p>
-          </div>
-        </div>
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {{ 'You have to select a shop if you want to create a customer.'|trans({}, 'Admin.Orderscustomers.Notification') }}
+        </p>
       </div>
     {% endif %}
 
-    <div class="row">
-      <div class="col-12">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerGrid} %}
-          {% block grid_panel_extra_content %}
-            {% include '@PrestaShop/Admin/Sell/Customer/Blocks/delete_modal.html.twig' %}
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': customerGrid} %}
+      {% block grid_panel_extra_content %}
+        {% include '@PrestaShop/Admin/Sell/Customer/Blocks/delete_modal.html.twig' %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 
   {% block customer_required_fields_form %}
-    <div class="row">
-      <div class="col-md-12">
-        <p>
-          <button class="btn btn-primary"
-                  type="button"
-                  data-toggle="collapse"
-                  data-target="#customerRequiredFieldsContainer"
-                  aria-expanded="false"
-                  aria-controls="customerRequiredFieldsContainer"
-          >
-            <i class="material-icons">add_circle</i>
-            {{ 'Set required fields for this section'|trans({}, 'Admin.Orderscustomers.Feature') }}
-          </button>
-        </p>
-      </div>
-
-      <div class="col-md-12">
-        {% include '@PrestaShop/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig' %}
-      </div>
-    </div>
+    <p>
+      <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#customerRequiredFieldsContainer" aria-expanded="false" aria-controls="customerRequiredFieldsContainer">
+        <i class="material-icons">add_circle</i>
+        {{ 'Set required fields for this section'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </button>
+    </p>
+    {% include '@PrestaShop/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig' %}
   {% endblock %}
 {% endblock %}
 
@@ -105,4 +76,3 @@
 
   {% include '@PrestaShop/Admin/Sell/Customer/Blocks/javascript.html.twig' %}
 {% endblock %}
-

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Customer/view.html.twig
@@ -47,13 +47,8 @@
     </div>
   </div>
 
-  <div class="row">
-    {{ renderhook('displayAdminCustomers', {'id_customer': customerInformation.customerId.value}) }}
-
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Customer/Blocks/View/addresses.html.twig' %}
-    </div>
-  </div>
+  {{ renderhook('displayAdminCustomers', {'id_customer': customerInformation.customerId.value}) }}
+  {% include '@PrestaShop/Admin/Sell/Customer/Blocks/View/addresses.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/CustomerThread/Block/thread_messages.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/CustomerThread/Block/thread_messages.html.twig
@@ -23,61 +23,57 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div class="row">
-  <div class="col">
-    <ul class="list-unstyled ml-5">
-      {% for message in customerThreadView.messages %}
-        {% if not loop.first %}
-          <li>
-            <hr class="mb-3 mt-0">
-          </li>
-        {% endif %}
+<ul class="list-unstyled ml-5">
+  {% for message in customerThreadView.messages %}
+    {% if not loop.first %}
+      <li>
+        <hr class="mb-3 mt-0">
+      </li>
+    {% endif %}
 
-        <li class="media">
-          {% if message.type == 'customer' %}
-            <i class="material-icons thread-message-icon">person</i>
+    <li class="media">
+      {% if message.type == 'customer' %}
+        <i class="material-icons thread-message-icon">person</i>
+      {% else %}
+        <img class="rounded-circle thread-message-employee-image" src="{{ message.employeeImage }}">
+      {% endif %}
+
+      <div class="media-body ml-2">
+        <h4 class="mt-0 mb-1">
+          <i class="material-icons text-muted">reply</i>
+
+          {% if message.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\CustomerService\\ValueObject\\CustomerThreadMessageType::CUSTOMER') %}
+            {{ message.customerName }}
           {% else %}
-            <img class="rounded-circle thread-message-employee-image" src="{{ message.employeeImage }}">
+            {{ message.employeeName }}
           {% endif %}
 
-          <div class="media-body ml-2">
-            <h4 class="mt-0 mb-1">
-              <i class="material-icons text-muted">reply</i>
+          <span class="text-muted">
+            <i class="material-icons text-muted font-16">calendar_today</i>
+            -
+            {{ format_date(message.date) }}
+            <i class="material-icons text-muted font-16">access_time</i>
+            -
+            {{ message.date|date('H:i') }}
+          </span>
 
-              {% if message.type == constant('PrestaShop\\PrestaShop\\Core\\Domain\\CustomerService\\ValueObject\\CustomerThreadMessageType::CUSTOMER') %}
-                {{ message.customerName }}
-              {% else %}
-                {{ message.employeeName }}
-              {% endif %}
+          {% if message.attachmentFile %}
+            <i class="material-icons font-16">attachment</i>
+            <a href="{{ message.attachmentFile }}" target="_blank">
+              {{ 'Attachment'|trans({}, 'Admin.Catalog.Feature') }}
+            </a>
+          {% endif %}
 
-              <span class="text-muted">
-                <i class="material-icons text-muted font-16">calendar_today</i>
-                -
-                {{ format_date(message.date) }}
-                <i class="material-icons text-muted font-16">access_time</i>
-                -
-                {{ message.date|date('H:i') }}
-              </span>
-
-              {% if message.attachmentFile %}
-                <i class="material-icons font-16">attachment</i>
-                <a href="{{ message.attachmentFile }}" target="_blank">
-                  {{ 'Attachment'|trans({}, 'Admin.Catalog.Feature') }}
-                </a>
-              {% endif %}
-
-              {% if message.productId %}
-                <i class="material-icons font-16">library_books</i>
-                <a href="{{ path('admin_product_form', {'id': message.productId}) }}">
-                  {{ 'Product'|trans({}, 'Admin.Global') }}
-                  {{ message.productName }}
-                </a>
-              {% endif %}
-            </h4>
-            <p class="pl-2 thread-message">{{ message.message|nl2br }}</p>
-          </div>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-</div>
+          {% if message.productId %}
+            <i class="material-icons font-16">library_books</i>
+            <a href="{{ path('admin_product_form', {'id': message.productId}) }}">
+              {{ 'Product'|trans({}, 'Admin.Global') }}
+              {{ message.productName }}
+            </a>
+          {% endif %}
+        </h4>
+        <p class="pl-2 thread-message">{{ message.message|nl2br }}</p>
+      </div>
+    </li>
+  {% endfor %}
+</ul>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/CustomerThread/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/CustomerThread/view.html.twig
@@ -26,45 +26,34 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      <div class="card">
-        <h3 class="card-header">
-          {{ 'Thread'|trans({}, 'Admin.Orderscustomers.Feature') }}
-          <strong>#{{ customerThreadView.customerThreadId.value }}</strong>
-        </h3>
-        <div class="card-body">
-          {% block customer_thread_actions %}
-            {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/thread_actions.html.twig' %}
-          {% endblock %}
+  <div class="card">
+    <h3 class="card-header">
+      {{ 'Thread'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      <strong>#{{ customerThreadView.customerThreadId.value }}</strong>
+    </h3>
+    <div class="card-body">
+      {% block customer_thread_actions %}
+        {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/thread_actions.html.twig' %}
+      {% endblock %}
 
-          {% block customer_information %}
-            {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/customer_information.html.twig' %}
-          {% endblock %}
+      {% block customer_information %}
+        {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/customer_information.html.twig' %}
+      {% endblock %}
 
-          {% block customer_thread_messages %}
-            {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/thread_messages.html.twig' %}
-          {% endblock %}
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col">
-      {% block customer_thread_reply %}
-        {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/your_answer.html.twig' %}
+      {% block customer_thread_messages %}
+        {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/thread_messages.html.twig' %}
       {% endblock %}
     </div>
   </div>
 
-  <div class="row">
-    <div class="col">
-      {% block customer_thread_timeline %}
-        {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/timeline.html.twig' %}
-      {% endblock %}
-    </div>
-  </div>
+  {% block customer_thread_reply %}
+    {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/your_answer.html.twig' %}
+  {% endblock %}
+
+  {% block customer_thread_timeline %}
+    {% include '@PrestaShop/Admin/Sell/CustomerService/CustomerThread/Block/timeline.html.twig' %}
+  {% endblock %}
+
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/MerchandiseReturn/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/MerchandiseReturn/index.html.twig
@@ -30,19 +30,11 @@
 
 {% block content %}
   {% block merchandise_returns_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': merchandiseReturnsGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': merchandiseReturnsGrid} %}
   {% endblock %}
 
   {% block merchandise_returns_options %}
-    <div class="row">
-      <div class="col-12">
-        {% include '@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/options.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/options.html.twig' %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/OrderMessage/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/OrderMessage/create.html.twig
@@ -26,12 +26,10 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% if multistoreIsUsed %}
+    {{ ps.infotip(multistoreInfoTip, true) }}
+  {% endif %}
+  {% include '@PrestaShop/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/OrderMessage/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/OrderMessage/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/OrderMessage/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/CustomerService/OrderMessage/index.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-12">
-      {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderMessageGrid} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderMessageGrid} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Cart/Blocks/View/order_information.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Cart/Blocks/View/order_information.html.twig
@@ -24,37 +24,27 @@
  *#}
 
 <div class="card">
-  <h3 class="card-header">
-    {{ 'Order information'|trans({}, 'Admin.Orderscustomers.Feature') }}
-  </h3>
+  <h3 class="card-header">{{ 'Order information'|trans({}, 'Admin.Orderscustomers.Feature') }}</h3>
   <div class="card-body">
-    <div class="row">
-      <div class="col">
-        {% if cartView.orderInformation.id %}
-          <h2>
-            <a href="{{ getAdminLink('AdminOrders', true, {'id_order': cartView.orderInformation.id, 'vieworder': 1}) }}">
-              {{ 'Order #%d'|trans({
-                '%d': cartView.orderInformation.id|format('"%06d')
-              }, 'Admin.Orderscustomers.Feature') }}
-            </a>
-          </h2>
-
-          <p class="mb-0">
-            {{ 'Made on:'|trans({}, 'Admin.Orderscustomers.Feature') }}
-            {{ cartView.orderInformation.placed_date }}
-          </p>
-        {% else %}
-          <h2>{{ 'No order was created from this cart.'|trans({}, 'Admin.Orderscustomers.Feature') }}</h2>
-
-          {% if cartView.customerInformation.id %}
-            <a href="{{ createOrderFromCartLink }}"
-               class="btn btn-outline-secondary"
-            >
-              {{ 'Create an order from this cart.'|trans({}, 'Admin.Orderscustomers.Feature') }}
-            </a>
-          {% endif %}
-        {% endif %}
-      </div>
-    </div>
+    {% if cartView.orderInformation.id %}
+      <h2>
+        <a href="{{ getAdminLink('AdminOrders', true, {'id_order': cartView.orderInformation.id, 'vieworder': 1}) }}">
+          {{ 'Order #%d'|trans({
+            '%d': cartView.orderInformation.id|format('"%06d')
+          }, 'Admin.Orderscustomers.Feature') }}
+        </a>
+      </h2>
+      <p class="mb-0">
+        {{ 'Made on:'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        {{ cartView.orderInformation.placed_date }}
+      </p>
+    {% else %}
+      <h2>{{ 'No order was created from this cart.'|trans({}, 'Admin.Orderscustomers.Feature') }}</h2>
+      {% if cartView.customerInformation.id %}
+        <a href="{{ createOrderFromCartLink }}" class="btn btn-outline-secondary">
+          {{ 'Create an order from this cart.'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        </a>
+      {% endif %}
+    {% endif %}
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Cart/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Cart/view.html.twig
@@ -27,16 +27,12 @@
 
 {% block content %}
   {% block cart_kpis %}
-    <div class="row">
-      <div class="col-md-12">
-        <div class="card card-kpis">
-          <div class="row">
-            {{ render(controller(
-              'PrestaShopBundle:Admin\\Common:renderKpiRow',
-              { 'kpiRow': cartKpi }
-            )) }}
-          </div>
-        </div>
+    <div class="card card-kpis">
+      <div class="row">
+        {{ render(controller(
+          'PrestaShopBundle:Admin\\Common:renderKpiRow',
+          { 'kpiRow': cartKpi }
+        )) }}
       </div>
     </div>
   {% endblock %}
@@ -54,11 +50,7 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="col">
-      {% block cart_summary %}
-        {% include '@PrestaShop/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig' %}
-      {% endblock %}
-    </div>
-  </div>
+  {% block cart_summary %}
+    {% include '@PrestaShop/Admin/Sell/Order/Cart/Blocks/View/cart_summary.html.twig' %}
+  {% endblock %}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/CreditSlip/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/CreditSlip/index.html.twig
@@ -27,27 +27,15 @@
 
 {% block content %}
   {% block credit_slips_listing %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': creditSlipGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': creditSlipGrid} %}
   {% endblock %}
 
   {% block credit_slips_print_pdf %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig' %}
   {% endblock %}
 
   {% block credit_slips_options %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig' %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Delivery/slip.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Delivery/slip.html.twig
@@ -31,86 +31,80 @@
     'attr' : {'class': 'form', 'autocomplete': 'off', id: 'form-delivery-slips-print-pdf'},
     'action': path('admin_order_delivery_slip_pdf') })
   }}
-    <div class="row justify-content-center">
-      {% block admin_form_order_delivery_slip_pdf %}
-        <div class="col-xl-12">
-          <div class="card" id="delivery_pdf_fieldset">
-            <h3 class="card-header">
-              <i class="material-icons">print</i> {{ 'Print PDF'|trans }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                <div class="form-group row">
-                  {{ ps.label_with_help('From'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(pdfForm.date_from) }}
-                    {{ form_widget(pdfForm.date_from) }}
-                  </div>
-                </div>
-                <div class="form-group row">
-                  {{ ps.label_with_help('To'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(pdfForm.date_to) }}
-                    {{ form_widget(pdfForm.date_to) }}
-                  </div>
-                </div>
-                {{ form_rest(pdfForm) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" id="generate-delivery-slip-by-date">{{ 'Generate PDF'|trans }}</button>
-              </div>
+  {% block admin_form_order_delivery_slip_pdf %}
+    <div class="card" id="delivery_pdf_fieldset">
+      <h3 class="card-header">
+        <i class="material-icons">print</i>
+        {{ 'Print PDF'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          <div class="form-group row">
+            {{ ps.label_with_help('From'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+            <div class="col-sm">
+              {{ form_errors(pdfForm.date_from) }}
+              {{ form_widget(pdfForm.date_from) }}
             </div>
           </div>
+          <div class="form-group row">
+            {{ ps.label_with_help('To'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+            <div class="col-sm">
+              {{ form_errors(pdfForm.date_to) }}
+              {{ form_widget(pdfForm.date_to) }}
+            </div>
+          </div>
+          {{ form_rest(pdfForm) }}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary" id="generate-delivery-slip-by-date">{{ 'Generate PDF'|trans }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(pdfForm) }}
 
   {{ form_start(optionsForm, {'attr' : {'class': 'form', 'id': 'form-delivery-slips-options'} }) }}
-    <div class="row justify-content-center">
-      {% block admin_form_order_delivery_slip_options %}
-        <div class="col-xl-12">
-          <div class="card" id="delivery_options_fieldset">
-            <h3 class="card-header">
-              <i class="material-icons">settings</i> {{ 'Delivery slip options'|trans }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                <div class="form-group row">
-                  {{ ps.label_with_help(('Delivery prefix'|trans), ('Prefix used for delivery slips.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(optionsForm.prefix) }}
-                    {{ form_widget(optionsForm.prefix) }}
-                  </div>
-                </div>
-                <div class="form-group row">
-                  {{ ps.label_with_help(('Delivery number'|trans), ('The next delivery slip will begin with this number and then increase with each additional slip.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(optionsForm.number) }}
-                    {{ form_widget(optionsForm.number) }}
-                  </div>
-                </div>
-                <div class="form-group row">
-                  {{ ps.label_with_help(('Enable product image'|trans), ('Add an image before product name on delivery slip'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-                  <div class="col-sm">
-                    {{ form_errors(optionsForm.enable_product_image) }}
-                    {{ form_widget(optionsForm.enable_product_image) }}
-                  </div>
-                </div>
-                {{ form_rest(optionsForm) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" id="save-delivery-slip-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-              </div>
+  {% block admin_form_order_delivery_slip_options %}
+    <div class="card" id="delivery_options_fieldset">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'Delivery slip options'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          <div class="form-group row">
+            {{ ps.label_with_help(('Delivery prefix'|trans), ('Prefix used for delivery slips.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+            <div class="col-sm">
+              {{ form_errors(optionsForm.prefix) }}
+              {{ form_widget(optionsForm.prefix) }}
             </div>
           </div>
+          <div class="form-group row">
+            {{ ps.label_with_help(('Delivery number'|trans), ('The next delivery slip will begin with this number and then increase with each additional slip.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+            <div class="col-sm">
+              {{ form_errors(optionsForm.number) }}
+              {{ form_widget(optionsForm.number) }}
+            </div>
+          </div>
+          <div class="form-group row">
+            {{ ps.label_with_help(('Enable product image'|trans), ('Add an image before product name on delivery slip'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+            <div class="col-sm">
+              {{ form_errors(optionsForm.enable_product_image) }}
+              {{ form_widget(optionsForm.enable_product_image) }}
+            </div>
+          </div>
+          {{ form_rest(optionsForm) }}
         </div>
-      {% endblock %}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary" id="save-delivery-slip-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
+  {% endblock %}
   {{ form_end(optionsForm) }}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig
@@ -27,37 +27,36 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block invoices_generate_by_date %}
-  <div class="col-xl-12">
-    {{ form_start(generateByDateForm, {method: 'POST', action: path('admin_order_invoices_generate_by_date'), attr: {id: 'form-generate-invoices-by-date'}}) }}
-    <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">date_range</i> {{ 'By date'|trans }}
-      </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            {{ ps.label_with_help(('From'|trans({}, 'Admin.Global')), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generateByDateForm.date_from) }}
-              {{ form_widget(generateByDateForm.date_from) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('To'|trans({}, 'Admin.Global')), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(generateByDateForm.date_to) }}
-              {{ form_widget(generateByDateForm.date_to) }}
-            </div>
+  {{ form_start(generateByDateForm, {method: 'POST', action: path('admin_order_invoices_generate_by_date'), attr: {id: 'form-generate-invoices-by-date'}}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">date_range</i>
+      {{ 'By date'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          {{ ps.label_with_help(('From'|trans({}, 'Admin.Global')), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generateByDateForm.date_from) }}
+            {{ form_widget(generateByDateForm.date_from) }}
           </div>
         </div>
-        {{ form_rest(generateByDateForm) }}
+        <div class="form-group row">
+          {{ ps.label_with_help(('To'|trans({}, 'Admin.Global')), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+          <div class="col-sm">
+            {{ form_errors(generateByDateForm.date_to) }}
+            {{ form_widget(generateByDateForm.date_to) }}
+          </div>
+        </div>
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary" id="generate-pdf-by-date-button">{{ 'Generate PDF file by date'|trans }}</button>
-        </div>
+      {{ form_rest(generateByDateForm) }}
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="generate-pdf-by-date-button">{{ 'Generate PDF file by date'|trans }}</button>
       </div>
     </div>
-    {{ form_end(generateByDateForm) }}
   </div>
+  {{ form_end(generateByDateForm) }}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig
@@ -29,30 +29,31 @@
 {% form_theme generateByStatusForm _self %}
 
 {% block invoices_generate_by_status %}
-  <div id="by-status-block" class="col-xl-12">
+  <div id="by-status-block">
     {{ form_start(generateByStatusForm, {method: 'POST', action: path('admin_order_invoices_generate_by_status'), attr: {id: 'form-generate-invoices-by-status'}}) }}
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">schedule</i> {{ 'By order status'|trans }}
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            <div class="form-group row">
-              {{ ps.label_with_help(('Order statuses'|trans), ('You can also export orders which have not been charged yet.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-              <div class="col-sm">
-                {{ form_errors(generateByStatusForm.order_states) }}
-                {{ form_widget(generateByStatusForm.order_states) }}
-              </div>
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">schedule</i>
+        {{ 'By order status'|trans }}
+      </h3>
+      <div class="card-block row">
+        <div class="card-text">
+          <div class="form-group row">
+            {{ ps.label_with_help(('Order statuses'|trans), ('You can also export orders which have not been charged yet.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
+            <div class="col-sm">
+              {{ form_errors(generateByStatusForm.order_states) }}
+              {{ form_widget(generateByStatusForm.order_states) }}
             </div>
           </div>
-          {{ form_rest(generateByStatusForm) }}
         </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary" id="generate-pdf-by-status-button">{{ 'Generate PDF file by status'|trans }}</button>
-          </div>
+        {{ form_rest(generateByStatusForm) }}
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary" id="generate-pdf-by-status-button">{{ 'Generate PDF file by status'|trans }}</button>
         </div>
       </div>
+    </div>
     {{ form_end(generateByStatusForm) }}
   </div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
@@ -27,113 +27,112 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block invoice_options %}
-  <div class="col">
-    {{ form_start(invoiceOptionsForm, {method: 'POST', action: path('admin_order_invoices_process'), attr: {id: 'form-invoices-options'}}) }}
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">settings</i> {{ 'Invoice options'|trans }}
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            <div class="form-group row">
-              {{ ps.label_with_help('Enable invoices'|trans, 'If enabled, your customers will receive an invoice for the purchase.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.enable_invoices) }}
-                {{ form_widget(invoiceOptionsForm.enable_invoices) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Enable tax breakdown'|trans, 'If required, show the total amount per rate of the corresponding tax.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.enable_tax_breakdown) }}
-                {{ form_widget(invoiceOptionsForm.enable_tax_breakdown) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Enable product image'|trans, 'Adds an image in front of the product name on the invoice'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.enable_product_images) }}
-                {{ form_widget(invoiceOptionsForm.enable_product_images) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Invoice prefix'|trans, 'Freely definable prefix for invoice number (e.g. #IN00001).'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.invoice_prefix) }}
-                {{ form_widget(invoiceOptionsForm.invoice_prefix) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Add current year to invoice number'|trans }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.add_current_year) }}
-                {{ form_widget(invoiceOptionsForm.add_current_year) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Reset sequential invoice number at the beginning of the year'|trans }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.reset_number_annually) }}
-                {{ form_widget(invoiceOptionsForm.reset_number_annually) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Position of the year date'|trans }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.year_position) }}
-                {{ form_widget(invoiceOptionsForm.year_position) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Invoice number'|trans, 'The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).'|trans({'%number%': invoiceOptionsForm.vars.next_invoice_number}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.invoice_number) }}
-                {{ form_widget(invoiceOptionsForm.invoice_number) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Legal free text'|trans, 'Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.legal_free_text) }}
-                {{ form_widget(invoiceOptionsForm.legal_free_text) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Footer text'|trans, 'This text will appear at the bottom of the invoice, below your company details.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.footer_text) }}
-                {{ form_widget(invoiceOptionsForm.footer_text) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Invoice model'|trans, 'Choose an invoice model.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.invoice_model) }}
-                {{ form_widget(invoiceOptionsForm.invoice_model) }}
-              </div>
-            </div>
-            <div class="form-group row">
-              {{ ps.label_with_help('Use the disk as cache for PDF invoices'|trans, 'Saves memory but slows down the PDF generation.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-              <div class="col-sm">
-                {{ form_errors(invoiceOptionsForm.use_disk_cache) }}
-                {{ form_widget(invoiceOptionsForm.use_disk_cache) }}
-              </div>
-            </div>
-            {{ form_rest(invoiceOptionsForm) }}
+  {{ form_start(invoiceOptionsForm, {method: 'POST', action: path('admin_order_invoices_process'), attr: {id: 'form-invoices-options'}}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">settings</i>
+      {{ 'Invoice options'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          {{ ps.label_with_help('Enable invoices'|trans, 'If enabled, your customers will receive an invoice for the purchase.'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.enable_invoices) }}
+            {{ form_widget(invoiceOptionsForm.enable_invoices) }}
           </div>
         </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary" id="save-invoices-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        <div class="form-group row">
+          {{ ps.label_with_help('Enable tax breakdown'|trans, 'If required, show the total amount per rate of the corresponding tax.'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.enable_tax_breakdown) }}
+            {{ form_widget(invoiceOptionsForm.enable_tax_breakdown) }}
           </div>
         </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Enable product image'|trans, 'Adds an image in front of the product name on the invoice'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.enable_product_images) }}
+            {{ form_widget(invoiceOptionsForm.enable_product_images) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Invoice prefix'|trans, 'Freely definable prefix for invoice number (e.g. #IN00001).'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.invoice_prefix) }}
+            {{ form_widget(invoiceOptionsForm.invoice_prefix) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Add current year to invoice number'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.add_current_year) }}
+            {{ form_widget(invoiceOptionsForm.add_current_year) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Reset sequential invoice number at the beginning of the year'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.reset_number_annually) }}
+            {{ form_widget(invoiceOptionsForm.reset_number_annually) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Position of the year date'|trans }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.year_position) }}
+            {{ form_widget(invoiceOptionsForm.year_position) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Invoice number'|trans, 'The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).'|trans({'%number%': invoiceOptionsForm.vars.next_invoice_number}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.invoice_number) }}
+            {{ form_widget(invoiceOptionsForm.invoice_number) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Legal free text'|trans, 'Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.legal_free_text) }}
+            {{ form_widget(invoiceOptionsForm.legal_free_text) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Footer text'|trans, 'This text will appear at the bottom of the invoice, below your company details.'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.footer_text) }}
+            {{ form_widget(invoiceOptionsForm.footer_text) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Invoice model'|trans, 'Choose an invoice model.'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.invoice_model) }}
+            {{ form_widget(invoiceOptionsForm.invoice_model) }}
+          </div>
+        </div>
+        <div class="form-group row">
+          {{ ps.label_with_help('Use the disk as cache for PDF invoices'|trans, 'Saves memory but slows down the PDF generation.'|trans({}, 'Admin.Orderscustomers.Help')) }}
+          <div class="col-sm">
+            {{ form_errors(invoiceOptionsForm.use_disk_cache) }}
+            {{ form_widget(invoiceOptionsForm.use_disk_cache) }}
+          </div>
+        </div>
+        {{ form_rest(invoiceOptionsForm) }}
       </div>
-    {{ form_end(invoiceOptionsForm) }}
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="save-invoices-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+      </div>
+    </div>
   </div>
+  {{ form_end(invoiceOptionsForm) }}
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/invoices.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Invoices/invoices.html.twig
@@ -25,23 +25,18 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    {# "By Date" block #}
-    {% include '@PrestaShop/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig' %}
+  {# "By Date" block #}
+  {% include '@PrestaShop/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig' %}
 
-    {# "By order status" block #}
-    {% include '@PrestaShop/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig' %}
+  {# "By order status" block #}
+  {% include '@PrestaShop/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig' %}
 
-  </div>
-
-  <div class="row justify-content-center">
-    {# "Invoice options" block #}
-    {% include '@PrestaShop/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig' %}
-  </div>
+  {# "Invoice options" block #}
+  {% include '@PrestaShop/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }}
+  {{ parent() }}
 
-    <script src="{{ asset('themes/new-theme/public/invoices.bundle.js') }}"></script>
+  <script src="{{ asset('themes/new-theme/public/invoices.bundle.js') }}"></script>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig
@@ -28,12 +28,10 @@
     {{ 'Addresses'|trans({}, 'Admin.Global') }}
   </h3>
   <div class="card-body">
-    <div class="row d-none" id="addresses-warning">
-      <div class="col">
-        <div class="alert alert-warning">
-          <div class="alert-text">
-            {{ 'You must add at least one address to process the order.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-          </div>
+    <div class="d-none" id="addresses-warning">
+      <div class="alert alert-warning">
+        <div class="alert-text">
+          {{ 'You must add at least one address to process the order.'|trans({}, 'Admin.Orderscustomers.Notification') }}
         </div>
       </div>
     </div>
@@ -61,12 +59,10 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col">
-        <a class="btn btn-primary" id="js-add-address-btn" href="{{ path('admin_addresses_create', {'liteDisplaying': 1, 'submitFormAjax': 1}) }}">
-          {{ 'Add new address'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </a>
-      </div>
+    <div>
+      <a class="btn btn-primary" id="js-add-address-btn" href="{{ path('admin_addresses_create', {'liteDisplaying': 1, 'submitFormAjax': 1}) }}">
+        {{ 'Add new address'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </a>
     </div>
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig
@@ -41,171 +41,154 @@
       </div>
     </div>
 
-    <div class="row js-no-products-found d-none">
-      <div class="col">
-        <div class="alert alert-danger" role="alert">
-          <p class="alert-text">{{ 'No products found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
-        </div>
+    <div class="js-no-products-found d-none">
+      <div class="alert alert-danger" role="alert">
+        <p class="alert-text">{{ 'No products found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
       </div>
     </div>
 
-    <div class="row js-searching-products d-none">
-      <div class="col">
-        <div class="alert alert-info" role="alert">
-          <p class="alert-text">{{ 'Searching for products'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
-        </div>
+    <div class="js-searching-products d-none">
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">{{ 'Searching for products'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
       </div>
     </div>
 
     <hr class="mt-3 mb-3">
 
-    <div class="row">
-      <div class="col">
-        <div id="product-search-results" class="d-none">
-          <form id="js-add-product-form">
+    <div id="product-search-results" class="d-none">
+      <form id="js-add-product-form">
 
-            <div class="row js-product-select-row">
-              <div class="col-3">
-                <span class="float-right">{{ 'Product'|trans({}, 'Admin.Global') }}</span>
-              </div>
-              <div class="col-4">
-                <select name="product_id" id="product-select" class="form-control custom-select" data-customization-label="{{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}"></select>
-              </div>
-            </div>
-
-            <div class="row mt-3 js-combinations-row d-none">
-              <div class="col-3">
-                <span class="float-right">{{ 'Combination'|trans({}, 'Admin.Global') }}</span>
-              </div>
-              <div class="col-4">
-                <select name="combination_id" id="combination-select" class="form-control custom-select"></select>
-              </div>
-            </div>
-
-            <div class="row mt-3 d-none" id="js-customization-container">
-              <div class="col-3">
-                <span class="float-right">
-                  {{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}
-                </span>
-              </div>
-              <div class="col-4 custom-fields-container" id="js-custom-fields-container"></div>
-            </div>
-
-            <div class="row mt-3 js-quantity-row">
-              <div class="col-3">
-                <span class="float-right">{{ 'Quantity'|trans({}, 'Admin.Global') }}</span>
-              </div>
-              <div class="col-2">
-                <input name="product_quantity" id="quantity-input" type="number" min="1" value="1" class="form-control">
-                {% if stockManagementEnabled %}
-                  <small class="form-text">
-                    {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
-                    <span class="js-in-stock-counter"></span>
-                  </small>
-                {% endif %}
-              </div>
-            </div>
-            <div class="row mt-3">
-              <div class="col-1 offset-sm-3">
-                <button id="add-product-to-cart-btn" type="button" class="btn btn-primary">
-                  {{ 'Add to cart'|trans({}, 'Admin.Orderscustomers.Feature') }}
-                </button>
-              </div>
-            </div>
-
-          </form>
-          <div class="row">
-            <div class="col">
-              <hr>
-            </div>
-          </div>
-        </div>
-        <div class="js-no-records-found"></div>
-        <div class="row">
-          <div class="col">
-            <table id="products-table" class="table d-none">
-              <thead>
-              <tr>
-                <th>{{ 'Product'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Price per unit'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                <th>{{ 'Quantity'|trans({}, 'Admin.Global') }}</th>
-                <th>{{ 'Price'|trans({}, 'Admin.Global') }}</th>
-                <th></th>
-              </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-        </div>
-        <div class="row js-tax-warning d-none">
-          <div class="col-4 offset-sm-3">
-            <div class="alert alert-warning">
-              <div class="alert-text">
-                {{ 'The prices are without taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="row">
+        <div class="row js-product-select-row">
           <div class="col-3">
-            <span class="float-right">
-              {{ 'Currency'|trans({}, 'Admin.Global') }}
-            </span>
+            <span class="float-right">{{ 'Product'|trans({}, 'Admin.Global') }}</span>
           </div>
           <div class="col-4">
-            <select class="form-control custom-select" id="js-cart-currency-select">
-              {% for name, id in currencies %}
-                <option value="{{ id }}">{{ name }}</option>
-              {% endfor %}
-            </select>
+            <select name="product_id" id="product-select" class="form-control custom-select" data-customization-label="{{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}"></select>
+          </div>
+        </div>
+
+        <div class="row mt-3 js-combinations-row d-none">
+          <div class="col-3">
+            <span class="float-right">{{ 'Combination'|trans({}, 'Admin.Global') }}</span>
+          </div>
+          <div class="col-4">
+            <select name="combination_id" id="combination-select" class="form-control custom-select"></select>
+          </div>
+        </div>
+
+        <div class="row mt-3 d-none" id="js-customization-container">
+          <div class="col-3">
+            <span class="float-right">
+              {{ 'Customization'|trans({}, 'Admin.Catalog.Feature') }}
+            </span>
+          </div>
+          <div class="col-4 custom-fields-container" id="js-custom-fields-container"></div>
+        </div>
+
+        <div class="row mt-3 js-quantity-row">
+          <div class="col-3">
+            <span class="float-right">{{ 'Quantity'|trans({}, 'Admin.Global') }}</span>
+          </div>
+          <div class="col-2">
+            <input name="product_quantity" id="quantity-input" type="number" min="1" value="1" class="form-control">
+            {% if stockManagementEnabled %}
+              <small class="form-text">
+                {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                <span class="js-in-stock-counter"></span>
+              </small>
+            {% endif %}
           </div>
         </div>
         <div class="row mt-3">
-          <div class="col-3">
-            <span class="float-right">
-              {{ 'Language'|trans({}, 'Admin.Global') }}
-            </span>
+          <div class="col-1 offset-sm-3">
+            <button id="add-product-to-cart-btn" type="button" class="btn btn-primary">
+              {{ 'Add to cart'|trans({}, 'Admin.Orderscustomers.Feature') }}
+            </button>
           </div>
-          <div class="col-4">
-            <select class="form-control custom-select" id="js-cart-language-select">
-              {% for name, id in languages %}
-                <option value="{{ id }}">{{ name }}</option>
-              {% endfor %}
-            </select>
+        </div>
+
+      </form>
+
+      <hr>
+
+    </div>
+    <div class="js-no-records-found"></div>
+
+    <table id="products-table" class="table d-none">
+      <thead>
+        <tr>
+          <th>{{ 'Product'|trans({}, 'Admin.Global') }}</th>
+          <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
+          <th>{{ 'Reference'|trans({}, 'Admin.Global') }}</th>
+          <th>{{ 'Price per unit'|trans({}, 'Admin.Catalog.Feature') }}</th>
+          <th>{{ 'Quantity'|trans({}, 'Admin.Global') }}</th>
+          <th>{{ 'Price'|trans({}, 'Admin.Global') }}</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <div class="row js-tax-warning d-none">
+      <div class="col-4 offset-sm-3">
+        <div class="alert alert-warning">
+          <div class="alert-text">
+            {{ 'The prices are without taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
           </div>
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col-3">
+        <span class="float-right">
+          {{ 'Currency'|trans({}, 'Admin.Global') }}
+        </span>
+      </div>
+      <div class="col-4">
+        <select class="form-control custom-select" id="js-cart-currency-select">
+          {% for name, id in currencies %}
+            <option value="{{ id }}">{{ name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    <div class="row mt-3">
+      <div class="col-3">
+        <span class="float-right">
+          {{ 'Language'|trans({}, 'Admin.Global') }}
+        </span>
+      </div>
+      <div class="col-4">
+        <select class="form-control custom-select" id="js-cart-language-select">
+          {% for name, id in languages %}
+            <option value="{{ id }}">{{ name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
   </div>
 </div>
 
 {% set requiredFieldMarkTemplate %}
-  <span class="js-required-field-mark text-danger d-none">*</span>
+<span class="js-required-field-mark text-danger d-none">*</span>
 {% endset %}
 
 <script id="js-product-custom-text-template" type="text/template">
-  <div class="row">
-    <div class="col">
-      {{ requiredFieldMarkTemplate }}
-      <label for="" class="js-product-custom-input-label"></label>
-      <input name="" type="text" class="form-control js-product-custom-input">
-    </div>
-  </div>
+  {{ requiredFieldMarkTemplate }}
+  <label for="" class="js-product-custom-input-label"></label>
+  <input name="" type="text" class="form-control js-product-custom-input">
 </script>
 
 <script id="js-product-custom-file-template" type="text/template">
-  <div class="row mt-3">
-    <div class="col">
-      {{ requiredFieldMarkTemplate }}
-      <label for="" class="js-product-custom-input-label"></label>
-      <div class="custom-file">
-        <input name="" type="file" class="custom-file-input js-product-custom-input">
-        <label class="custom-file-label">
-          {{ 'Choose file(s)'|trans({}, 'Admin.Actions') }}
-        </label>
-      </div>
+  <div class="mt-3">
+    {{ requiredFieldMarkTemplate }}
+    <label for="" class="js-product-custom-input-label"></label>
+    <div class="custom-file">
+      <input name="" type="file" class="custom-file-input js-product-custom-input">
+      <label class="custom-file-label">
+        {{ 'Choose file(s)'|trans({}, 'Admin.Actions') }}
+      </label>
     </div>
   </div>
 </script>
@@ -222,7 +205,7 @@
     <td>
       <input type="number" min="1" class="form-control js-product-qty-input" style="max-width: 100px;{% if not stockManagementEnabled %}margin-top:0px;{% endif %}">
       {% if stockManagementEnabled %}
-        <small class="form-text">  
+        <small class="form-text">
           {{ 'In stock'|trans({}, 'Admin.Orderscustomers.Feature') }}
           <span class="js-product-qty-stock"></span>
         </small>
@@ -254,7 +237,8 @@
   <div class="row">
     <small class="col d-inline">
       <span class="js-customization-name"></span>
-      <span>: </span>
+      <span>:
+      </span>
       <span class="js-customization-value"></span>
     </small>
   </div>
@@ -264,8 +248,10 @@
   <div class="row">
     <small class="col d-inline">
       <span class="js-customization-name"></span>
-      <span>: </span>
-      <span class="js-customization-value"> <img src="" alt=""></span>
+      <span>:
+      </span>
+      <span class="js-customization-value">
+        <img src="" alt=""></span>
     </small>
   </div>
 </script>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig
@@ -31,10 +31,7 @@
         <span class="float-right">{{ 'Search for a customer'|trans({}, 'Admin.Orderscustomers.Feature') }}</span>
       </div>
       <div class="col-4">
-        <input type="text"
-               class="form-control"
-               id="customer-search-input"
-        >
+        <input type="text" class="form-control" id="customer-search-input">
         <small class="form-text">
           {{ 'Search for an existing customer by typing the first letters of his/her name.'|trans({}, 'Admin.Orderscustomers.Help') }}
         </small>
@@ -48,90 +45,59 @@
       </div>
     </div>
 
-    <div id="customer-search-empty-result-warn" class="row d-none">
-      <div class="col">
-        <div class="col">
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">{{ 'No customers found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
-          </div>
-        </div>
+    <div id="customer-search-empty-result-warn" class="d-none">
+      <div class="alert alert-warning" role="alert">
+        <p class="alert-text">{{ 'No customers found'|trans({}, 'Admin.Orderscustomers.Notification') }}</p>
       </div>
     </div>
 
-    <div id="customer-search-loading-notice" class="row d-none">
-      <div class="col">
-        <div class="col">
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'Searching for customers'|trans({}, 'Admin.Orderscustomers.Notification') }}
+    <div id="customer-search-loading-notice" class="d-none">
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {{ 'Searching for customers'|trans({}, 'Admin.Orderscustomers.Notification') }}
+        </p>
+      </div>
+    </div>
+
+    <div class="row js-customer-search-results"></div>
+
+    <div class="d-none" id="customer-checkout-history">
+      <ul class="nav nav-pills" role="tablist">
+        <li class="nav-item">
+          <a class="nav-link active show js-customer-carts-tab" id="customer-carts-tab" data-toggle="pill" href="#customer-carts-tab-content" role="tab" aria-controls="pills-home" aria-expanded="true" aria-selected="true">
+            {{ 'Carts'|trans({}, 'Admin.Global') }}
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link js-customer-orders-tab" id="customer-orders-tab" data-toggle="pill" href="#customer-orders-tab-content" role="tab" aria-controls="pills-home" aria-expanded="true" aria-selected="true">
+            {{ 'Orders'|trans({}, 'Admin.Global') }}
+          </a>
+        </li>
+        <li class="nav-item ml-auto">
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#customer-tab-content-container" id="customer-tab-content-container-toggler" aria-expanded="true" aria-label="{{ 'Toggle'|trans({}, 'Admin.Global') }}">
+            <p class="mb-0 mt-2">
+              <i class="material-icons"></i>
             </p>
-          </div>
+          </button>
+        </li>
+      </ul>
+      <div class="tab-content collapse show" id="customer-tab-content-container">
+        <div class="tab-pane fade active show" id="customer-carts-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
+          <table class="table" id="customer-carts-table">
+            <thead class="d-none">
+              <tr>
+                <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Total'|trans({}, 'Admin.Global') }}</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
         </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">
-        <div class="row js-customer-search-results"></div>
-      </div>
-    </div>
-    <div class="row d-none" id="customer-checkout-history">
-      <div class="col">
-        <ul class="nav nav-pills" role="tablist">
-          <li class="nav-item">
-            <a class="nav-link active show js-customer-carts-tab"
-               id="customer-carts-tab"
-               data-toggle="pill"
-               href="#customer-carts-tab-content"
-               role="tab"
-               aria-controls="pills-home"
-               aria-expanded="true"
-               aria-selected="true"
-            >
-              {{ 'Carts'|trans({}, 'Admin.Global') }}
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link js-customer-orders-tab"
-               id="customer-orders-tab"
-               data-toggle="pill"
-               href="#customer-orders-tab-content"
-               role="tab"
-               aria-controls="pills-home"
-               aria-expanded="true"
-               aria-selected="true"
-            >
-              {{ 'Orders'|trans({}, 'Admin.Global') }}
-            </a>
-          </li>
-          <li class="nav-item ml-auto">
-            <button class="navbar-toggler" type="button"
-                    data-toggle="collapse"
-                    data-target="#customer-tab-content-container"
-                    id="customer-tab-content-container-toggler"
-                    aria-expanded="true"
-                    aria-label="{{ 'Toggle'|trans({}, 'Admin.Global') }}">
-              <p class="mb-0 mt-2"><i class="material-icons"></i></p>
-            </button>
-          </li>
-        </ul>
-        <div class="tab-content collapse show" id="customer-tab-content-container">
-          <div class="tab-pane fade active show" id="customer-carts-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
-            <table class="table" id="customer-carts-table">
-              <thead class="d-none">
-                <tr>
-                  <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-                  <th>{{ 'Total'|trans({}, 'Admin.Global') }}</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-          <div class="tab-pane fade" id="customer-orders-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
-            <table class="table" id="customer-orders-table">
-              <thead class="d-none">
+        <div class="tab-pane fade" id="customer-orders-tab-content" role="tabpanel" aria-labelledby="pills-home-tab">
+          <table class="table" id="customer-orders-table">
+            <thead class="d-none">
               <tr>
                 <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
                 <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
@@ -141,10 +107,9 @@
                 <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
                 <th></th>
               </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
+            </thead>
+            <tbody></tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -185,15 +150,11 @@
     <td class="js-cart-date"></td>
     <td class="js-cart-total"></td>
     <td class="text-right">
-      <a
-        title="{{ 'View this cart'|trans({}, 'Admin.Orderscustomers.Feature') }}"
-        class="btn btn-outline-primary js-cart-details-btn">
+      <a title="{{ 'View this cart'|trans({}, 'Admin.Orderscustomers.Feature') }}" class="btn btn-outline-primary js-cart-details-btn">
         {{ 'Details'|trans({}, 'Admin.Global') }}
       </a>
 
-      <button
-        title="{{ 'Use this cart'|trans({}, 'Admin.Orderscustomers.Feature') }}"
-        class="btn btn-outline-primary js-use-cart-btn">
+      <button title="{{ 'Use this cart'|trans({}, 'Admin.Orderscustomers.Feature') }}" class="btn btn-outline-primary js-use-cart-btn">
         {{ 'Use'|trans({}, 'Admin.Orderscustomers.Feature') }}
       </button>
     </td>
@@ -209,15 +170,11 @@
     <td class="js-order-payment-method"></td>
     <td class="js-order-status"></td>
     <td class="text-right">
-      <a
-        title="{{ 'View this order'|trans({}, 'Admin.Orderscustomers.Feature') }}"
-        class="btn btn-outline-primary js-order-details-btn">
+      <a title="{{ 'View this order'|trans({}, 'Admin.Orderscustomers.Feature') }}" class="btn btn-outline-primary js-order-details-btn">
         {{ 'Details'|trans({}, 'Admin.Global') }}
       </a>
 
-      <button
-        title="{{ 'Duplicate this order'|trans({}, 'Admin.Orderscustomers.Feature') }}"
-        class="btn btn-outline-primary js-use-order-btn">
+      <button title="{{ 'Duplicate this order'|trans({}, 'Admin.Orderscustomers.Feature') }}" class="btn btn-outline-primary js-use-order-btn">
         {{ 'Use'|trans({}, 'Admin.Orderscustomers.Feature') }}
       </button>
     </td>
@@ -228,7 +185,9 @@
   <tr class="empty_row js-empty-row">
     <td colspan="8" class="border-0">
       <div class="text-center grid-table-empty">
-        <p class="mb-0 mt-2"><i class="material-icons">warning</i></p>
+        <p class="mb-0 mt-2">
+          <i class="material-icons">warning</i>
+        </p>
         <p class="mb-2">{{ 'No records found'|trans({}, 'Admin.Global') }}</p>
       </div>
     </td>
@@ -239,7 +198,9 @@
   <tr class="empty_row js-empty-row">
     <td colspan="8" class="border-0">
       <div class="text-center grid-table-empty">
-        <p class="mb-0 mt-2"><i class="material-icons">autorenew</i></p>
+        <p class="mb-0 mt-2">
+          <i class="material-icons">autorenew</i>
+        </p>
         <p class="mb-2">{{ 'Loading...'|trans({}, 'Admin.Global') }}</p>
       </div>
     </td>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig
@@ -34,106 +34,96 @@
     <div class="alert alert-danger d-none" id="js-summary-error-block">
       <div class="alert-text"></div>
     </div>
-    <div class="row">
-      <div class="col">
-        <div class="card">
-          <div class="card-body">
-            <div class="row">
-              <div class="col text-center">
-                <p class="mb-0 text-muted">
-                  <strong>{{ 'Total products'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-                </p>
-                <strong class="js-total-products"></strong>
-              </div>
-              <div class="col text-center">
-                <p class="mb-0 text-muted">
-                  <strong>{{ 'Total vouchers (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-                </p>
-                <strong class="js-total-discounts"></strong>
-              </div>
-              <div class="col text-center">
-                <p class="mb-0 text-muted">
-                  <strong>{{ 'Total shipping (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-                </p>
-                <strong class="js-total-shipping"></strong>
-              </div>
-              <div class="col text-center">
-                <p class="mb-0 text-muted">
-                  <strong>{{ 'Total taxes'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-                </p>
-                <strong class="js-total-taxes"></strong>
-              </div>
-              <div class="col text-center">
-                <p class="mb-0 text-muted">
-                  <strong>{{ 'Total (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-                </p>
-                <strong class="js-total-without-tax"></strong>
-              </div>
-              <div class="col text-center">
-                <p class="mb-0 text-muted">
-                  <strong>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-                </p>
-                <span class="js-total-with-tax badge rounded badge-dark"></span>
-              </div>
-            </div>
+
+    <div class="card">
+      <div class="card-body">
+        <div class="row">
+          <div class="col text-center">
+            <p class="mb-0 text-muted">
+              <strong>{{ 'Total products'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <strong class="js-total-products"></strong>
+          </div>
+          <div class="col text-center">
+            <p class="mb-0 text-muted">
+              <strong>{{ 'Total vouchers (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <strong class="js-total-discounts"></strong>
+          </div>
+          <div class="col text-center">
+            <p class="mb-0 text-muted">
+              <strong>{{ 'Total shipping (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <strong class="js-total-shipping"></strong>
+          </div>
+          <div class="col text-center">
+            <p class="mb-0 text-muted">
+              <strong>{{ 'Total taxes'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <strong class="js-total-taxes"></strong>
+          </div>
+          <div class="col text-center">
+            <p class="mb-0 text-muted">
+              <strong>{{ 'Total (Tax excl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <strong class="js-total-without-tax"></strong>
+          </div>
+          <div class="col text-center">
+            <p class="mb-0 text-muted">
+              <strong>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <span class="js-total-with-tax badge rounded badge-dark"></span>
           </div>
         </div>
       </div>
     </div>
 
     {{ form_start(summaryForm, {'action': path('admin_orders_place')}) }}
-      <div class="row mt-3">
-        <div class="col col-11">
+    <div class="row mt-3">
+      <div class="col col-11">
 
-          <div id="js-order-message-wrap">
-            {{ ps.form_group_row(summaryForm.order_message, {}, {
+        <div id="js-order-message-wrap">
+          {{ ps.form_group_row(summaryForm.order_message, {}, {
               'label': 'Order message'|trans({}, 'Admin.Orderscustomers.Feature'),
             }) }}
-          </div>
+        </div>
 
-          {{ ps.form_group_row(summaryForm.payment_module, {}, {
+        {{ ps.form_group_row(summaryForm.payment_module, {}, {
             'label': 'Payment'|trans({}, 'Admin.Global'),
           }) }}
 
-          {{ ps.form_group_row(summaryForm.order_state, {}, {
+        {{ ps.form_group_row(summaryForm.order_state, {}, {
             'label': 'Order status'|trans({}, 'Admin.Orderscustomers.Feature'),
           }) }}
 
-          <div class="form-group row mt-4">
-            <div class="col-sm offset-sm-4">
-              <button class="btn btn-primary" type="submit" id="create-order-button">
-                {{ 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        <div class="form-group row mt-4">
+          <div class="col-sm offset-sm-4">
+            <button class="btn btn-primary" type="submit" id="create-order-button">
+              {{ 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') }}
+            </button>
+
+            <div class="btn-group">
+              <button class="btn btn-outline-primary dropdown-toggle" type="button" id="dropdown-menu-actions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {{ 'More actions'|trans({}, 'Admin.Orderscustomers.Feature') }}
               </button>
 
-              <div class="btn-group">
-                <button
-                  class="btn btn-outline-primary dropdown-toggle"
-                  type="button"
-                  id="dropdown-menu-actions"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                >
-                  {{ 'More actions'|trans({}, 'Admin.Orderscustomers.Feature') }}
+              <div class="dropdown-menu" aria-labelledby="dropdown-menu-actions">
+                <button type="button" class="dropdown-item" id="js-send-process-order-email-btn">
+                  {{ 'Send pre-filled order to the customer by email'|trans({}, 'Admin.Orderscustomers.Feature') }}
                 </button>
+                <a class="dropdown-item" id="js-process-order-link" target="_blank">
+                  {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Feature') }}
+                </a>
 
-                <div class="dropdown-menu" aria-labelledby="dropdown-menu-actions">
-                  <button type="button" class="dropdown-item" id="js-send-process-order-email-btn">
-                    {{ 'Send pre-filled order to the customer by email'|trans({}, 'Admin.Orderscustomers.Feature') }}
-                  </button>
-                  <a class="dropdown-item" id="js-process-order-link" target="_blank">
-                    {{ 'Proceed to checkout in the front office'|trans({}, 'Admin.Orderscustomers.Feature') }}
-                  </a>
-
-                  {{ renderhook('displayAdminOrderCreateExtraButtons') }}
-                </div>
+                {{ renderhook('displayAdminOrderCreateExtraButtons') }}
               </div>
-
-              {{ form_row(summaryForm.cart_id, {'attr': {'class': 'js-place-order-cart-id'}}) }}
             </div>
+
+            {{ form_row(summaryForm.cart_id, {'attr': {'class': 'js-place-order-cart-id'}}) }}
           </div>
         </div>
       </div>
+    </div>
     {{ form_end(summaryForm) }}
 
   </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
@@ -25,83 +25,75 @@
 
 <div class="modal fade" id="addOrderDiscountModal" tabindex="-1" role="dialog">
   {{ form_start(addOrderCartRuleForm, {'action': path('admin_orders_add_cart_rule', {'orderId': orderForViewing.id})}) }}
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">
-            {{ 'Add new cart rule'|trans({}, 'Admin.Catalog.Feature') }}
-          </h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-            <span aria-hidden="true">×</span>
-          </button>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">
+          {{ 'Add new cart rule'|trans({}, 'Admin.Catalog.Feature') }}
+        </h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-control-label" for="{{ addOrderCartRuleForm.name.vars.id }}">
+            {{ 'Name'|trans({}, 'Admin.Global') }}
+          </label>
+
+          {{ form_widget(addOrderCartRuleForm.name) }}
         </div>
-        <div class="modal-body">
-          <div class="row">
-            <div class="col">
-              <div class="form-group">
-                <label class="form-control-label" for="{{ addOrderCartRuleForm.name.vars.id }}">
-                  {{ 'Name'|trans({}, 'Admin.Global') }}
-                </label>
 
-                {{ form_widget(addOrderCartRuleForm.name) }}
-              </div>
+        <div class="row">
+          <div class="col">
+            <div class="form-group">
+              <label class="form-control-label" for="{{ addOrderCartRuleForm.type.vars.id }}">
+                {{ 'Type'|trans({}, 'Admin.Global') }}
+              </label>
+
+              {{ form_widget(addOrderCartRuleForm.type) }}
             </div>
           </div>
+          <div class="col">
+            <div class="form-group mb-0">
+              <label class="form-control-label" for="{{ addOrderCartRuleForm.value.vars.id }}">
+                {{ 'Value'|trans({}, 'Admin.Global') }}
+              </label>
 
-          <div class="row">
-            <div class="col">
-              <div class="form-group">
-                <label class="form-control-label" for="{{ addOrderCartRuleForm.type.vars.id }}">
-                  {{ 'Type'|trans({}, 'Admin.Global') }}
-                </label>
-
-                {{ form_widget(addOrderCartRuleForm.type) }}
-              </div>
-            </div>
-            <div class="col">
-              <div class="form-group mb-0">
-                <label class="form-control-label" for="{{ addOrderCartRuleForm.value.vars.id }}">
-                  {{ 'Value'|trans({}, 'Admin.Global') }}
-                </label>
-
-                <div class="input-group">
-                  <div class="input-group-prepend">
-                    <div class="input-group-text" id="add_order_cart_rule_value_unit" data-currency-symbol="{{ orderCurrency.symbol }}">%</div>
-                  </div>
-                  {{ form_widget(addOrderCartRuleForm.value) }}
+              <div class="input-group">
+                <div class="input-group-prepend">
+                  <div class="input-group-text" id="add_order_cart_rule_value_unit" data-currency-symbol="{{ orderCurrency.symbol }}">%</div>
                 </div>
-                <small class="text-muted js-cart-rule-value-help d-none">
-                  {{ 'This value must include taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-                </small>
+                {{ form_widget(addOrderCartRuleForm.value) }}
               </div>
+              <small class="text-muted js-cart-rule-value-help d-none">
+                {{ 'This value must include taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
+              </small>
             </div>
           </div>
+        </div>
 
-          <div class="{% if not orderForViewing.hasInvoice %}d-none{% endif %}">
-            <div class="row">
-              <div class="col">
-                <div class="form-group">
-                  <label class="form-control-label" for="{{ addOrderCartRuleForm.invoice_id.vars.id }}">
-                    {{ 'Invoice'|trans({}, 'Admin.Global') }}
-                  </label>
+        <div class="{% if not orderForViewing.hasInvoice %}d-none{% endif %}">
+          <div class="form-group">
+            <label class="form-control-label" for="{{ addOrderCartRuleForm.invoice_id.vars.id }}">
+              {{ 'Invoice'|trans({}, 'Admin.Global') }}
+            </label>
 
-                  {{ form_widget(addOrderCartRuleForm.invoice_id, {'attr': {
+            {{ form_widget(addOrderCartRuleForm.invoice_id, {'attr': {
                     'disabled': not orderForViewing.hasInvoice
                   }}) }}
-                </div>
-              </div>
-            </div>
           </div>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-          </button>
-          <button type="submit" class="btn btn-primary" id="add_order_cart_rule_submit">
-            {{ 'Add'|trans({}, 'Admin.Actions') }}
-          </button>
-        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </button>
+        <button type="submit" class="btn btn-primary" id="add_order_cart_rule_submit">
+          {{ 'Add'|trans({}, 'Admin.Actions') }}
+        </button>
       </div>
     </div>
+  </div>
   {{ form_end(addOrderCartRuleForm) }}
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/Modal/add_product_modal.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/Modal/add_product_modal.html.twig
@@ -36,28 +36,20 @@
         </button>
       </div>
       <div class="modal-body">
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.product_id.vars.id }}">
-                {{ 'Product'|trans({}, 'Admin.Global') }}
-              </label>
+        <div class="form-group">
+          <label class="form-control-label" for="{{ addProductToOrderForm.product_id.vars.id }}">
+            {{ 'Product'|trans({}, 'Admin.Global') }}
+          </label>
 
-              {{ form_widget(addProductToOrderForm.product_id) }}
-            </div>
-          </div>
+          {{ form_widget(addProductToOrderForm.product_id) }}
         </div>
 
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.combination_id.vars.id }}">
-                {{ 'Combination'|trans({}, 'Admin.Global') }}
-              </label>
+        <div class="form-group">
+          <label class="form-control-label" for="{{ addProductToOrderForm.combination_id.vars.id }}">
+            {{ 'Combination'|trans({}, 'Admin.Global') }}
+          </label>
 
-              {{ form_widget(addProductToOrderForm.combination_id) }}
-            </div>
-          </div>
+          {{ form_widget(addProductToOrderForm.combination_id) }}
         </div>
 
         <div class="row">
@@ -91,16 +83,12 @@
           </div>
         </div>
 
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.quantity.vars.id }}">
-                {{ 'Quantity'|trans({}, 'Admin.Global') }}
-              </label>
+        <div class="form-group">
+          <label class="form-control-label" for="{{ addProductToOrderForm.quantity.vars.id }}">
+            {{ 'Quantity'|trans({}, 'Admin.Global') }}
+          </label>
 
-              {{ form_widget(addProductToOrderForm.quantity) }}
-            </div>
-          </div>
+          {{ form_widget(addProductToOrderForm.quantity) }}
         </div>
       </div>
       <div class="modal-footer">

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/history.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/history.html.twig
@@ -44,7 +44,8 @@
       </td>
       <td class="text-right">
         {% if status.withEmail %}
-          <form method="post" action="{{ path('admin_orders_resend_email', {'orderId': orderForViewing.id, 'orderHistoryId': status.orderHistoryId, 'orderStatusId': status.orderStatusId}) }}">
+          <form method="post" 
+                action="{{ path('admin_orders_resend_email', {'orderId': orderForViewing.id, 'orderHistoryId': status.orderHistoryId, 'orderStatusId': status.orderStatusId}) }}">
             <button class="btn btn-link pt-0 pb-0">
               {{ 'Resend email'|trans({}, 'Admin.Orderscustomers.Feature') }}
             </button>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -35,6 +35,7 @@
 {% endfor %}
 
 <div class="card" id="orderProductsPanel">
+
   <div class="card-header">
     <h3 class="card-header-title">
       {{ 'Products'|trans({}, 'Admin.Global') }} (<span id="orderProductsPanelCount">{{ orderForViewing.products.products|length }}</span>)
@@ -42,80 +43,85 @@
   </div>
 
   <div class="card-body">
+
     <div class="spinner-order-products-container" id="orderProductsLoading">
       <div class="spinner spinner-primary"></div>
     </div>
+
     {% set formOptions = {
-      'attr': {
-        'data-order-id': orderForViewing.id,
-        'data-is-delivered': orderForViewing.isDelivered,
-        'data-is-tax-included': orderForViewing.isTaxIncluded,
-        'data-discounts-amount': orderForViewing.prices.discountsAmountRaw,
-        'data-price-specification': priceSpecification|json_encode
-      }
-    } %}
+          'attr': {
+            'data-order-id': orderForViewing.id,
+            'data-is-delivered': orderForViewing.isDelivered,
+            'data-is-tax-included': orderForViewing.isTaxIncluded,
+            'data-discounts-amount': orderForViewing.prices.discountsAmountRaw,
+            'data-price-specification': priceSpecification|json_encode
+          }
+        } %}
     {{ form_start(cancelProductForm, formOptions) }}
+
+    {# PRODUCT TABLE #}
     <table class="table" id="orderProductsTable" data-currency-precision="{{ orderCurrency.precision }}">
       <thead>
-      <tr>
-        <th>
-          <p>{{ 'Product'|trans({}, 'Admin.Global') }}</p>
-        </th>
-        <th></th>
-        <th>
-          <p class="mb-0">{{ 'Price per unit'|trans({}, 'Admin.Advparameters.Feature') }}</p>
-          <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
-        </th>
-        <th>
-          <p>{{ 'Quantity'|trans({}, 'Admin.Global') }}</p>
-        </th>
-        <th class="cellProductLocation{% if not isColumnLocationDisplayed %} d-none{% endif %}">
-          <p>{{ 'Stock location'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
-        </th>
-        <th class="cellProductRefunded{% if not isColumnRefundedDisplayed %} d-none{% endif %}">
-          <p>{{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
-        </th>
-        <th {% if not isAvailableQuantityDisplayed %}class="d-none"{% endif %}>
-          <p>{{ 'Available'|trans({}, 'Admin.Global') }}</p>
-        </th>
-        <th>
-          <p class="mb-0">{{ 'Total'|trans({}, 'Admin.Global') }}</p>
-          <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
-        </th>
-        {% if orderForViewing.hasInvoice() %}
+        <tr>
           <th>
-            <p>{{ 'Invoice'|trans({}, 'Admin.Global') }}</p>
+            <p>{{ 'Product'|trans({}, 'Admin.Global') }}</p>
           </th>
-        {% endif %}
-        {% if not orderForViewing.delivered %}
-          <th class="text-right product_actions d-print-none">
-            <p>{{ 'Actions'|trans({}, 'Admin.Global') }}</p>
+          <th></th>
+          <th>
+            <p class="mb-0">{{ 'Price per unit'|trans({}, 'Admin.Advparameters.Feature') }}</p>
+            <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
           </th>
-        {% endif %}
-        <th class="text-center cancel-product-element">
-          <p>{{ 'Partial refund'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
-        </th>
-      </tr>
+          <th>
+            <p>{{ 'Quantity'|trans({}, 'Admin.Global') }}</p>
+          </th>
+          <th class="cellProductLocation{% if not isColumnLocationDisplayed %} d-none{% endif %}">
+            <p>{{ 'Stock location'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+          </th>
+          <th class="cellProductRefunded{% if not isColumnRefundedDisplayed %} d-none{% endif %}">
+            <p>{{ 'Refunded'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+          </th>
+          <th {% if not isAvailableQuantityDisplayed %} class="d-none" {% endif %}>
+            <p>{{ 'Available'|trans({}, 'Admin.Global') }}</p>
+          </th>
+          <th>
+            <p class="mb-0">{{ 'Total'|trans({}, 'Admin.Global') }}</p>
+            <small class="text-muted">{{ orderForViewing.taxMethod }}</small>
+          </th>
+          {% if orderForViewing.hasInvoice() %}
+            <th>
+              <p>{{ 'Invoice'|trans({}, 'Admin.Global') }}</p>
+            </th>
+          {% endif %}
+          {% if not orderForViewing.delivered %}
+            <th class="text-right product_actions d-print-none">
+              <p>{{ 'Actions'|trans({}, 'Admin.Global') }}</p>
+            </th>
+          {% endif %}
+          <th class="text-center cancel-product-element">
+            <p>{{ 'Partial refund'|trans({}, 'Admin.Orderscustomers.Feature') }}</p>
+          </th>
+        </tr>
       </thead>
       <tbody>
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig' %}
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig' %}
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig' %}
+        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/product_list.html.twig' %}
+        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/add_product_row.html.twig' %}
+        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/edit_product_row.html.twig' %}
       </tbody>
     </table>
 
-    <div class="mb-3">
-      <div class="col-md-6 text-left d-print-none order-product-pagination">
-        <div class="form-group row">
+
+    {# PAGINATION AND ADD NEW PRODUCT/DISCOUNT #}
+    <div class="row mb-3">
+      <div class="col-xl-6 d-print-none order-product-pagination">
+        <div class="form-group">
           <label for="paginator_select_page_limit" class="col-form-label ml-3">{{ "Items per page:"|trans({}, 'Admin.Catalog.Feature') }}</label>
-          <div class="col">
-            <select id="orderProductsTablePaginationNumberSelector" class="pagination-link custom-select">
-              {% for numPageOption in paginationNumOptions %}
-                <option value="{{ numPageOption }}"{% if numPageOption == paginationNum %} selected{% endif %}>{{ numPageOption }}</option>
-              {% endfor %}
-            </select>
-          </div>
+          <select id="orderProductsTablePaginationNumberSelector" class="pagination-link custom-select">
+            {% for numPageOption in paginationNumOptions %}
+              <option value="{{ numPageOption }}" {% if numPageOption == paginationNum %} selected {% endif %}>{{ numPageOption }}</option>
+            {% endfor %}
+          </select>
         </div>
+
         {% set numPages = max(orderForViewing.products.products|length / paginationNum, 1)|round(0, 'ceil') %}
         <nav aria-label="Products Navigation"{% if orderForViewing.products.products|length <= paginationNum %} class="d-none"{% endif %} id="orderProductsNavPagination">
           <ul class="pagination" id="orderProductsTablePagination" data-num-per-page="{{ paginationNum }}" data-num-pages="{{ numPages }}">
@@ -126,9 +132,13 @@
               </a>
             </li>
             {% for numPage in 1..numPages %}
-              <li class="page-item{% if numPage==1 %} active{% endif %}"><span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page="{{ numPage }}">{{ numPage }}</span></li>
+              <li class="page-item{% if numPage==1 %} active{% endif %}">
+                <span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page="{{ numPage }}">{{ numPage }}</span>
+              </li>
             {% endfor %}
-            <li class="page-item d-none"><span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page=""></span></li>
+            <li class="page-item d-none">
+              <span class="page-link" data-order-id="{{ orderForViewing.id }}" data-page=""></span>
+            </li>
             <li class="page-item" id="orderProductsTablePaginationNext">
               <a class="page-link" href="javascript:void(0);" aria-label="Next">
                 <span aria-hidden="true">&raquo;</span>
@@ -138,7 +148,8 @@
           </ul>
         </nav>
       </div>
-      <div class="col-md-6 text-right discount-action">
+
+      <div class="col-xl-6 text-xl-right discount-action">
         {% if not orderForViewing.delivered %}
           <button type="button" class="btn btn-outline-secondary js-product-action-btn mr-3" id="addProductBtn">
             <i class="material-icons">add_circle_outline</i>
@@ -151,109 +162,127 @@
         </button>
       </div>
 
-      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig' with {
+    </div>
+
+    {# DISCOUNT LIST #}
+    {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig' with {
         'discounts': orderForViewing.discounts.discounts,
         'orderId': orderForViewing.id
-      } %}
+    } %}
 
-      <div class="col-md-12">
-        <div class="col-md-12">
-          <div class="info-block">
-            <div class="row">
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Products'|trans({}, 'Admin.Global') }}</strong></p>
-                <strong id="orderProductsTotal">{{ orderForViewing.prices.productsPriceFormatted }}</strong>
-              </div>
 
-              <div id="order-discounts-total-container" class="col-sm text-center{% if not orderForViewing.prices.discountsAmountRaw.greaterThan((number(0))) %} d-none{% endif %}">
-                <p class="text-muted mb-0"><strong>{{ 'Discounts'|trans({}, 'Admin.Global') }}</strong></p>
-                <strong id="orderDiscountsTotal">-{{ orderForViewing.prices.discountsAmountFormatted }}</strong>
-              </div>
+    {# ORDER TOTALS #}
 
-              {% if orderForViewing.prices.wrappingPriceRaw.greaterThan(number(0)) %}
-                <div class="col-sm text-center">
-                  <p class="text-muted mb-0"><strong>{{ 'Wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong></p>
-                  <strong id="orderWrappingTotal">{{ orderForViewing.prices.wrappingPriceFormatted }}</strong>
-                </div>
-              {% endif %}
+    <div class="info-block">
+      <div class="row">
 
-              <div id="order-shipping-total-container" class="col-sm text-center{% if not orderForViewing.prices.shippingPriceRaw.greaterThan((number(0))) %} d-none{% endif %}">
-                <p class="text-muted mb-0"><strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong></p>
-                <div class="shipping-price">
-                  <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
-                  <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-                    <div class="input-group">
-                      {{ form_widget(cancelProductForm.shipping_amount) }}
-                      <div class="input-group-append">
-                        <div class="input-group-text">{{ orderCurrency.symbol }}</div>
-                      </div>
-                    </div>
-                    <p class="text-center">(max {{ orderForViewing.prices.shippingRefundableAmountFormatted }} tax included)</p>
-                  </div>
-                </div>
-              </div>
-
-              {% if not orderForViewing.taxIncluded %}
-                <div class="col-sm text-center">
-                  <p class="text-muted mb-0"><strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong></p>
-                  <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
-                </div>
-              {% endif %}
-
-              <div class="col-sm text-center">
-                <p class="text-muted mb-0"><strong>{{ 'Total'|trans({}, 'Admin.Global') }}</strong></p>
-                <span class="badge rounded badge-dark font-size-100" id="orderTotal">{{ orderForViewing.prices.totalAmountFormatted }}</span>
-              </div>
-
-            </div>
-          </div>
-        </div>
-
-        <div class="col-md-12">
-          <p class="mb-0 mt-1 text-center text-muted">
-            <small>
-              {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
-                '%tax_method%': orderForViewing.taxMethod,
-                '[1]': '<strong>',
-                '[/1]': '</strong>'
-              }, 'Admin.Orderscustomers.Notification')|raw }}.
-
-              {% if not configuration('PS_ORDER_RETURN') %}
-                <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
-              {% endif %}
-            </small>
+        <div class="col-sm text-center">
+          <p class="text-muted mb-0">
+            <strong>{{ 'Products'|trans({}, 'Admin.Global') }}</strong>
           </p>
-          <div class="cancel-product-element refund-checkboxes-container">
-            <div class="cancel-product-element form-group restock-products">
-              {{ form_widget(cancelProductForm.restock) }}
-            </div>
-            <div class="cancel-product-element form-group refund-credit-slip">
-              {{ form_widget(cancelProductForm.credit_slip) }}
-            </div>
-            <div class="cancel-product-element form-group refund-voucher">
-              {{ form_widget(cancelProductForm.voucher) }}
-            </div>
-            <div class="cancel-product-element shipping-refund{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-              <div class="form-group">
-                {{ form_widget(cancelProductForm.shipping) }}
-                <small class="shipping-refund-amount">({{ orderForViewing.prices.shippingRefundableAmountFormatted }})</small>
+          <strong id="orderProductsTotal">{{ orderForViewing.prices.productsPriceFormatted }}</strong>
+        </div>
+
+        <div id="order-discounts-total-container" class="col-sm text-center{% if not orderForViewing.prices.discountsAmountRaw.greaterThan((number(0))) %} d-none{% endif %}">
+          <p class="text-muted mb-0">
+            <strong>{{ 'Discounts'|trans({}, 'Admin.Global') }}</strong>
+          </p>
+          <strong id="orderDiscountsTotal">-{{ orderForViewing.prices.discountsAmountFormatted }}</strong>
+        </div>
+
+        {% if orderForViewing.prices.wrappingPriceRaw.greaterThan(number(0)) %}
+          <div class="col-sm text-center">
+            <p class="text-muted mb-0">
+              <strong>{{ 'Wrapping'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <strong id="orderWrappingTotal">{{ orderForViewing.prices.wrappingPriceFormatted }}</strong>
+          </div>
+        {% endif %}
+
+        <div id="order-shipping-total-container" class="col-sm text-center{% if not orderForViewing.prices.shippingPriceRaw.greaterThan((number(0))) %} d-none{% endif %}">
+          <p class="text-muted mb-0">
+            <strong>{{ 'Shipping'|trans({}, 'Admin.Catalog.Feature') }}</strong>
+          </p>
+          <div class="shipping-price">
+            <strong id="orderShippingTotal">{{ orderForViewing.prices.shippingPriceFormatted }}</strong>
+            <div class="cancel-product-element shipping-refund-amount{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+              <div class="input-group">
+                {{ form_widget(cancelProductForm.shipping_amount) }}
+                <div class="input-group-append">
+                  <div class="input-group-text">{{ orderCurrency.symbol }}</div>
+                </div>
               </div>
-            </div>
-            <div class="cancel-product-element form-group voucher-refund-type{% if orderForViewing.prices.discountsAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
-              {{ 'This order has been partially paid by voucher. Choose the amount you want to refund:'|trans({}, 'Admin.Orderscustomers.Feature') }}
-              {{ form_widget(cancelProductForm.voucher_refund_type) }}
-              <div class="voucher-refund-type-negative-error">
-                {{ 'Error. You cannot refund a negative amount.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-              </div>
+              <p class="text-center">(max
+                {{ orderForViewing.prices.shippingRefundableAmountFormatted }}
+                tax included)</p>
             </div>
           </div>
         </div>
-        <div class="cancel-product-element form-submit text-right">
-          {{ form_widget(cancelProductForm.cancel) }}
-          {{ form_widget(cancelProductForm.save) }}
+
+        {% if not orderForViewing.taxIncluded %}
+          <div class="col-sm text-center">
+            <p class="text-muted mb-0">
+              <strong>{{ 'Taxes'|trans({}, 'Admin.Global') }}</strong>
+            </p>
+            <strong id="orderTaxesTotal">{{ orderForViewing.prices.taxesAmountFormatted }}</strong>
+          </div>
+        {% endif %}
+
+        <div class="col-sm text-center">
+          <p class="text-muted mb-0">
+            <strong>{{ 'Total'|trans({}, 'Admin.Global') }}</strong>
+          </p>
+          <span class="badge rounded badge-dark font-size-100" id="orderTotal">{{ orderForViewing.prices.totalAmountFormatted }}</span>
+        </div>
+
+      </div>
+    </div>
+
+    {# PRICE DISPLAY #}
+    <p class="mb-0 mt-1 text-center text-muted">
+      <small>
+        {{ 'For this customer group, prices are displayed as: [1]%tax_method%[/1]'|trans({
+          '%tax_method%': orderForViewing.taxMethod,
+          '[1]': '<strong>',
+          '[/1]': '</strong>'
+        }, 'Admin.Orderscustomers.Notification')|raw }}.
+
+        {% if not configuration('PS_ORDER_RETURN') %}
+          <strong>{{ 'Merchandise returns are disabled'|trans({}, 'Admin.Orderscustomers.Notification') }}</strong>
+        {% endif %}
+      </small>
+    </p>
+
+    {# PRODUCT CANCEL #}
+    <div class="cancel-product-element refund-checkboxes-container">
+      <div class="cancel-product-element form-group restock-products">
+        {{ form_widget(cancelProductForm.restock) }}
+      </div>
+      <div class="cancel-product-element form-group refund-credit-slip">
+        {{ form_widget(cancelProductForm.credit_slip) }}
+      </div>
+      <div class="cancel-product-element form-group refund-voucher">
+        {{ form_widget(cancelProductForm.voucher) }}
+      </div>
+      <div class="cancel-product-element shipping-refund{% if orderForViewing.prices.shippingRefundableAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+        <div class="form-group">
+          {{ form_widget(cancelProductForm.shipping) }}
+          <small class="shipping-refund-amount">({{ orderForViewing.prices.shippingRefundableAmountFormatted }})</small>
+        </div>
+      </div>
+      <div class="cancel-product-element form-group voucher-refund-type{% if orderForViewing.prices.discountsAmountRaw.lowerOrEqualThan(number(0)) %} hidden{% endif %}">
+        {{ 'This order has been partially paid by voucher. Choose the amount you want to refund:'|trans({}, 'Admin.Orderscustomers.Feature') }}
+        {{ form_widget(cancelProductForm.voucher_refund_type) }}
+        <div class="voucher-refund-type-negative-error">
+          {{ 'Error. You cannot refund a negative amount.'|trans({}, 'Admin.Orderscustomers.Notification') }}
         </div>
       </div>
     </div>
+    <div class="cancel-product-element form-submit text-right">
+      {{ form_widget(cancelProductForm.cancel) }}
+      {{ form_widget(cancelProductForm.save) }}
+    </div>
+
     {{ form_end(cancelProductForm) }}
   </div>
 </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/Blocks/View/shipping.html.twig
@@ -26,11 +26,11 @@
 {% if not orderForViewing.virtual %}
 
     {% if orderForViewing.shipping.giftMessage %}
-      <div class="row col-lg-12">
+      <div>
         <label>
           {{ 'Gift message:'|trans({}, 'Admin.Global') }}
         </label>
-        <div id="gift-message" class="col-lg-9">
+        <div id="gift-message">
            {{ orderForViewing.shipping.giftMessage }}
         </div>
       </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/create.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/create.html.twig
@@ -33,37 +33,13 @@
 
 {% block content %}
   <div id="order-creation-container">
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/customer.html.twig' %}
     <div id="js-cart-info-wrapper">
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart_rules.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig' %}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig' %}
-        </div>
-      </div>
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/cart_rules.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/addresses.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/shipping.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/Create/summary.html.twig' %}
     </div>
   </div>
 {% endblock %}

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/index.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/index.html.twig
@@ -33,26 +33,18 @@
   {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/change_orders_status_modal.html.twig' %}
 
   {% block orders_kpi %}
-    <div class="row">
-      <div class="col-md-12">
-        <div class="card card-kpis">
-          <div class="row orders-kpi">
-            {{ render(controller(
-              'PrestaShopBundle:Admin\\Common:renderKpiRow',
-              { 'kpiRow': orderKpi }
-            )) }}
-          </div>
-        </div>
+    <div class="card card-kpis">
+      <div class="row orders-kpi">
+        {{ render(controller(
+          'PrestaShopBundle:Admin\\Common:renderKpiRow',
+          { 'kpiRow': orderKpi }
+        )) }}
       </div>
     </div>
   {% endblock %}
 
   {% block order_grid_row %}
-    <div class="row">
-      <div class="col-12">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': orderGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/view.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Sell/Order/Order/view.html.twig
@@ -35,44 +35,32 @@
 {% endblock %}
 
 {% block content %}
-  <div id="order-view-page"
-       data-order-title="{{ 'Order'|trans({}, 'Admin.Global') }} #{{ orderForViewing.id }} {{ orderForViewing.reference }}">
-    <div class="row d-print-none">
+  <div id="order-view-page" data-order-title="{{ 'Order'|trans({}, 'Admin.Global') }} #{{ orderForViewing.id }} {{ orderForViewing.reference }}">
+    <div class="d-print-none">
       {% set displayAdminOrderTopHookContent = renderhook('displayAdminOrderTop', {'id_order': orderForViewing.id}) %}
-
       {% if displayAdminOrderTopHookContent != '' %}
-        <div class="col-md-12">
-          {{ displayAdminOrderTopHookContent|raw }}
-        </div>
+        {{ displayAdminOrderTopHookContent|raw }}
       {% endif %}
-      <div class="order-actions col-md-12">
+      <div class="order-actions">
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/order_actions.html.twig' %}
       </div>
     </div>
 
-    <div class="row d-none d-print-block mb-4">
-      <div class="col-md-12">
-        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/print_order_statistics.html.twig' %}
-      </div>
+    <div class="d-none d-print-block mb-4">
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/print_order_statistics.html.twig' %}
     </div>
 
-    <div class="row d-none mb-4">
-      <div class="col-12" id="orderProductsModificationPosition"></div>
-    </div>
+    <div id="orderProductsModificationPosition" class="d-none mb-4"></div>
 
-    <div class="row d-none d-print-block mb-4">
-      <div class="col-md-12">
-        {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/print_title.html.twig' %}
-      </div>
+    <div class="d-none d-print-block mb-4">
+      {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/print_title.html.twig' %}
     </div>
 
     <div class="product-row row">
       <div class="col-md-4 left-column">
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/customer.html.twig' %}
-
         {{ renderhook('displayAdminOrderSide', {'id_order': orderForViewing.id}) }}
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/messages.html.twig' %}
-
         {{ renderhook('displayAdminOrderSideBottom', {'id_order': orderForViewing.id}) }}
       </div>
 
@@ -81,17 +69,15 @@
           {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/products.html.twig' %}
         </div>
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/details.html.twig' %}
-
         {{ renderhook('displayAdminOrderMain', {'id_order': orderForViewing.id}) }}
         {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/payments.html.twig' %}
-
         {{ renderhook('displayAdminOrderMainBottom', {'id_order': orderForViewing.id}) }}
       </div>
     </div>
 
     {% if orderForViewing.sources.sources is not empty %}
-      <div class="product-row row">
-        <div class="col-md-12 left-column">
+      <div class="product-row">
+        <div class="left-column">
           {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/sources.html.twig' %}
         </div>
       </div>

--- a/templates/bundles/PrestaShopBundle/Admin/Stock/overview.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Stock/overview.html.twig
@@ -29,18 +29,13 @@
 {% endblock %}
 
 {% block content %}
-
     {% if is_shop_context %}
         <div id="stock-app"></div>
-
     {% else %}
-        <div class="col-md-12">
-            <div class="alert alert-danger" role="alert">
-                <p class="alert-text">{{ 'You can\'t manage your stock in this shop context: select a shop instead of a group of shops.'|trans({}, 'Admin.Catalog.Notification') }}</p>
-            </div>
+        <div class="alert alert-danger" role="alert">
+            <p class="alert-text">{{ 'You can\'t manage your stock in this shop context: select a shop instead of a group of shops.'|trans({}, 'Admin.Catalog.Notification') }}</p>
         </div>
     {% endif %}
-
 {% endblock %}
 
 {% block javascripts %}

--- a/templates/bundles/PrestaShopBundle/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -827,7 +827,7 @@
 
 {% block form_hint %}
   {% if hint %}
-    <div class="row col-lg hint-box">
+    <div class="hint-box">
       <div class="alert alert-info">{{ hint|raw }}</div>
     </div>
   {% endif %}

--- a/templates/bundles/PrestaShopBundle/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -314,7 +314,10 @@
     {% set form_method = "POST" %}
   {%- endif -%}
   <form name="{{ name }}"
-        method="{{ form_method|lower }}" action="{{ action }}"{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
+        method="{{ form_method|lower }}" 
+        action="{{ action }}"
+        {% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
+        {% if multipart %} enctype="multipart/form-data"{% endif %}>
   {%- if form_method != method -%}
     <input type="hidden" name="_method" value="{{ method }}"/>
   {%- endif -%}

--- a/templates/bundles/PrestaShopBundle/Admin/macros.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/macros.html.twig
@@ -88,7 +88,8 @@
 
 {# Show link to import file sample #}
 {% macro import_file_sample(label, filename) %}
-    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
+    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" 
+       href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
         {{ label|trans({}, 'Admin.Advparameters.Feature') }}
     </a>
 {% endmacro %}


### PR DESCRIPTION
**This PR was split to multiple groups, for easier review and management:**
- https://github.com/PrestaShop/PrestaShop/pull/26060
- https://github.com/PrestaShop/PrestaShop/pull/26061
- https://github.com/PrestaShop/PrestaShop/pull/26062
- https://github.com/PrestaShop/PrestaShop/pull/26063
- https://github.com/PrestaShop/PrestaShop/pull/26064

______________________


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See description below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Go through BO and see if nothing is broken by this PR. There should be no visible change.
| Possible impacts? | no

### BC Break
This PR should be considered as a BC because of lot of HTML structure changes and they might be used by a module or anything else, but it's acceptable.

### Description
- I went through all templates and removed 99% of unneeded boostrap code like `<div class="row"><div class="col">XXX</div></div>`. It will reduce render depth and complexity by several layers - easier to navigate, debug CSS, maybe faster to render on slower PCs.
- I fixed all places where somebody used single quotations or no quotations at all.
- I fixed all places where somebody combined row and column in same element, this is not allowed.
- I fixed all places where somebody used syntax line `col-sm-12 col-md-12` or `col-md-12 col-lg-6`. The first one is not needed.
- Small fixes here and there - removed some `container` classes, fixed module position page responsivity a bit, fixed virtual product block responsivity etc.

### Additional notes
- It should produce no BC breaks, unless some 3rd party module was targetting some classes they shouldn't have OR they targeted it by child or parent.
- There is a small change in one JS file to fix moving of products panel on order page. There was a dependency on .row class.
- I left it in some places where it was smelly, like here: https://github.com/PrestaShop/PrestaShop/blob/9fafd445255bc8126af09affc5df71cc364f1d60/templates/bundles/PrestaShopBundle/Admin/Improve/Shipping/Carriers/index.html.twig#L45

### TODO
- ❗ smelly selector - \admin-dev\themes\new-theme\js\pages\product\product-map.js
- Remove all `container` and `container-fluid` classes.
- Wrap all tables in table-responsive div and remove the manually set scrolls.
- Recode `Module\Includes\card_list.html.twig` - invalid code `<div class="col-lg-11 row">`, container used, boostrap column hacked etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25312)
<!-- Reviewable:end -->

Ping @NeOMakinG 
