### PR TITLE
Use _DB_PREFIX_ constant instead of ps_ in SQL queries

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -676,9 +676,9 @@ class CartRuleCore extends ObjectModel
 
                 $quantityUsed += (int) Db::getInstance()->getValue('
                     SELECT count(*)
-                    FROM ps_cart_cart_rule ccr
-                    INNER JOIN ps_cart c ON c.id_cart = ccr.id_cart
-                    LEFT JOIN ps_orders o ON o.id_cart = c.id_cart
+                    FROM ' . _DB_PREFIX_ . 'cart_cart_rule ccr
+                    INNER JOIN ' . _DB_PREFIX_ . 'cart c ON c.id_cart = ccr.id_cart
+                    LEFT JOIN ' . _DB_PREFIX_ . 'orders o ON o.id_cart = c.id_cart
                     WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
                 ');
             } else {

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -676,9 +676,9 @@ class CartRuleCore extends ObjectModel
 
                 $quantityUsed += (int) Db::getInstance()->getValue('
                     SELECT count(*)
-                    FROM ' . _DB_PREFIX_ . 'cart_cart_rule ccr
-                    INNER JOIN ' . _DB_PREFIX_ . 'cart c ON c.id_cart = ccr.id_cart
-                    LEFT JOIN ' . _DB_PREFIX_ . 'orders o ON o.id_cart = c.id_cart
+                    FROM `' . _DB_PREFIX_ . 'cart_cart_rule` ccr
+                    INNER JOIN `' . _DB_PREFIX_ . 'cart` c ON c.id_cart = ccr.id_cart
+                    LEFT JOIN `' . _DB_PREFIX_ . 'orders` o ON o.id_cart = c.id_cart
                     WHERE c.id_customer = ' . $cart->id_customer . ' AND c.id_cart = ' . $cart->id . ' AND ccr.id_cart_rule = ' . (int) $this->id . ' AND o.id_order IS NULL
                 ');
             } else {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | _DB_PREFIX_ is not used, so it throws an error with installations not using 'ps_' as database prefix
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25617
| How to test?      | Ci is green
| Possible impacts? | none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25629)
<!-- Reviewable:end -->
