### PR TITLE
Use editable customer and avoid loading unnecessary data

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -615,6 +615,13 @@ class CustomerCore extends ObjectModel
         return self::$_customerHasAddress[$key];
     }
 
+    public static function resetStaticCache()
+    {
+        self::$_customerHasAddress = [];
+        self::$_customer_groups = [];
+        self::$_defaultGroupId = [];
+    }
+
     /**
      * Reset Address cache.
      *

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForEditingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForEditingHandler.php
@@ -78,7 +78,8 @@ final class GetCustomerForEditingHandler implements GetCustomerForEditingHandler
             (string) $customer->website,
             (float) $customer->outstanding_allow_amount,
             (int) $customer->max_payment_days,
-            (int) $customer->id_risk
+            (int) $customer->id_risk,
+            (bool) $customer->isGuest()
         );
     }
 }

--- a/src/Core/Domain/Customer/QueryResult/EditableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/EditableCustomer.php
@@ -172,7 +172,7 @@ class EditableCustomer
         $allowedOutstandingAmount,
         $maxPaymentDays,
         $riskId,
-        bool $isGuest
+        bool $isGuest = false
     ) {
         $this->customerId = $customerId;
         $this->genderId = $genderId;

--- a/src/Core/Domain/Customer/QueryResult/EditableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/EditableCustomer.php
@@ -128,6 +128,11 @@ class EditableCustomer
     private $riskId;
 
     /**
+     * @var bool
+     */
+    private $isGuest;
+
+    /**
      * @param CustomerId $customerId
      * @param int $genderId
      * @param FirstName $firstName
@@ -146,6 +151,7 @@ class EditableCustomer
      * @param float $allowedOutstandingAmount
      * @param int $maxPaymentDays
      * @param int $riskId
+     * @param bool $isGuest
      */
     public function __construct(
         CustomerId $customerId,
@@ -165,7 +171,8 @@ class EditableCustomer
         $website,
         $allowedOutstandingAmount,
         $maxPaymentDays,
-        $riskId
+        $riskId,
+        bool $isGuest
     ) {
         $this->customerId = $customerId;
         $this->genderId = $genderId;
@@ -185,6 +192,7 @@ class EditableCustomer
         $this->allowedOutstandingAmount = $allowedOutstandingAmount;
         $this->maxPaymentDays = $maxPaymentDays;
         $this->riskId = $riskId;
+        $this->isGuest = $isGuest;
     }
 
     /**
@@ -329,5 +337,13 @@ class EditableCustomer
     public function isNewsletterSubscribed()
     {
         return $this->isNewsletterSubscribed;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGuest(): bool
+    {
+        return $this->isGuest;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProvider.php
@@ -94,6 +94,7 @@ final class CustomerFormDataProvider implements FormDataProviderInterface
             'is_partner_offers_subscribed' => $editableCustomer->isPartnerOffersSubscribed(),
             'group_ids' => $editableCustomer->getGroupIds(),
             'default_group_id' => $editableCustomer->getDefaultGroupId(),
+            'is_guest' => $editableCustomer->isGuest(),
         ];
 
         if ($this->isB2bFeatureEnabled) {
@@ -127,6 +128,7 @@ final class CustomerFormDataProvider implements FormDataProviderInterface
                 $defaultGroups->getCustomersGroup()->getId(),
             ],
             'default_group_id' => (int) $this->configuration->get('PS_CUSTOMER_GROUP'),
+            'is_guest' => false,
         ];
 
         if ($this->isB2bFeatureEnabled) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -208,8 +208,8 @@ class CustomerController extends AbstractAdminController
     public function editAction($customerId, Request $request)
     {
         $this->addGroupSelectionToRequest($request);
-        /** @var ViewableCustomer $customerInformation */
-        $customerInformation = $this->getQueryBus()->handle(new GetCustomerForViewing((int) $customerId));
+        /** @var EditableCustomer $customerInformation */
+        $customerInformation = $this->getQueryBus()->handle(new GetCustomerForEditing((int) $customerId));
         $customerFormOptions = [
             'is_password_required' => false,
         ];

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/edit.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% set enableSidebar = true %}
-{% set fullName = '%s. %s'|format(customerInformation.personalInformation.firstName[:1], customerInformation.personalInformation.lastName) %}
+{% set fullName = '%s. %s'|format(customerInformation.firstName.getValue[:1], customerInformation.lastName.getValue) %}
 {% set layoutTitle = 'Editing customer %name%'|trans({'%name%': fullName}, 'Admin.Orderscustomers.Feature') %}
 
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
@@ -32,7 +32,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Customer/Blocks/form.html.twig' with {'isGuest': customerInformation.personalInformation.guest} %}
+      {% include '@PrestaShop/Admin/Sell/Customer/Blocks/form.html.twig' with {'isGuest': customerInformation.isGuest} %}
     </div>
   </div>
 {% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/CustomerManagerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerManagerFeatureContext.php
@@ -27,6 +27,8 @@
 namespace Tests\Integration\Behaviour\Features\Context;
 
 use Behat\Gherkin\Node\TableNode;
+use Customer;
+use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\DeleteCustomerCommand;
@@ -167,6 +169,9 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
 
         DataTransfer::transferAttributesFromArrayToObject($data, $command);
         $commandBus->handle($command);
+
+        // Clear static cache or same cached groups will always be returned
+        Customer::resetStaticCache();
     }
 
     /**
@@ -183,17 +188,28 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @When I delete customer ":customerReference" with "allow registration after deletion" checked
+     * @When I delete customer ":customerReference" and allow it to register again
      */
-    public function deleteCustomerWithAllowCustomerRegistration($customerReference)
+    public function deleteCustomerWithAllowCustomerRegistration(string $customerReference): void
     {
         $this->deleteCustomer($customerReference, CustomerDeleteMethod::ALLOW_CUSTOMER_REGISTRATION);
     }
 
     /**
-     * @When /^I delete customer "(.+)" with method "(.+)"$/
+     * @When I delete customer ":customerReference" and prevent it from registering again
      */
-    public function deleteCustomer($customerReference, $methodName)
+    public function deleteCustomerWithDenyCustomerRegistration(string $customerReference): void
+    {
+        $this->deleteCustomer($customerReference, CustomerDeleteMethod::DENY_CUSTOMER_REGISTRATION);
+    }
+
+    /**
+     * @param string $customerReference
+     * @param string $methodName
+     *
+     * @throws \Exception
+     */
+    private function deleteCustomer(string $customerReference, string $methodName): void
     {
         $this->assertCustomerReferenceExistsInRegistry($customerReference);
         $this->validateDeleteCustomerMethod($methodName);
@@ -208,7 +224,7 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Then /^if I query customer "(.+)" I should get a Customer with properties:$/
+     * @When /^I query customer "(.+)" I should get a Customer with properties:$/
      */
     public function assertQueryCustomerProperties($customerReference, TableNode $table)
     {
@@ -227,6 +243,17 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
         DataComparator::assertDataSetsAreIdentical($expectedData, $realData);
 
         $this->latestResult = null;
+    }
+
+    /**
+     * @When customer ":customerReference" should be soft deleted
+     *
+     * @param string $customerReference
+     */
+    public function checkSoftDeleted(string $customerReference): void
+    {
+        $customer = new Customer($this->customerRegistry[$customerReference]);
+        Assert::assertTrue((bool) $customer->deleted);
     }
 
     /**
@@ -323,6 +350,14 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
         }
         if (array_key_exists('isPartnerOffersSubscribed', $data)) {
             $data['isPartnerOffersSubscribed'] = PrimitiveUtils::castStringBooleanIntoBoolean($data['isPartnerOffersSubscribed']);
+        }
+        if (array_key_exists('newsletterSubscribed', $data)) {
+            $data['newsletterSubscribed'] = PrimitiveUtils::castStringBooleanIntoBoolean($data['newsletterSubscribed']);
+        }
+        if (!empty($data['riskId'])) {
+            $data['riskId'] = SharedStorage::getStorage()->get($data['riskId']);
+        } else {
+            $data['riskId'] = 0;
         }
 
         return $data;

--- a/tests/Integration/Behaviour/Features/Context/RiskFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/RiskFeatureContext.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context;
+
+use Configuration;
+use Risk;
+use RuntimeException;
+
+class RiskFeatureContext extends AbstractPrestaShopFeatureContext
+{
+    /**
+     * @Given risk :reference in default language named :name exists
+     */
+    public function checkRiskWithNameExists($reference, $name)
+    {
+        $defaultLanguageId = Configuration::get('PS_LANG_DEFAULT');
+        $risks = Risk::getRisks($defaultLanguageId);
+
+        $searchedRisk = null;
+        /** @var Risk $risk */
+        foreach ($risks as $risk) {
+            if ($risk->name === $name) {
+                $searchedRisk = $risk;
+                break;
+            }
+        }
+
+        if (!$searchedRisk) {
+            throw new RuntimeException(sprintf('Cannot find risk with name %s', $name));
+        }
+
+        SharedStorage::getStorage()->set($reference, $searchedRisk->id);
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -1,5 +1,6 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags customer-management
 @reset-database-before-feature
+@customer-management
 Feature: Customer Management
   PrestaShop allows BO users to manage customers in the Customers > Customers page
   As a BO user
@@ -7,6 +8,8 @@ Feature: Customer Management
 
   Background:
     Given groups feature is activated
+    And risk none in default language named None exists
+    And risk low in default language named Low exists
 
   Scenario: Create a simple customer and edit it
     When I create a customer "CUST-1" with following properties:
@@ -14,13 +17,14 @@ Feature: Customer Management
       | lastName  | Napoler                    |
       | email     | napoler.dev@prestashop.com |
       | password  | PrestaShopForever1_!       |
-    Then if I query customer "CUST-1" I should get a Customer with properties:
+    When I query customer "CUST-1" I should get a Customer with properties:
       | firstName | Mathieu                    |
       | lastName  | Napoler                    |
       | email     | napoler.dev@prestashop.com |
+      | guest     | false                      |
     When I edit customer "CUST-1" and I change the following properties:
       | firstName | Jean |
-    Then if I query customer "CUST-1" I should get a Customer with properties:
+    When I query customer "CUST-1" I should get a Customer with properties:
       | firstName | Jean |
 
   Scenario: Fail to create a duplicate customer
@@ -48,28 +52,64 @@ Feature: Customer Management
       | isEnabled                 | false                     |
       | isPartnerOffersSubscribed | true                      |
       | birthday                  | 1987-02-22                |
-    Then if I query customer "CUST-4" I should get a Customer with properties:
-      | firstName               | Mathieu                   |
-      | lastName                | Polarn                    |
-      | email                   | polarn.dev@prestashop.com |
-      | defaultGroupId          | Guest                     |
-      | groupIds                | [Guest, Customer]         |
-      | genderId                | Mrs.                      |
-      | enabled                 | false                     |
-      | partnerOffersSubscribed | true                      |
-      | birthday                | 1987-02-22                |
+    When I query customer "CUST-4" I should get a Customer with properties:
+      | firstName                | Mathieu                   |
+      | lastName                 | Polarn                    |
+      | email                    | polarn.dev@prestashop.com |
+      | defaultGroupId           | Guest                     |
+      | groupIds                 | [Guest, Customer]         |
+      | genderId                 | Mrs.                      |
+      | enabled                  | false                     |
+      | partnerOffersSubscribed  | true                      |
+      | newsletterSubscribed     | false                     |
+      | birthday                 | 1987-02-22                |
+      | guest                    | false                     |
+      | companyName              |                           |
+      | siretCode                |                           |
+      | apeCode                  |                           |
+      | website                  |                           |
+      | allowedOutstandingAmount | 0.00                      |
+      | maxPaymentDays           | 0                         |
+      | riskId                   |                           |
     When I edit customer "CUST-4" and I change the following properties:
-      | firstName                 | Jean       |
-      | defaultGroupId            | Customer   |
-      | isPartnerOffersSubscribed | false      |
-      | birthday                  | 1987-02-24 |
-    Then if I query customer "CUST-4" I should get a Customer with properties:
-      | firstName            | Jean       |
-      | defaultGroupId       | Customer   |
-      | newsletterSubscribed | false      |
-      | birthday             | 1987-02-24 |
+      | firstName                 | Jean                      |
+      | lastName                  | Reno                      |
+      | email                     | jean.reno@prestashop.com  |
+      | defaultGroupId            | Customer                  |
+      | groupIds                  | [Customer]                |
+      | genderId                  | Mr.                       |
+      | isEnabled                 | true                      |
+      | isPartnerOffersSubscribed | false                     |
+      | newsletterSubscribed      | true                      |
+      | birthday                  | 1987-02-24                |
+      | companyName               | PrestaShop                |
+      | siretCode                 | 426169                    |
+      | apeCode                   | 2845B                     |
+      | website                   | http://www.prestashop.com |
+      | allowedOutstandingAmount  | 3.14                      |
+      | maxPaymentDays            | 7                         |
+      | riskId                    | low                       |
+    When I query customer "CUST-4" I should get a Customer with properties:
+      | firstName                | Jean                      |
+      | lastName                 | Reno                      |
+      | email                    | jean.reno@prestashop.com  |
+      | defaultGroupId           | Customer                  |
+      | groupIds                 | [Customer]                |
+      | genderId                 | Mr.                       |
+      | enabled                  | true                      |
+      | partnerOffersSubscribed  | false                     |
+      | newsletterSubscribed     | true                      |
+      | birthday                 | 1987-02-24                |
+      | guest                    | false                     |
+      | companyName              | PrestaShop                |
+      | siretCode                | 426169                    |
+      | apeCode                  | 2845B                     |
+      | website                  | http://www.prestashop.com |
+      | allowedOutstandingAmount  | 3.14                     |
+      | maxPaymentDays            | 7                        |
+      | riskId                    | low                      |
 
-  Scenario: Delete customer
+  Scenario: Delete customer but allow to register (pure delete from DB)
     When I create a customer "CUST-5" with following properties:
       | firstName      | Mathieu                   |
       | lastName       | Abigal                    |
@@ -77,5 +117,37 @@ Feature: Customer Management
       | password       | PrestaShopForever1_!      |
       | defaultGroupId | Guest                     |
       | groupIds       | [Guest]                   |
-    And I delete customer "CUST-5" with "allow registration after deletion" checked
+    And I delete customer "CUST-5" and allow it to register again
     Then the customer "CUST-5" should not be found
+    # I can create another customer with the same mail
+    When I create a customer "CUST-6" with following properties:
+      | firstName      | Mathieu                   |
+      | lastName       | Abigal                    |
+      | email          | abigal.dev@prestashop.com |
+      | password       | PrestaShopForever1_!      |
+      | defaultGroupId | Guest                     |
+      | groupIds       | [Guest]                   |
+    When I query customer "CUST-6" I should get a Customer with properties:
+      | firstName      | Mathieu                   |
+      | lastName       | Abigal                    |
+      | email          | abigal.dev@prestashop.com |
+      | defaultGroupId | Guest                     |
+      | groupIds       | [Guest]                   |
+
+  Scenario: Delete customer but prevent to register (soft delete from DB, the customer cannot be recreated)
+    When I create a customer "CUST-7" with following properties:
+      | firstName      | Walter                       |
+      | lastName       | Bishop                       |
+      | email          | walter.bishop@prestashop.com |
+      | password       | PrestaShopForever1_!         |
+      | defaultGroupId | Guest                        |
+      | groupIds       | [Guest]                      |
+    And I delete customer "CUST-7" and prevent it from registering again
+    # Customer is still present in DB but soft deleted
+    When I query customer "CUST-7" I should get a Customer with properties:
+      | firstName      | Walter                       |
+      | lastName       | Bishop                       |
+      | email          | walter.bishop@prestashop.com |
+      | defaultGroupId | Guest                        |
+      | groupIds       | [Guest]                      |
+    And customer "CUST-7" should be soft deleted

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_private_note.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_private_note.feature
@@ -1,5 +1,6 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags customer-private-note
 @reset-database-before-feature
+@customer-private-note
 Feature: Setting private note about customer
   In order to have private notes about FO customers
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_required_fields_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_required_fields_management.feature
@@ -1,5 +1,6 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags customer-required-fields
 @reset-database-before-feature
+@customer-required-fields
 Feature: Customer Required fields management
   PrestaShop allows BO users to manage required fields for FO customer profile
   As a BO user

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -21,6 +21,7 @@ default:
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerManagerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\RiskFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -87,7 +87,7 @@ class CustomerFormDataProviderTest extends TestCase
                     36.99,
                     10,
                     1,
-                    true
+                    false
                 )
             )
         ;

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -134,6 +134,7 @@ class CustomerFormDataProviderTest extends TestCase
             'is_partner_offers_subscribed' => true,
             'group_ids' => [1, 2, 3],
             'default_group_id' => 3,
+            'is_guest' => false,
         ], $customerFormDataProvider->getData(1));
     }
 
@@ -163,6 +164,7 @@ class CustomerFormDataProviderTest extends TestCase
             'allowed_outstanding_amount' => 36.99,
             'max_payment_days' => 10,
             'risk_id' => 1,
+            'is_guest' => false,
         ], $customerFormDataProvider->getData(1));
     }
 
@@ -180,6 +182,7 @@ class CustomerFormDataProviderTest extends TestCase
             'is_partner_offers_subscribed' => false,
             'group_ids' => [1, 2, 3],
             'default_group_id' => 3,
+            'is_guest' => false,
         ], $customerFormDataProvider->getDefaultData());
     }
 
@@ -199,6 +202,7 @@ class CustomerFormDataProviderTest extends TestCase
             'default_group_id' => 3,
             'allowed_outstanding_amount' => 0,
             'max_payment_days' => 0,
+            'is_guest' => false,
         ], $customerFormDataProvider->getDefaultData());
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -87,7 +87,7 @@ class CustomerFormDataProviderTest extends TestCase
                     36.99,
                     10,
                     1,
-                    0
+                    true
                 )
             )
         ;

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CustomerFormDataProviderTest.php
@@ -86,7 +86,8 @@ class CustomerFormDataProviderTest extends TestCase
                     'prestashop.com',
                     36.99,
                     10,
-                    1
+                    1,
+                    0
                 )
             )
         ;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prestashop was loading `ViewableCustomer` with a lot of unnecessary information (hundreds of queries and slowing down the opening of the edit form) instead of lightweight `EditableCustomer`. I also needed to add `isGuest` to `EditableCustomer` due to it being used in the template, we will need it anyway for other things.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes part of #25683
| How to test?      | Try to edit some customers and see its working fine.
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25686)
<!-- Reviewable:end -->
