### PR TITLE
Removed ecotax in invoice/orderslip PDF if ecotax is disabled

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -423,14 +423,14 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
     /**
      * Returns different tax breakdown elements.
      *
-     * @return array Different tax breakdown elements
+     * @return array|bool Different tax breakdown elements
      */
     protected function getTaxBreakdown()
     {
         $breakdowns = [
             'product_tax' => $this->order_invoice->getProductTaxesBreakdown($this->order),
             'shipping_tax' => $this->order_invoice->getShippingTaxesBreakdown($this->order),
-            'ecotax_tax' => $this->order_invoice->getEcoTaxTaxesBreakdown(),
+            'ecotax_tax' => Configuration::get('PS_USE_ECOTAX') ? $this->order_invoice->getEcoTaxTaxesBreakdown() : [],
             'wrapping_tax' => $this->order_invoice->getWrappingTaxesBreakdown(),
         ];
 
@@ -441,7 +441,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         }
 
         if (empty($breakdowns)) {
-            $breakdowns = false;
+            return false;
         }
 
         if (isset($breakdowns['product_tax'])) {

--- a/classes/pdf/HTMLTemplateOrderSlip.php
+++ b/classes/pdf/HTMLTemplateOrderSlip.php
@@ -39,7 +39,9 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
      */
     public $order_slip;
 
-    /** @var int Cart id */
+    /**
+     * @var int Cart id
+     */
     public $id_cart;
 
     /**
@@ -233,14 +235,14 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
     /**
      * Returns different tax breakdown elements.
      *
-     * @return array Different tax breakdown elements
+     * @return array|bool Different tax breakdown elements
      */
     protected function getTaxBreakdown()
     {
         $breakdowns = [
             'product_tax' => $this->getProductTaxesBreakdown(),
             'shipping_tax' => $this->getShippingTaxesBreakdown(),
-            'ecotax_tax' => $this->order_slip->getEcoTaxTaxesBreakdown(),
+            'ecotax_tax' => Configuration::get('PS_USE_ECOTAX') ? $this->order_slip->getEcoTaxTaxesBreakdown() : [],
         ];
 
         foreach ($breakdowns as $type => $bd) {
@@ -250,7 +252,7 @@ class HTMLTemplateOrderSlipCore extends HTMLTemplateInvoice
         }
 
         if (empty($breakdowns)) {
-            $breakdowns = false;
+            return false;
         }
 
         if (isset($breakdowns['product_tax'])) {

--- a/pdf/invoice.tax-tab.tpl
+++ b/pdf/invoice.tax-tab.tpl
@@ -47,26 +47,29 @@
       {foreach $tax_breakdowns as $label => $bd}
         {assign var=label_printed value=false}
 
-			{foreach $bd as $line}
-				{if $line.rate == 0 and $label != 'ecotax_tax'}
-					{continue}
-				{/if}
-				{assign var=has_line value=true}
-				<tr>
-					<td class="white">
-						{if !$label_printed}
-							{if $label == 'product_tax'}
-								{l s='Products' d='Shop.Pdf' pdf='true'}
-							{elseif $label == 'shipping_tax'}
-								{l s='Shipping' d='Shop.Pdf' pdf='true'}
-							{elseif $label == 'ecotax_tax'}
-								{l s='Ecotax' d='Shop.Pdf' pdf='true'}
-							{elseif $label == 'wrapping_tax'}
-								{l s='Wrapping' d='Shop.Pdf' pdf='true'}
-							{/if}
-							{assign var=label_printed value=true}
-						{/if}
-					</td>
+			  {foreach $bd as $line}
+          {* We force the display of the ecotax even if the ecotax rate is equals to 0 *}
+          {if $line.rate == 0 and $label != 'ecotax_tax'}
+            {continue}
+          {/if}
+
+          {assign var=has_line value=true}
+
+          <tr>
+            <td class="white">
+              {if !$label_printed}
+                {if $label == 'product_tax'}
+                  {l s='Products' d='Shop.Pdf' pdf='true'}
+                {elseif $label == 'shipping_tax'}
+                  {l s='Shipping' d='Shop.Pdf' pdf='true'}
+                {elseif $label == 'ecotax_tax'}
+                  {l s='Ecotax' d='Shop.Pdf' pdf='true'}
+                {elseif $label == 'wrapping_tax'}
+                  {l s='Wrapping' d='Shop.Pdf' pdf='true'}
+                {/if}
+                {assign var=label_printed value=true}
+              {/if}
+            </td>
 
             <td class="center white">
               {$line.rate} %


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Removed ecotax/orderslip in invoice PDF : ecotax must not be calculated if ecotax is disabled
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25493
| How to test?      | Cf. #25493

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25497)
<!-- Reviewable:end -->
