### PR TITLE
Add parameters to thumbnail call to regenerate pic

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -348,7 +348,7 @@ class HelperListCore extends Helper
                     } else {
                         $path_to_image = _PS_IMG_DIR_ . $params['image'] . '/' . Image::getImgFolderStatic($tr['id_image']) . (int) $tr['id_image'] . '.' . $this->imageType;
                     }
-                    $this->_list[$index][$key] = ImageManager::thumbnail($path_to_image, $this->table . '_mini_' . $item_id . '_' . $this->context->shop->id . '.' . $this->imageType, self::LIST_THUMBNAIL_SIZE, $this->imageType);
+                    $this->_list[$index][$key] = ImageManager::thumbnail($path_to_image, $this->table . '_mini_' . $item_id . '_' . $this->context->shop->id . '.' . $this->imageType, self::LIST_THUMBNAIL_SIZE, $this->imageType, false, true);
                 } elseif (isset($params['icon'], $tr[$key]) && (isset($params['icon'][$tr[$key]]) || isset($params['icon']['default']))) {
                     if (!$this->bootstrap) {
                         if (isset($params['icon'][$tr[$key]]) && is_array($params['icon'][$tr[$key]])) {


### PR DESCRIPTION
https://github.com/PrestaShop/PrestaShop/blob/5cb0ddc2bb24c88306e54faa39f722804014f73d/classes/ImageManager.php#L60

By default, cache is disabled (so there is a cache buster timestamp added to the URL) and regeneration is not done.

https://github.com/PrestaShop/PrestaShop/blob/5cb0ddc2bb24c88306e54faa39f722804014f73d/classes/helper/HelperList.php#L351
The call is made without the two last parameters so cache is not disabled (but we don't about the cache buster timestamp in view list) and pic is not regenerated (we want the pic to be regenerated)

Correction is to provide the two parameters false and true to at least regenerate the pics

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x / 1.7.7.x
| Description?      | see #25716 
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25716
| How to test?      | see #25716 
| Possible impacts? | see #25716

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25717)
<!-- Reviewable:end -->
