### PR TITLE
ImageManagerCore::validateUpload() now returns correct extensions depending on the $types parameter

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -475,7 +475,8 @@ class ImageManagerCore
             return Context::getContext()->getTranslator()->trans('Image is too large (%1$d kB). Maximum allowed: %2$d kB', [$file['size'] / 1024, $maxFileSize / 1024], 'Admin.Notifications.Error');
         }
         if (!ImageManager::isRealImage($file['tmp_name'], $file['type'], $mimeTypeList) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
-            return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png', [], 'Admin.Notifications.Error');
+            $typesTxt = $types ? '.' . implode(', .', $types) : '.gif, .jpg, .png';
+            return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: %s', array($typesTxt), 'Admin.Notifications.Error');
         }
         if ($file['error']) {
             return Context::getContext()->getTranslator()->trans('Error while uploading image; please change your server\'s settings. (Error code: %s)', [$file['error']], 'Admin.Notifications.Error');

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -476,6 +476,7 @@ class ImageManagerCore
         }
         if (!ImageManager::isRealImage($file['tmp_name'], $file['type'], $mimeTypeList) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
             $typesTxt = $types ? '.' . implode(', .', $types) : '.gif, .jpg, .png';
+
             return Context::getContext()->getTranslator()->trans(
                 'Image format not recognized, allowed formats are: %s',
                 [$typesTxt],

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -476,7 +476,11 @@ class ImageManagerCore
         }
         if (!ImageManager::isRealImage($file['tmp_name'], $file['type'], $mimeTypeList) || !ImageManager::isCorrectImageFileExt($file['name'], $types) || preg_match('/\%00/', $file['name'])) {
             $typesTxt = $types ? '.' . implode(', .', $types) : '.gif, .jpg, .png';
-            return Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: %s', array($typesTxt), 'Admin.Notifications.Error');
+            return Context::getContext()->getTranslator()->trans(
+                'Image format not recognized, allowed formats are: %s',
+                [$typesTxt],
+                 'Admin.Notifications.Error'
+             );
         }
         if ($file['error']) {
             return Context::getContext()->getTranslator()->trans('Error while uploading image; please change your server\'s settings. (Error code: %s)', [$file['error']], 'Admin.Notifications.Error');


### PR DESCRIPTION
2nd PR for #18391 issue

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | ImageManagerCore::validateUpload() now returns correct extensions depending on the `$types` parameter
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #18391
| How to test?      | see issue #18391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25516)
<!-- Reviewable:end -->
