### PR TITLE
Make sure order variable exists and also return the order_list variable in actionValidateOrderAfter hook

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -731,13 +731,18 @@ abstract class PaymentModuleCore extends Module
             if (self::DEBUG_MODE) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - End of validateOrder', 1, null, 'Cart', (int) $id_cart, true);
             }
-            Hook::exec('actionValidateOrderAfter', [
-                'cart' => $this->context->cart,
-                'order' => $order,
-                'customer' => $this->context->customer,
-                'currency' => $this->context->currency,
-                'orderStatus' => new OrderState($order->current_state),
-            ]);
+
+            Hook::exec(
+                'actionValidateOrderAfter',
+                [
+                    'cart' => $this->context->cart,
+                    'order' => $order ?? null,
+                    'orders' => $order_list,
+                    'customer' => $this->context->customer,
+                    'currency' => $this->context->currency,
+                    'orderStatus' => new OrderState($order->current_state),
+                ]
+            );
 
             return true;
         } else {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Make sure order variable exists and also return the order_list variable in act ionValidateOrderAfter hook.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is green
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25410)
<!-- Reviewable:end -->
