### PR TITLE
Fix overflowing buttons

### DIFF
--- a/admin-dev/themes/default/scss/partials/_buttons.scss
+++ b/admin-dev/themes/default/scss/partials/_buttons.scss
@@ -1,5 +1,6 @@
 .btn {
   font-weight: 600;
+  white-space: normal;
 
   &.btn-default {
     &,

--- a/admin-dev/themes/new-theme/scss/components/_button.scss
+++ b/admin-dev/themes/new-theme/scss/components/_button.scss
@@ -1,4 +1,6 @@
 .btn {
+  white-space: normal;
+
   &.btn-action {
     color: #576c72;
     background-color: $white;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes native BS4 behavior that prevents buttons to wrap. This behavior was fixed in BS5, we need to do it manually. Related UI kit PR - https://github.com/PrestaShop/prestashop-ui-kit/pull/167
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25422 - partially, do not close.
| How to test?      | Apply PR, open inspector, set width to iPhone 5 and make a super long button text. In both legacy and modern page.
| Possible impacts? | - 

**Before & After**
![buttons](https://user-images.githubusercontent.com/6097524/126970314-ac6ae02a-7147-4ecc-a093-66ead5ddded9.jpg)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25427)
<!-- Reviewable:end -->
