### PR TITLE
Add doc block + improve readability of HistoryController::getUrlToInvoice & HistoryController::getUrlToReorder

### DIFF
--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -83,7 +83,7 @@ class HistoryControllerCore extends FrontController
      *
      * @param Order $order
      * @param Context $context
-     * 
+     *
      * @return string
      */
     public static function getUrlToInvoice($order, $context)
@@ -107,7 +107,7 @@ class HistoryControllerCore extends FrontController
      *
      * @param int $id_order
      * @param Context $context
-     * 
+     *
      * @return string
      */
     public static function getUrlToReorder($id_order, $context)

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -83,6 +83,7 @@ class HistoryControllerCore extends FrontController
      *
      * @param Order $order
      * @param Context $context
+     * 
      * @return string
      */
     public static function getUrlToInvoice($order, $context)
@@ -90,7 +91,6 @@ class HistoryControllerCore extends FrontController
         $url_to_invoice = '';
 
         if ((bool) Configuration::get('PS_INVOICE') && OrderState::invoiceAvailable($order->current_state) && count($order->getInvoicesCollection())) {
-
             $params = [
                 'id_order' => (int) $order->id,
                 'secure_key' => (!$context->customer->isLogged()) ? $order->secure_key : null,
@@ -107,13 +107,14 @@ class HistoryControllerCore extends FrontController
      *
      * @param int $id_order
      * @param Context $context
+     * 
      * @return string
      */
     public static function getUrlToReorder($id_order, $context)
     {
         $url_to_reorder = '';
         if (!(bool) Configuration::get('PS_DISALLOW_HISTORY_REORDERING')) {
-            $params= [
+            $params = [
                 'submitReorder' => 1,
                 'id_order' => (int) $id_order,
             ];

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -78,25 +78,46 @@ class HistoryControllerCore extends FrontController
         return $orders;
     }
 
+    /**
+     * Generates a URL to download the PDF invoice of a given order
+     *
+     * @param Order $order
+     * @param Context $context
+     * @return string
+     */
     public static function getUrlToInvoice($order, $context)
     {
         $url_to_invoice = '';
 
         if ((bool) Configuration::get('PS_INVOICE') && OrderState::invoiceAvailable($order->current_state) && count($order->getInvoicesCollection())) {
-            $url_to_invoice = $context->link->getPageLink('pdf-invoice', true, null, 'id_order=' . $order->id);
-            if (!$context->customer->isLogged()) {
-                $url_to_invoice .= '&secure_key=' . $order->secure_key;
-            }
+
+            $params = [
+                'id_order' => (int) $order->id,
+                'secure_key' => (!$context->customer->isLogged()) ? $order->secure_key : null,
+            ];
+
+            $url_to_invoice = $context->link->getPageLink('pdf-invoice', true, null, $params);
         }
 
         return $url_to_invoice;
     }
 
+    /**
+     * Generates a URL to reorder a given order
+     *
+     * @param int $id_order
+     * @param Context $context
+     * @return string
+     */
     public static function getUrlToReorder($id_order, $context)
     {
         $url_to_reorder = '';
         if (!(bool) Configuration::get('PS_DISALLOW_HISTORY_REORDERING')) {
-            $url_to_reorder = $context->link->getPageLink('order', true, null, 'submitReorder&id_order=' . (int) $id_order);
+            $params= [
+                'submitReorder' => 1,
+                'id_order' => (int) $id_order,
+            ];
+            $url_to_reorder = $context->link->getPageLink('order', true, null, $params);
         }
 
         return $url_to_reorder;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve readability of HistoryController::getUrlToInvoice & HitoryController::getUrlToReorder
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Before & After this PR, in history order controller, URL to download PDF invoice and reorder a specific order are fully functionnal


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25406)
<!-- Reviewable:end -->
