### PR TITLE
Disable failing Behat test about product duplicate translation

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -120,7 +120,7 @@ Feature: Duplicate product from Back Office (BO).
     And product "copy_of_product1" localized "name" should be:
       | locale | value                       |
       | en-US  | copy of smart sunglasses    |
-      | fr-FR  | copie de lunettes de soleil |
+      #| fr-FR  | copie de lunettes de soleil |
     And product "copy_of_product1" localized "description" should be:
       | locale | value           |
       | en-US  | nice sunglasses |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Disable failing Behat test about product duplicate translation (issue https://github.com/PrestaShop/PrestaShop/issues/25317). This issue is random and after 2 days of work, we think it is a CDN issue. I suggest to disable the test for now and re-enable it when CDN issue is fixed.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Linked to https://github.com/PrestaShop/PrestaShop/issues/25317
| How to test?      | 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25344)
<!-- Reviewable:end -->
