### PR TITLE
Add `supplier` and `manufacturer` image link in `smarty url helper`

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1530,14 +1530,14 @@ class LinkCore
                 break;
             case 'manufacturerImage':
                 $link = $context->link->getManufacturerImageLink(
-                    (int)$params['id'],
+                    (int) $params['id'],
                     $params['type'] = (isset($params['type']) ? $params['type'] : null)
                 );
 
                 break;
             case 'supplierImageLink':
                 $link = $context->link->getSupplierImageLink(
-                    (int)$params['id'],
+                    (int) $params['id'],
                     $params['type'] = (isset($params['type']) ? $params['type'] : null)
                 );
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1535,6 +1535,13 @@ class LinkCore
                 );
 
                 break;
+            case 'supplierImageLink':
+                $link = $context->link->getSupplierImageLink(
+                    (int)$params['id'],
+                    $params['type'] = (isset($params['type']) ? $params['type'] : null)
+                );
+
+                break;
             case 'cms':
                 $link = $context->link->getCMSLink(
                     new CMS($params['id'], $params['id_lang']),

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1528,6 +1528,13 @@ class LinkCore
                 );
 
                 break;
+            case 'manufacturerImage':
+                $link = $context->link->getManufacturerImageLink(
+                    (int)$params['id'],
+                    $params['type'] = (isset($params['type']) ? $params['type'] : null)
+                );
+
+                break;
             case 'cms':
                 $link = $context->link->getCMSLink(
                     new CMS($params['id'], $params['id_lang']),

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1535,7 +1535,7 @@ class LinkCore
                 );
 
                 break;
-            case 'supplierImageLink':
+            case 'supplierImage':
                 $link = $context->link->getSupplierImageLink(
                     (int) $params['id'],
                     $params['type'] = (isset($params['type']) ? $params['type'] : null)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add `supplier` and `manufacturer` image link in `smarty url helper`.
| Type?             | improvement 
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | See description below 👇🏿
| Possible impacts? | N/A

## How to test

- Add a new `supplier` and a new `manufacturer` (with logo please 😉)
- edit `/themes/classic/templates/_partials/header.tpl` or another theme `.tpl` file and add : 

```html
   <img src='{url entity=supplierImage id=MY_NEW_SUPPLIER_ID_HERE}'>
   <img src='{url entity=manufacturerImage id=MY_NEW_MANUFACTURER_ID_HERE}'>
```
- now see your supplier and manufacturer images ;)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25543)
<!-- Reviewable:end -->
