### PR TITLE
Use node_14.x instead of node_10.x

### DIFF
--- a/tests/UI/.docker/prestashop/Dockerfile
+++ b/tests/UI/.docker/prestashop/Dockerfile
@@ -13,11 +13,11 @@ RUN apt install -y \
     curl \
     git \
     software-properties-common \
-    nodejs \
     poppler-utils
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt update
 RUN apt install -y nodejs
 
 COPY ["./.docker/prestashop/wait-for-it.sh", "./.docker/prestashop/docker_run.sh", "/tmp/"]


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The nodejs version is badly choice.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests are green.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25676)
<!-- Reviewable:end -->
