### PR TITLE
Deprecate FrameworkBundleAdminController::overviewAction

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -71,10 +71,14 @@ class FrameworkBundleAdminController extends AbstractController
     /**
      * @Template
      *
+     * @deprecated Since 8.0, to be removed in the next major version
+     *
      * @return array Template vars
      */
     public function overviewAction()
     {
+        @trigger_error(__FUNCTION__ . 'is deprecated since version 8.0 and will be removed in the next major version.', E_USER_DEPRECATED);
+
         return [
             'is_shop_context' => (new Context())->isShopContext(),
             'layoutTitle' => empty($this->layoutTitle) ? '' : $this->trans($this->layoutTitle, 'Admin.Navigation.Menu'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `FrameworkBundleAdminController::overviewAction` is only used by the Stocks and Translations controllers to display their Vue-based pages. This has been refactored out in #25561 and #25562 so this method can be safely be sunsetted.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes, `FrameworkBundleAdminController::overviewAction()` is deprecated
| Fixed ticket?     | N/A
| How to test?      | Nothing to test
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25563)
<!-- Reviewable:end -->
