### PR TITLE
Do not let customer select a carrier if this carrier cannot deliver all items in the cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2634,6 +2634,10 @@ class CartCore extends ObjectModel
                     }
                 }
             }
+            
+            if (!$product['is_virtual'] && empty($product['carrier_list'])) {
+                return [];
+            }
 
             if (!isset($grouped_by_warehouse[$product['id_address_delivery']]['in_stock'][$id_warehouse])) {
                 $grouped_by_warehouse[$product['id_address_delivery']]['in_stock'][$id_warehouse] = [];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Cart::getPackageList(), if one of the products cannot be delivered, early return. This should inform customer using message 'No carrier available for this delivery address.' and avoid customer buying a product then never receive it.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #15304
| How to test?      | Instructions on how to test can be read at https://github.com/PrestaShop/PrestaShop/issues/25405
| Possible impacts? | The logic to get carriers is modified


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25407)
<!-- Reviewable:end -->
