### PR TITLE
Improve layout of datetime columns when there's not enough space

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -75,10 +75,10 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     public $language_code;
 
     /** @var string date format http://http://php.net/manual/en/function.date.php with the date only */
-    public $date_format_lite = 'Y-m-d';
+    public $date_format_lite = 'Y‑m‑d'; // note the use of non-breaking hyphens (U+2011)
 
     /** @var string date format http://http://php.net/manual/en/function.date.php with hours and minutes */
-    public $date_format_full = 'Y-m-d H:i:s';
+    public $date_format_full = 'Y‑m‑d H:i:s'; // note the use of non-breaking hyphens (U+2011)
 
     /** @var bool true if this language is right to left language */
     public $is_rtl = false;

--- a/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
+++ b/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
@@ -51,7 +51,7 @@ final class DateTimeColumn extends AbstractColumn
                 'field',
             ])
             ->setDefaults([
-                'format' => 'Y-m-d H:i:s',
+                'format' => 'Y‑m‑d H:i:s', // note the use of non-breaking hyphens (U+2011)
                 'empty_data' => '',
                 'clickable' => false,
             ])

--- a/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
+++ b/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Column\Type\Common;
 
 use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DateTimeColumn extends AbstractColumn
@@ -42,6 +43,10 @@ final class DateTimeColumn extends AbstractColumn
      * Note the use of non-breaking hyphens (U+2011)
      */
     const DATETIME_WITHOUT_SECONDS = 'Y‑m‑d H:i';
+
+    private const FORMAT_NORMALIZATION_MAP = [
+        '-' => '‑', // convert hyphens into non-breaking hyphens
+    ];
 
     /**
      * {@inheritdoc}
@@ -70,6 +75,12 @@ final class DateTimeColumn extends AbstractColumn
             ->setAllowedTypes('format', 'string')
             ->setAllowedTypes('field', 'string')
             ->setAllowedTypes('empty_data', 'string')
-            ->setAllowedTypes('clickable', 'bool');
+            ->setAllowedTypes('clickable', 'bool')
+            ->setNormalizer(
+                'format',
+                function (Options $options, $value) {
+                    return strtr($value, self::FORMAT_NORMALIZATION_MAP);
+                }
+            );
     }
 }

--- a/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
+++ b/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
@@ -32,6 +32,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class DateTimeColumn extends AbstractColumn
 {
     /**
+     * Default date format.
+     * Note the use of non-breaking hyphens (U+2011)
+     */
+    const DEFAULT_FORMAT = 'Y‑m‑d H:i:s';
+
+    /**
+     * Complete datetime format, without seconds.
+     * Note the use of non-breaking hyphens (U+2011)
+     */
+    const DATETIME_WITHOUT_SECONDS = 'Y‑m‑d H:i';
+
+    /**
      * {@inheritdoc}
      */
     public function getType()
@@ -51,7 +63,7 @@ final class DateTimeColumn extends AbstractColumn
                 'field',
             ])
             ->setDefaults([
-                'format' => 'Y‑m‑d H:i:s', // note the use of non-breaking hyphens (U+2011)
+                'format' => self::DEFAULT_FORMAT,
                 'empty_data' => '',
                 'clickable' => false,
             ])

--- a/src/Core/Grid/Definition/Factory/CatalogPriceRuleGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CatalogPriceRuleGridDefinitionFactory.php
@@ -143,7 +143,7 @@ final class CatalogPriceRuleGridDefinitionFactory extends AbstractGridDefinition
             ->add((new DateTimeColumn('date_from'))
             ->setName($this->trans('Beginning', [], 'Admin.Catalog.Feature'))
             ->setOptions([
-                'format' => 'Y-m-d H:i',
+                'format' => 'Y‑m‑d H:i', // note the use of non-breaking hyphens (U+2011)
                 'field' => 'date_from',
             ])
             )

--- a/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/LogGridDefinitionFactory.php
@@ -51,7 +51,7 @@ final class LogGridDefinitionFactory extends AbstractGridDefinitionFactory
     public const GRID_ID = 'logs';
 
     /**
-     * @var string
+     * @var string Date format for the current user
      */
     private $contextDateFormat;
 

--- a/src/Core/Util/DateTime/DateTime.php
+++ b/src/Core/Util/DateTime/DateTime.php
@@ -46,6 +46,11 @@ final class DateTime
     public const DEFAULT_DATETIME_FORMAT = 'Y-m-d H:i:s';
 
     /**
+     * ISO Date time format string
+     */
+    public const ISO_DATETIME_FORMAT = 'c';
+
+    /**
      * DateTime value which should be considered same as null
      */
     public const NULL_DATETIME = '0000-00-00 00:00:00';

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/date_time.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/date_time.html.twig
@@ -23,10 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set valueToDisplay = record[column.id]|date(column.options.format) %}
-
 {% if record[column.id] == constant('PrestaShop\\PrestaShop\\Core\\Util\\DateTime\\DateTime::NULL_VALUE') %}
-  {% set valueToDisplay = column.options.empty_data %}
+  {{  column.options.empty_data }}
+{% else %}
+  <time datetime="{{ record[column.id]|date(constant('PrestaShop\\PrestaShop\\Core\\Util\\DateTime\\DateTime::ISO_DATETIME_FORMAT')) }}">{{ record[column.id]|date(column.options.format) }}</time>
 {% endif %}
-
-{{ valueToDisplay }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This change adds:<br>- Replace dashes with non-breaking hyphens (U+2011) in datetime default formats, so that the date is not broken up when there's not enough space.<br>- Use the appropriate date format in the logs page, according to the user's language (or configuration).<br>- Wrap the content of DateTimeColumns in `<time>` tags.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | Yes - `PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory` now takes a second constructor parameter: `string $contextDateFormat`.
| Deprecations?     | no
| Fixed ticket?     | N/A - but reported by @Hlavtox 
| How to test?      | Go to a grid that has dates, then make the screen narrower. You might need to install a different language than French to get dashes, or change the date format yourself in settings.
| Possible impacts? | Might cause issues if for some reason dates are displayed using the modified code on older terminals that don't support UTF-8

Before:
<img width="355" alt="Broken date" src="https://user-images.githubusercontent.com/1009343/125348558-c81ac680-e332-11eb-91a6-754097dda934.png">

After:
<img width="262" alt="Corrected format" src="https://user-images.githubusercontent.com/1009343/125820842-94229de6-698d-4cb9-8bbd-f83456bc1c6a.png">

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25327)
<!-- Reviewable:end -->
