### PR TITLE
Add possibility to add custom column type with custom templates

### DIFF
--- a/src/Core/Grid/Column/AbstractColumn.php
+++ b/src/Core/Grid/Column/AbstractColumn.php
@@ -35,6 +35,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 abstract class AbstractColumn implements ColumnInterface
 {
     /**
+     * @const string default column content template path
+     */
+    public const BASE_COLUMN_CONTENT_TEMPLATE_PATH = '@PrestaShop/Admin/Common/Grid/Columns/Content';
+
+    /**
+     * @const string default column header template path
+     */
+    public const BASE_COLUMN_HEADER_TEMPLATE_PATH = '@PrestaShop/Admin/Common/Grid/Columns/Header/Content';
+
+    /**
      * @var string
      */
     private $id;
@@ -118,6 +128,26 @@ abstract class AbstractColumn implements ColumnInterface
     }
 
     /**
+     * Column content template path
+     *
+     * @return string
+     */
+    protected function getContentTemplatePath(): string
+    {
+        return self::BASE_COLUMN_CONTENT_TEMPLATE_PATH;
+    }
+
+    /**
+     * Column header template path
+     *
+     * @return string
+     */
+    protected function getHeaderTemplatePath(): string
+    {
+        return self::BASE_COLUMN_HEADER_TEMPLATE_PATH;
+    }
+
+    /**
      * Default column options configuration. You can override or extend it needed options.
      *
      * @param OptionsResolver $resolver
@@ -129,11 +159,15 @@ abstract class AbstractColumn implements ColumnInterface
                 'sortable' => true,
                 'clickable' => false,
                 'alignment' => 'left',
+                'content_template_path' => $this->getContentTemplatePath(),
+                'header_template_path' => $this->getHeaderTemplatePath(),
             ])
             ->setAllowedTypes('sortable', 'bool')
             ->setAllowedTypes('clickable', 'bool')
             ->setAllowedTypes('alignment', 'string')
-            ->setAllowedValues('alignment', ['center', 'left', 'right', 'justify']);
+            ->setAllowedValues('alignment', ['center', 'left', 'right', 'justify'])
+            ->setAllowedTypes('content_template_path', 'string')
+            ->setAllowedTypes('header_template_path', 'string');
     }
 
     /**

--- a/src/PrestaShopBundle/Twig/Extension/GridExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/GridExtension.php
@@ -142,7 +142,7 @@ class GridExtension extends AbstractExtension
             $template = $this->getTemplatePath(
                 $column,
                 $grid,
-                $column['options']['header_template_path'] ?? self::BASE_COLUMN_HEADER_TEMPLATE_PATH,
+                $column['options']['header_template_path'],
                 'default.html.twig'
             );
 

--- a/src/PrestaShopBundle/Twig/Extension/GridExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/GridExtension.php
@@ -100,7 +100,7 @@ class GridExtension extends AbstractExtension
             $template = $this->getTemplatePath(
                 $column,
                 $grid,
-                $column['options']['content_template_path'] ?? self::BASE_COLUMN_CONTENT_TEMPLATE_PATH
+                $column['options']['content_template_path']
             );
 
             if (null === $template) {

--- a/src/PrestaShopBundle/Twig/Extension/GridExtension.php
+++ b/src/PrestaShopBundle/Twig/Extension/GridExtension.php
@@ -100,7 +100,7 @@ class GridExtension extends AbstractExtension
             $template = $this->getTemplatePath(
                 $column,
                 $grid,
-                self::BASE_COLUMN_CONTENT_TEMPLATE_PATH
+                $column['options']['content_template_path'] ?? self::BASE_COLUMN_CONTENT_TEMPLATE_PATH
             );
 
             if (null === $template) {
@@ -142,7 +142,7 @@ class GridExtension extends AbstractExtension
             $template = $this->getTemplatePath(
                 $column,
                 $grid,
-                self::BASE_COLUMN_HEADER_TEMPLATE_PATH,
+                $column['options']['header_template_path'] ?? self::BASE_COLUMN_HEADER_TEMPLATE_PATH,
                 'default.html.twig'
             );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add possibility to add custom column type with custom templates.
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25055
| How to test?      | see description below
| Possible impacts? | N/A


# How to test

### 1 - Create a custom column type 

By overriding `SeverityLevelColumn` for example : 

```php

<?php

namespace PrestaShop\Module\Mymodule\Grid\Column\Type;

use PrestaShop\PrestaShop\Core\Grid\Column\Type\Status\SeverityLevelColumn;
use Symfony\Component\OptionsResolver\OptionsResolver;

final class MyCustomColumn extends SeverityLevelColumn
{
    /**
     * {@inheritdoc}
     */
    public function getType()
    {
        return 'my_custom_column';
    }

    protected function getContentTemplatePath(): string{
        return '@Modules/mymodule/path/of/my/template'; // oveeride default core template
    }
}

```

###  2 - Make sure this file exists in your module

`/mymodule/path/of/my/template/my_custom_column.html.twig`

```html
<p>coucou petite perruche</p>
```


###  3 - Use the new column type in your grid definition factory

```php

namespace PrestaShop\Module\Mymodule\Grid\Definition\Factory;

use namespace PrestaShop\Module\Mymodule\Grid\Column\Type\MyCustomColumn;

final class MyGridDefinitionFactory extends AbstractGridDefinitionFactory
{
    /**
     * {@inheritdoc}
     */
    protected function getColumns()
    {
        $columns = new ColumnCollection();
        
        $columns
            ->add(
                (new MyCustomColumn('mycsutomcolunmfield'))
                    ->setName($this->trans('My custom column field', [], 'Modules.Mymodule.Admin'))
                    ->setOptions([
                        'with_message' => false,
                        'field' => 'mycsutomcolunmfield',
                        // I can also, dynamically during execution define my content template ;)
                        //'content_template_path' => '@Modules/mymodule/path/of/my/template' 
                    ])
            )
            ;
        
        return $columns;
    }

}
```
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25576)
<!-- Reviewable:end -->
