### PR TITLE
Fix inputs prefilling bug when a combination is added to an order

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
+++ b/admin-dev/themes/new-theme/js/pages/order/view/order-product-add.js
@@ -65,24 +65,20 @@ export default class OrderProductAdd {
 
   setupListener() {
     this.combinationsSelect.on('change', (event) => {
-      const taxExcluded = this.priceTaxExcludedInput.val(
-        window.ps_round(
-          $(event.currentTarget)
-            .find(':selected')
-            .data('priceTaxExcluded'),
-          this.currencyPrecision,
-        ),
+      const taxExcluded = window.ps_round(
+        $(event.currentTarget)
+          .find(':selected')
+          .data('priceTaxExcluded'),
+        this.currencyPrecision,
       );
       this.priceTaxExcludedInput.val(taxExcluded);
       this.taxExcluded = parseFloat(taxExcluded);
 
-      const taxIncluded = this.priceTaxIncludedInput.val(
-        window.ps_round(
-          $(event.currentTarget)
-            .find(':selected')
-            .data('priceTaxIncluded'),
-          this.currencyPrecision,
-        ),
+      const taxIncluded = window.ps_round(
+        $(event.currentTarget)
+          .find(':selected')
+          .data('priceTaxIncluded'),
+        this.currencyPrecision,
       );
       this.priceTaxIncludedInput.val(taxIncluded);
       this.taxIncluded = parseFloat(taxIncluded);

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/discount_list.html.twig
@@ -22,28 +22,30 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<table class="table discountList{% if discounts is empty %} d-none{% endif %}">
-  <thead>
-  <tr>
-    <th>{{ 'Name'|trans({}, 'Admin.Global') }}</th>
-    <th>{{ 'Value'|trans({}, 'Admin.Global') }}</th>
-    <th class="text-right d-print-none">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
-  </tr>
-  </thead>
-  <tbody>
-  {% for discount in discounts %}
+<div class="col-md-12">
+  <table class="table discountList{% if discounts is empty %} d-none{% endif %}">
+    <thead>
     <tr>
-      <td class="discountList-name">{{ discount.name }}</td>
-      <td>
-        {% if discount.amountRaw.greaterThan(number(0)) %}-{% endif %}
-        {{ discount.amountFormatted }}
-      </td>
-      <td class="text-right d-print-none">
-        <a class="delete-cart-rule btn btn-text" href="{{ path('admin_orders_remove_cart_rule', {'orderId': orderId, 'orderCartRuleId': discount.orderCartRuleId}) }}">
-          <i class="material-icons">delete</i>
-        </a>
-      </td>
+      <th>{{ 'Name'|trans({}, 'Admin.Global') }}</th>
+      <th>{{ 'Value'|trans({}, 'Admin.Global') }}</th>
+      <th class="text-right d-print-none">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
     </tr>
-  {% endfor %}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+    {% for discount in discounts %}
+      <tr>
+        <td class="discountList-name">{{ discount.name }}</td>
+        <td>
+          {% if discount.amountRaw.greaterThan(number(0)) %}-{% endif %}
+          {{ discount.amountFormatted }}
+        </td>
+        <td class="text-right d-print-none">
+          <a class="delete-cart-rule btn btn-text" href="{{ path('admin_orders_remove_cart_rule', {'orderId': orderId, 'orderCartRuleId': discount.orderCartRuleId}) }}">
+            <i class="material-icons">delete</i>
+          </a>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/products.html.twig
@@ -104,7 +104,7 @@
       </tbody>
     </table>
 
-    <div class="mb-3">
+    <div class="row mb-3">
       <div class="col-md-6 text-left d-print-none order-product-pagination">
         <div class="form-group row">
           <label for="paginator_select_page_limit" class="col-form-label ml-3">{{ "Items per page:"|trans({}, 'Admin.Catalog.Feature') }}</label>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR fixes a bug introduced by this merge PR https://github.com/PrestaShop/PrestaShop/pull/25297 The computed value was actually the jQuery object which resulted in an incorrect prefilling of the input fields<br>Also fix a bug related to display that was introduced by this PR https://github.com/PrestaShop/PrestaShop/pull/24447 The discounts were better displayed but it broke the original layout of the buttons at the same time We need the `row` class on the container or else the columns system can't work
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25347 and #25140
| How to test?      | See issue, try to add a combination in the order the prices must be correctly prefilled Also the buttons "Add product" and "Add discount" are now correctly aligned on the right
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25364)
<!-- Reviewable:end -->
