### PR TITLE
Allow ordering as a guest, even after a you made an account

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -285,7 +285,8 @@ class CustomerCore extends ObjectModel
      */
     public function addWs($autodate = true, $null_values = false)
     {
-        if (Customer::customerExists($this->email)) {
+        // Check if registered customer exists with the email we are trying to add
+        if (!$this->isGuest() && Customer::customerExists($this->email)) {
             WebserviceRequest::getInstance()->setError(
                 500,
                 $this->trans(
@@ -354,9 +355,10 @@ class CustomerCore extends ObjectModel
      */
     public function updateWs($nullValues = false)
     {
-        if (Customer::customerExists($this->email)
-            && Customer::customerExists($this->email, true) !== (int) $this->id
-        ) {
+        // Check if registered customer exists with the email we are trying to add.
+        // Also check if the customer found is a different customer than our object.
+        $customerExists = (int) Customer::customerExists($this->email, true);
+        if (!$this->isGuest() && $customerExists > 0 && $customerExists !== (int) $this->id) {
             WebserviceRequest::getInstance()->setError(
                 500,
                 $this->trans(

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -123,17 +123,6 @@ class CustomerFormCore extends AbstractForm
 
     public function validate()
     {
-        $emailField = $this->getField('email');
-        $id_customer = Customer::customerExists($emailField->getValue(), true, true);
-        $customer = $this->getCustomer();
-        if ($id_customer && $id_customer != $customer->id) {
-            $emailField->addError($this->translator->trans(
-                'The email is already used, please choose another one or sign in',
-                [],
-                'Shop.Notifications.Error'
-            ));
-        }
-
         // check birthdayField against null case is mandatory.
         $birthdayField = $this->getField('birthday');
         if (!empty($birthdayField) &&

--- a/classes/form/CustomerFormatter.php
+++ b/classes/form/CustomerFormatter.php
@@ -182,7 +182,8 @@ class CustomerFormatterCore implements FormFormatterInterface
                         'Shop.Forms.Labels'
                     )
                 )
-                ->setRequired($this->password_is_required);
+                ->setRequired($this->password_is_required)
+                ->setAutocompleteAttribute('new-password');
         }
 
         if ($this->ask_for_new_password) {
@@ -195,7 +196,8 @@ class CustomerFormatterCore implements FormFormatterInterface
                         [],
                         'Shop.Forms.Labels'
                     )
-                );
+                )
+                ->setAutocompleteAttribute('new-password');
         }
 
         if ($this->ask_for_birthdate) {

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -135,17 +135,16 @@ class CustomerPersisterCore
             $customer->id_default_group = (int) Configuration::get('PS_CUSTOMER_GROUP');
         }
 
-        if ($customer->is_guest || $guestToCustomerConversion) {
-            // guest cannot update their email to that of an existing real customer
-            if (Customer::customerExists($customer->email, false, true)) {
-                $this->errors['email'][] = $this->translator->trans(
-                    'An account was already registered with this email address',
-                    [],
-                    'Shop.Notifications.Error'
-                );
+        // If we are converting to a registered customer, we must check if a customer
+        // with this email doesn't already exist.
+        if ($guestToCustomerConversion && Customer::customerExists($customer->email)) {
+            $this->errors['email'][] = $this->translator->trans(
+                'The email is already used, please choose another one or sign in',
+                [],
+                'Shop.Notifications.Error'
+            );
 
-                return false;
-            }
+            return false;
         }
 
         if ($customer->email != $this->context->customer->email) {
@@ -205,15 +204,13 @@ class CustomerPersisterCore
         }
 
         /*
-         * Check that there is not a customer registered with this email,
-         * we can't have two registered customers with the same email.
-         *
-         * Currently, it also checks for guests, because we don't allow guest checkout
-         * if there is a registered customer already, will be changed.
+         * If a password was entered in the forn, check that there is not
+         * a customer registered with this email, we can't have two
+         * registered customers with the same email.
          */
-        if (Customer::customerExists($customer->email, false, true)) {
+        if (!$customer->isGuest() && Customer::customerExists($customer->email)) {
             $this->errors['email'][] = $this->translator->trans(
-                'An account was already registered with this email address',
+                'The email is already used, please choose another one or sign in',
                 [],
                 'Shop.Notifications.Error'
             );

--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -152,7 +152,7 @@ class GuestTrackingControllerCore extends FrontController
         }
 
         // Kept for backwards compatibility (is_customer), inline it in later versions
-        $registered_customer_exists = Customer::customerExists(Tools::getValue('email'), false, true);
+        $registered_customer_exists = Customer::customerExists(Tools::getValue('email'));
 
         $this->context->smarty->assign([
             'order' => (new OrderPresenter())->present($this->order),

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -219,7 +219,7 @@ class OrderConfirmationControllerCore extends FrontController
             'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn($this->order),
             'order' => (new OrderPresenter())->present($this->order),
             'order_customer' => (new ObjectPresenter())->present($this->customer),
-            'registered_customer_exists' => Customer::customerExists($this->customer->email, false, true),
+            'registered_customer_exists' => Customer::customerExists($this->customer->email),
         ]);
         $this->setTemplate('checkout/order-confirmation');
 

--- a/src/Adapter/Customer/CommandHandler/TransformGuestToCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/TransformGuestToCustomerHandler.php
@@ -83,6 +83,8 @@ final class TransformGuestToCustomerHandler implements TransformGuestToCustomerH
     }
 
     /**
+     * Checks if a customer with the same email already exists in database.
+     *
      * @param Customer $customer
      *
      * @throws CustomerTransformationException

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -914,10 +914,10 @@ class CustomerController extends AbstractAdminController
                 'This customer does not exist.',
                 'Admin.Orderscustomers.Notification'
             ),
-            DuplicateCustomerEmailException::class => sprintf(
-                '%s %s',
-                $this->trans('An account already exists for this email address:', 'Admin.Orderscustomers.Notification'),
-                $e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : ''
+            DuplicateCustomerEmailException::class => $this->trans(
+                'You can\'t update the email to "%s", because a registered customer with this email already exists.',
+                'Admin.Orderscustomers.Notification',
+                [$e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : '']
             ),
             CustomerDefaultGroupAccessException::class => $this->trans(
                 'A default customer group must be selected in group box.',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23007, Fixes https://github.com/PrestaShop/PrestaShop/issues/25355
| How to test?      | See below
| Possible impacts? | -

### Changes
- This PR allows to make an order as a guest even if a registered customer customer exists. This fixes a nonsense behavior when there could be a thousand guest accouts before making a customer account, but you were unable to order as a guest afterwards.
- You are now able to freely change guest account emails. It's checked only if the customer is not a guest. Error message was improved to - `You can't update the email to "john.doe@prestashop.com", because a registered customer with this email already exists.` I will add an automatic test in another PR, after https://github.com/PrestaShop/PrestaShop/pull/31375 is merged, because I can't create guests in tests now.
- In webservice, emails are also checked only in case of registered customers.

### Technical
- I have prepared my ground a bit in another PRs, so it's not much changes.
- Webservice
  - classes/Customer.php - Improved webservice validation.
  - classes/form/CustomerForm.php - I removed validation from the form.
- FO
  - classes/form/CustomerFormatter.php - Attempt to disable autocomplete on password register fields, not sure if browsers will follow. They should.
  - classes/form/CustomerPersister.php - Changed condition and transferred the error message from form validation, so it doesn't change.
  - Front controllers - removed some extra parameters from a call - they are default.
- Admin
  - EditCustomerHandler.php - Added the guest condition to email check.
  - CustomerController.php - Improved the error message 

### How to test FO, guest orders enabled
- Order something and register yourself, log out.
- Go order something and enter the same email as before AND a password. ➡️ You cannot continue as normal, error shown.
- Go order something and enter the same email as before, don't enter password. ➡️ You can still continue in the order as a guest. ✅
- Finish the order and see that **it will not show you the box to convert your account**, because registered customer with that email already exists. - Tackled before in https://github.com/PrestaShop/PrestaShop/pull/25395 ✔️

### How to test FO, guest orders disabled
- Disable guest ordering in Prestashop settings.
- Go order something and enter the same email as before.
- See error that this customer already exists.

### How to test BO
- Go to BO >Customers
- Have three customers:
  - krystian@prestashop.com, registered
  - hiba@prestashop.com, registered
  - matthieu@prestashop.com, guest
- See that:
  - You can change matthieu's email to anything.
  - You cannot change krystian's email to hiba or hiba to krystian.
