### PR TITLE
Smarty Modifier Classname - compatibility with CSS BEM method

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -177,7 +177,7 @@ function smartyCleanHtml($data)
 function smartyClassname($classname)
 {
     $classname = Tools::replaceAccentedChars(strtolower($classname));
-    $classname = preg_replace(array("/[^A-Za-z0-9-_]/", "/[-]{3,}/", "/[-]+$/"), array("-", '-', '') , $classname);
+    $classname = preg_replace(['/[^A-Za-z0-9-_]/', '/-{3,}/', '/-+$/'], ['-', '-', ''] , $classname);
     return $classname;
 }
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -177,9 +177,7 @@ function smartyCleanHtml($data)
 function smartyClassname($classname)
 {
     $classname = Tools::replaceAccentedChars(strtolower($classname));
-    $classname = preg_replace('/[^A-Za-z0-9]/', '-', $classname);
-    $classname = preg_replace('/[-]+/', '-', $classname);
-
+    $classname = preg_replace(array("/[^A-Za-z0-9-_]/", "/[-]{3,}/", "/[-]+$/"), array("-", '-', '') , $classname);
     return $classname;
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  I am facing an issue with using the [CSS BEM method](http://getbem.com/naming/) with the Smarty Classnames Modifier. The function removes the double dashes, except it is the method to make "modifier" classes in CSS BEM. I am proposing an improvement, which adds the possibility of using this class format while keeping the previous security.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25502.
| How to test?      | You can test with the [documentation](https://devdocs.prestashop.com/1.7/development/components/smarty-extensions/#classname) class and with the following class: block__elem--mod
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25501)
<!-- Reviewable:end -->
