### PR TITLE
Load medium size thumbnail on click on FO product page, instead of large

### DIFF
--- a/themes/classic/_dev/js/product.js
+++ b/themes/classic/_dev/js/product.js
@@ -64,7 +64,7 @@ $(document).ready(() => {
       $(prestashop.themeSelectors.product.modalProductCover).attr('src', newSelectedThumb.data('image-large-src'));
       selectedThumb.removeClass('selected');
       newSelectedThumb.addClass('selected');
-      productCover.prop('src', newSelectedThumb.data('image-large-src'));
+      productCover.prop('src', newSelectedThumb.data('image-medium-src'));
     };
 
     $(prestashop.themeSelectors.product.thumb).on('click', (event) => {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x 
| Description?      | Loads correct image size when clicking on product's thumbnail in FO product page, classic theme.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25663
| How to test?      | see issue #25663
| Possible impacts? | not that I know of


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25665)
<!-- Reviewable:end -->
