### PR TITLE
Fixed selector call for enabling back the confirmation modal when changing the currency by default

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/localization/LocalizationPageMap.js
+++ b/admin-dev/themes/new-theme/js/pages/localization/LocalizationPageMap.js
@@ -22,13 +22,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-import LocalizationPageMap from '@pages/localization/LocalizationPageMap';
 
-const {$} = window;
+/* eslint-disable max-len */
 
-$(() => {
-  // Show warning message when currency is changed
-  $(LocalizationPageMap.formDefaultCurrency).on('change', function () {
-    alert($(this).data('warning-message'));
-  });
-});
+export default {
+  formDefaultCurrency: '#form_default_currency',
+};


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixed selector call for enabling back the confirmation modal when changing the currency by default
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25264
| How to test?      | Cf. #25264


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25386)
<!-- Reviewable:end -->
