### PR TITLE
Fix urlBelongsToShop for www. shop domains

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -488,7 +488,7 @@ class ToolsCore
     {
         $urlHost = Tools::extractHost($url);
 
-        return empty($urlHost) || $urlHost === Tools::getServerName();
+        return empty($urlHost) || ($urlHost === Tools::getServerName() || $urlHost === 'www.'.Tools::getServerName());
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When using Link::getModule link to obtain a full URL to a module controller, using that in the auth-redirect FO mechanism does not work for domains that have base urls like www.test.com instead of test.com, as Tools::urlBelongsToShop returns false for these valid shop urls. This PR fixes this. Tools::getServerName and the underlying $_SERVER variable do not return the www. prefix
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Create a minimal module front controller with auth = true and a specified authRedirection on a domain with www. prefix
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25392)
<!-- Reviewable:end -->
