### PR TITLE
Fix product list layout on responsive on classic theme

### DIFF
--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -25,7 +25,8 @@ $product-description-height: 70px;
 
   .thumbnail-container {
     position: relative;
-    width: $thumbnail-size;
+    width: 100%;
+    max-width: $thumbnail-size;
     height: auto;
     margin-bottom: 1.563rem;
     overflow: hidden;
@@ -145,7 +146,10 @@ $product-description-height: 70px;
 
     @at-root .page-index &, .page-search & {
       width: 25%;
-      min-width: 250px;
+
+      @include media-breakpoint-down(xl) {
+        width: auto;
+      }
     }
   }
 

--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -11,6 +11,11 @@ $product-description-height: 70px;
     justify-content: flex-start;
   }
 
+  .product {
+    display: flex;
+    justify-content: center;
+  }
+
   .product-thumbnail {
     display: block;
   }
@@ -141,21 +146,7 @@ $product-description-height: 70px;
     background: $white;
   }
 
-  .product {
-    padding: 0;
-
-    @at-root .page-index &, .page-search & {
-      width: 25%;
-
-      @include media-breakpoint-down(xl) {
-        width: auto;
-      }
-    }
-  }
-
   .product-miniature {
-    margin: 0 0.8125rem;
-
     .product-flags {
       li.product-flag {
         min-width: 3.125rem;

--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -30,8 +30,6 @@ $product-description-height: 70px;
 
   .thumbnail-container {
     position: relative;
-    width: 100%;
-    max-width: $thumbnail-size;
     height: auto;
     margin-bottom: 1.563rem;
     overflow: hidden;
@@ -139,8 +137,8 @@ $product-description-height: 70px;
     position: relative;
     bottom: 0;
     z-index: 3;
-    width: $thumbnail-size;
     height: auto;
+    padding: 0.25rem;
     padding-bottom: 0.7rem;
     overflow: hidden;
     background: $white;

--- a/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -30,5 +30,5 @@
       {l s='%s other products in the same category:' sprintf=[$products|@count] d='Shop.Theme.Catalog'}
     {/if}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-sm-6 col-md-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
 </section>

--- a/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -30,5 +30,5 @@
       {l s='%s other products in the same category:' sprintf=[$products|@count] d='Shop.Theme.Catalog'}
     {/if}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-sm-6 col-md-6 col-lg-4 col-xl-3"}
 </section>

--- a/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -30,5 +30,5 @@
       {l s='%s other products in the same category:' sprintf=[$products|@count] d='Shop.Theme.Catalog'}
     {/if}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-xs-6 col-lg-4 col-xl-3"}
 </section>

--- a/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
+++ b/themes/classic/modules/ps_categoryproducts/views/templates/hook/ps_categoryproducts.tpl
@@ -30,5 +30,5 @@
       {l s='%s other products in the same category:' sprintf=[$products|@count] d='Shop.Theme.Catalog'}
     {/if}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-lg-4 col-xl-3"}
 </section>

--- a/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -26,7 +26,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='Popular Products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row"}
+  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-sm-6 col-md-6 col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allProductsLink}">
     {l s='All products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -26,7 +26,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='Popular Products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-sm-6 col-md-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allProductsLink}">
     {l s='All products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -26,7 +26,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='Popular Products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allProductsLink}">
     {l s='All products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
+++ b/themes/classic/modules/ps_featuredproducts/views/templates/hook/ps_featuredproducts.tpl
@@ -26,7 +26,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='Popular Products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-xs-6 col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allProductsLink}">
     {l s='All products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -27,7 +27,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='New products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-sm-6 col-md-6 col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allNewProductsLink}">
     {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -27,7 +27,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='New products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-xs-6 col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allNewProductsLink}">
     {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -27,7 +27,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='New products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-sm-6 col-md-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allNewProductsLink}">
     {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
+++ b/themes/classic/modules/ps_newproducts/views/templates/hook/ps_newproducts.tpl
@@ -27,7 +27,7 @@
   <h2 class="h2 products-section-title text-uppercase">
     {l s='New products' d='Shop.Theme.Catalog'}
   </h2>
-  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-6 col-lg-4 col-xl-3"}
+  {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-lg-4 col-xl-3"}
   <a class="all-product-link float-xs-left float-md-right h4" href="{$allNewProductsLink}">
     {l s='All new products' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
   </a>

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -30,6 +30,7 @@
         {if $product.cover}
           <a href="{$product.url}" class="thumbnail product-thumbnail">
             <img
+              class="img-fluid"
               src="{$product.cover.bySize.home_default.url}"
               alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
               loading="lazy"

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 {block name='product_miniature_item'}
-<div class="product">
+<div class="product col-sm-6 col-md-6 col-lg-4 col-xl-3">
   <article class="product-miniature js-product-miniature" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}">
     <div class="thumbnail-container">
       {block name='product_thumbnail'}

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 {block name='product_miniature_item'}
-<div class="product col-sm-6 col-md-6 col-lg-4 col-xl-3">
+<div class="product{if !empty($productClasses)} {$productClasses}{/if}">
   <article class="product-miniature js-product-miniature" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}">
     <div class="thumbnail-container">
       {block name='product_thumbnail'}

--- a/themes/classic/templates/catalog/_partials/productlist.tpl
+++ b/themes/classic/templates/catalog/_partials/productlist.tpl
@@ -22,8 +22,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
+
+{capture assign="productClasses"}{if !empty($productClass)}{$productClass}{/if}{/capture}
+
 <div class="products{if !empty($cssClass)} {$cssClass}{/if}">
     {foreach from=$products item="product" key="position"}
-        {include file="catalog/_partials/miniatures/product.tpl" product=$product position=$position}
+        {include file="catalog/_partials/miniatures/product.tpl" product=$product position=$position productClasses=$productClasses}
     {/foreach}
 </div>

--- a/themes/classic/templates/catalog/_partials/productlist.tpl
+++ b/themes/classic/templates/catalog/_partials/productlist.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-{capture assign="productClasses"}{if !empty($productClass)}{$productClass}{/if}{/capture}
+{capture assign="productClasses"}{if !empty($productClass)}{$productClass}{else}col-xs-6 col-xl-4{/if}{/capture}
 
 <div class="products{if !empty($cssClass)} {$cssClass}{/if}">
     {foreach from=$products item="product" key="position"}

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -60,7 +60,7 @@
 
         <div>
           {block name='product_list'}
-            {include file='catalog/_partials/products.tpl' listing=$listing}
+            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-sm-6 col-md-6 col-lg-6 col-xl-4"}
           {/block}
         </div>
 

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -60,7 +60,7 @@
 
         <div>
           {block name='product_list'}
-            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-xl-4"}
+            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-xs-6 col-xl-4"}
           {/block}
         </div>
 

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -60,7 +60,7 @@
 
         <div>
           {block name='product_list'}
-            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-6 col-xl-4"}
+            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-xl-4"}
           {/block}
         </div>
 

--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -60,7 +60,7 @@
 
         <div>
           {block name='product_list'}
-            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-sm-6 col-md-6 col-lg-6 col-xl-4"}
+            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-6 col-xl-4"}
           {/block}
         </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Product list no home was wrong on responsive, product width were too small, there were no spacings
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25283.
| How to test?      | Go on home and see if product list adapt well when resizing to mobile gradually (mainly check on tablet
| Possible impacts? | Home and search product list


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25556)
<!-- Reviewable:end -->
