### PR TITLE
Add possibility to resize `ImageColumn` Type

### DIFF
--- a/src/Core/Grid/Column/Type/Common/ImageColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ImageColumn.php
@@ -53,8 +53,11 @@ final class ImageColumn extends AbstractColumn
             ])
             ->setDefaults([
                 'clickable' => true,
+                'height' => 'auto',
             ])
             ->setAllowedTypes('src_field', 'string')
-            ->setAllowedTypes('clickable', 'bool');
+            ->setAllowedTypes('clickable', 'bool')
+            ->setAllowedTypes('width', ['null', 'string'])
+            ->setAllowedTypes('height', 'string');
     }
 }

--- a/src/Core/Grid/Column/Type/Common/ImageColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ImageColumn.php
@@ -53,6 +53,7 @@ final class ImageColumn extends AbstractColumn
             ])
             ->setDefaults([
                 'clickable' => true,
+                'width' => '',
                 'height' => 'auto',
             ])
             ->setAllowedTypes('src_field', 'string')

--- a/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Columns/Content/image.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Columns/Content/image.html.twig
@@ -26,4 +26,4 @@
 {% set width  = record[column.options.width] %}
 {% set height = record[column.options.height] %}
 
-<img src="{{ record[column.options.src_field] }}" {% if width %} style="width: {{ width }}; height: {{ height }};" {% endif %}>
+<img src="{{ record[column.options.src_field] }}"{% if width is not empty or height is not empty %} style="{% if width is not empty %}width:{{ width }};{% endif %}{% if height is not empty %}height:{{ height }};{% endif %}"{% endif %}>

--- a/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Columns/Content/image.html.twig
+++ b/templates/bundles/PrestaShopBundle/Admin/Common/Grid/Columns/Content/image.html.twig
@@ -22,5 +22,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
+ 
+{% set width  = record[column.options.width] %}
+{% set height = record[column.options.height] %}
 
-<img src="{{ record[column.options.src_field] }}">
+<img src="{{ record[column.options.src_field] }}" {% if width %} style="width: {{ width }}; height: {{ height }};" {% endif %}>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add possibility to resize `ImageColumn` Type.
| Type?             |  improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Please see description below.
| Possible impacts? | N/A


# How to test 

1 - Edit manufacturer [grid definition factory](https://github.com/PrestaShop/PrestaShop/blob/develop/src/Core/Grid/Definition/Factory/ManufacturerGridDefinitionFactory.php#L92) (logo column) and add the new options (`width` and `height`)
```php

->add((new ImageColumn('logo'))
     ->setName($this->trans('Logo', [], 'Admin.Global'))
     ->setOptions([
          'src_field' => 'logo',
          'width' => '1000px',
          'height' => '300px',
 ])

```

2 - Clear cache ;)

3 - Go to `BO > Manufacturer`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25603)
<!-- Reviewable:end -->
