### PR TITLE
Fix broken prices update in italian language 

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-form-model.js
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-form-model.js
@@ -118,7 +118,7 @@ export default class ProductFormModel {
 
     switch (event.modelKey) {
       case 'product.price.priceTaxIncluded': {
-        const priceTaxIncluded = new BigNumber(this.getProduct().price.priceTaxIncluded);
+        const priceTaxIncluded = new BigNumber(this.getProduct().price.priceTaxIncluded.replace(/,/g, '.'));
         this.mapper.set(
           'product.price.priceTaxExcluded',
           priceTaxIncluded.dividedBy(taxRatio).toFixed(this.precision),
@@ -126,7 +126,7 @@ export default class ProductFormModel {
         break;
       }
       default: {
-        const priceTaxExcluded = new BigNumber(this.getProduct().price.priceTaxExcluded);
+        const priceTaxExcluded = new BigNumber(this.getProduct().price.priceTaxExcluded.replace(/,/g, '.'));
         this.mapper.set('product.price.priceTaxIncluded', priceTaxExcluded.times(taxRatio).toFixed(this.precision));
         break;
       }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Comma must be replaced by a dot before being used by BigNumber js library
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24889
| How to test?      | see #24889 and https://www.awesomescreenshot.com/video/4050320?key=3b48730df51513e9bfe3d50fec052661
| Possible impacts? | none

## READ THIS BEFORE REVIEW:

@PierreRambaud,

I saw that you added a new `CommaTransformerExtension` for the `NumberType` form type, but here we are dealing with a `MoneyType` form type.

I tried adding the `js-comma-transformer` class on the fields, but it didn't fix the bug, in the end I replaced the comma by a dot manually...  maybe that's not what this new extension is supposed to do? 

I'd like your opinion on this PR, just in case I should have used your extension somehow 👍 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25574)
<!-- Reviewable:end -->
