### PR TITLE
Remove unused parameters from Tools::addonsRequest()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3982,10 +3982,6 @@ exit;
                 $post_data .= '&method=listing&action=must-have';
 
                 break;
-            case 'must-have-themes':
-                $post_data .= '&method=listing&action=must-have-themes';
-
-                break;
             case 'customer':
                 $post_data .= '&method=listing&action=customer&username=' . urlencode(trim(Context::getContext()->cookie->username_addons))
                     . '&password=' . urlencode(trim(Context::getContext()->cookie->password_addons));

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3987,11 +3987,6 @@ exit;
                     . '&password=' . urlencode(trim(Context::getContext()->cookie->password_addons));
 
                 break;
-            case 'customer_themes':
-                $post_data .= '&method=listing&action=customer-themes&username=' . urlencode(trim(Context::getContext()->cookie->username_addons))
-                    . '&password=' . urlencode(trim(Context::getContext()->cookie->password_addons));
-
-                break;
             case 'check_customer':
                 $post_data .= '&method=check_customer&username=' . urlencode($params['username_addons']) . '&password=' . urlencode($params['password_addons']);
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3974,10 +3974,6 @@ exit;
                 $post_data .= '&method=listing&action=native';
 
                 break;
-            case 'native_all':
-                $post_data .= '&method=listing&action=native&iso_code=all';
-
-                break;
             case 'must-have':
                 $post_data .= '&method=listing&action=must-have';
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3974,10 +3974,6 @@ exit;
                 $post_data .= '&method=listing&action=native';
 
                 break;
-            case 'partner':
-                $post_data .= '&method=listing&action=partner';
-
-                break;
             case 'service':
                 $post_data .= '&method=listing&action=service';
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4015,13 +4015,6 @@ exit;
                 }
 
                 break;
-            case 'hosted_module':
-                $post_data .= '&method=module&id_module=' . urlencode((int) $params['id_module']) . '&username=' . urlencode($params['hosted_email'])
-                    . '&password=' . urlencode($params['password_addons'])
-                    . '&shop_url=' . urlencode(isset($params['shop_url']) ? $params['shop_url'] : Tools::getShopDomain())
-                    . '&mail=' . urlencode(isset($params['email']) ? $params['email'] : Configuration::get('PS_SHOP_EMAIL'));
-
-                break;
             case 'install-modules':
                 $post_data .= '&method=listing&action=install-modules';
                 $post_data .= defined('_PS_HOST_MODE_') ? '-od' : '';

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3974,10 +3974,6 @@ exit;
                 $post_data .= '&method=listing&action=native';
 
                 break;
-            case 'service':
-                $post_data .= '&method=listing&action=service';
-
-                break;
             case 'native_all':
                 $post_data .= '&method=listing&action=native&iso_code=all';
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed unused requests from `Tools::addonsRequest()`
| Type?             | new feature
| Category?         | CO
| BC breaks?        | yes - The option is no longer available
| Deprecations?     | no
| Fixed ticket?     | Fixes #24740, fixes #24741, fixes #24744, fixes #24747, fixes #24751
| How to test?      | Nothing to test
| Possible impacts? | Calls to `Tools::addonsRequest()` using any of the removed values listed above will return `false`.

I wasn't able to find any calls to the following requests in the Core, MBO or any of the native modules:

- Tools::addonsRequest('partner')
- Tools::addonsRequest('service')
- Tools::addonsRequest('hosted_module')
- Tools::addonsRequest('must-have-themes')
- Tools::addonsRequest('customer_themes')
- Tools::addonsRequest('native_all')

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25714)
<!-- Reviewable:end -->
