### PR TITLE
Fix performance issue on Smarty template caching

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2443,6 +2443,9 @@ abstract class ModuleCore implements ModuleInterface
             if ($cache_id !== null) {
                 Tools::enableCache();
             }
+            if ($compile_id === null) {
+                $compile_id = Context::getContext()->shop->theme->getName();
+            }
 
             $result = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->fetch();
 
@@ -2504,6 +2507,9 @@ abstract class ModuleCore implements ModuleInterface
             ) {
                 $template = $this->getTemplatePath($template);
             }
+            if ($compile_id === null) {
+                $compile_id = Context::getContext()->shop->theme->getName();
+            }
 
             $this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id] = $this->context->smarty->createTemplate(
                 $template,
@@ -2556,6 +2562,9 @@ abstract class ModuleCore implements ModuleInterface
         if (false === strpos($template, 'module:') && !file_exists(_PS_ROOT_DIR_ . '/' . $template)) {
             $template = $this->getTemplatePath($template);
         }
+        if ($compile_id === null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
+        }
 
         $is_cached = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->isCached($template, $cache_id, $compile_id);
         Tools::restoreCacheSettings();
@@ -2577,6 +2586,9 @@ abstract class ModuleCore implements ModuleInterface
         static $ps_smarty_clear_cache = null;
         if ($ps_smarty_clear_cache === null) {
             $ps_smarty_clear_cache = Configuration::get('PS_SMARTY_CLEAR_CACHE');
+        }
+        if ($compile_id === null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
         }
 
         if (static::$_batch_mode) {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3534,7 +3534,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return string
      */
-    public function getDefaultCompileId()
+    public function getDefaultCompileId(): string
     {
         return Context::getContext()->shop->theme->getName();
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2500,6 +2500,10 @@ abstract class ModuleCore implements ModuleInterface
      */
     protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
     {
+        if ($compile_id === null) {
+            $compile_id = Context::getContext()->shop->theme->getName();
+        }
+
         if (!isset($this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id])) {
             if (false === strpos($template, 'module:') &&
                 !file_exists(_PS_ROOT_DIR_ . '/' . $template) &&

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3534,7 +3534,7 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @return string
      */
-    public function getDefaultCompileId(): string
+    public function getDefaultCompileId()
     {
         return Context::getContext()->shop->theme->getName();
     }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2444,7 +2444,7 @@ abstract class ModuleCore implements ModuleInterface
                 Tools::enableCache();
             }
             if ($compile_id === null) {
-                $compile_id = Context::getContext()->shop->theme->getName();
+                $compile_id = $this->getDefaultCompileId();
             }
 
             $result = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->fetch();
@@ -2474,7 +2474,7 @@ abstract class ModuleCore implements ModuleInterface
             Tools::enableCache();
         }
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         $template = $this->context->smarty->createTemplate(
@@ -2501,7 +2501,7 @@ abstract class ModuleCore implements ModuleInterface
     protected function getCurrentSubTemplate($template, $cache_id = null, $compile_id = null)
     {
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         if (!isset($this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id])) {
@@ -2510,9 +2510,6 @@ abstract class ModuleCore implements ModuleInterface
                 !file_exists($template)
             ) {
                 $template = $this->getTemplatePath($template);
-            }
-            if ($compile_id === null) {
-                $compile_id = Context::getContext()->shop->theme->getName();
             }
 
             $this->current_subtemplate[$template . '_' . $cache_id . '_' . $compile_id] = $this->context->smarty->createTemplate(
@@ -2567,7 +2564,7 @@ abstract class ModuleCore implements ModuleInterface
             $template = $this->getTemplatePath($template);
         }
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         $is_cached = $this->getCurrentSubTemplate($template, $cache_id, $compile_id)->isCached($template, $cache_id, $compile_id);
@@ -2592,7 +2589,7 @@ abstract class ModuleCore implements ModuleInterface
             $ps_smarty_clear_cache = Configuration::get('PS_SMARTY_CLEAR_CACHE');
         }
         if ($compile_id === null) {
-            $compile_id = Context::getContext()->shop->theme->getName();
+            $compile_id = $this->getDefaultCompileId();
         }
 
         if (static::$_batch_mode) {
@@ -3530,6 +3527,16 @@ abstract class ModuleCore implements ModuleInterface
     public function saveDashConfig(array $config)
     {
         return false;
+    }
+
+    /**
+     * Returns shop theme name from context as a default compile Id.
+     *
+     * @return string
+     */
+    public function getDefaultCompileId()
+    {
+        return Context::getContext()->shop->theme->getName();
     }
 }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | From 1.7.7.0 version Module class function isCached fails to check if tpl is cached. This PR fixes that.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24235.
| How to test?      | In order to test if it is fixed you need to check if function isCached works properly or try to reproduce issue. How to reproduce issue is described in issue ticket.
| Possible impacts? | Smarty cache compile / fetch / clear

Cherry-pick PR for https://github.com/PrestaShop/PrestaShop/pull/24241

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25413)
<!-- Reviewable:end -->
