### PR TITLE
Global smarty $urls variable changes when child theme is being used

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1509,13 +1509,13 @@ class FrontControllerCore extends Controller
 
             if ($themeAssetsConfig && isset($themeAssetsConfig['use_parent_assets']) && $themeAssetsConfig['use_parent_assets']) {
                 $assign_array['theme_assets'] = _PS_PARENT_THEME_URI_ . 'assets/';
-                $assign_array['img_url'] = _PS_PARENT_THEME_URI_ . 'assets/img/';
-                $assign_array['css_url'] = _PS_PARENT_THEME_URI_ . 'assets/css/';
-                $assign_array['js_url'] = _PS_PARENT_THEME_URI_ . 'assets/js/';
+                $assign_array['img_url'] = $assign_array['theme_assets'] . 'img/';
+                $assign_array['css_url'] = $assign_array['theme_assets'] . 'css/';
+                $assign_array['js_url'] = $assign_array['theme_assets'] . 'js/';
                 $assign_array['child_theme_assets'] = _THEME_DIR_ . 'assets/';
-                $assign_array['child_img_url'] = _THEME_DIR_ . 'assets/img/';
-                $assign_array['child_css_url'] = _THEME_DIR_ . 'assets/css/';
-                $assign_array['child_js_url'] = _THEME_DIR_ . 'assets/js/';
+                $assign_array['child_img_url'] = $assign_array['child_theme_assets'] . 'img/';
+                $assign_array['child_css_url'] = $assign_array['child_theme_assets'] . 'css/';
+                $assign_array['child_js_url'] = $assign_array['child_theme_assets'] . 'js/';
             }
 
             foreach ($assign_array as $assign_key => $assign_value) {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1502,7 +1502,21 @@ class FrontControllerCore extends Controller
                 'css_url' => _THEME_CSS_DIR_,
                 'js_url' => _THEME_JS_DIR_,
                 'pic_url' => _THEME_PROD_PIC_DIR_,
+                'theme_assets' => _THEME_DIR_ . 'assets/',
             ];
+
+            $themeAssetsConfig = $this->context->shop->theme->get('assets', false);
+
+            if ($themeAssetsConfig && isset($themeAssetsConfig['use_parent_assets']) && $themeAssetsConfig['use_parent_assets']) {
+                $assign_array['theme_assets'] = _PS_PARENT_THEME_URI_ . 'assets/';
+                $assign_array['img_url'] = _PS_PARENT_THEME_URI_ . 'assets/img/';
+                $assign_array['css_url'] = _PS_PARENT_THEME_URI_ . 'assets/css/';
+                $assign_array['js_url'] = _PS_PARENT_THEME_URI_ . 'assets/js/';
+                $assign_array['child_theme_assets'] = _THEME_DIR_ . 'assets/';
+                $assign_array['child_img_url'] = _THEME_DIR_ . 'assets/img/';
+                $assign_array['child_css_url'] = _THEME_DIR_ . 'assets/css/';
+                $assign_array['child_js_url'] = _THEME_DIR_ . 'assets/js/';
+            }
 
             foreach ($assign_array as $assign_key => $assign_value) {
                 if (substr($assign_value, 0, 1) == '/' || $this->ssl) {
@@ -1529,8 +1543,6 @@ class FrontControllerCore extends Controller
             $urls['pages'] = $pages;
 
             $urls['alternative_langs'] = $this->getAlternativeLangsUrl();
-
-            $urls['theme_assets'] = __PS_BASE_URI__ . 'themes/' . $this->context->shop->theme->getName() . '/assets/';
 
             $urls['actions'] = [
                 'logout' => $this->context->link->getPageLink('index', true, null, 'mylogout'),

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1507,7 +1507,7 @@ class FrontControllerCore extends Controller
 
             $themeAssetsConfig = $this->context->shop->theme->get('assets', false);
 
-            if ($themeAssetsConfig && isset($themeAssetsConfig['use_parent_assets']) && $themeAssetsConfig['use_parent_assets']) {
+            if (!empty($themeAssetsConfig['use_parent_assets'])) {
                 $assign_array['theme_assets'] = _PS_PARENT_THEME_URI_ . 'assets/';
                 $assign_array['img_url'] = $assign_array['theme_assets'] . 'img/';
                 $assign_array['css_url'] = $assign_array['theme_assets'] . 'css/';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we are using child theme and in child theme.yml `assets.use_parent_assets` option is true. We should also provide different smarty `$urls` that will cover current (child theme) url and parent theme.
| Type?             |  improvement
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #25667.
| How to test?      | Create child theme from classic. Set inside child theme theme.yml file `assets.use_parent_assets` to `true`. Dump `{$urls}` variables inside FO template. Change `assets.use_parent_assets` to `false` (remove saved json file in `config/themes/{theme_name}/*.json` to clear config cache) check if prefixed `child_` field still exists in `{$urls}` array and if for examle `img_url` is pointing to current child theme. 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25668)
<!-- Reviewable:end -->
