### PR TITLE
Allow editing guest emails

### DIFF
--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -215,6 +215,12 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
             return;
         }
 
+        // We check this only if dealing with a registered customer
+        // Two guests with the same email can co-exist, two registered customers can not
+        if ($customer->is_guest) {
+            return;
+        }
+
         $customerByEmail = new Customer();
         $customerByEmail->getByEmail($command->getEmail()->getValue());
 

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -151,3 +151,37 @@ Feature: Customer Management
       | defaultGroupId | Guest                        |
       | groupIds       | [Guest]                      |
     And customer "CUST-7" should be soft deleted
+
+  Scenario: Edit guest customer email
+    When I create a customer "CUST-8" with following properties:
+      | firstName      | Mathieu                     |
+      | lastName       | Guest                       |
+      | email          | guest@prestashop.com        |
+      | password       | PrestaShopForever1_!        |
+      | defaultGroupId | Guest                       |
+      | groupIds       | [Guest]                     |
+      | isGuest        | true                        |
+    And I create a customer "CUST-9" with following properties:
+      | firstName | Mathieu                     |
+      | lastName  | Customer                    |
+      | email     | customernine@prestashop.com |
+      | password  | PrestaShopForever1_!        |
+    And I edit customer "CUST-8" and I change the following properties:
+      | email | customernine@prestashop.com |
+    Then if I query customer "CUST-8" I should get a Customer with properties:
+      | email | customernine@prestashop.com |
+
+  Scenario: Edit registered customer email
+    When I create a customer "CUST-10" with following properties:
+      | firstName | Mathieu                     |
+      | lastName  | Customertwo                 |
+      | email     | customereten@prestashop.com  |
+      | password  | PrestaShopForever1_!        |
+    And I create a customer "CUST-11" with following properties:
+      | firstName | Mathieu                     |
+      | lastName  | Customer                    |
+      | email     | customereleven@prestashop.com     |
+      | password  | PrestaShopForever1_!        |
+    And I edit customer "CUST-10" and I change the following properties:
+      | email | customereleven@prestashop.com |
+    Then I should be returned an error message 'Customer with email "customereleven@prestashop.com" already exists'    


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In case of guest accounts, you should be able to edit their emails to whatever you want to. See related issue.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25355
| How to test?      | See below
| Possible impacts? | None

## How to reproduce
- **BEFORE PR**
- Make a guest account with email **john.doe@prestashop.com**.
- Make a registered account with the same email **john.doe@prestashop.com**.
- Edit the guest account and change the email to something - **john.doe@google.com**.
- Go edit the guest account again and try to change it back to what it was - **john.doe@prestashop.com**. See error.
- **AFTER PR**
- Go edit the guest account and try to change it back and see that it works fine.
- Make a another registered account with different email - **daniel.doe@prestashop.com**. 
- Try to change this account to **john.doe@prestashop.com** and see that it shows the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25356)
<!-- Reviewable:end -->
