### PR TITLE
Db::numRows is unreliable and Db::Affected_Rows throws exception if previous query failed silently

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -87,9 +87,9 @@ abstract class DbCore
     protected $last_query_hash;
 
     /**
-     * Last cached query.
+     * Was last query cached?
      *
-     * @var string
+     * @var bool
      */
     protected $last_cached;
 
@@ -132,6 +132,8 @@ abstract class DbCore
 
     /**
      * Get number of affected rows in previous database operation.
+     *
+     * @throws Exception if previous query failed silently
      *
      * @return int
      */
@@ -704,6 +706,11 @@ abstract class DbCore
 
     /**
      * Get number of rows for last result.
+     * Must be used solely with select queries.
+     * Results are unreliable with DbPDO (https://www.php.net/manual/en/pdostatement.rowcount.php)
+     * With Db Caching enabled, it works only after `executeS()` and `getRow()`
+     *
+     * @deprecated Never used throughout current codebase
      *
      * @return int
      */

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -240,7 +240,7 @@ class DbPDOCore extends Db
      *
      * @see DbCore::Affected_Rows()
      *
-     * @throws Exception if previous query failed silently (`$this->result` is not a `PDOStatement`)
+     * @throws Error if previous query failed silently (`$this->result` is not a `PDOStatement`)
      *
      * @return int
      */

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -240,6 +240,8 @@ class DbPDOCore extends Db
      *
      * @see DbCore::Affected_Rows()
      *
+     * @throws Exception if previous query failed silently (`$this->result` is not a `PDOStatement`)
+     *
      * @return int
      */
     public function Affected_Rows()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improvement of phpdoc, deprecation of unused and unreliable method Db::numRows() 
| Type?             | documentation
| Category?         | CO
| BC breaks?        | no The deprecated function is not used in the whole codebase 
| Deprecations?     | yes Db::numRows()
| Fixed ticket?     | Fixes #25515.
| How to test?      | 
| Possible impacts? | Should not have impacts, since the method is not used anymore.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25514)
<!-- Reviewable:end -->
