### PR TITLE
Fix floating button spacing on migrated pages

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -61,3 +61,9 @@
     padding-left: $size-navbar-width-mini + ($grid-gutter-width / 2);
   }
 }
+
+.mobile {
+  .content-div {
+    padding-bottom: 5rem;
+  }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Floating button was over some elements on some pages, I fixed this using a padding on migrated page on `.content-div` on mobile, as the floating button should be on every pages
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25423.
| How to test?      | Go on any migrated pages and see if the button is not over an element on mobile (see issue for an example)
| Possible impacts? | Every migrated pages bottom padding on mobile


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25557)
<!-- Reviewable:end -->
