### PR TITLE
Disable "Options -MultiViews" by default

### DIFF
--- a/admin-dev/.htaccess
+++ b/admin-dev/.htaccess
@@ -14,7 +14,7 @@ DirectoryIndex index.php
 # Disabling MultiViews prevents unwanted negotiation, e.g. "/app" should not resolve
 # to the front controller "/app.php" but be rewritten to "/app.php/app".
 <IfModule mod_negotiation.c>
-    Options -MultiViews
+    #Options -MultiViews
 </IfModule>
 
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Leaving this option active will cause an HTTP error 500 on shared hostings when attempting to upgrade using the "1-Click Upgrade" plugin. Due to this fact, it is not possible to use the plugin for a seamless update. To perform the update correctly, the update archive must be downloaded and modified and the store updated from it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25535.
| How to test?      | It can be tested by trying to update the existing e-shop on shared hosting.
| Possible impacts? | No negative effects were observed during deactivation.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25534)
<!-- Reviewable:end -->
