### PR TITLE
Fix helpbox outside form label on product page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig
@@ -42,9 +42,11 @@
                     </div>
                   {% endif %}
                   <div class="col-md-4">
-                    <label class="form-control-label">{{ formStockMinimalQuantity.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    <label class="form-control-label">
+                      {{ formStockMinimalQuantity.vars.label }}
+                      <span class="help-box" data-toggle="popover"
+                        data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    </label>
                     {{ form_errors(formStockMinimalQuantity) }}
                     {{ form_widget(formStockMinimalQuantity) }}
                   </div>
@@ -95,9 +97,11 @@
                 {{ form_errors(formVirtualProduct) }}
                 <div class="col-md-12">
                   <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.file.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Upload a file from your computer (%maxUploadSize% max.)"|trans({'%maxUploadSize%': max_upload_size}, 'Admin.Catalog.Help') }}" ></span>
+                    <label class="form-control-label">
+                      {{ formVirtualProduct.file.vars.label }}
+                      <span class="help-box" data-toggle="popover"
+                        data-content="{{ "Upload a file from your computer (%maxUploadSize% max.)"|trans({'%maxUploadSize%': max_upload_size}, 'Admin.Catalog.Help') }}" ></span>
+                    </label>
                     <div id="form_step3_virtual_product_file_input" class="{{ formVirtualProduct.vars.value.filename is defined ? 'hide' : 'show' }}">
                       {{ form_widget(formVirtualProduct.file) }}
                     </div>
@@ -109,36 +113,44 @@
                 </div>
                 <div class="col-md-6">
                   <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.name.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    <label class="form-control-label">
+                      {{ formVirtualProduct.name.vars.label }}
+                      <span class="help-box" data-toggle="popover"
+                        data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    </label>
                     {{ form_errors(formVirtualProduct.name) }}
                     {{ form_widget(formVirtualProduct.name) }}
                   </fieldset>
                 </div>
                 <div class="col-md-6">
                   <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.nb_downloadable.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    <label class="form-control-label">
+                      {{ formVirtualProduct.nb_downloadable.vars.label }}
+                      <span class="help-box" data-toggle="popover"
+                        data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    </label>
                     {{ form_errors(formVirtualProduct.nb_downloadable) }}
                     {{ form_widget(formVirtualProduct.nb_downloadable) }}
                   </fieldset>
                 </div>
                 <div class="col-md-6">
                   <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.expiration_date.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    <label class="form-control-label">
+                      {{ formVirtualProduct.expiration_date.vars.label }}
+                      <span class="help-box" data-toggle="popover"
+                        data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    </label>
                     {{ form_errors(formVirtualProduct.expiration_date) }}
                     {{ form_widget(formVirtualProduct.expiration_date) }}
                   </fieldset>
                 </div>
                 <div class="col-md-6">
                   <fieldset class="form-group">
-                    <label class="form-control-label">{{ formVirtualProduct.nb_days.vars.label }}</label>
-                    <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    <label class="form-control-label">
+                      {{ formVirtualProduct.nb_days.vars.label }}
+                      <span class="help-box" data-toggle="popover"
+                        data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                    </label>
                     {{ form_errors(formVirtualProduct.nb_days) }}
                     {{ form_widget(formVirtualProduct.nb_days) }}
                   </fieldset>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Helpboxes were outside of the label of the form inside virtual product tabs
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25610
| How to test?      | Go on product page, add new product, virtual product and virtual product tab, every helpboxes should be aligned with labels
| Possible impacts? | Product page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25612)
<!-- Reviewable:end -->
