### PR TITLE
Associate attribute designations by id

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2734,6 +2734,7 @@ class ProductCore extends ObjectModel
             $combination_id_product_attribute = $combination['id_product_attribute'];
             //Grab the designation of the current id and add it to the result element.
             $combination['attribute_designation'] = $id_product_attribute_keys[$combination_id_product_attribute]['attribute_designation'];
+
             return $combination;
         }, $combinations);
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2730,7 +2730,7 @@ class ProductCore extends ObjectModel
         //Convert designations to an indexed array by id
         $id_product_attribute_keys = array_column($lang, null, 'id_product_attribute');
         //Loop through the combinations
-        $combinations = array_map(function($combination) use($id_product_attribute_keys){
+        $combinations = array_map(function ($combination) use ($id_product_attribute_keys) {
             $combination_id_product_attribute = $combination['id_product_attribute'];
             //Grab the designation of the current id and add it to the result element.
             $combination['attribute_designation'] = $id_product_attribute_keys[$combination_id_product_attribute]['attribute_designation'];

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2726,9 +2726,16 @@ class ProductCore extends ObjectModel
                 GROUP BY pac.id_product_attribute
                 ORDER BY pac.id_product_attribute');
 
-        foreach ($lang as $k => $row) {
-            $combinations[$k]['attribute_designation'] = $row['attribute_designation'];
-        }
+        //Append the attribute designation label to the combinations array by the id of the product attribute
+        //Convert designations to an indexed array by id
+        $id_product_attribute_keys = array_column($lang, null, 'id_product_attribute');
+        //Loop through the combinations
+        $combinations = array_map(function($combination) use($id_product_attribute_keys){
+            $combination_id_product_attribute = $combination['id_product_attribute'];
+            //Grab the designation of the current id and add it to the result element.
+            $combination['attribute_designation'] = $id_product_attribute_keys[$combination_id_product_attribute]['attribute_designation'];
+            return $combination;
+        }, $combinations);
 
         $computingPrecision = Context::getContext()->getComputingPrecision();
         //Get quantity of each variations


### PR DESCRIPTION
Append the attribute designation label to the combinations array by the id of the product attribute and not by the order of the sql queries.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Appends the attribute designation label to the combinations array by the id of the product attribute and not by the order of the sql queries. Without this patch, the attributes designations label depends on the order of 2 separated sql results. At some scenarios that order may variate. Particularly if the Products and/or Combinations are created using WebServices calls.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25503.
| How to test?      | There is no simple method to test this as it includes alternation of the order on the db records. Only regression test may apply confirming that the Supplier section of the Product BO page displays the list of attributes by supplier correctly.
| Possible impacts? | Supplier section of the Product BO.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25504)
<!-- Reviewable:end -->
