### PR TITLE
Fix `ObjectModel::add()` force_id usage for multilang model

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -580,7 +580,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         // Get object id in database if force_id is not true
-        if (!$this->force_id) {
+        if (!$this->force_id || empty($this->id)) {
             $this->id = Db::getInstance()->Insert_ID();
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -580,7 +580,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         // Get object id in database if force_id is not true
-        if (isset($this->id) && !$this->force_id) {
+        if (!$this->force_id) {
             $this->id = Db::getInstance()->Insert_ID();
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -580,7 +580,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         // Get object id in database if force_id is not true
-        if (!$this->force_id || empty($this->id)) {
+        if (empty($this->id)) {
             $this->id = Db::getInstance()->Insert_ID();
         }
 

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -579,8 +579,10 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             return false;
         }
 
-        // Get object id in database
-        $this->id = Db::getInstance()->Insert_ID();
+        // Get object id in database if force_id is not true
+        if (isset($this->id) && !$this->force_id) {
+            $this->id = Db::getInstance()->Insert_ID();
+        }
 
         // Database insertion for multishop fields related to the object
         if (Shop::isTableAssociated($this->def['table'])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In objectModel, force_id is useful if you wants to set your id, by example if you have a primary as id_product in an extra table. When you call add() method, it works well for base table but not for _lang table.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25432
| How to test?      | see Issue
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25433)
<!-- Reviewable:end -->
