### PR TITLE
Removed Addons Connect button in Edit Employee Form in BO

### DIFF
--- a/src/Adapter/Employee/EmployeeFormAccessChecker.php
+++ b/src/Adapter/Employee/EmployeeFormAccessChecker.php
@@ -29,8 +29,6 @@ namespace PrestaShop\PrestaShop\Adapter\Employee;
 use PrestaShop\PrestaShop\Core\Employee\Access\EmployeeFormAccessCheckerInterface;
 use PrestaShop\PrestaShop\Core\Employee\ContextEmployeeProviderInterface;
 use PrestaShop\PrestaShop\Core\Employee\EmployeeDataProviderInterface;
-use PrestaShopBundle\Entity\Repository\TabRepository;
-use Tab;
 
 /**
  * Class EmployeeFormAccessChecker checks employee's access to the employee form.
@@ -43,11 +41,6 @@ final class EmployeeFormAccessChecker implements EmployeeFormAccessCheckerInterf
     private $contextEmployeeProvider;
 
     /**
-     * @var TabRepository
-     */
-    private $tabRepository;
-
-    /**
      * @var EmployeeDataProviderInterface
      */
     private $employeeDataProvider;
@@ -55,16 +48,13 @@ final class EmployeeFormAccessChecker implements EmployeeFormAccessCheckerInterf
     /**
      * @param ContextEmployeeProviderInterface $contextEmployeeProvider
      * @param EmployeeDataProviderInterface $employeeDataProvider
-     * @param TabRepository $tabRepository
      */
     public function __construct(
         ContextEmployeeProviderInterface $contextEmployeeProvider,
-        EmployeeDataProviderInterface $employeeDataProvider,
-        TabRepository $tabRepository
+        EmployeeDataProviderInterface $employeeDataProvider
     ) {
         $this->contextEmployeeProvider = $contextEmployeeProvider;
         $this->employeeDataProvider = $employeeDataProvider;
-        $this->tabRepository = $tabRepository;
     }
 
     /**
@@ -90,15 +80,5 @@ final class EmployeeFormAccessChecker implements EmployeeFormAccessCheckerInterf
         }
 
         return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function canAccessAddonsConnect()
-    {
-        return Tab::checkTabRights(
-            $this->tabRepository->findOneIdByClassName('AdminModulesController')
-        );
     }
 }

--- a/src/Core/Employee/Access/EmployeeFormAccessCheckerInterface.php
+++ b/src/Core/Employee/Access/EmployeeFormAccessCheckerInterface.php
@@ -52,11 +52,4 @@ interface EmployeeFormAccessCheckerInterface
      * @return bool
      */
     public function canAccessEditFormFor($employeeId);
-
-    /**
-     * Check if context employee can access addons connect form control.
-     *
-     * @return bool
-     */
-    public function canAccessAddonsConnect();
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -298,7 +298,6 @@ class EmployeeController extends FrameworkBundleAdminController
 
         $templateVars = [
             'employeeForm' => $employeeForm->createView(),
-            'showAddonsConnectButton' => false,
             'enableSidebar' => true,
         ];
 
@@ -349,13 +348,11 @@ class EmployeeController extends FrameworkBundleAdminController
         }
 
         $isRestrictedAccess = $formAccessChecker->isRestrictedAccess((int) $employeeId);
-        $canAccessAddonsConnect = $formAccessChecker->canAccessAddonsConnect();
 
         try {
             $employeeForm = $this->getEmployeeFormBuilder()->getFormFor((int) $employeeId, [], [
                 'is_restricted_access' => $isRestrictedAccess,
                 'is_for_editing' => true,
-                'show_addons_connect_button' => $canAccessAddonsConnect,
             ]);
         } catch (Exception $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
@@ -387,7 +384,6 @@ class EmployeeController extends FrameworkBundleAdminController
         $templateVars = [
             'employeeForm' => $employeeForm->createView(),
             'isRestrictedAccess' => $isRestrictedAccess,
-            'showAddonsConnectButton' => $canAccessAddonsConnect,
             'editableEmployee' => $editableEmployee,
         ];
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email as EmployeeEmail;
-use PrestaShopBundle\Form\Admin\Type\AddonsConnectType;
 use PrestaShopBundle\Form\Admin\Type\ChangePasswordType;
 use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
@@ -142,16 +141,6 @@ final class EmployeeType extends AbstractType
 
         if ($options['is_restricted_access']) {
             $builder->add('change_password', ChangePasswordType::class);
-
-            if ($options['show_addons_connect_button']) {
-                $builder->add(
-                    'prestashop_addons',
-                    AddonsConnectType::class,
-                    [
-                        'label' => $this->trans('Sign in', [], 'Admin.Advparameters.Feature'),
-                    ]
-                );
-            }
         } else {
             $builder->add('password', PasswordType::class, [
                 'required' => !$options['is_for_editing'],
@@ -221,13 +210,9 @@ final class EmployeeType extends AbstractType
 
                 // Is this form used for editing the employee.
                 'is_for_editing' => false,
-
-                // Whether to show addons connect button in the form.
-                'show_addons_connect_button' => true,
             ])
             ->setAllowedTypes('is_restricted_access', 'bool')
             ->setAllowedTypes('is_for_editing', 'bool')
-            ->setAllowedTypes('show_addons_connect_button', 'bool')
         ;
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/employee.yml
@@ -34,7 +34,6 @@ services:
     arguments:
       - '@prestashop.adapter.data_provider.employee'
       - '@prestashop.adapter.employee.data_provider'
-      - '@prestashop.core.admin.tab.repository'
 
   prestashop.adapter.employee.command_handler.add_employee_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Profile\Employee\CommandHandler\AddEmployeeHandler'

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -149,48 +149,6 @@
           }) }}
         {% endif %}
 
-        {% if isRestrictedAccess and showAddonsConnectButton %}
-          <div class="form-group row">
-            <label class="form-control-label">
-              PrestaShop Addons
-            </label>
-            <div class="col-sm">
-              {% if employeeForm.prestashop_addons.vars.is_addons_connected %}
-                <p>
-                  <i class="material-icons">account_circle</i>
-                  {{ 'You are currently connected as %username%'
-                        |trans({}, 'Admin.Advparameters.Feature')
-                        |replace({ '%username%': employeeForm.prestashop_addons.vars.addons_username })
-                  }}
-                </p>
-              {% endif %}
-
-              <div>
-                {% if employeeForm.prestashop_addons.vars.is_addons_connected %}
-                  {% set label, target =
-                    'Sign out from PrestaShop Addons'|trans({}, 'Admin.Advparameters.Feature'),
-                    '#module-modal-addons-logout'
-                  %}
-                {% else %}
-                  {% set label, target =
-                    'Sign in'|trans({}, 'Admin.Advparameters.Feature'),
-                    '#module-modal-addons-connect'
-                  %}
-                {% endif %}
-
-                {{ form_widget(employeeForm.prestashop_addons, {
-                  attr: {
-                    'class': 'btn-outline-secondary',
-                    'data-toggle': 'modal',
-                    'data-target': target,
-                  },
-                  label: label,
-                }) }}
-              </div>
-            </div>
-          </div>
-        {% endif %}
-
         {{ ps.form_group_row(employeeForm.language, {}, {
           'label': 'Language'|trans({}, 'Admin.Global')
         }) }}

--- a/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
@@ -48,7 +48,6 @@
         errorMessage: errorMessage,
         isRestrictedAccess: isRestrictedAccess,
         superAdminProfileId: superAdminProfileId,
-        showAddonsConnectButton: showAddonsConnectButton,
         getTabsUrl: getTabsUrl,
         avatarUrl: editableEmployee.avatarUrl
       } %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed Addons Connect button in Edit Employee Form in BO
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #25468
| How to test?      | Cf. #25468

**:notebook: BC Breaks :**
* In `src/Core/Employee/Access/EmployeeFormAccessCheckerInterface.php`, remove the declared method `public function canAccessAddonsConnect();`
* In `src/Adapter/Employee/EmployeeFormAccessChecker.php`:
  * the 3rd parameter has been removed `PrestaShopBundle\Entity\Repository\TabRepository $tabRepository`
  * the method `canAccessAddonsConnect()` has been removed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25559)
<!-- Reviewable:end -->
