### PR TITLE
Fix option selection issue in order creation page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/addresses-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/addresses-renderer.ts
@@ -78,12 +78,13 @@ export default class AddressesRenderer {
     const deliveryAddressOption = {
       value: address.addressId,
       text: address.alias,
-      selected: '',
+      selected: false,
     };
 
     if (address.delivery) {
       $(createOrderMap.deliveryAddressDetails).html(address.formattedAddress);
-      deliveryAddressOption.selected = 'selected';
+      deliveryAddressOption.selected = true;
+
       $(createOrderMap.deliveryAddressEditBtn).prop(
         'href',
         this.router.generate('admin_cart_addresses_edit', {
@@ -116,12 +117,12 @@ export default class AddressesRenderer {
     const invoiceAddressOption = {
       value: address.addressId,
       text: address.alias,
-      selected: '',
+      selected: false,
     };
 
     if (address.invoice) {
       $(createOrderMap.invoiceAddressDetails).html(address.formattedAddress);
-      invoiceAddressOption.selected = 'selected';
+      invoiceAddressOption.selected = true;
       $(createOrderMap.invoiceAddressEditBtn).prop(
         'href',
         this.router.generate('admin_cart_addresses_edit', {

--- a/admin-dev/themes/new-theme/js/pages/order/create/addresses-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/addresses-renderer.ts
@@ -84,7 +84,6 @@ export default class AddressesRenderer {
     if (address.delivery) {
       $(createOrderMap.deliveryAddressDetails).html(address.formattedAddress);
       deliveryAddressOption.selected = true;
-
       $(createOrderMap.deliveryAddressEditBtn).prop(
         'href',
         this.router.generate('admin_cart_addresses_edit', {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | By default all options in the address selectors had the `selected` attribute set to empty, which would still select the element in the browser, so in the end all options were selected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25437
| How to test?      | See issue #25437
| Possible impacts? | none other than what it's fixing


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25465)
<!-- Reviewable:end -->
