### PR TITLE
Allow GitHub UI tests to run on branch push

### DIFF
--- a/.github/workflows/sanity-72.yml
+++ b/.github/workflows/sanity-72.yml
@@ -1,9 +1,5 @@
 name: UI tests - PHP 7.2
-
-on:
-  pull_request:
-    types: [opened,reopened,synchronize]
-
+on: [push, pull_request]
 jobs:
 
   sanity:

--- a/.github/workflows/sanity-73.yml
+++ b/.github/workflows/sanity-73.yml
@@ -1,9 +1,5 @@
 name: UI tests - PHP 7.3
-
-on:
-  pull_request:
-    types: [opened,reopened,synchronize]
-
+on: [push, pull_request]
 jobs:
 
   sanity:

--- a/.github/workflows/sanity-74.yml
+++ b/.github/workflows/sanity-74.yml
@@ -1,9 +1,5 @@
 name: UI tests - PHP 7.4
-
-on:
-  pull_request:
-    types: [opened,reopened,synchronize]
-
+on: [push, pull_request]
 jobs:
 
   sanity:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow GitHub UI tests to run on branch push. Currently it is not possible to monitor UI tests results on your own fork because events on branches are ignored. Other GitHub workflows monitor pull_request and branch events.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | N/A
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25325)
<!-- Reviewable:end -->
