### PR TITLE
Fix actionAdminOrdersTrackingNumberUpdate call location

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3495,5 +3495,10 @@
       <title>Modify back office order data after creating it</title>
       <description>This hook allows to modify order created from back office data after it is created</description>
     </hook>
+    <hook id="actionAdminOrdersTrackingNumberUpdate">
+      <name>actionAdminOrdersTrackingNumberUpdate</name>
+      <title>After setting the tracking number for the order</title>
+      <description>This hook allows you to execute code after the unique tracking number for the order was added</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.9.0.sql
+++ b/install-dev/upgrade/sql/1.7.9.0.sql
@@ -9,3 +9,6 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 ;
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after validating an order by core', '1');
+
+INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
+  (NULL, 'actionAdminOrdersTrackingNumberUpdate', 'After setting the tracking number for the order', 'This hook allows you to execute code after the unique tracking number for the order was added', '1');

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -117,7 +117,7 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
                 'customer' => $customer,
                 'carrier' => $carrier,
             ], null, false, true, false, $order->id_shop);
-            
+
             if (!$orderCarrier->sendInTransitEmail($order)) {
                 throw new TransistEmailSendingException('An error occurred while sending an email to the customer.');
             }

--- a/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateOrderShippingDetailsHandler.php
@@ -109,10 +109,6 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
 
         //send mail only if tracking number is different AND not empty
         if (!empty($trackingNumber) && $oldTrackingNumber != $trackingNumber) {
-            if (!$orderCarrier->sendInTransitEmail($order)) {
-                throw new TransistEmailSendingException('An error occurred while sending an email to the customer.');
-            }
-
             $customer = new Customer((int) $order->id_customer);
             $carrier = new Carrier((int) $order->id_carrier, (int) $order->getAssociatedLanguage()->getId());
 
@@ -121,6 +117,10 @@ final class UpdateOrderShippingDetailsHandler extends AbstractOrderHandler imple
                 'customer' => $customer,
                 'carrier' => $carrier,
             ], null, false, true, false, $order->id_shop);
+            
+            if (!$orderCarrier->sendInTransitEmail($order)) {
+                throw new TransistEmailSendingException('An error occurred while sending an email to the customer.');
+            }
         }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is a problem with the hook actionAdminOrdersTrackingNumberUpdate. The hook is never called because I have an TransistEmailSendingException but the trackingNumber is updated. The hook should be call before email exception.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25490


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25491)
<!-- Reviewable:end -->
