### PR TITLE
Move TranslationsController into Admin/Improve/International

### DIFF
--- a/.github/workflows/phpstan/strict-types-for-new-classes-rule-exclusion-list.php
+++ b/.github/workflows/phpstan/strict-types-for-new-classes-rule-exclusion-list.php
@@ -392,7 +392,7 @@ $baseline = [
     'PrestaShopBundle\Api\Stock\Movement',
     'PrestaShopBundle\Api\Stock\MovementsCollection',
     'PrestaShopBundle\Command\SecurityAnnotationLinterCommand',
-    'PrestaShopBundle\Controller\Admin\TranslationsController',
+    'PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController',
     'PrestaShopBundle\Controller\Admin\Sell\Catalog\CategoryController',
     'PrestaShopBundle\Controller\Admin\SupplierController',
     'PrestaShopBundle\Command\LegacyLinkLinterCommand',

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -73,7 +73,7 @@ class FrameworkBundleAdminController extends AbstractController
      *
      * @deprecated Since 8.0, to be removed in the next major version
      *
-     * @return array Template vars
+     * @return array|Response Template vars if the action uses template annotation, or a Response object
      */
     public function overviewAction()
     {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
@@ -36,6 +36,7 @@ use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 /**
@@ -96,7 +97,7 @@ class TranslationsController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @return array
+     * @return Response
      */
     public function showSettingsAction(Request $request)
     {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
@@ -24,14 +24,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShopBundle\Controller\Admin;
+namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Language\Copier\LanguageCopierConfig;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\InvalidModuleException;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,8 +43,6 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  */
 class TranslationsController extends FrameworkBundleAdminController
 {
-    protected $layoutTitle = 'Translations';
-
     public const CONTROLLER_NAME = 'ADMINTRANSLATIONS';
 
     /**
@@ -52,11 +51,14 @@ class TranslationsController extends FrameworkBundleAdminController
     public const controller_name = self::CONTROLLER_NAME;
 
     /**
-     * @Template("@PrestaShop/Admin/Translations/overview.html.twig")
+     * Renders the translation page
      */
     public function overviewAction()
     {
-        return parent::overviewAction();
+        return $this->render('@PrestaShop/Admin/Improve/International/Translations/overview.html.twig', [
+            'is_shop_context' => (new Context())->isShopContext(),
+            'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
+        ]);
     }
 
     /**
@@ -90,7 +92,6 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Show translations settings page.
      *
-     * @Template("@PrestaShop/Admin/Improve/International/Translations/translations_settings.html.twig")
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param Request $request
@@ -107,7 +108,7 @@ class TranslationsController extends FrameworkBundleAdminController
         $exportCataloguesForm = $this->getExportTranslationCataloguesFormHandler()->getForm();
         $copyLanguageForm = $this->getCopyLanguageTranslationsFormHandler()->getForm();
 
-        return [
+        return $this->render('@PrestaShop/Admin/Improve/International/Translations/translations_settings.html.twig', [
             'layoutTitle' => $this->trans('Translations', 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
@@ -117,7 +118,7 @@ class TranslationsController extends FrameworkBundleAdminController
             'addUpdateLanguageForm' => $addUpdateLanguageForm->createView(),
             'modifyTranslationsForm' => $modifyTranslationsForm->createView(),
             'addLanguageUrl' => $legacyContext->getAdminLink('AdminLanguages', true, ['addlang' => '']),
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -2,7 +2,7 @@ admin_international_translation_overview:
   path: /
   methods: [ GET ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\TranslationsController::overviewAction
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController::overviewAction
     _legacy_controller: AdminTranslations
     _legacy_link: AdminTranslationSf
 
@@ -10,7 +10,7 @@ admin_international_translations_export_catalogues:
   path: /export
   methods: [ POST ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\TranslationsController::exportCataloguesAction
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController::exportCataloguesAction
     _legacy_controller: AdminTranslations
     _legacy_link: AdminTranslations:submitExport
 
@@ -18,7 +18,7 @@ admin_international_translations_show_settings:
   path: /settings
   methods: [ GET ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\TranslationsController::showSettingsAction
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController::showSettingsAction
     _legacy_controller: AdminTranslations
     _legacy_link: AdminTranslations:settings
 
@@ -26,14 +26,14 @@ admin_international_translations_modify:
   path: /modify
   methods: [ GET ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\TranslationsController::modifyTranslationsAction
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController::modifyTranslationsAction
     _legacy_controller: AdminTranslations
 
 admin_international_translations_add_update_language:
   path: /add-update-language
   methods: [ POST ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\TranslationsController::addUpdateLanguageAction
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController::addUpdateLanguageAction
     _legacy_controller: AdminTranslations
     _legacy_link: AdminTranslations:submitAddLanguage
 
@@ -41,6 +41,6 @@ admin_international_translations_copy_language:
   path: /copy
   methods: [ POST ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\TranslationsController::copyLanguageAction
+    _controller: PrestaShopBundle\Controller\Admin\Improve\International\TranslationsController::copyLanguageAction
     _legacy_controller: AdminTranslations
     _legacy_link: AdminTranslations:submitCopyLang

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/overview.html.twig
@@ -25,34 +25,34 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-    <div id="translations-app"></div>
+  <div id="translations-app"></div>
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }}
+  {{ parent() }}
 
-    <script>
-        var data = {
-            baseUrl: '{{ app.request.getBasePath() }}',
-            locale: '{{ app.request.query.get('locale') }}',
-            type: '{{ app.request.query.get('type') }}',
-            currentTheme: {{ theme.name|json_encode|raw }},
-            selected: '{{ app.request.query.get('selected') }}',
-            domainsTreeUrl: '{{ url('api_translation_domains_tree', {
-              'lang' : app.request.query.get('lang'),
-              'type' : app.request.query.get('type'),
-              'selected': app.request.query.get('selected')
-            }) }}',
-            translationUrl: '{{ url('api_i18n_translations_list', {'page' : 'international'}) }}',
-            internationalUrl: '{{ getAdminLink("AdminLocalization")|raw }}',
-            translationsUrl: '{{ getAdminLink("AdminTranslations")|raw }}'
-        }
-    </script>
+  <script>
+    var data = {
+      baseUrl: '{{ app.request.getBasePath() }}',
+      locale: '{{ app.request.query.get('locale') }}',
+      type: '{{ app.request.query.get('type') }}',
+      currentTheme: {{ theme.name|json_encode|raw }},
+      selected: '{{ app.request.query.get('selected') }}',
+      domainsTreeUrl: '{{ url('api_translation_domains_tree', {
+        'lang' : app.request.query.get('lang'),
+        'type' : app.request.query.get('type'),
+        'selected': app.request.query.get('selected')
+      }) }}',
+      translationUrl: '{{ url('api_i18n_translations_list', {'page' : 'international'}) }}',
+      internationalUrl: '{{ getAdminLink("AdminLocalization")|raw }}',
+      translationsUrl: '{{ getAdminLink("AdminTranslations")|raw }}'
+    }
+  </script>
 
-    {% if webpack_server %}
-        <script src="http://localhost:8080/translations.bundle.js"></script>
-    {% else %}
-        <script src="{{ asset('themes/new-theme/public/translations.bundle.js') }}"></script>
-    {% endif %}
+  {% if webpack_server %}
+    <script src="http://localhost:8080/translations.bundle.js"></script>
+  {% else %}
+    <script src="{{ asset('themes/new-theme/public/translations.bundle.js') }}"></script>
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Moved TranslationsController into the appropriate namespace
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes - the controller's namespace and path changed
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | The translation interface loads (the page features are handled in a different controller)
| Possible impacts? | Nothing that I can think of


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25562)
<!-- Reviewable:end -->
