### PR TITLE
Allow negative quantity for product stock

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -339,9 +339,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['combinations'][$k]['attribute_unity'] = abs(
                 $this->floatParser->fromString($combination['attribute_unity'])
             );
-            $form_data['combinations'][$k]['attribute_quantity'] = abs(
-                $this->floatParser->fromString($combination['attribute_quantity'])
-            );
+            $form_data['combinations'][$k]['attribute_quantity'] =
+                $this->floatParser->fromString($combination['attribute_quantity']);
             $form_data['combinations'][$k]['attribute_wholesale_price'] = abs(
                 $this->floatParser->fromString($combination['attribute_wholesale_price'])
             );

--- a/src/PrestaShopBundle/Utils/FloatParser.php
+++ b/src/PrestaShopBundle/Utils/FloatParser.php
@@ -78,6 +78,12 @@ class FloatParser
         // replace arabic numbers by latin
         $value = $this->arabicToLatinNumberConverter->convert($value);
 
+        // CLDR defines few different minusSigns, convert those first
+        // minussigns from CLDR. '−' is the important one, others currently have some js things happening to them
+        $pattern = '/[\-‒⁻₋−➖﹣－]/u';
+        $replacement = '-'; // regular - sign
+        $value = preg_replace($pattern, $replacement, $value);
+
         // remove all non-digit characters
         $split = preg_split('/[^\dE-]+/', $value);
 

--- a/tests/Unit/PrestaShopBundle/Utils/FloatParserTest.php
+++ b/tests/Unit/PrestaShopBundle/Utils/FloatParserTest.php
@@ -69,7 +69,7 @@ class FloatParserTest extends TestCase
     {
         $expected = 1234567.89;
 
-        return [
+        $data = [
             ['1234567.89', $expected],
             ['1234567,89', $expected],
             ['1,234,567.89', $expected],
@@ -97,6 +97,29 @@ class FloatParserTest extends TestCase
             ['', 0.0],
             ['   ', 0.0],
         ];
+
+        // cldr minus signs
+        $cldr_minus_signs = $this->str_split_unicode('-‒⁻₋−➖﹣－');
+        foreach ($cldr_minus_signs as $cldr_minus_sign) {
+            $data[] = [$cldr_minus_sign . $expected, $expected * -1];
+        }
+
+        return $data;
+    }
+
+    /**
+     * php str_split is not unicode aware..
+     * do the split ourself
+     */
+    private function str_split_unicode($str)
+    {
+        $len = mb_strlen($str, 'UTF-8');
+        $result = [];
+        for ($i = 0; $i < $len; ++$i) {
+            $result[] = mb_substr($str, $i, 1, 'UTF-8');
+        }
+
+        return $result;
     }
 
     public function provideInvalidValues()

--- a/tests/Unit/PrestaShopBundle/Utils/FloatParserTest.php
+++ b/tests/Unit/PrestaShopBundle/Utils/FloatParserTest.php
@@ -69,7 +69,7 @@ class FloatParserTest extends TestCase
     {
         $expected = 1234567.89;
 
-        $data = [
+        return [
             ['1234567.89', $expected],
             ['1234567,89', $expected],
             ['1,234,567.89', $expected],
@@ -96,30 +96,16 @@ class FloatParserTest extends TestCase
             ['1 thousand and 10', 1.1],
             ['', 0.0],
             ['   ', 0.0],
+            // cldr minus signs
+            ['-' . $expected, -1 * $expected],
+            ['‒' . $expected, -1 * $expected],
+            ['⁻' . $expected, -1 * $expected],
+            ['₋' . $expected, -1 * $expected],
+            ['−' . $expected, -1 * $expected],
+            ['➖' . $expected, -1 * $expected],
+            ['﹣' . $expected, -1 * $expected],
+            ['－' . $expected, -1 * $expected],
         ];
-
-        // cldr minus signs
-        $cldr_minus_signs = $this->str_split_unicode('-‒⁻₋−➖﹣－');
-        foreach ($cldr_minus_signs as $cldr_minus_sign) {
-            $data[] = [$cldr_minus_sign . $expected, $expected * -1];
-        }
-
-        return $data;
-    }
-
-    /**
-     * php str_split is not unicode aware..
-     * do the split ourself
-     */
-    private function str_split_unicode($str)
-    {
-        $len = mb_strlen($str, 'UTF-8');
-        $result = [];
-        for ($i = 0; $i < $len; ++$i) {
-            $result[] = mb_substr($str, $i, 1, 'UTF-8');
-        }
-
-        return $result;
     }
 
     public function provideInvalidValues()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product stock quantity should be allowed to be negative. Adapter wrongly always got the abs value when saving combinations in BO
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25545
| How to test?      | Save negative value to product combination stocklevel, check that the value is negative in ps_stock_available table also. reload the page, check that the value is still negative in the combination edit list.
| Possible impacts? |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25549)
<!-- Reviewable:end -->
