### PR TITLE
Fixed error on View Order when contains a customized product which has been deleted

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -111,11 +111,15 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
             $customizations = [];
             if (is_array($product['customizedDatas'])) {
                 foreach ($product['customizedDatas'] as $customizationPerAddress) {
-                    foreach ($customizationPerAddress as $customizationId => $customization) {
+                    foreach ($customizationPerAddress as $customization) {
                         $customized_product_quantity += (int) $customization['quantity'];
                         foreach ($customization['datas'] as $datas) {
                             foreach ($datas as $data) {
-                                $customizations[] = new OrderProductCustomizationForViewing((int) $data['type'], $data['name'], $data['value']);
+                                $customizations[] = new OrderProductCustomizationForViewing(
+                                    (int) $data['type'],
+                                    (string) $data['name'],
+                                    $data['value']
+                                );
                             }
                         }
                     }

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_product.feature
@@ -1,0 +1,59 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-product
+@reset-database-before-feature
+@reset-product-price-cache
+@order-product
+Feature: Order from Back Office (BO)
+  In order to manage orders for FO customers
+  As a BO user
+  I need to be able to customize orders from the BO
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And I create an empty cart "dummy_cart" for customer "testCustomer"
+
+  Scenario: Get informations about a customized deleted product
+    ## Add a new product
+    When I add product "product12345" with following information:
+      | name[en-US] | Customizable Postcard |
+      | type        | standard              |
+    And I update product product12345 with following customization fields:
+      | reference   | type | name[en-US] | is required |
+      | customField | text | back image  | false       |
+    And I update product "product12345" stock with following information:
+      | out_of_stock_type             | available |
+    And I update product "product12345" details with following values:
+      | reference | product12345      |
+    Then product "product12345" should allow customization
+    And product product12345 should have 1 customizable text field
+    And product "product12345" should have following stock information:
+      | out_of_stock_type             | available |
+    ## Add product to cart
+    When I add 2 customized products with reference "product12345" with all its customizations to the cart "dummy_cart"
+    ## Select address
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
+    ## Place order
+    And I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Awaiting bank wire payment |
+    ## Check order
+    Then order "bo_order1" should contain 2 products "Customizable Postcard"
+    ## Check customization
+    Then the order "bo_order1" should have following customizations:
+      | productReference | type | name       | value |
+      | product12345     | text | back image | Toto  |
+
+    ## Remove product
+    When I delete product product12345
+    Then product product12345 should not exist anymore
+    ## Check customization
+    Then the order "bo_order1" should have following customizations:
+      | productReference | type | name       | value |
+      | product12345     | text |            | Toto  |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -107,6 +107,12 @@ default:
                 - Tests\Integration\Behaviour\Features\Transform\SharedStorageTransformContext
                 - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
         currency:
             paths:
                 - %paths.base%/Features/Scenario/Currency


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixed error on View Order when contains a customized product which has been deleted
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25644
| How to test?      | Cf #25644


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25704)
<!-- Reviewable:end -->
