### PR TITLE
Fix next icon going outside imageslider on classic theme

### DIFF
--- a/themes/classic/_dev/css/components/imageslider.scss
+++ b/themes/classic/_dev/css/components/imageslider.scss
@@ -127,6 +127,14 @@
     background-color: $gray-light;
     box-shadow: none;
 
+    .carousel-control {
+      .icon-prev,
+      .icon-next {
+        width: auto;
+        height: auto;
+      }
+    }
+
     .carousel-item {
       .caption {
         position: static;
@@ -165,7 +173,7 @@
 
         .icon-next {
           right: 0;
-          margin-right: 0.78rem;
+          margin-right: 0;
         }
 
         i {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The next icon of imageslider was going outside, creating an overflow even on mobile and tablet (under 991), This partially fix the issue, because it fix a bug on mobile user agent, but it doesn't fix it when you resize the window on a desktop computer (because it's inside a global container). The FULL fix is almost undoable properly and maintainable because of the container wrapping every sections, if we do this, this is a lot of work and a BC...
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25459.
| How to test?      | Go on homepage, activate slider on mobile, open under 991px of width and see if imageslider is well dipslayed
| Possible impacts? | Imageslider design


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25569)
<!-- Reviewable:end -->
