### PR TITLE
Fix revisiting order confirmation and guest to customer conversion in FO

### DIFF
--- a/controllers/front/GuestTrackingController.php
+++ b/controllers/front/GuestTrackingController.php
@@ -81,12 +81,28 @@ class GuestTrackingControllerCore extends FrontController
             $customer = new Customer((int) $this->order->id_customer);
             $password = Tools::getValue('password');
 
-            if (strlen($password) < Validate::PASSWORD_LENGTH) {
+            if (empty($password)) {
+                $this->errors[] = $this->trans(
+                    'Enter a password to transform your guest account into a customer account.',
+                    [],
+                    'Shop.Forms.Help'
+                );
+            } elseif (strlen($password) < Validate::PASSWORD_LENGTH) {
                 $this->errors[] = $this->trans(
                     'Your password must be at least %min% characters long.',
                     ['%min%' => Validate::PASSWORD_LENGTH],
                     'Shop.Forms.Help'
                 );
+            // Prevent error
+            // A) either on page refresh
+            // B) if we already transformed him in other window or through backoffice
+            } elseif ($customer->is_guest == 0) {
+                $this->errors[] = $this->trans(
+                    'A customer account has already been created from this guest account. Please sign in.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+            // Attempt to convert the customer
             } elseif ($customer->transformToCustomer($this->context->language->id, $password)) {
                 $this->success[] = $this->trans(
                     'Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.',
@@ -94,7 +110,7 @@ class GuestTrackingControllerCore extends FrontController
                     'Shop.Notifications.Success'
                 );
             } else {
-                $this->success[] = $this->trans(
+                $this->errors[] = $this->trans(
                     'An unexpected error occurred while creating your account.',
                     [],
                     'Shop.Notifications.Error'
@@ -124,12 +140,14 @@ class GuestTrackingControllerCore extends FrontController
             );
         }
 
-        $presented_order = (new OrderPresenter())->present($this->order);
+        // Kept for backwards compatibility (is_customer), inline it in later versions
+        $registered_customer_exists = Customer::customerExists(Tools::getValue('email'), false, true);
 
         $this->context->smarty->assign([
-            'order' => $presented_order,
+            'order' => (new OrderPresenter())->present($this->order),
             'guest_email' => Tools::getValue('email'),
-            'is_customer' => Customer::customerExists(Tools::getValue('email'), false, true),
+            'registered_customer_exists' => $registered_customer_exists,
+            'is_customer' => $registered_customer_exists, // Kept for backwards compatibility
             'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $this->order]),
         ]);
 

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -89,8 +89,8 @@ class OrderConfirmationControllerCore extends FrontController
             if ($this->order->module !== 'free_order') {
                 Tools::redirect($redirectLink);
             }
-        // Otherwise we run a normal check that module matches
         } else {
+            // Otherwise we run a normal check that module matches
             $module = Module::getInstanceById((int) ($this->id_module));
             if ($this->order->module !== $module->name) {
                 Tools::redirect($redirectLink);

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -23,18 +23,24 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderPresenter;
 
 class OrderConfirmationControllerCore extends FrontController
 {
     public $ssl = true;
     public $php_self = 'order-confirmation';
+    /** @var int Cart ID */
     public $id_cart;
     public $id_module;
     public $id_order;
-    public $reference;
     public $secure_key;
-    public $order_presenter;
+    /** @var Order Order object we found by cart ID */
+    protected $order;
+    /** @var Customer Customer object related to the cart */
+    protected $customer;
+    public $reference; // Deprecated
+    public $order_presenter; // Deprecated
 
     /**
      * Initialize order confirmation controller.
@@ -45,42 +51,104 @@ class OrderConfirmationControllerCore extends FrontController
     {
         parent::init();
 
-        // for free orders do extra checks and validations and redirect back here
-        // with bit more data.
+        // If we are coming to this page to finish free order we do extra checks and validations
+        // and redirect back here with bit more data.
         if (true === (bool) Tools::getValue('free_order')) {
             $this->checkFreeOrder();
         }
 
+        /*
+         * Because of order splitting scenarios, we must get the data by id_cart parameter (not id_order),
+         * so we can display all orders made from this cart.
+         *
+         * It's not implemented yet, however.
+         */
         $this->id_cart = (int) (Tools::getValue('id_cart', 0));
-
-        $redirectLink = 'index.php?controller=history';
-
-        $this->id_module = (int) (Tools::getValue('id_module', 0));
         $this->id_order = Order::getIdByCartId((int) ($this->id_cart));
         $this->secure_key = Tools::getValue('key', false);
-        $order = new Order((int) ($this->id_order));
+        $this->order = new Order((int) ($this->id_order));
+        $this->id_module = (int) (Tools::getValue('id_module', 0));
 
+        // This data is kept only for backward compatibility purposes
+        $this->reference = (string) $this->order->reference;
+
+        $redirectLink = $this->context->link->getPageLink('history', $this->ssl);
+
+        // The confirmation link must contain a unique order secure key matching the key saved in database,
+        // this prevents user to view other customer's order confirmations
         if (!$this->id_order || !$this->id_module || !$this->secure_key || empty($this->secure_key)) {
             Tools::redirect($redirectLink . (Tools::isSubmit('slowvalidation') ? '&slowvalidation' : ''));
         }
-        $this->reference = $order->reference;
-        if (!Validate::isLoadedObject($order) || $order->id_customer != $this->context->customer->id || $this->secure_key != $order->secure_key) {
+
+        if (!Validate::isLoadedObject($this->order) || $this->secure_key != $this->order->secure_key) {
             Tools::redirect($redirectLink);
         }
 
-        // free order uses -1 as id_module, it has a special check here
+        // Free order uses -1 as id_module, it has a special check here
         if ($this->id_module == -1) {
-            if ($order->module !== 'free_order') {
+            if ($this->order->module !== 'free_order') {
                 Tools::redirect($redirectLink);
             }
+        // Otherwise we run a normal check that module matches
         } else {
-            // and the normal check that module matches
             $module = Module::getInstanceById((int) ($this->id_module));
-            if ($order->module !== $module->name) {
+            if ($this->order->module !== $module->name) {
                 Tools::redirect($redirectLink);
             }
         }
-        $this->order_presenter = new OrderPresenter();
+
+        // If checks passed, initialize customer, we will need him anyway
+        $this->customer = new Customer((int) ($this->order->id_customer));
+    }
+
+    /**
+     * Logic after submitting forms
+     *
+     * @see FrontController::postProcess()
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('submitTransformGuestToCustomer')) {
+            // Only variable we need is the password
+            // There is no need to check other variables, because hacker would be kicked out in init(), if he tried to convert another customer
+            $password = Tools::getValue('password');
+
+            if (empty($password)) {
+                $this->errors[] = $this->trans(
+                    'Enter a password to transform your guest account into a customer account.',
+                    [],
+                    'Shop.Forms.Help'
+                );
+            } elseif (strlen($password) < Validate::PASSWORD_LENGTH) {
+                $this->errors[] = $this->trans(
+                    'Your password must be at least %min% characters long.',
+                    ['%min%' => Validate::PASSWORD_LENGTH],
+                    'Shop.Forms.Help'
+                );
+            // Prevent error
+            // A) either on page refresh
+            // B) if we already transformed him in other window or through backoffice
+            } elseif ($this->customer->is_guest == 0) {
+                $this->errors[] = $this->trans(
+                    'A customer account has already been created from this guest account. Please sign in.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+            // Attempt to convert the customer
+            } elseif ($this->customer->transformToCustomer($this->context->language->id, $password)) {
+                $this->success[] = $this->trans(
+                    'Your guest account has been successfully transformed into a customer account. You can now log in as a registered shopper.',
+                    [],
+                    'Shop.Notifications.Success'
+                );
+            } else {
+                $this->errors[] = $this->trans(
+                    'An unexpected error occurred while creating your account.',
+                    [],
+                    'Shop.Notifications.Error'
+                );
+            }
+        }
     }
 
     /**
@@ -90,31 +158,21 @@ class OrderConfirmationControllerCore extends FrontController
      */
     public function initContent()
     {
-        if (Configuration::isCatalogMode()) {
-            Tools::redirect('index.php');
-        }
-
-        $order = new Order(Order::getIdByCartId((int) ($this->id_cart)));
-        $presentedOrder = $this->order_presenter->present($order);
-        $register_form = $this
-            ->makeCustomerForm()
-            ->setGuestAllowed(false)
-            ->fillWith(Tools::getAllValues());
-
         parent::initContent();
 
         $this->context->smarty->assign([
-            'HOOK_ORDER_CONFIRMATION' => $this->displayOrderConfirmation($order),
-            'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn($order),
-            'order' => $presentedOrder,
-            'register_form' => $register_form,
+            'HOOK_ORDER_CONFIRMATION' => $this->displayOrderConfirmation($this->order),
+            'HOOK_PAYMENT_RETURN' => $this->displayPaymentReturn($this->order),
+            'order' => (new OrderPresenter())->present($this->order),
+            'order_customer' => (new ObjectPresenter())->present($this->customer),
+            'registered_customer_exists' => Customer::customerExists($this->customer->email, false, true),
         ]);
+        $this->setTemplate('checkout/order-confirmation');
 
+        // If logged in guest we clear the cookie for security reasons
         if ($this->context->customer->is_guest) {
-            /* If guest we clear the cookie for security reason */
             $this->context->customer->mylogout();
         }
-        $this->setTemplate('checkout/order-confirmation');
     }
 
     /**

--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -13,7 +13,7 @@
             {/block}
 
             <p>
-              {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
+              {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $order_customer.email]}
               {if $order.details.invoice_url}
                 {* [1][/1] is for a HTML tag. *}
                 {l
@@ -92,16 +92,15 @@
     {/if}
   {/block}
 
-  {block name='customer_registration_form'}
-    {if $customer.is_guest}
-      <div id="registration-form" class="card">
+  {if !$registered_customer_exists}
+    {block name='account_transformation_form'}
+      <div class="card">
         <div class="card-block">
-          <h4 class="h4">{l s='Save time on your next order, sign up now' d='Shop.Theme.Checkout'}</h4>
-          {render file='customer/_partials/customer-form.tpl' ui=$register_form}
+          {include file='customer/_partials/account-transformation-form.tpl'}
         </div>
       </div>
-    {/if}
-  {/block}
+    {/block}
+  {/if}
 
   {block name='hook_order_confirmation_1'}
     {hook h='displayOrderConfirmation1'}

--- a/themes/classic/templates/customer/_partials/account-transformation-form.tpl
+++ b/themes/classic/templates/customer/_partials/account-transformation-form.tpl
@@ -22,23 +22,23 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
-{extends file='customer/order-detail.tpl'}
-
-{block name='page_title'}
-  {l s='Guest Tracking' d='Shop.Theme.Customeraccount'}
+{block name='account_transformation_form'}
+  <h4>{l s='Save time on your next order, sign up now' d='Shop.Theme.Checkout'}</h4>
+  <ul>
+    <li> - {l s='Personalized and secure access' d='Shop.Theme.Customeraccount'}</li>
+    <li> - {l s='Fast and easy checkout' d='Shop.Theme.Customeraccount'}</li>
+    <li> - {l s='Easier merchandise return' d='Shop.Theme.Customeraccount'}</li>
+  </ul>
+  <form method="post">
+    <div class="form-group">
+      <label class="form-control-label required" for="field-email">
+        {l s='Set your password:' d='Shop.Forms.Labels'}
+      </label>
+      <input type="password" class="form-control" data-validate="isPasswd" required name="password" value="">
+    </div>
+    <footer class="form-footer">
+      <input type="hidden" name="submitTransformGuestToCustomer" value="1">
+      <button class="btn btn-primary" type="submit">{l s='Create account' d='Shop.Theme.Actions'}</button>
+    </footer>
+  </form>
 {/block}
-
-{block name='order_detail'}
-  {include file='customer/_partials/order-detail-no-return.tpl'}
-{/block}
-
-{block name='order_messages'}
-{/block}
-
-{if !$registered_customer_exists}
-  {block name='page_content' append}
-    {block name='account_transformation_form'}
-      {include file='customer/_partials/account-transformation-form.tpl'}
-    {/block}
-  {/block}
-{/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #14414 and #20388 and #23230
| How to test?      | See below
| Possible impacts? | -

## Description
- I rewrote and improved order confirmation controller inner workings. This allowed to fix several things, made things cleaner and more bulletproof.
- ✔️ When you refreshed order confirmation page, you got redirected to login screen or order history. This is now working 100% properly.
- ✔️ When you wanted to convert your account to customer, you had to enter many things and it didn't work at all.
- ✔️ When you enabled catalog mode after making an order, you could no longer access the confirmation screen. This is now working.

## Technical details
- Email on confirmation screen is now taken from the order itself, not from the context. So you can checkout an order in your browser history you made from a different account, and still see the correct information.
- There is a check removed on id_customer, that prevented the revisiting the page, because guests are "logged out" from cookie on first confirm visit. This check is not needed. Mechanism that prevents customer to see other customer's order is the secure_key.
- The PR is prepared for another PR, that will fix ordering as a guest with customer existing - https://github.com/PrestaShop/PrestaShop/pull/25353.
- I removed check on Catalog mode. If you enable catalog mode after customers have been ordering, why they can't view their order confirmation?

## Guest to customer conversion
- The box is shown only to guests and only if a customer account with the same email does not exist.
- They now only need to enter the password (like on guest tracking page), not the name and email again.
- There is a nice error/notification for all cases - empty password, short password, on page refresh, if they already converted him in BO.
- I unified both forms on confirmation page and guest tracking page to a single TPL.
- I added a check for empty password and already converted customer also to guest tracking controller.
- I renamed a variable I added in my previous PR, so it's unified.
![Výstřižek](https://user-images.githubusercontent.com/6097524/126567914-2d6acedd-62b2-4f74-8928-62ac4a2ba6ca.JPG)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25395)
<!-- Reviewable:end -->
