### PR TITLE
Create empty Customer when the customer or the guest has been deleted

### DIFF
--- a/src/Adapter/Customer/CustomerDataProvider.php
+++ b/src/Adapter/Customer/CustomerDataProvider.php
@@ -45,7 +45,7 @@ class CustomerDataProvider
     public function getCustomer($id)
     {
         if (!$id) {
-            throw new LogicException('You need to provide a customer id', null, 5002);
+            throw new LogicException('You need to provide a customer id', 5002);
         }
 
         $customer = new Customer($id);

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Order\QueryHandler;
 
 use Address;
 use Carrier;
+use Cart;
 use ConnectionsSource;
 use Context;
 use Country;
@@ -188,6 +189,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             new ShopConstraint((int) $order->id_shop, (int) $order->id_shop_group)
         );
 
+        $orderInvoiceAddress = $this->getOrderInvoiceAddress($order);
+
         return new OrderForViewing(
             (int) $order->id,
             (int) $order->id_currency,
@@ -205,9 +208,9 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $order->hasBeenShipped(),
             $invoiceManagementIsEnabled,
             new DateTimeImmutable($order->date_add),
-            $this->getOrderCustomer($order),
+            $this->getOrderCustomer($order, $orderInvoiceAddress),
             $this->getOrderShippingAddress($order),
-            $this->getOrderInvoiceAddress($order),
+            $orderInvoiceAddress,
             $this->getOrderProducts($query->getOrderId(), $query->getProductsSorting()->getValue()),
             $this->getOrderHistory($order),
             $this->getOrderDocuments($order),
@@ -229,29 +232,35 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
      *
      * @return OrderCustomerForViewing|null
      */
-    private function getOrderCustomer(Order $order): ?OrderCustomerForViewing
+    private function getOrderCustomer(Order $order, OrderInvoiceAddressForViewing $invoiceAddress): ?OrderCustomerForViewing
     {
         $currency = new Currency($order->id_currency);
         $customer = new Customer($order->id_customer);
+        $genderName = '';
+        $totalSpentSinceRegistration = null;
 
         if (!Validate::isLoadedObject($customer)) {
-            return null;
+            $cart = new Cart($order->id_cart);
+
+            $customer->firstname = $invoiceAddress->getFirstName();
+            $customer->lastname = $invoiceAddress->getLastName();
+            $customer->email = '';
+            $customer->id_lang = $cart->getAssociatedLanguage()->getId();
+            $customerStats = ['nb_orders' => 1]; // Count this current order as loaded
+        } else {
+            $gender = new Gender($customer->id_gender);
+            if (Validate::isLoadedObject($gender)) {
+                $genderName = $gender->name[(int) $order->getAssociatedLanguage()->getId()];
+            }
+
+            $customerStats = $customer->getStats();
+            $totalSpentSinceRegistration = Tools::convertPrice($customerStats['total_orders'], $order->id_currency);
         }
-
-        $gender = new Gender($customer->id_gender);
-        $genderName = '';
-
-        if (Validate::isLoadedObject($gender)) {
-            $genderName = $gender->name[(int) $order->getAssociatedLanguage()->getId()];
-        }
-
-        $customerStats = $customer->getStats();
-        $totalSpentSinceRegistration = Tools::convertPrice($customerStats['total_orders'], $order->id_currency);
 
         $isB2BEnabled = $this->configuration->getBoolean('PS_B2B_ENABLE');
 
         return new OrderCustomerForViewing(
-            $customer->id,
+            (int) $customer->id,
             $customer->firstname,
             $customer->lastname,
             $genderName,

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -240,12 +240,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $totalSpentSinceRegistration = null;
 
         if (!Validate::isLoadedObject($customer)) {
-            $cart = new Cart($order->id_cart);
-
-            $customer->firstname = $invoiceAddress->getFirstName();
-            $customer->lastname = $invoiceAddress->getLastName();
-            $customer->email = '';
-            $customer->id_lang = $cart->getAssociatedLanguage()->getId();
+            $this->buildFakeCustomerObject($order, $invoiceAddress, $customer);
             $customerStats = ['nb_orders' => 1]; // Count this current order as loaded
         } else {
             $gender = new Gender($customer->id_gender);
@@ -850,5 +845,26 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         return $this->getOrderProductsForViewingHandler->handle(
             GetOrderProductsForViewing::all($orderId->getValue(), $productsOrder)
         );
+    }
+
+    /**
+     * If there is no valid customer attached to the order, the customer must have been deleted
+     * from the database. We then create a fake customer object, using the invoice address data
+     * and cart language.
+     *
+     * @param Order $order Order object
+     * @param OrderInvoiceAddressForViewing $invoiceAddress Invoice address information
+     * @param Customer $customer Customer object
+     *
+     * @return void
+     */
+    private function buildFakeCustomerObject(Order $order, OrderInvoiceAddressForViewing $invoiceAddress, Customer $customer): void
+    {
+        $cart = new Cart($order->id_cart);
+
+        $customer->firstname = $invoiceAddress->getFirstName();
+        $customer->lastname = $invoiceAddress->getLastName();
+        $customer->email = '';
+        $customer->id_lang = $cart->getAssociatedLanguage()->getId();
     }
 }

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -240,7 +240,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         $totalSpentSinceRegistration = null;
 
         if (!Validate::isLoadedObject($customer)) {
-            $this->buildFakeCustomerObject($order, $invoiceAddress, $customer);
+            $customer = $this->buildFakeCustomerObject($order, $invoiceAddress);
             $customerStats = ['nb_orders' => 1]; // Count this current order as loaded
         } else {
             $gender = new Gender($customer->id_gender);
@@ -854,17 +854,20 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
      *
      * @param Order $order Order object
      * @param OrderInvoiceAddressForViewing $invoiceAddress Invoice address information
-     * @param Customer $customer Customer object
      *
-     * @return void
+     * @return Customer The created customer
      */
-    private function buildFakeCustomerObject(Order $order, OrderInvoiceAddressForViewing $invoiceAddress, Customer $customer): void
+    private function buildFakeCustomerObject(Order $order, OrderInvoiceAddressForViewing $invoiceAddress): Customer
     {
         $cart = new Cart($order->id_cart);
 
+        $customer = new Customer();
         $customer->firstname = $invoiceAddress->getFirstName();
         $customer->lastname = $invoiceAddress->getLastName();
         $customer->email = '';
         $customer->id_lang = $cart->getAssociatedLanguage()->getId();
+        $customer->is_guest = true;
+
+        return $customer;
     }
 }

--- a/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
@@ -170,6 +170,22 @@ class OrderInvoiceAddressForViewing
     /**
      * @return string
      */
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @return string
+     */
     public function getFullName(): string
     {
         return sprintf('%s %s', $this->firstName, $this->lastName);

--- a/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
@@ -188,7 +188,7 @@ class OrderInvoiceAddressForViewing
      */
     public function getFullName(): string
     {
-        return sprintf('%s %s', $this->firstName, $this->lastName);
+        return sprintf('%s %s', $this->getFirstName(), $this->getLastName());
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -447,7 +447,7 @@ class OrderController extends FrameworkBundleAdminController
         $changeOrderAddressForm = null;
         $privateNoteForm = null;
 
-        if (null !== $orderForViewing->getCustomer()) {
+        if (null !== $orderForViewing->getCustomer() && $orderForViewing->getCustomer()->getId() !== 0) {
             $changeOrderAddressForm = $this->createForm(ChangeOrderAddressType::class, [], [
                 'customer_id' => $orderForViewing->getCustomer()->getId(),
             ]);

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/private_note.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/private_note.html.twig
@@ -35,12 +35,14 @@
       </p>
     </div>
 
-    {{ form_start(privateNoteForm, {'action': path('admin_customers_set_private_note', {'customerId': customerInformation.customerId.value})}) }}
-      {{ form_widget(privateNoteForm.note) }}
+    {% if privateNoteForm is not null %}
+      {{ form_start(privateNoteForm, {'action': path('admin_customers_set_private_note', {'customerId': customerInformation.customerId.value})}) }}
+        {{ form_widget(privateNoteForm.note) }}
 
-      <button class="btn btn-primary float-right mt-3" type="submit">
-        {{ 'Save'|trans({}, 'Admin.Actions') }}
-      </button>
-    {{ form_end(privateNoteForm) }}
+        <button class="btn btn-primary float-right mt-3" type="submit">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+      {{ form_end(privateNoteForm) }}
+    {% endif %}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig
@@ -1,61 +1,63 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://devdocs.prestashop.com/ for more information.
+  *
+  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  *#}
 
-<div class="modal fade" id="updateCustomerAddressModal">
-  {{ form_start(changeOrderAddressForm,
-    {'action': path('admin_orders_change_customer_address', {'orderId': orderForViewing.id, 'customerId': orderForViewing.customer.id})}) }}
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">
-            {{ 'Select another address'|trans({}, 'Admin.Actions') }}
-          </h5>
+{% if changeOrderAddressForm is not null %}
+  <div class="modal fade" id="updateCustomerAddressModal">
+    {{ form_start(changeOrderAddressForm,
+      {'action': path('admin_orders_change_customer_address', {'orderId': orderForViewing.id, 'customerId': orderForViewing.customer.id})}) }}
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">
+              {{ 'Select another address'|trans({}, 'Admin.Actions') }}
+            </h5>
 
-          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-            <span aria-hidden="true">×</span>
-          </button>
-        </div>
+            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+              <span aria-hidden="true">×</span>
+            </button>
+          </div>
 
-        <div class="modal-body">
-        <div class="form-group m-0">
-            {{ form_widget(changeOrderAddressForm.new_address_id) }}
+          <div class="modal-body">
+            <div class="form-group m-0">
+              {{ form_widget(changeOrderAddressForm.new_address_id) }}
+            </div>
+          </div>
+
+          {{ form_widget(changeOrderAddressForm.address_type) }}
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+              {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+            </button>
+
+            <button type="submit" class="btn btn-primary">
+              {{ 'Select'|trans({}, 'Admin.Actions') }}
+            </button>
           </div>
         </div>
-
-        {{ form_widget(changeOrderAddressForm.address_type) }}
-
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-          </button>
-
-          <button type="submit" class="btn btn-primary">
-            {{ 'Select'|trans({}, 'Admin.Actions') }}
-          </button>
-        </div>
       </div>
-    </div>
-  {{ form_end(changeOrderAddressForm) }}
-</div>
+    {{ form_end(changeOrderAddressForm) }}
+  </div>
+{% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/view_all_messages_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/view_all_messages_modal.html.twig
@@ -30,7 +30,7 @@
         <div class="row">
           <div class="col">
             <h3 class="card-header-title">
-              {% if orderForViewing.customer is not null %}
+              {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
                 {{ 'Message history with %name%'|trans({'%name%': orderForViewing.customer.firstName ~ ' ' ~ orderForViewing.customer.lastName}, 'Admin.Global') }}
               {% else %}
                 {{ 'Message history'|trans({}, 'Admin.Global') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -1,27 +1,27 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://devdocs.prestashop.com/ for more information.
+  *
+  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  *#}
 
 <div id="customerCard" class="customer card">
   <div class="card-header">
@@ -33,152 +33,154 @@
   <div class="card-body">
     <div id="customerInfo" class="info-block">
       <div class="row">
-        {% if orderForViewing.customer is not null %}
-        <div class="col-md-6">
-          <h2 class="mb-0">
-            <i class="material-icons">account_box</i>
+        {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
+          <div class="col-md-6">
+            <h2 class="mb-0">
+              <i class="material-icons">account_box</i>
 
-            {{ orderForViewing.customer.gender }}
-            {{ orderForViewing.customer.firstName }}
-            {{ orderForViewing.customer.lastName }}
+              {{ orderForViewing.customer.gender }}
+              {{ orderForViewing.customer.firstName }}
+              {{ orderForViewing.customer.lastName }}
 
-            <strong class="text-muted ml-2">#{{ orderForViewing.customer.id }}</strong>
-          </h2>
-          {%  if orderForViewing.customer.isGuest %}
-            <strong class="text-muted">Guest</strong>
-          {% endif %}
-        </div>
-        <div id="viewFullDetails" class="col-md-6 text-right">
-          <a class="d-print-none" href="{{ path('admin_customers_view', {'customerId': orderForViewing.customer.id }) }}">
-            {{ 'View full details'|trans({}, 'Admin.Actions') }}
-          </a>
-        </div>
+              <strong class="text-muted ml-2">#{{ orderForViewing.customer.id }}</strong>
+            </h2>
+            {% if orderForViewing.customer.isGuest %}
+              <strong class="text-muted">Guest</strong>
+            {% endif %}
+          </div>
+
+          <div id="viewFullDetails" class="col-md-6 text-right">
+            <a class="d-print-none" href="{{ path('admin_customers_view', {'customerId': orderForViewing.customer.id }) }}">
+              {{ 'View full details'|trans({}, 'Admin.Actions') }}
+            </a>
+          </div>
         {% else %}
-        <div class="col">
-          <h2 class="mb-0">{{ 'Deleted customer'|trans({}, 'Admin.Global') }}</h2>
-        </div>
+          <div class="col">
+            <h2 class="mb-0">{{ 'Deleted customer'|trans({}, 'Admin.Global') }}</h2>
+          </div>
         {% endif %}
       </div>
     </div>
-    {% if orderForViewing.customer is not null %}
-    <div class="row mt-3">
-      <div id="customerEmail" class="col-md-6">
-        <p class="mb-1">
-          <strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong>
-        </p>
-        <p>
-          <a href="mailto:{{ orderForViewing.customer.email }}">
-            {{ orderForViewing.customer.email }}
-          </a>
-        </p>
 
-        {%  if orderForViewing.customer.isGuest is same as(false) %}
+    {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
+      <div class="row mt-3">
+        <div id="customerEmail" class="col-md-6">
           <p class="mb-1">
-            <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-          </p>
-          <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
-        {% endif %}
-
-        {%  if orderForViewing.customer.siret is not empty %}
-          <p class="mb-1">
-            <strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-          </p>
-          <p>{{ orderForViewing.customer.siret }}</p>
-        {% endif %}
-
-        {%  if orderForViewing.customer.ape is not empty %}
-          <p class="mb-1 d-block d-md-none">
-            <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-          </p>
-          <p class="d-block d-md-none">{{ orderForViewing.customer.ape }}</p>
-        {% endif %}
-      </div>
-      <div id="validatedOrders" class="col-md-6">
-        <p class="mb-1">
-          <strong>{{ 'Validated orders placed:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-        </p>
-        <p>
-          <span class="badge rounded badge-dark">{{ orderForViewing.customer.validOrdersPlaced }}</span>
-        </p>
-
-        {%  if orderForViewing.customer.isGuest is same as(false) %}
-          <p class="mb-1">
-            <strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            <strong>{{ 'Email:'|trans({}, 'Admin.Global') }}</strong>
           </p>
           <p>
-            <span class="badge rounded badge-dark">{{ orderForViewing.customer.totalSpentSinceRegistration }}</span>
+            <a href="mailto:{{ orderForViewing.customer.email }}">
+              {{ orderForViewing.customer.email }}
+            </a>
           </p>
-        {% endif %}
 
-        {%  if orderForViewing.customer.ape is not empty %}
-          <p class="mb-1 d-none d-md-block">
-            <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+          {%  if orderForViewing.customer.isGuest is same as(false) %}
+            <p class="mb-1">
+              <strong>{{ 'Account registered:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <p>{{ orderForViewing.customer.accountRegistrationDate|date_format_full }}</p>
+          {% endif %}
+
+          {%  if orderForViewing.customer.siret is not empty %}
+            <p class="mb-1">
+              <strong>{{ 'SIRET'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <p>{{ orderForViewing.customer.siret }}</p>
+          {% endif %}
+
+          {%  if orderForViewing.customer.ape is not empty %}
+            <p class="mb-1 d-block d-md-none">
+              <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <p class="d-block d-md-none">{{ orderForViewing.customer.ape }}</p>
+          {% endif %}
+        </div>
+        <div id="validatedOrders" class="col-md-6">
+          <p class="mb-1">
+            <strong>{{ 'Validated orders placed:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
           </p>
-          <p class="d-none d-md-block">{{ orderForViewing.customer.ape }}</p>
-        {% endif %}
+          <p>
+            <span class="badge rounded badge-dark">{{ orderForViewing.customer.validOrdersPlaced }}</span>
+          </p>
+
+          {%  if orderForViewing.customer.isGuest is same as(false) %}
+            <p class="mb-1">
+              <strong>{{ 'Total spent since registration:'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <p>
+              <span class="badge rounded badge-dark">{{ orderForViewing.customer.totalSpentSinceRegistration }}</span>
+            </p>
+          {% endif %}
+
+          {%  if orderForViewing.customer.ape is not empty %}
+            <p class="mb-1 d-none d-md-block">
+              <strong>{{ 'APE'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+            </p>
+            <p class="d-none d-md-block">{{ orderForViewing.customer.ape }}</p>
+          {% endif %}
+        </div>
       </div>
-    </div>
     {% endif %}
     <div class="info-block mt-2">
       <div class="row">
         {% if orderForViewing.virtual is same as(false) %}
-        <div id="addressShipping" class="info-block-col col-xl-6">
-          <div class="row justify-content-between no-gutters">
-            <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
-            {% if orderForViewing.customer is not null %}
-            <a class="tooltip-link d-print-none" href="#" data-toggle="dropdown">
-              <i class="material-icons">more_vert</i>
-            </a>
+          <div id="addressShipping" class="info-block-col col-xl-6">
+            <div class="row justify-content-between no-gutters">
+              <strong>{{ 'Shipping address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
+              {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
+                <a class="tooltip-link d-print-none" href="#" data-toggle="dropdown">
+                  <i class="material-icons">more_vert</i>
+                </a>
 
-            <div class="dropdown-menu dropdown-menu-right">
-              <a class="dropdown-item" id="js-delivery-address-edit-btn"
-                 href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'delivery', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
-              >
-                {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
-              </a>
+                <div class="dropdown-menu dropdown-menu-right">
+                  <a class="dropdown-item" id="js-delivery-address-edit-btn"
+                     href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'delivery', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
+                  >
+                    {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
+                  </a>
 
-              <a href="#"
-                class="dropdown-item js-update-customer-address-modal-btn"
-                data-toggle="modal"
-                data-target="#updateCustomerAddressModal"
-                data-address-type="shipping"
-              >
-                {{ 'Select another address'|trans({}, 'Admin.Actions') }}
-              </a>
+                  <a href="#"
+                     class="dropdown-item js-update-customer-address-modal-btn"
+                     data-toggle="modal"
+                     data-target="#updateCustomerAddressModal"
+                     data-address-type="shipping"
+                  >
+                    {{ 'Select another address'|trans({}, 'Admin.Actions') }}
+                  </a>
+                </div>
+              {% endif %}
             </div>
-            {% endif %}
-          </div>
 
-          {% for line in orderForViewing.shippingAddressFormatted|split("\n") %}
-            <p class="mb-0">{{ line }}</p>
-          {% endfor %}
-        </div>
+            {% for line in orderForViewing.shippingAddressFormatted|split("\n") %}
+              <p class="mb-0">{{ line }}</p>
+            {% endfor %}
+          </div>
         {% endif %}
         <div id="addressInvoice" class="info-block-col {% if orderForViewing.virtual %}col-md-12{% else %}col-md-6{% endif %}">
           <div class="row justify-content-between no-gutters">
             <strong>{{ 'Invoice address'|trans({}, 'Admin.Orderscustomers.Feature') }}</strong>
 
-            {% if orderForViewing.customer is not null %}
-            <a class="tooltip-link d-print-none" href="#" data-toggle="dropdown">
-              <i class="material-icons">more_vert</i>
-            </a>
-
-            <div class="dropdown-menu dropdown-menu-right">
-              <a class="dropdown-item" id="js-invoice-address-edit-btn"
-                 href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'invoice', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
-              >
-                {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
+            {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
+              <a class="tooltip-link d-print-none" href="#" data-toggle="dropdown">
+                <i class="material-icons">more_vert</i>
               </a>
 
-              <a href="#"
-                class="dropdown-item js-update-customer-address-modal-btn"
-                data-toggle="modal"
-                data-target="#updateCustomerAddressModal"
-                data-address-type="invoice"
-              >
-                {{ 'Select another address'|trans({}, 'Admin.Actions') }}
-              </a>
-            </div>
+              <div class="dropdown-menu dropdown-menu-right">
+                <a class="dropdown-item" id="js-invoice-address-edit-btn"
+                   href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'invoice', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
+                >
+                  {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
+                </a>
+
+                <a href="#"
+                   class="dropdown-item js-update-customer-address-modal-btn"
+                   data-toggle="modal"
+                   data-target="#updateCustomerAddressModal"
+                   data-address-type="invoice"
+                >
+                  {{ 'Select another address'|trans({}, 'Admin.Actions') }}
+                </a>
+              </div>
             {% endif %}
           </div>
 
@@ -188,53 +190,54 @@
         </div>
       </div>
     </div>
-    {% if orderForViewing.customer is not null and privateNoteForm is not null %}
-    <div id="privateNote" class="mt-2 info-block">
-      <div class="row">
-        {% set isPrivateNoteOpen = not orderForViewing.customer.privateNote is empty %}
 
-        <div class="col-md-6">
-          <h3 class="mb-0{{ not isPrivateNoteOpen ? ' d-print-none': '' }}">
-            {{ 'Private note'|trans({}, 'Admin.Orderscustomers.Feature') }}
-          </h3>
-        </div>
-        <div class="col-md-6 text-right d-print-none">
-          <a href="#"
-             class="float-right tooltip-link js-private-note-toggle-btn {% if isPrivateNoteOpen %}is-opened{% endif %}"
-          >
-            {% if isPrivateNoteOpen %}
-              <i class="material-icons">remove</i>
-            {% else %}
-              <i class="material-icons">add</i>
-            {% endif %}
-          </a>
-        </div>
+    {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 and privateNoteForm is not null %}
+      <div id="privateNote" class="mt-2 info-block">
+        <div class="row">
+          {% set isPrivateNoteOpen = not orderForViewing.customer.privateNote is empty %}
 
-        <div class="col-md-12 mt-3 js-private-note-block {% if not isPrivateNoteOpen %}d-none{% endif %}">
-          {{ form_start(privateNoteForm, {
-            'action': path('admin_customers_set_private_note', {
-              'customerId': orderForViewing.customer.id,
-              'back': path('admin_orders_view', {'orderId': orderForViewing.id})
-            })
-          }) }}
+          <div class="col-md-6">
+            <h3 class="mb-0{{ not isPrivateNoteOpen ? ' d-print-none': '' }}">
+              {{ 'Private note'|trans({}, 'Admin.Orderscustomers.Feature') }}
+            </h3>
+          </div>
+          <div class="col-md-6 text-right d-print-none">
+            <a href="#"
+               class="float-right tooltip-link js-private-note-toggle-btn {% if isPrivateNoteOpen %}is-opened{% endif %}"
+            >
+              {% if isPrivateNoteOpen %}
+                <i class="material-icons">remove</i>
+              {% else %}
+                <i class="material-icons">add</i>
+              {% endif %}
+            </a>
+          </div>
 
-          {{ form_widget(privateNoteForm.note) }}
-            <div class="d-none">
-              {{ form_rest(privateNoteForm) }}
-            </div>
+          <div class="col-md-12 mt-3 js-private-note-block {% if not isPrivateNoteOpen %}d-none{% endif %}">
+            {{ form_start(privateNoteForm, {
+              'action': path('admin_customers_set_private_note', {
+                'customerId': orderForViewing.customer.id,
+                'back': path('admin_orders_view', {'orderId': orderForViewing.id})
+              })
+              }) }}
 
-            <div class="mt-2 text-right">
-              <button type="submit"
-                      class="btn btn-primary btn-sm js-private-note-btn"
-                      {% if orderForViewing.customer.privateNote is empty %}disabled{% endif %}
-              >
-                {{ 'Save'|trans({}, 'Admin.Actions') }}
-              </button>
-            </div>
-          {{ form_end(privateNoteForm) }}
+              {{ form_widget(privateNoteForm.note) }}
+              <div class="d-none">
+                {{ form_rest(privateNoteForm) }}
+              </div>
+
+              <div class="mt-2 text-right">
+                <button type="submit"
+                        class="btn btn-primary btn-sm js-private-note-btn"
+                        {% if orderForViewing.customer.privateNote is empty %}disabled{% endif %}
+                >
+                  {{ 'Save'|trans({}, 'Admin.Actions') }}
+                </button>
+              </div>
+            {{ form_end(privateNoteForm) }}
+          </div>
         </div>
       </div>
-    </div>
     {% endif %}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -188,7 +188,7 @@
         </div>
       </div>
     </div>
-    {% if orderForViewing.customer is not null %}
+    {% if orderForViewing.customer is not null and privateNoteForm is not null %}
     <div id="privateNote" class="mt-2 info-block">
       <div class="row">
         {% set isPrivateNoteOpen = not orderForViewing.customer.privateNote is empty %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/header.html.twig
@@ -1,27 +1,27 @@
 {#**
- * Copyright since 2007 PrestaShop SA and Contributors
- * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.md.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
- * @author    PrestaShop SA and Contributors <contact@prestashop.com>
- * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+  * Copyright since 2007 PrestaShop SA and Contributors
+  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+  *
+  * NOTICE OF LICENSE
+  *
+  * This source file is subject to the Open Software License (OSL 3.0)
+  * that is bundled with this package in the file LICENSE.md.
+  * It is also available through the world-wide-web at this URL:
+  * https://opensource.org/licenses/OSL-3.0
+  * If you did not receive a copy of the license and are unable to
+  * obtain it through the world-wide-web, please send an email
+  * to license@prestashop.com so we can send you a copy immediately.
+  *
+  * DISCLAIMER
+  *
+  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+  * versions in the future. If you wish to customize PrestaShop for your
+  * needs please refer to https://devdocs.prestashop.com/ for more information.
+  *
+  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+  * @copyright Since 2007 PrestaShop SA and Contributors
+  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+  *#}
 
 <h1 class="d-inline">
   <strong class="text-muted">#{{ orderForViewing.id }}</strong>
@@ -31,7 +31,7 @@
 <p class="lead d-inline">
   {{ 'from'|trans({}, 'Admin.Global') }}
 
-  {% if orderForViewing.customer is not null %}
+  {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
     {{ orderForViewing.customer.firstName }}
     {{ orderForViewing.customer.lastName }}
   {% else %}
@@ -40,14 +40,14 @@
 </p>
 
 <span class="badge rounded badge-dark ml-2 mr-2 font-size-100">
-    {{ orderForViewing.prices.totalAmountFormatted }}
-  </span>
+  {{ orderForViewing.prices.totalAmountFormatted }}
+</span>
 
 <p class="lead d-inline">
   {{ orderForViewing.createdAt|date_format_lite }}
   <span class="text-muted">
-      {{ 'at'|trans({}, 'Admin.Global') }}
+    {{ 'at'|trans({}, 'Admin.Global') }}
 
     {{ orderForViewing.createdAt|date('H:i:s') }}
-    </span>
+  </span>
 </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -102,9 +102,10 @@
 
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig' %}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig' %}
-    {% if orderForViewing.customer is not null %}
+    {% if orderForViewing.customer is not null and orderForViewing.customer.id != 0 %}
       {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig' %}
     {% endif %}
+
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/view_all_messages_modal.html.twig' %}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/view_product_pack_modal.html.twig' %}
   </div>

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_customer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_customer.feature
@@ -14,12 +14,21 @@ Feature: Order from Back Office (BO)
     And country "US" is enabled
     And the module "dummy_payment" is installed
     And I am logged in as "test@prestashop.com" employee
-    And there is customer "testCustomer" with email "pub@prestashop.com"
-    And customer "testCustomer" has address in "US" country
-    And the customer "testCustomer" has SIRET "49791663500061"
-    And the customer "testCustomer" has APE "5829C"
-    And I create an empty cart "dummy_cart" for customer "testCustomer"
-    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    And there is a customer named "testOrderCustomer" whose email is "order+test@prestashop.com"
+    And I add new address to customer "testOrderCustomer" with following details:
+      | Address alias    | test-customer-address              |
+      | First name       | testFirstName                      |
+      | Last name        | testLastName                       |
+      | Address          | Work address st. 1234567890        |
+      | City             | Birmingham                         |
+      | Country          | United States                      |
+      | State            | Alabama                            |
+      | Postal code      | 12345                              |
+    And customer "testOrderCustomer" has address in "US" country
+    And the customer "testOrderCustomer" has SIRET "49791663500061"
+    And the customer "testOrderCustomer" has APE "5829C"
+    And I create an empty cart "dummy_cart" for customer "testOrderCustomer"
+    And I select "US" address as delivery and invoice address for customer "testOrderCustomer" in cart "dummy_cart"
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
     And I add order "bo_order1" with the following details:
       | cart                | dummy_cart                 |
@@ -36,3 +45,11 @@ Feature: Order from Back Office (BO)
     Given shop configuration for "PS_B2B_ENABLE" is set to 1
     Then the customer of the order "bo_order1" has the APE Code "5829C"
     And the customer of the order "bo_order1" has the SIRET Code "49791663500061"
+
+  Scenario: I check an order after having removed the Customer
+    Given email sending is disabled
+    And I generate invoice for "bo_order1" order
+    And the customer of the order "bo_order1" has been deleted
+    Then the customer firstname of the order "bo_order1" is "testFirstName"
+    Then the customer lastname of the order "bo_order1" is "testLastName"
+    Then the customer id of the order "bo_order1" is "0"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | Create empty Customer when the customer or the guest has been deleted. Also, a lot of forms are optional but there is no condition telling the form has to be displayed or not, so a `form is not null` has been added
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25319.
| How to test?      | Follow ticket instruction.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25326)
<!-- Reviewable:end -->
