### PR TITLE
Do not use name in admin_orders_display_customization_image_route

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -1700,12 +1700,11 @@ class OrderController extends FrameworkBundleAdminController
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param int $orderId
-     * @param string $name
      * @param string $value
      *
      * @return BinaryFileResponse|RedirectResponse
      */
-    public function displayCustomizationImageAction(int $orderId, string $name, string $value)
+    public function displayCustomizationImageAction(int $orderId, string $value)
     {
         $uploadDir = $this->get('prestashop.adapter.legacy.context')->getUploadDirectory();
         $filePath = $uploadDir . $value;
@@ -1721,7 +1720,7 @@ class OrderController extends FrameworkBundleAdminController
             }
 
             $imageFile = new File($filePath);
-            $fileName = sprintf('%s-customization-%s.%s', $orderId, $name, $imageFile->guessExtension() ?? 'jpg');
+            $fileName = sprintf('%s-customization-%s.%s', $orderId, $value, $imageFile->guessExtension() ?? 'jpg');
 
             return $this->file($filePath, $fileName);
         } catch (Exception $e) {

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/orders.yml
@@ -378,14 +378,13 @@ admin_orders_configure_product_pagination:
     expose: true
 
 admin_orders_display_customization_image:
-  path: /display-customization-image/{orderId}/{name}/{value}
+  path: /display-customization-image/{orderId}/{value}
   methods: [GET]
   defaults:
     _controller: PrestaShopBundle:Admin/Sell/Order/Order:displayCustomizationImage
     _legacy_controller: AdminOrders
   requirements:
     orderId: \d+
-    name: .+
     value: .+
 
 admin_orders_product_prices:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/product.html.twig
@@ -161,7 +161,7 @@
               <div class="mr-4">
                 <p><strong>{{ customization.name }}</strong></p>
                 <p>
-                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, 'name': customization.name|url_encode|replace({'%': '_'}), "value": customization.value})}}" download>
+                  <a href="{{ path('admin_orders_display_customization_image', {'orderId': orderForViewing.id, "value": customization.value})}}" download>
                     <img src="{{ customization.image }}" alt="{{ customization.name }}">
                   </a>
                 </p>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.7.x
| Description?      | The name is not mandatory and shouldn't be forced to be set to generate an URL. We have the value, we can put the value inside the customization image name instead of the encoded name.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #25631 
| How to test?      | Follow ticket instructions.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


## BC breaks

- The method `displayCustomizationImageAction` doesn't contains `string $name` anymore

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25634)
<!-- Reviewable:end -->
