### PR TITLE
Don't set UPGRADE as a main button in module list

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -307,13 +307,6 @@ class AdminModuleDataProvider implements ModuleInterface
                     unset($urls['configure']);
                 }
 
-                if ($addon->canBeUpgraded()) {
-                    $url_active = 'upgrade';
-                } else {
-                    unset(
-                        $urls['upgrade']
-                    );
-                }
                 if (!$addon->database->getBoolean('active_on_mobile')) {
                     unset($urls['disable_mobile']);
                 } else {

--- a/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_list.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Module/Includes/card_list.html.twig
@@ -70,7 +70,7 @@
           </h3>
         </div>
         <div class="col-sm-12 col-md-2">
-          <span class="text-ellipsis small-text">
+          <div class="text-ellipsis small-text">
             {% block addon_version %}
               {% if module.attributes.productType == "service" %}
                 {{ 'Service by %author%'|trans({'%author%' : '<b>' ~ module.attributes.author ~ '</b>'}, 'Admin.Modules.Feature')|raw }}
@@ -78,7 +78,12 @@
                 {{ 'v%version% - by %author%'|trans({ '%version%' : module.attributes.version, '%author%' : '<b>' ~ module.attributes.author ~ '</b>' }, 'Admin.Modules.Feature')|raw }}
               {% endif %}
             {% endblock %}
-          </span>
+          </div>
+          <div>
+            {% if module.attributes.urls.upgrade is defined %}
+                <span class="badge badge-success my-1">{{ 'Upgrade available'|trans({}, 'Admin.Modules.Feature') }}</span>
+            {% endif %}
+          </div>          
         </div>
         <div class="col-sm-12 col-md-8 col-lg-7">
           {% block addon_description %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Keep upgrade button in the dropdown and instead, show a label, that update is available. Product team approved in the issue.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #17137
| How to test?      | Try on some shop where upgrades are available. Two quick file changes to make.
| Possible impacts? | -

**How it looks**

![Výstřižek](https://user-images.githubusercontent.com/6097524/125179080-2177de00-e1eb-11eb-98f0-1930e6d80601.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25314)
<!-- Reviewable:end -->
